### PR TITLE
fix: add missing ratelimit plugin import

### DIFF
--- a/cmd/ferrogw-cli/main.go
+++ b/cmd/ferrogw-cli/main.go
@@ -15,6 +15,7 @@ import (
 	_ "github.com/ferro-labs/ai-gateway/internal/plugins/logger"
 	_ "github.com/ferro-labs/ai-gateway/internal/plugins/maxtoken"
 	_ "github.com/ferro-labs/ai-gateway/internal/plugins/wordfilter"
+	_ "github.com/ferro-labs/ai-gateway/internal/plugins/ratelimit"
 )
 
 const usage = `ferrogw-cli — Ferro Labs AI Gateway command line tool


### PR DESCRIPTION
## Summary
Add missing ratelimit plugin import so CLI lists all built-in plugins.

## Changes
- Added import for internal/plugins/ratelimit

## Fix
Closes #10