### PR TITLE
fix: add missing rate-limit plugin import to CLI

### DIFF
--- a/cmd/ferrogw-cli/main.go
+++ b/cmd/ferrogw-cli/main.go
@@ -14,6 +14,7 @@ import (
 	_ "github.com/ferro-labs/ai-gateway/internal/plugins/cache"
 	_ "github.com/ferro-labs/ai-gateway/internal/plugins/logger"
 	_ "github.com/ferro-labs/ai-gateway/internal/plugins/maxtoken"
+	_ "github.com/ferro-labs/ai-gateway/internal/plugins/ratelimit"
 	_ "github.com/ferro-labs/ai-gateway/internal/plugins/wordfilter"
 )
 


### PR DESCRIPTION
## Summary
Fix `ferrogw-cli plugins` to include the built-in `rate-limit` plugin.

## Problem
The CLI binary was missing the blank import for the ratelimit plugin, so `plugin.RegisteredPlugins()` only returned 4 plugins instead of 5.

## Solution
Add the missing blank import in `cmd/ferrogw-cli/main.go`:
```go
_ "github.com/ferro-labs/ai-gateway/internal/plugins/ratelimit"
```

## Testing
```bash
go run ./cmd/ferrogw-cli plugins
# Should now include rate-limit in the output
```

Closes #10