### PR TITLE
Release/v1.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.0.5] — 2026-04-28
+
+Feature release adding first-class Ollama Cloud support and broader embedding coverage while keeping the gateway's public API OpenAI-compatible for end users.
+
+### Added
+
+- **Ollama Cloud provider** ([#94](https://github.com/ferro-labs/ai-gateway/issues/94)): Added `ollama-cloud` as a separate provider from local `ollama`, using Ollama Cloud's documented `https://ollama.com/api` endpoints with Bearer token authentication via `OLLAMA_API_KEY`.
+- **OpenAI-compatible gateway surface for Ollama Cloud**: Users can call the existing `/v1/chat/completions` endpoint with normal OpenAI-style payloads while the provider internally adapts requests to Ollama Cloud's native `/api/chat` API.
+- **Streaming and model discovery**: Added native NDJSON streaming support and live model discovery from `/api/tags`, exposed through the gateway's normalized streaming and model-list interfaces.
+- **Ollama Cloud model catalog entries**: Added `ollama-cloud/*` catalog entries for initial direct Cloud model IDs, including `gpt-oss:120b`, `gpt-oss:20b`, `qwen3-coder:480b`, and `deepseek-v3.1:671b`, in both the primary and embedded backup catalogs.
+- **Expanded embeddings**: Bedrock, Cohere, Databricks, Fireworks, Gemini, Mistral, Novita, Together, and Vertex AI now implement the gateway's `EmbeddingProvider` interface, advertise the `embed` capability, and route `/v1/embeddings` requests through provider-native or OpenAI-compatible embedding APIs with normalized vectors and token-usage responses.
+- **Embedding provider tests and registry guardrails**: Added package-local embedding tests for success, invalid input, upstream errors, auth/path mapping, and usage mapping, plus a registry consistency test that keeps `CapabilityEmbed` aligned with actual `EmbeddingProvider` implementations.
+- **Implementation plan documentation**: Added `docs/ollama-cloud-implementation-plan.md` documenting provider identity, API mapping, catalog policy, testing scope, and known open questions.
+
+### Changed
+
+- **Provider registry and examples**: Updated provider registration, stability tests, config examples, Docker environment comments, and README provider counts for the new 30th provider.
+- **Catalog pricing policy for Ollama Cloud**: Ollama Cloud catalog entries use `null` token pricing because Ollama currently documents plan/GPU-usage-based limits rather than fixed per-token rates.
+- **Proxy scope**: Ollama Cloud intentionally does not advertise pass-through proxy support yet because Ollama Cloud's documented direct API is `/api/*`, not `/v1/*`.
+
+---
+
 ## [1.0.4] — 2026-04-09
 
 Patch release focused on security maintenance, cache correctness, and refreshed project messaging. This release keeps the `v1.0.x` line stable while improving the published release notes for GitHub releases.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   <img src="docs/logo.png" alt="Ferro Labs AI Gateway" height="60" align="absmiddle" /> Ferro Labs AI Gateway
 </h1>
 
-**High-performance AI gateway in Go. Route LLM requests across 29 providers via a single OpenAI-compatible API.**
+**High-performance AI gateway in Go. Route LLM requests across 30 providers via a single OpenAI-compatible API.**
 
 **Deploy templates**
 
@@ -21,7 +21,7 @@
 [![Code Scanning](https://github.com/ferro-labs/ai-gateway/actions/workflows/code-scanning.yml/badge.svg)](https://github.com/ferro-labs/ai-gateway/actions/workflows/code-scanning.yml)
 [![Discord](https://img.shields.io/badge/Discord-Join%20Us-5865F2?logo=discord&logoColor=white)](https://discord.gg/yCAeYvJeDV)
 
-🔀 **29 providers, 2,500+ models — one API**<br/>
+🔀 **30 providers, 2,500+ models — one API**<br/>
 ⚡ **13,925 RPS at 1,000 concurrent users**<br/>
 📦 **Single binary, zero dependencies, 32 MB base memory**
 
@@ -129,7 +129,7 @@ Most AI gateways are Python proxies that crack under load or JavaScript services
 |:-----------------|:------------|:--------|:-----------|:------------|
 | Language         | Go          | Python  | Go         | Go/Lua      |
 | Single binary    | ✅          | ❌      | ✅         | ❌          |
-| Providers        | 29          | 100+    | 20+        | 10+         |
+| Providers        | 30          | 100+    | 20+        | 10+         |
 | MCP support      | ✅          | ❌      | ✅         | ❌          |
 | Response cache   | ✅          | ✅      | ✅         | ❌ (paid)   |
 | Guardrails       | ✅          | ✅      | ❌         | ❌ (paid)   |
@@ -195,11 +195,11 @@ Full methodology, raw results, and flamegraph analysis:
 - Provider failover with configurable retry policies and status code filters
 - Per-request model aliases (`fast → gpt-4o-mini`, `smart → claude-3-5-sonnet`)
 
-### 🔌 Providers (29)
+### 🔌 Providers (30)
 
 | OpenAI & Compatible | Anthropic & Google | Cloud & Enterprise | Open Source & Inference |
 |:---|:---|:---|:---|
-| OpenAI | Anthropic | AWS Bedrock | Ollama |
+| OpenAI | Anthropic | AWS Bedrock | Ollama, Ollama Cloud |
 | Azure OpenAI | Google Gemini | Azure Foundry | Hugging Face |
 | OpenRouter | Vertex AI | Databricks | Replicate |
 | DeepSeek | | Cloudflare Workers AI | Together AI |

--- a/config.example.json
+++ b/config.example.json
@@ -100,6 +100,9 @@
       "virtual_key": "ollama"
     },
     {
+      "virtual_key": "ollama-cloud"
+    },
+    {
       "virtual_key": "cerebras"
     },
     {

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -74,6 +74,7 @@ targets:
   - virtual_key: vertex-ai
   - virtual_key: hugging-face
   - virtual_key: ollama
+  - virtual_key: ollama-cloud
   - virtual_key: cerebras
   - virtual_key: cloudflare
   - virtual_key: databricks

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,6 +63,10 @@ services:
       # Ollama (local):
       # - OLLAMA_HOST=http://host.docker.internal:11434
       # - OLLAMA_MODELS=llama3,gemma
+      # Ollama Cloud:
+      # - OLLAMA_API_KEY=...
+      # - OLLAMA_CLOUD_MODELS=gpt-oss:20b,gpt-oss:120b
+      # - OLLAMA_CLOUD_BASE_URL=https://ollama.com
       # Optional config file:
       # - GATEWAY_CONFIG=/etc/ferrogw/config.yaml
     # volumes:

--- a/docs/embedding-providers-implementation-plan.md
+++ b/docs/embedding-providers-implementation-plan.md
@@ -1,0 +1,176 @@
+# Embedding Providers Implementation Plan
+
+This document tracks the implementation plan and final status for making
+`/v1/embeddings` support consistent across built-in providers that have text
+embedding support in the model catalog or expose an embedding-capable API.
+
+## Goal
+
+Expand `core.EmbeddingProvider` coverage so the gateway can route OpenAI-style
+`POST /v1/embeddings` requests to every supported built-in text embedding
+provider, with normalized request validation, response mapping, token usage,
+registry capabilities, tests, and model visibility.
+
+## Current State
+
+The gateway has a normalized embedding interface:
+
+- `core.EmbeddingProvider`
+- `core.EmbeddingRequest`
+- `core.EmbeddingResponse`
+- `Gateway.Embed`
+- `cmd/ferrogw` route: `POST /v1/embeddings`
+
+Providers that implement and advertise `CapabilityEmbed`:
+
+| Provider ID | Status | Notes |
+|---|---|---|
+| `openai` | Implemented | Uses OpenAI embeddings API and has tests. |
+| `cloudflare` | Implemented | Uses Workers AI `/embeddings` adapter and has tests. |
+| `hugging-face` | Implemented | Uses `/embeddings` adapter and has tests. |
+| `cohere` | Implemented | Uses Cohere `/v1/embed`; dedicated `Embed` tests added. |
+| `bedrock` | Implemented for text | Supports Titan text and Cohere embedding model families; image/multimodal families are deferred. |
+| `databricks` | Implemented | Uses OpenAI-compatible model-serving embeddings endpoint. |
+| `fireworks` | Implemented | Uses OpenAI-compatible `/v1/embeddings`. |
+| `gemini` | Implemented for text | Uses native Gemini `batchEmbedContents`. |
+| `mistral` | Implemented | Uses OpenAI-compatible `/v1/embeddings`. |
+| `novita` | Implemented | Uses OpenAI-compatible `/embeddings` under Novita's `/openai/v1` base. |
+| `together` | Implemented | Uses OpenAI-compatible `/v1/embeddings`. |
+| `vertex-ai` | Implemented for text | Uses Vertex AI publisher model `:predict`; multimodal embeddings are deferred. |
+
+Catalog entries also exist for non-built-in or differently named providers such
+as `azure`, `voyage`, `volcengine`, `vercel_ai_gateway`, `github_copilot`,
+`gigachat`, and `llamagate`. Those remain out of scope unless corresponding
+built-in provider packages are added or provider IDs are normalized first.
+
+## Principles
+
+- End users keep using the gateway's OpenAI-compatible `/v1/embeddings` route.
+- Provider implementations adapt to each upstream API internally.
+- Only advertise `CapabilityEmbed` after a provider has a working `Embed`
+  method and tests.
+- Keep `SupportsModel` precise enough that embedding requests do not get routed
+  to providers that only support similarly named chat models.
+- Add compile-time assertions for every new implementation:
+  `var _ core.EmbeddingProvider = (*Provider)(nil)`.
+- Keep catalog and `SupportedModels()` behavior aligned enough for `/v1/models`
+  to expose common embedding models.
+- Use provider-specific tests with `httptest` or fake clients; do not require
+  real API keys.
+
+## Completed Cross-Cutting Work
+
+1. Added package-local tests for new and hardened embedding providers covering:
+   request path/auth, string input, `[]string` input, invalid input, empty input,
+   upstream non-200 errors, response vector/index mapping, and token usage.
+2. Added a registry consistency test:
+   every provider advertising `CapabilityEmbed` must implement
+   `core.EmbeddingProvider`, and every provider implementing
+   `core.EmbeddingProvider` should advertise `CapabilityEmbed`.
+3. Hardened Cohere embedding behavior so unsafe `[]interface{}` values now
+   return a clear error instead of silently dropping non-string entries.
+4. Added embedding model IDs to `SupportedModels()` where provider lists were
+   chat-focused.
+
+## Provider Implementation Status
+
+### Cohere
+
+Status: complete.
+
+- Added dedicated `Embed` tests for `/v1/embed`, Bearer auth, success mapping,
+  string and array input, invalid input, empty input, unsafe `[]interface{}`,
+  token usage, and upstream errors.
+- Added common Cohere embedding models such as `embed-v4.0`,
+  `embed-english-v3.0`, and `embed-multilingual-v3.0` to `SupportedModels()`.
+
+### OpenAI-compatible providers
+
+Status: complete.
+
+| Provider | Endpoint |
+|---|---|
+| `mistral` | `POST {baseURL}/v1/embeddings` |
+| `together` | `POST {baseURL}/v1/embeddings` |
+| `fireworks` | `POST {baseURL}/v1/embeddings` |
+| `novita` | `POST {baseURL}/embeddings` |
+| `databricks` | `POST {normalizedBaseURL}/embeddings` |
+
+Each provider supports string and array inputs, maps OpenAI-style embedding
+responses into `core.EmbeddingResponse`, advertises `CapabilityEmbed`, and has
+package-local tests for success and error paths.
+
+### Gemini
+
+Status: complete for text embeddings.
+
+- Uses `POST /v1beta/models/{model}:batchEmbedContents?key=...`.
+- Maps string and array text input into Gemini content parts.
+- Supports `dimensions` through `outputDimensionality`.
+- Maps Gemini embedding values and token metadata into
+  `core.EmbeddingResponse`.
+
+### Vertex AI
+
+Status: complete for text embeddings.
+
+- Uses `POST /v1/projects/{project}/locations/{region}/publishers/google/models/{model}:predict`.
+- Supports `text-embedding-*`, `textembedding-gecko*`,
+  `text-multilingual-embedding-*`, and `gemini-embedding-001` text embedding
+  model families.
+- Supports API-key and service-account authorization paths through existing
+  provider auth helpers.
+- Defers multimodal embedding models because `core.EmbeddingRequest` currently
+  models text input only.
+
+### Bedrock
+
+Status: complete for text embeddings.
+
+- Uses the existing Bedrock Runtime `InvokeModel` client.
+- Supports `amazon.titan-embed-text-*` text embedding models.
+- Supports `cohere.embed-*` text embedding models, including Cohere v4 float
+  embedding responses.
+- Defers Titan image, Nova multimodal, TwelveLabs, and other non-text embedding
+  families until the core embedding request supports non-text inputs.
+
+## Validation Plan
+
+Run after provider changes:
+
+```bash
+go test ./providers/<provider>/...
+go test ./providers/...
+```
+
+Run before merging the full feature:
+
+```bash
+go test ./...
+make build
+git diff --check
+```
+
+## Open Questions
+
+- Should gateway discovery results rebuild embedding indexes after discovery
+  updates? Today discovery updates `AllModels()` output, but model indexes are
+  built from provider `SupportedModels()`.
+- Should `core.EmbeddingRequest` grow multimodal input support before enabling
+  image/multimodal embedding models from Bedrock or Vertex AI?
+- Should catalog provider key `vertex_ai` be normalized to the runtime provider
+  ID `vertex-ai` for consistent cost lookup?
+- Should `azure` catalog embedding models be mapped to `azure-openai`, or should
+  Azure OpenAI embedding support be planned separately?
+
+## Definition of Done
+
+- Every built-in provider with supported text embedding models in the catalog
+  implements `EmbeddingProvider`.
+- Registry `CapabilityEmbed` matches actual interface implementation.
+- `/v1/embeddings` routes correctly for each implemented provider.
+- Tests cover success, invalid input, and upstream error paths for every
+  implemented provider.
+- Catalog, provider model lists, and routing behavior are consistent enough that
+  users can discover and call embedding models without provider-specific request
+  shapes.

--- a/docs/ollama-cloud-implementation-plan.md
+++ b/docs/ollama-cloud-implementation-plan.md
@@ -1,0 +1,238 @@
+# Ollama Cloud Provider Implementation Plan
+
+This document is the single source of truth for implementing GitHub issue #94:
+add Ollama Cloud as a first-class provider while preserving the gateway's
+OpenAI-compatible public API.
+
+## Goal
+
+Add a clean `ollama-cloud` provider that lets users call the existing gateway
+OpenAI-compatible endpoint (`/v1/chat/completions`) with normal chat completion
+payloads while the provider internally talks to Ollama Cloud's documented API.
+
+The existing local `ollama` provider must continue to represent local Ollama
+instances and local cloud-offload models. Ollama Cloud direct API access should
+be a separate provider because it has a different base URL, authentication
+requirements, model IDs, and documented endpoint shape.
+
+## Design Decisions
+
+### Provider identity
+
+- Add canonical provider ID: `ollama-cloud`
+- Add package path: `providers/ollama_cloud`
+- Add public root constant: `providers.NameOllamaCloud`
+- Do not change the existing `providers.NameOllama` value or local Ollama
+  behavior.
+
+### End-user compatibility
+
+Users should not need to learn Ollama's native API to use this provider through
+the gateway. They continue using:
+
+```http
+POST /v1/chat/completions
+```
+
+with OpenAI-compatible request fields such as `model`, `messages`,
+`temperature`, `max_tokens`, and `stream`.
+
+The provider adapts gateway `core.Request` values to Ollama Cloud's native
+`/api/chat` request and adapts Ollama Cloud responses back to `core.Response`
+and `core.StreamChunk`.
+
+### Upstream API target
+
+Use Ollama Cloud's documented direct API:
+
+- Default host: `https://ollama.com`
+- Chat: `POST /api/chat`
+- Models: `GET /api/tags`
+- Authentication: `Authorization: Bearer <OLLAMA_API_KEY>`
+
+Do not depend on undocumented `https://ollama.com/v1/*` routes for the initial
+implementation. If those routes are later verified and documented, proxy support
+can be added separately.
+
+### Proxy support
+
+Do not implement `core.ProxiableProvider` for `ollama-cloud` initially.
+
+Reason: the gateway proxy forwards unhandled `/v1/*` paths to provider
+`BaseURL()`. Ollama Cloud's documented direct API is `/api/*`, so advertising
+OpenAI pass-through could create confusing 404s or silently depend on
+undocumented behavior.
+
+### Model routing
+
+The provider should support explicit configured models and live discovery:
+
+- `OLLAMA_CLOUD_MODELS` can provide a comma-separated static list for routing.
+- `DiscoverModels(ctx)` should fetch `GET /api/tags` and map the returned model
+  names to `core.ModelInfo`.
+- `SupportsModel(model)` should return true for configured/discovered models
+  when a list is available, and may use a conservative fallback only if needed
+  for compatibility with provider routing.
+
+Avoid making `ollama-cloud` support every arbitrary model name if doing so would
+steal traffic from other providers during fallback routing.
+
+## Catalog Plan
+
+Current catalog state:
+
+- `models/catalog.json` and `models/catalog_backup.json` include 29 `ollama/*`
+  entries.
+- Four of those entries are local cloud-offload style models:
+  - `ollama/gpt-oss:120b-cloud`
+  - `ollama/gpt-oss:20b-cloud`
+  - `ollama/qwen3-coder:480b-cloud`
+  - `ollama/deepseek-v3.1:671b-cloud`
+- There are no `ollama-cloud/*` entries today.
+
+Add separate `ollama-cloud/*` entries for direct Ollama Cloud model IDs. Initial
+entries should include the model IDs confirmed by Ollama Cloud's public
+`/api/tags` endpoint and docs, for example:
+
+- `ollama-cloud/gpt-oss:120b`
+- `ollama-cloud/gpt-oss:20b`
+- `ollama-cloud/qwen3-coder:480b`
+- `ollama-cloud/deepseek-v3.1:671b`
+
+Keep existing `ollama/*-cloud` entries because they represent local Ollama
+cloud-offload mode, where the local Ollama host handles auth/session behavior.
+
+Pricing caution:
+
+- Ollama Cloud public pricing is currently plan/GPU-usage oriented, not fixed
+  token pricing.
+- The implementation uses `null` token pricing for `ollama-cloud/*` entries so
+  cost reporting does not imply fixed per-token billing where Ollama has not
+  published it.
+- If Ollama publishes fixed per-token pricing later, update the catalog entries
+  then.
+
+Both `models/catalog.json` and `models/catalog_backup.json` must be updated
+together to keep remote and embedded fallback behavior consistent.
+
+## Implementation Steps
+
+1. Create `providers/ollama_cloud/ollama_cloud.go`.
+2. Implement constructor:
+   - `New(apiKey, baseURL string, models []string) (*Provider, error)`
+   - require a non-empty API key
+   - default empty base URL to `https://ollama.com`
+   - validate `http`/`https` base URLs with a host
+   - trim trailing slashes
+3. Implement provider methods:
+   - `Name() string`
+   - `SupportedModels() []string`
+   - `SupportsModel(model string) bool`
+   - `Models() []core.ModelInfo`
+   - `Complete(ctx, req core.Request) (*core.Response, error)`
+   - `CompleteStream(ctx, req core.Request) (<-chan core.StreamChunk, error)`
+   - `DiscoverModels(ctx) ([]core.ModelInfo, error)`
+4. Add compile-time assertions:
+   - `core.Provider`
+   - `core.StreamProvider`
+   - `core.DiscoveryProvider`
+5. Add native request mapping for `/api/chat`:
+   - `model`
+   - `messages`
+   - `stream`
+   - `temperature`
+   - `top_p`
+   - `max_tokens`, mapped to Ollama `options.num_predict` if needed by the
+     native API
+   - `tools` if supported by Ollama's request schema
+6. Add native response mapping:
+   - Ollama `message.role/content/tool_calls` to `core.Message`
+   - `done_reason` to `finish_reason`
+   - `prompt_eval_count` to `Usage.PromptTokens`
+   - `eval_count` to `Usage.CompletionTokens`
+   - sum to `Usage.TotalTokens`
+   - set `Provider` to `ollama-cloud`
+7. Add stream parsing:
+   - parse Ollama native newline-delimited JSON chunks from `/api/chat`
+   - emit gateway `core.StreamChunk` values
+   - include final usage when Ollama sends final counts
+   - surface scanner/read errors through `StreamChunk{Error: err}`
+8. Add model discovery:
+   - call `GET {baseURL}/api/tags`
+   - include Bearer auth
+   - parse `models[].name` or `models[].model`
+   - convert `modified_at` to Unix `Created` when possible
+   - set `OwnedBy` to `ollama-cloud`
+9. Register provider:
+   - import package in `providers/names.go`
+   - add `NameOllamaCloud`
+   - add it to `AllProviderNames()` in alphabetical order
+   - add `ProviderEntry` in `providers/providers_list.go`
+10. Add env mappings:
+    - `OLLAMA_API_KEY` required
+    - `OLLAMA_CLOUD_BASE_URL` optional
+    - `OLLAMA_CLOUD_MODELS` optional
+11. Update configuration examples:
+    - add `virtual_key: ollama-cloud` in `config.example.yaml`
+    - add `{ "virtual_key": "ollama-cloud" }` in `config.example.json`
+    - add commented env vars in `docker-compose.yml`
+12. Update model catalogs:
+    - add `ollama-cloud/*` entries to `models/catalog.json`
+    - add matching entries to `models/catalog_backup.json`
+13. Update tests:
+    - new `providers/ollama_cloud/ollama_cloud_test.go`
+    - update `providers/stability_test.go`
+    - update any provider-count expectations or documentation strings if they
+      are asserted in tests
+14. Run validation:
+    - `go test ./providers/...`
+    - `go test ./internal/transport/...` if adding a transport preset
+    - `go test ./...` before finalizing
+
+## Test Coverage Details
+
+Provider tests should cover:
+
+- constructor rejects empty API key
+- constructor defaults base URL to `https://ollama.com`
+- constructor rejects invalid base URLs
+- auth header is sent on chat and discovery requests
+- non-streaming `/api/chat` response maps message, finish reason, provider, and
+  token usage correctly
+- non-200 responses surface useful error messages
+- streaming parses newline-delimited JSON chunks and final usage
+- discovery parses `/api/tags` model names and timestamps
+- `SupportsModel` does not unintentionally claim unrelated provider model IDs
+
+Registry/stability tests should cover:
+
+- `NameOllamaCloud` is stable
+- `AllProviderNames()` includes `ollama-cloud`
+- `AllProviders()` includes exactly one `ollama-cloud` entry
+- provider capabilities include `chat`, `stream`, and `discovery`
+- env mappings have a required configured gate
+
+## Open Questions
+
+- Whether direct Ollama Cloud supports `/v1/chat/completions` with Bearer auth.
+  If verified and documented, a later change can add `core.ProxiableProvider`
+  or simplify the provider implementation.
+- Whether Ollama will publish fixed per-token pricing. Until then, cost
+  reporting for `ollama-cloud` should avoid pretending usage-based plan limits
+  are token prices.
+- How aggressive `SupportsModel` should be before first discovery has run. The
+  safest default is to use configured/static models and rely on discovery for
+  the broader model list.
+
+## Definition of Done
+
+- Users can configure Ollama Cloud with `OLLAMA_API_KEY`.
+- Users can call the gateway's normal `/v1/chat/completions` endpoint for
+  `ollama-cloud` models without using Ollama-specific request shapes.
+- Streaming works through the gateway's normal SSE response path.
+- `/v1/models` includes `ollama-cloud` models from static config and/or
+  discovery, enriched from catalog where entries exist.
+- Local `ollama` behavior remains unchanged.
+- Catalog fallback remains consistent by updating both catalog files.
+- Provider registry stability tests pass.
+- Full Go test suite passes.

--- a/gateway.go
+++ b/gateway.go
@@ -751,8 +751,10 @@ func (p *cbProvider) Complete(ctx context.Context, req providers.Request) (*prov
 	}
 	resp, err := p.Provider.Complete(ctx, req)
 	if err != nil {
-		p.cb.RecordFailure()
-		metrics.CircuitBreakerState.WithLabelValues(p.name).Set(float64(p.cb.State()))
+		if !isRateLimitError(err) {
+			p.cb.RecordFailure()
+			metrics.CircuitBreakerState.WithLabelValues(p.name).Set(float64(p.cb.State()))
+		}
 		return nil, err
 	}
 	p.cb.RecordSuccess()
@@ -771,13 +773,21 @@ func (p *cbProvider) CompleteStream(ctx context.Context, req providers.Request) 
 	}
 	ch, err := sp.CompleteStream(ctx, req)
 	if err != nil {
-		p.cb.RecordFailure()
-		metrics.CircuitBreakerState.WithLabelValues(p.name).Set(float64(p.cb.State()))
+		if !isRateLimitError(err) {
+			p.cb.RecordFailure()
+			metrics.CircuitBreakerState.WithLabelValues(p.name).Set(float64(p.cb.State()))
+		}
 		return nil, err
 	}
 	p.cb.RecordSuccess()
 	metrics.CircuitBreakerState.WithLabelValues(p.name).Set(0)
 	return ch, nil
+}
+
+// isRateLimitError checks if the error is a 429 rate limit response.
+// Rate limits are expected and temporary — they should not trip the circuit breaker.
+func isRateLimitError(err error) bool {
+	return providers.ParseStatusCode(err) == 429
 }
 
 // LoadPlugins initializes and registers plugins from the gateway configuration.

--- a/models/catalog.json
+++ b/models/catalog.json
@@ -64107,6 +64107,50 @@
     "updated_at": "2026-02-28",
     "tier": "standard"
   },
+  "ollama-cloud/deepseek-v3.1:671b": {
+    "provider": "ollama-cloud",
+    "model_id": "deepseek-v3.1:671b",
+    "display_name": "deepseek-v3.1:671b",
+    "mode": "chat",
+    "context_window": 163840,
+    "max_output_tokens": 163840,
+    "pricing": {
+      "input_per_m_tokens": null,
+      "output_per_m_tokens": null,
+      "cache_read_per_m_tokens": null,
+      "cache_write_per_m_tokens": null,
+      "reasoning_per_m_tokens": null,
+      "image_per_tile": null,
+      "audio_input_per_minute": null,
+      "audio_output_per_character": null,
+      "embedding_per_m_tokens": null,
+      "finetune_train_per_m_tokens": null,
+      "finetune_input_per_m_tokens": null,
+      "finetune_output_per_m_tokens": null
+    },
+    "capabilities": {
+      "vision": false,
+      "audio_input": false,
+      "audio_output": false,
+      "function_calling": true,
+      "parallel_tool_calls": false,
+      "json_mode": true,
+      "response_schema": false,
+      "prompt_caching": false,
+      "reasoning": false,
+      "streaming": true,
+      "finetuneable": false
+    },
+    "lifecycle": {
+      "status": "ga",
+      "deprecation_date": null,
+      "sunset_date": null,
+      "successor": null
+    },
+    "source": "https://docs.ollama.com/cloud",
+    "updated_at": "2026-04-28",
+    "tier": "standard"
+  },
   "ollama/gpt-oss:120b-cloud": {
     "provider": "ollama",
     "model_id": "gpt-oss:120b-cloud",
@@ -64151,6 +64195,50 @@
     "updated_at": "2026-02-28",
     "tier": "standard"
   },
+  "ollama-cloud/gpt-oss:120b": {
+    "provider": "ollama-cloud",
+    "model_id": "gpt-oss:120b",
+    "display_name": "gpt-oss:120b",
+    "mode": "chat",
+    "context_window": 131072,
+    "max_output_tokens": 131072,
+    "pricing": {
+      "input_per_m_tokens": null,
+      "output_per_m_tokens": null,
+      "cache_read_per_m_tokens": null,
+      "cache_write_per_m_tokens": null,
+      "reasoning_per_m_tokens": null,
+      "image_per_tile": null,
+      "audio_input_per_minute": null,
+      "audio_output_per_character": null,
+      "embedding_per_m_tokens": null,
+      "finetune_train_per_m_tokens": null,
+      "finetune_input_per_m_tokens": null,
+      "finetune_output_per_m_tokens": null
+    },
+    "capabilities": {
+      "vision": false,
+      "audio_input": false,
+      "audio_output": false,
+      "function_calling": true,
+      "parallel_tool_calls": false,
+      "json_mode": true,
+      "response_schema": false,
+      "prompt_caching": false,
+      "reasoning": false,
+      "streaming": true,
+      "finetuneable": false
+    },
+    "lifecycle": {
+      "status": "ga",
+      "deprecation_date": null,
+      "sunset_date": null,
+      "successor": null
+    },
+    "source": "https://docs.ollama.com/cloud",
+    "updated_at": "2026-04-28",
+    "tier": "standard"
+  },
   "ollama/gpt-oss:20b-cloud": {
     "provider": "ollama",
     "model_id": "gpt-oss:20b-cloud",
@@ -64193,6 +64281,50 @@
     },
     "source": "",
     "updated_at": "2026-02-28",
+    "tier": "standard"
+  },
+  "ollama-cloud/gpt-oss:20b": {
+    "provider": "ollama-cloud",
+    "model_id": "gpt-oss:20b",
+    "display_name": "gpt-oss:20b",
+    "mode": "chat",
+    "context_window": 131072,
+    "max_output_tokens": 131072,
+    "pricing": {
+      "input_per_m_tokens": null,
+      "output_per_m_tokens": null,
+      "cache_read_per_m_tokens": null,
+      "cache_write_per_m_tokens": null,
+      "reasoning_per_m_tokens": null,
+      "image_per_tile": null,
+      "audio_input_per_minute": null,
+      "audio_output_per_character": null,
+      "embedding_per_m_tokens": null,
+      "finetune_train_per_m_tokens": null,
+      "finetune_input_per_m_tokens": null,
+      "finetune_output_per_m_tokens": null
+    },
+    "capabilities": {
+      "vision": false,
+      "audio_input": false,
+      "audio_output": false,
+      "function_calling": true,
+      "parallel_tool_calls": false,
+      "json_mode": true,
+      "response_schema": false,
+      "prompt_caching": false,
+      "reasoning": false,
+      "streaming": true,
+      "finetuneable": false
+    },
+    "lifecycle": {
+      "status": "ga",
+      "deprecation_date": null,
+      "sunset_date": null,
+      "successor": null
+    },
+    "source": "https://docs.ollama.com/cloud",
+    "updated_at": "2026-04-28",
     "tier": "standard"
   },
   "ollama/internlm2_5-20b-chat": {
@@ -64985,6 +65117,50 @@
     },
     "source": "",
     "updated_at": "2026-02-28",
+    "tier": "standard"
+  },
+  "ollama-cloud/qwen3-coder:480b": {
+    "provider": "ollama-cloud",
+    "model_id": "qwen3-coder:480b",
+    "display_name": "qwen3-coder:480b",
+    "mode": "chat",
+    "context_window": 262144,
+    "max_output_tokens": 262144,
+    "pricing": {
+      "input_per_m_tokens": null,
+      "output_per_m_tokens": null,
+      "cache_read_per_m_tokens": null,
+      "cache_write_per_m_tokens": null,
+      "reasoning_per_m_tokens": null,
+      "image_per_tile": null,
+      "audio_input_per_minute": null,
+      "audio_output_per_character": null,
+      "embedding_per_m_tokens": null,
+      "finetune_train_per_m_tokens": null,
+      "finetune_input_per_m_tokens": null,
+      "finetune_output_per_m_tokens": null
+    },
+    "capabilities": {
+      "vision": false,
+      "audio_input": false,
+      "audio_output": false,
+      "function_calling": true,
+      "parallel_tool_calls": false,
+      "json_mode": true,
+      "response_schema": false,
+      "prompt_caching": false,
+      "reasoning": false,
+      "streaming": true,
+      "finetuneable": false
+    },
+    "lifecycle": {
+      "status": "ga",
+      "deprecation_date": null,
+      "sunset_date": null,
+      "successor": null
+    },
+    "source": "https://docs.ollama.com/cloud",
+    "updated_at": "2026-04-28",
     "tier": "standard"
   },
   "ollama/vicuna": {

--- a/models/catalog_backup.json
+++ b/models/catalog_backup.json
@@ -64107,6 +64107,50 @@
     "updated_at": "2026-02-28",
     "tier": "standard"
   },
+  "ollama-cloud/deepseek-v3.1:671b": {
+    "provider": "ollama-cloud",
+    "model_id": "deepseek-v3.1:671b",
+    "display_name": "deepseek-v3.1:671b",
+    "mode": "chat",
+    "context_window": 163840,
+    "max_output_tokens": 163840,
+    "pricing": {
+      "input_per_m_tokens": null,
+      "output_per_m_tokens": null,
+      "cache_read_per_m_tokens": null,
+      "cache_write_per_m_tokens": null,
+      "reasoning_per_m_tokens": null,
+      "image_per_tile": null,
+      "audio_input_per_minute": null,
+      "audio_output_per_character": null,
+      "embedding_per_m_tokens": null,
+      "finetune_train_per_m_tokens": null,
+      "finetune_input_per_m_tokens": null,
+      "finetune_output_per_m_tokens": null
+    },
+    "capabilities": {
+      "vision": false,
+      "audio_input": false,
+      "audio_output": false,
+      "function_calling": true,
+      "parallel_tool_calls": false,
+      "json_mode": true,
+      "response_schema": false,
+      "prompt_caching": false,
+      "reasoning": false,
+      "streaming": true,
+      "finetuneable": false
+    },
+    "lifecycle": {
+      "status": "ga",
+      "deprecation_date": null,
+      "sunset_date": null,
+      "successor": null
+    },
+    "source": "https://docs.ollama.com/cloud",
+    "updated_at": "2026-04-28",
+    "tier": "standard"
+  },
   "ollama/gpt-oss:120b-cloud": {
     "provider": "ollama",
     "model_id": "gpt-oss:120b-cloud",
@@ -64151,6 +64195,50 @@
     "updated_at": "2026-02-28",
     "tier": "standard"
   },
+  "ollama-cloud/gpt-oss:120b": {
+    "provider": "ollama-cloud",
+    "model_id": "gpt-oss:120b",
+    "display_name": "gpt-oss:120b",
+    "mode": "chat",
+    "context_window": 131072,
+    "max_output_tokens": 131072,
+    "pricing": {
+      "input_per_m_tokens": null,
+      "output_per_m_tokens": null,
+      "cache_read_per_m_tokens": null,
+      "cache_write_per_m_tokens": null,
+      "reasoning_per_m_tokens": null,
+      "image_per_tile": null,
+      "audio_input_per_minute": null,
+      "audio_output_per_character": null,
+      "embedding_per_m_tokens": null,
+      "finetune_train_per_m_tokens": null,
+      "finetune_input_per_m_tokens": null,
+      "finetune_output_per_m_tokens": null
+    },
+    "capabilities": {
+      "vision": false,
+      "audio_input": false,
+      "audio_output": false,
+      "function_calling": true,
+      "parallel_tool_calls": false,
+      "json_mode": true,
+      "response_schema": false,
+      "prompt_caching": false,
+      "reasoning": false,
+      "streaming": true,
+      "finetuneable": false
+    },
+    "lifecycle": {
+      "status": "ga",
+      "deprecation_date": null,
+      "sunset_date": null,
+      "successor": null
+    },
+    "source": "https://docs.ollama.com/cloud",
+    "updated_at": "2026-04-28",
+    "tier": "standard"
+  },
   "ollama/gpt-oss:20b-cloud": {
     "provider": "ollama",
     "model_id": "gpt-oss:20b-cloud",
@@ -64193,6 +64281,50 @@
     },
     "source": "",
     "updated_at": "2026-02-28",
+    "tier": "standard"
+  },
+  "ollama-cloud/gpt-oss:20b": {
+    "provider": "ollama-cloud",
+    "model_id": "gpt-oss:20b",
+    "display_name": "gpt-oss:20b",
+    "mode": "chat",
+    "context_window": 131072,
+    "max_output_tokens": 131072,
+    "pricing": {
+      "input_per_m_tokens": null,
+      "output_per_m_tokens": null,
+      "cache_read_per_m_tokens": null,
+      "cache_write_per_m_tokens": null,
+      "reasoning_per_m_tokens": null,
+      "image_per_tile": null,
+      "audio_input_per_minute": null,
+      "audio_output_per_character": null,
+      "embedding_per_m_tokens": null,
+      "finetune_train_per_m_tokens": null,
+      "finetune_input_per_m_tokens": null,
+      "finetune_output_per_m_tokens": null
+    },
+    "capabilities": {
+      "vision": false,
+      "audio_input": false,
+      "audio_output": false,
+      "function_calling": true,
+      "parallel_tool_calls": false,
+      "json_mode": true,
+      "response_schema": false,
+      "prompt_caching": false,
+      "reasoning": false,
+      "streaming": true,
+      "finetuneable": false
+    },
+    "lifecycle": {
+      "status": "ga",
+      "deprecation_date": null,
+      "sunset_date": null,
+      "successor": null
+    },
+    "source": "https://docs.ollama.com/cloud",
+    "updated_at": "2026-04-28",
     "tier": "standard"
   },
   "ollama/internlm2_5-20b-chat": {
@@ -64985,6 +65117,50 @@
     },
     "source": "",
     "updated_at": "2026-02-28",
+    "tier": "standard"
+  },
+  "ollama-cloud/qwen3-coder:480b": {
+    "provider": "ollama-cloud",
+    "model_id": "qwen3-coder:480b",
+    "display_name": "qwen3-coder:480b",
+    "mode": "chat",
+    "context_window": 262144,
+    "max_output_tokens": 262144,
+    "pricing": {
+      "input_per_m_tokens": null,
+      "output_per_m_tokens": null,
+      "cache_read_per_m_tokens": null,
+      "cache_write_per_m_tokens": null,
+      "reasoning_per_m_tokens": null,
+      "image_per_tile": null,
+      "audio_input_per_minute": null,
+      "audio_output_per_character": null,
+      "embedding_per_m_tokens": null,
+      "finetune_train_per_m_tokens": null,
+      "finetune_input_per_m_tokens": null,
+      "finetune_output_per_m_tokens": null
+    },
+    "capabilities": {
+      "vision": false,
+      "audio_input": false,
+      "audio_output": false,
+      "function_calling": true,
+      "parallel_tool_calls": false,
+      "json_mode": true,
+      "response_schema": false,
+      "prompt_caching": false,
+      "reasoning": false,
+      "streaming": true,
+      "finetuneable": false
+    },
+    "lifecycle": {
+      "status": "ga",
+      "deprecation_date": null,
+      "sunset_date": null,
+      "successor": null
+    },
+    "source": "https://docs.ollama.com/cloud",
+    "updated_at": "2026-04-28",
     "tier": "standard"
   },
   "ollama/vicuna": {

--- a/providers/bedrock/bedrock.go
+++ b/providers/bedrock/bedrock.go
@@ -29,10 +29,15 @@ type Options struct {
 	SessionToken    string
 }
 
+type bedrockRuntimeClient interface {
+	InvokeModel(context.Context, *bedrockruntime.InvokeModelInput, ...func(*bedrockruntime.Options)) (*bedrockruntime.InvokeModelOutput, error)
+	InvokeModelWithResponseStream(context.Context, *bedrockruntime.InvokeModelWithResponseStreamInput, ...func(*bedrockruntime.Options)) (*bedrockruntime.InvokeModelWithResponseStreamOutput, error)
+}
+
 // Provider implements the AWS Bedrock API client.
 type Provider struct {
 	name   string
-	client *bedrockruntime.Client
+	client bedrockRuntimeClient
 	region string
 }
 
@@ -40,6 +45,7 @@ type Provider struct {
 var (
 	_ core.Provider          = (*Provider)(nil)
 	_ core.StreamProvider    = (*Provider)(nil)
+	_ core.EmbeddingProvider = (*Provider)(nil)
 	_ core.ProxiableProvider = (*Provider)(nil)
 )
 
@@ -116,11 +122,36 @@ func (p *Provider) SupportedModels() []string {
 		"meta.llama3-1-8b-instruct-v1:0",
 		"meta.llama3-70b-instruct-v1:0",
 		"meta.llama3-8b-instruct-v1:0",
+		"amazon.titan-embed-text-v1",
+		"amazon.titan-embed-text-v2:0",
+		"cohere.embed-english-v3",
+		"cohere.embed-multilingual-v3",
+		"cohere.embed-v4:0",
 	}
 }
 
-// SupportsModel returns true for any model — AWS Bedrock validates model IDs.
-func (p *Provider) SupportsModel(_ string) bool { return true }
+// SupportsModel returns true for model families with request shapes implemented
+// by this provider. Bedrock still validates the exact model ID upstream.
+func (p *Provider) SupportsModel(model string) bool {
+	model = bedrockModelRoutingID(model)
+	for _, supported := range p.SupportedModels() {
+		if model == supported {
+			return true
+		}
+	}
+	for _, prefix := range []string{
+		"anthropic.claude-",
+		"amazon.titan-text-",
+		"amazon.titan-embed-text-",
+		"cohere.embed-",
+		"meta.llama",
+	} {
+		if strings.HasPrefix(model, prefix) {
+			return true
+		}
+	}
+	return false
+}
 
 // Models returns structured model metadata.
 func (p *Provider) Models() []core.ModelInfo {
@@ -189,6 +220,224 @@ type bedrockLlamaResponse struct {
 	PromptTokenCount     int    `json:"prompt_token_count"`
 	GenerationTokenCount int    `json:"generation_token_count"`
 	StopReason           string `json:"stop_reason"`
+}
+
+// ── Embeddings ───────────────────────────────────────────────────────────────
+
+type bedrockTitanEmbedRequest struct {
+	InputText  string `json:"inputText"`
+	Dimensions *int   `json:"dimensions,omitempty"`
+}
+
+type bedrockTitanEmbedResponse struct {
+	Embedding           []float64 `json:"embedding"`
+	InputTextTokenCount int       `json:"inputTextTokenCount"`
+}
+
+type bedrockCohereEmbedRequest struct {
+	Texts          []string `json:"texts"`
+	InputType      string   `json:"input_type"`
+	EmbeddingTypes []string `json:"embedding_types,omitempty"`
+}
+
+type bedrockCohereEmbeddingVectors [][]float64
+
+func (v *bedrockCohereEmbeddingVectors) UnmarshalJSON(data []byte) error {
+	var vectors [][]float64
+	if err := json.Unmarshal(data, &vectors); err == nil {
+		*v = vectors
+		return nil
+	}
+
+	var typed map[string][][]float64
+	if err := json.Unmarshal(data, &typed); err != nil {
+		return err
+	}
+	if vectors, ok := typed["float"]; ok {
+		*v = vectors
+		return nil
+	}
+	return fmt.Errorf("cohere embedding response did not include float embeddings")
+}
+
+type bedrockCohereEmbedResponse struct {
+	Embeddings bedrockCohereEmbeddingVectors `json:"embeddings"`
+	Meta       struct {
+		BilledUnits struct {
+			InputTokens int `json:"input_tokens"`
+		} `json:"billed_units"`
+	} `json:"meta"`
+}
+
+// Embed sends a text embedding request to AWS Bedrock.
+func (p *Provider) Embed(ctx context.Context, req core.EmbeddingRequest) (*core.EmbeddingResponse, error) {
+	texts, err := bedrockEmbeddingTexts(req.Input)
+	if err != nil {
+		return nil, err
+	}
+
+	switch req.EncodingFormat {
+	case "", "float":
+	default:
+		return nil, fmt.Errorf("embed: unsupported encoding_format %q; Bedrock embeddings return float vectors", req.EncodingFormat)
+	}
+
+	modelID := bedrockModelRoutingID(req.Model)
+	switch {
+	case isBedrockTitanTextEmbeddingModel(modelID):
+		return p.embedTitan(ctx, req, modelID, texts)
+	case isBedrockCohereEmbeddingModel(modelID):
+		return p.embedCohere(ctx, req, modelID, texts)
+	default:
+		return nil, fmt.Errorf("unsupported Bedrock embedding model: %s", req.Model)
+	}
+}
+
+func bedrockEmbeddingTexts(input interface{}) ([]string, error) {
+	switch v := input.(type) {
+	case string:
+		return []string{v}, nil
+	case []string:
+		if len(v) == 0 {
+			return nil, fmt.Errorf("embed: Input must not be an empty array")
+		}
+		return v, nil
+	case []interface{}:
+		if len(v) == 0 {
+			return nil, fmt.Errorf("embed: Input must not be an empty array")
+		}
+		texts := make([]string, 0, len(v))
+		for i, item := range v {
+			s, ok := item.(string)
+			if !ok {
+				return nil, fmt.Errorf("embed: Input[%d] is %T, want string", i, item)
+			}
+			texts = append(texts, s)
+		}
+		return texts, nil
+	case nil:
+		return nil, fmt.Errorf("embed: Input must not be nil")
+	default:
+		return nil, fmt.Errorf("embed: unsupported Input type %T; want string or []string", input)
+	}
+}
+
+func (p *Provider) embedTitan(ctx context.Context, req core.EmbeddingRequest, modelID string, texts []string) (*core.EmbeddingResponse, error) {
+	if req.Dimensions != nil && !strings.HasPrefix(modelID, "amazon.titan-embed-text-v2") {
+		return nil, fmt.Errorf("embed: dimensions are only supported for amazon.titan-embed-text-v2 models")
+	}
+
+	data := make([]core.Embedding, 0, len(texts))
+	promptTokens := 0
+	for i, text := range texts {
+		titanReq := bedrockTitanEmbedRequest{
+			InputText:  text,
+			Dimensions: req.Dimensions,
+		}
+		var titanResp bedrockTitanEmbedResponse
+		if err := p.invokeModelJSON(ctx, req.Model, titanReq, &titanResp); err != nil {
+			return nil, err
+		}
+		data = append(data, core.Embedding{
+			Object:    "embedding",
+			Embedding: titanResp.Embedding,
+			Index:     i,
+		})
+		promptTokens += titanResp.InputTextTokenCount
+	}
+
+	return &core.EmbeddingResponse{
+		Object: "list",
+		Data:   data,
+		Model:  req.Model,
+		Usage: core.EmbeddingUsage{
+			PromptTokens: promptTokens,
+			TotalTokens:  promptTokens,
+		},
+	}, nil
+}
+
+func (p *Provider) embedCohere(ctx context.Context, req core.EmbeddingRequest, modelID string, texts []string) (*core.EmbeddingResponse, error) {
+	if req.Dimensions != nil {
+		return nil, fmt.Errorf("embed: dimensions are not supported for Bedrock Cohere embeddings")
+	}
+
+	cohereReq := bedrockCohereEmbedRequest{
+		Texts:     texts,
+		InputType: "search_document",
+	}
+	if strings.HasPrefix(modelID, "cohere.embed-v4") {
+		cohereReq.EmbeddingTypes = []string{"float"}
+	}
+
+	var cohereResp bedrockCohereEmbedResponse
+	if err := p.invokeModelJSON(ctx, req.Model, cohereReq, &cohereResp); err != nil {
+		return nil, err
+	}
+	if len(cohereResp.Embeddings) != len(texts) {
+		return nil, fmt.Errorf("bedrock cohere embed response returned %d embeddings for %d inputs", len(cohereResp.Embeddings), len(texts))
+	}
+
+	data := make([]core.Embedding, len(cohereResp.Embeddings))
+	for i, emb := range cohereResp.Embeddings {
+		data[i] = core.Embedding{
+			Object:    "embedding",
+			Embedding: emb,
+			Index:     i,
+		}
+	}
+	inputTokens := cohereResp.Meta.BilledUnits.InputTokens
+	return &core.EmbeddingResponse{
+		Object: "list",
+		Data:   data,
+		Model:  req.Model,
+		Usage: core.EmbeddingUsage{
+			PromptTokens: inputTokens,
+			TotalTokens:  inputTokens,
+		},
+	}, nil
+}
+
+func (p *Provider) invokeModelJSON(ctx context.Context, modelID string, payload interface{}, out interface{}) error {
+	body, err := core.MarshalJSON(payload)
+	if err != nil {
+		return fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	output, err := p.client.InvokeModel(ctx, &bedrockruntime.InvokeModelInput{
+		ModelId:     aws.String(modelID),
+		ContentType: aws.String("application/json"),
+		Accept:      aws.String("application/json"),
+		Body:        body,
+	})
+	if err != nil {
+		return fmt.Errorf("bedrock invoke failed: %w", err)
+	}
+
+	if err := json.Unmarshal(output.Body, out); err != nil {
+		return fmt.Errorf("failed to unmarshal response: %w", err)
+	}
+	return nil
+}
+
+func bedrockModelRoutingID(model string) string {
+	if idx := strings.LastIndex(model, "/"); idx >= 0 && idx < len(model)-1 {
+		model = model[idx+1:]
+	}
+	for _, prefix := range []string{"us.", "eu.", "apac."} {
+		if strings.HasPrefix(model, prefix) {
+			return strings.TrimPrefix(model, prefix)
+		}
+	}
+	return model
+}
+
+func isBedrockTitanTextEmbeddingModel(model string) bool {
+	return strings.HasPrefix(model, "amazon.titan-embed-text-")
+}
+
+func isBedrockCohereEmbeddingModel(model string) bool {
+	return strings.HasPrefix(model, "cohere.embed-")
 }
 
 // Complete sends a request to AWS Bedrock and returns the response.

--- a/providers/bedrock/bedrock_test.go
+++ b/providers/bedrock/bedrock_test.go
@@ -1,8 +1,16 @@
 package bedrock
 
 import (
+	"context"
+	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime"
+
+	"github.com/ferro-labs/ai-gateway/providers/core"
 )
 
 func TestNewBedrock_DefaultRegion(t *testing.T) {
@@ -51,3 +59,269 @@ func TestNewBedrockWithOptions_InvalidStaticCredentials(t *testing.T) {
 		t.Errorf("error = %q, want static-credentials validation message", err.Error())
 	}
 }
+
+func TestBedrockProvider_Embed_Interface(_ *testing.T) {
+	var _ core.EmbeddingProvider = (*Provider)(nil)
+}
+
+func TestBedrockProvider_SupportedEmbeddingModels(t *testing.T) {
+	p := &Provider{name: Name}
+	models := p.SupportedModels()
+	for _, want := range []string{
+		"amazon.titan-embed-text-v1",
+		"amazon.titan-embed-text-v2:0",
+		"cohere.embed-english-v3",
+		"cohere.embed-multilingual-v3",
+		"cohere.embed-v4:0",
+	} {
+		if !containsString(models, want) {
+			t.Errorf("SupportedModels() missing %q", want)
+		}
+		if !p.SupportsModel(want) {
+			t.Errorf("SupportsModel(%q) = false, want true", want)
+		}
+	}
+
+	for _, wantSupported := range []string{
+		"us.amazon.titan-embed-text-v2:0",
+		"us-gov-east-1/amazon.titan-embed-text-v1",
+		"cohere.embed-future:0",
+	} {
+		if !p.SupportsModel(wantSupported) {
+			t.Errorf("SupportsModel(%q) = false, want true", wantSupported)
+		}
+	}
+
+	for _, wantRejected := range []string{
+		"text-embedding-3-small",
+		"amazon.titan-embed-image-v1",
+		"amazon.nova-2-multimodal-embeddings-v1:0",
+	} {
+		if p.SupportsModel(wantRejected) {
+			t.Errorf("SupportsModel(%q) = true, want false", wantRejected)
+		}
+	}
+}
+
+func TestBedrockProvider_Embed_TitanTextLoopsAndMapsResponse(t *testing.T) {
+	fake := &fakeBedrockRuntimeClient{
+		responses: [][]byte{
+			[]byte(`{"embedding":[0.1,0.2],"inputTextTokenCount":2}`),
+			[]byte(`{"embedding":[0.3,0.4],"inputTextTokenCount":3}`),
+		},
+	}
+	p := &Provider{name: Name, client: fake}
+	dimensions := 512
+
+	resp, err := p.Embed(context.Background(), core.EmbeddingRequest{
+		Model:      "amazon.titan-embed-text-v2:0",
+		Input:      []string{"first", "second"},
+		Dimensions: &dimensions,
+	})
+	if err != nil {
+		t.Fatalf("Embed() error: %v", err)
+	}
+
+	if len(fake.invokeCalls) != 2 {
+		t.Fatalf("InvokeModel calls = %d, want 2", len(fake.invokeCalls))
+	}
+	for i, call := range fake.invokeCalls {
+		if got := aws.ToString(call.ModelId); got != "amazon.titan-embed-text-v2:0" {
+			t.Errorf("call %d ModelId = %q", i, got)
+		}
+		if got := aws.ToString(call.ContentType); got != "application/json" {
+			t.Errorf("call %d ContentType = %q", i, got)
+		}
+		if got := aws.ToString(call.Accept); got != "application/json" {
+			t.Errorf("call %d Accept = %q", i, got)
+		}
+	}
+
+	var firstReq, secondReq bedrockTitanEmbedRequest
+	mustUnmarshalBody(t, fake.invokeCalls[0].Body, &firstReq)
+	mustUnmarshalBody(t, fake.invokeCalls[1].Body, &secondReq)
+	if firstReq.InputText != "first" || secondReq.InputText != "second" {
+		t.Errorf("Titan inputText values = %q, %q; want first, second", firstReq.InputText, secondReq.InputText)
+	}
+	if firstReq.Dimensions == nil || *firstReq.Dimensions != dimensions {
+		t.Errorf("Titan dimensions = %v, want %d", firstReq.Dimensions, dimensions)
+	}
+
+	if resp.Object != "list" || resp.Model != "amazon.titan-embed-text-v2:0" {
+		t.Errorf("response metadata = (%q, %q), want (list, amazon.titan-embed-text-v2:0)", resp.Object, resp.Model)
+	}
+	if len(resp.Data) != 2 {
+		t.Fatalf("len(Data) = %d, want 2", len(resp.Data))
+	}
+	if resp.Data[0].Index != 0 || resp.Data[0].Embedding[0] != 0.1 || resp.Data[1].Index != 1 || resp.Data[1].Embedding[0] != 0.3 {
+		t.Errorf("embedding data = %+v, want order preserved", resp.Data)
+	}
+	if resp.Usage.PromptTokens != 5 || resp.Usage.TotalTokens != 5 {
+		t.Errorf("usage = %+v, want 5 prompt/total tokens", resp.Usage)
+	}
+}
+
+func TestBedrockProvider_Embed_CohereBatchesAndMapsArrayResponse(t *testing.T) {
+	fake := &fakeBedrockRuntimeClient{
+		responses: [][]byte{
+			[]byte(`{"embeddings":[[0.1,0.2],[0.3,0.4]],"meta":{"billed_units":{"input_tokens":7}}}`),
+		},
+	}
+	p := &Provider{name: Name, client: fake}
+
+	resp, err := p.Embed(context.Background(), core.EmbeddingRequest{
+		Model: "cohere.embed-english-v3",
+		Input: []interface{}{"first", "second"},
+	})
+	if err != nil {
+		t.Fatalf("Embed() error: %v", err)
+	}
+
+	if len(fake.invokeCalls) != 1 {
+		t.Fatalf("InvokeModel calls = %d, want 1", len(fake.invokeCalls))
+	}
+	var body bedrockCohereEmbedRequest
+	mustUnmarshalBody(t, fake.invokeCalls[0].Body, &body)
+	if len(body.Texts) != 2 || body.Texts[0] != "first" || body.Texts[1] != "second" {
+		t.Errorf("Cohere texts = %#v, want [first second]", body.Texts)
+	}
+	if body.InputType != "search_document" {
+		t.Errorf("Cohere input_type = %q, want search_document", body.InputType)
+	}
+	if len(body.EmbeddingTypes) != 0 {
+		t.Errorf("Cohere embedding_types = %#v, want omitted for v3", body.EmbeddingTypes)
+	}
+
+	if len(resp.Data) != 2 || resp.Data[0].Embedding[0] != 0.1 || resp.Data[1].Embedding[0] != 0.3 {
+		t.Errorf("embedding data = %+v, want mapped array response", resp.Data)
+	}
+	if resp.Usage.PromptTokens != 7 || resp.Usage.TotalTokens != 7 {
+		t.Errorf("usage = %+v, want 7 prompt/total tokens", resp.Usage)
+	}
+}
+
+func TestBedrockProvider_Embed_CohereV4MapsTypedFloatResponse(t *testing.T) {
+	fake := &fakeBedrockRuntimeClient{
+		responses: [][]byte{
+			[]byte(`{"embeddings":{"float":[[1.1,1.2]]},"meta":{"billed_units":{"input_tokens":4}}}`),
+		},
+	}
+	p := &Provider{name: Name, client: fake}
+
+	resp, err := p.Embed(context.Background(), core.EmbeddingRequest{
+		Model: "cohere.embed-v4:0",
+		Input: "hello",
+	})
+	if err != nil {
+		t.Fatalf("Embed() error: %v", err)
+	}
+
+	var body bedrockCohereEmbedRequest
+	mustUnmarshalBody(t, fake.invokeCalls[0].Body, &body)
+	if len(body.EmbeddingTypes) != 1 || body.EmbeddingTypes[0] != "float" {
+		t.Errorf("Cohere v4 embedding_types = %#v, want [float]", body.EmbeddingTypes)
+	}
+	if len(resp.Data) != 1 || resp.Data[0].Embedding[0] != 1.1 {
+		t.Errorf("embedding data = %+v, want typed float embeddings", resp.Data)
+	}
+}
+
+func TestBedrockProvider_Embed_Validation(t *testing.T) {
+	cases := []struct {
+		name string
+		req  core.EmbeddingRequest
+	}{
+		{
+			name: "nil input",
+			req:  core.EmbeddingRequest{Model: "amazon.titan-embed-text-v1", Input: nil},
+		},
+		{
+			name: "unsupported input type",
+			req:  core.EmbeddingRequest{Model: "amazon.titan-embed-text-v1", Input: 42},
+		},
+		{
+			name: "empty string slice",
+			req:  core.EmbeddingRequest{Model: "amazon.titan-embed-text-v1", Input: []string{}},
+		},
+		{
+			name: "empty interface slice",
+			req:  core.EmbeddingRequest{Model: "amazon.titan-embed-text-v1", Input: []interface{}{}},
+		},
+		{
+			name: "non-string interface item",
+			req:  core.EmbeddingRequest{Model: "amazon.titan-embed-text-v1", Input: []interface{}{"ok", 42}},
+		},
+		{
+			name: "base64 encoding",
+			req:  core.EmbeddingRequest{Model: "amazon.titan-embed-text-v1", Input: "hello", EncodingFormat: "base64"},
+		},
+		{
+			name: "unsupported model family",
+			req:  core.EmbeddingRequest{Model: "amazon.titan-embed-image-v1", Input: "hello"},
+		},
+		{
+			name: "dimensions on cohere",
+			req:  core.EmbeddingRequest{Model: "cohere.embed-english-v3", Input: "hello", Dimensions: intPtr(256)},
+		},
+		{
+			name: "dimensions on titan v1",
+			req:  core.EmbeddingRequest{Model: "amazon.titan-embed-text-v1", Input: "hello", Dimensions: intPtr(256)},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fake := &fakeBedrockRuntimeClient{}
+			p := &Provider{name: Name, client: fake}
+			_, err := p.Embed(context.Background(), tc.req)
+			if err == nil {
+				t.Fatal("Embed() error = nil, want error")
+			}
+			if len(fake.invokeCalls) != 0 {
+				t.Fatalf("InvokeModel calls = %d, want 0 for validation error", len(fake.invokeCalls))
+			}
+		})
+	}
+}
+
+type fakeBedrockRuntimeClient struct {
+	invokeCalls []*bedrockruntime.InvokeModelInput
+	responses   [][]byte
+	err         error
+}
+
+func (f *fakeBedrockRuntimeClient) InvokeModel(_ context.Context, input *bedrockruntime.InvokeModelInput, _ ...func(*bedrockruntime.Options)) (*bedrockruntime.InvokeModelOutput, error) {
+	copied := *input
+	copied.Body = append([]byte(nil), input.Body...)
+	f.invokeCalls = append(f.invokeCalls, &copied)
+	if f.err != nil {
+		return nil, f.err
+	}
+	idx := len(f.invokeCalls) - 1
+	if idx >= len(f.responses) {
+		return nil, fmt.Errorf("missing fake response for call %d", idx)
+	}
+	return &bedrockruntime.InvokeModelOutput{Body: f.responses[idx]}, nil
+}
+
+func (f *fakeBedrockRuntimeClient) InvokeModelWithResponseStream(context.Context, *bedrockruntime.InvokeModelWithResponseStreamInput, ...func(*bedrockruntime.Options)) (*bedrockruntime.InvokeModelWithResponseStreamOutput, error) {
+	return nil, fmt.Errorf("streaming not implemented in fake")
+}
+
+func mustUnmarshalBody(t *testing.T, body []byte, out interface{}) {
+	t.Helper()
+	if err := json.Unmarshal(body, out); err != nil {
+		t.Fatalf("failed to unmarshal body %s: %v", string(body), err)
+	}
+}
+
+func containsString(values []string, target string) bool {
+	for _, value := range values {
+		if value == target {
+			return true
+		}
+	}
+	return false
+}
+
+func intPtr(v int) *int { return &v }

--- a/providers/cohere/cohere.go
+++ b/providers/cohere/cohere.go
@@ -364,6 +364,17 @@ func (p *Provider) Embed(ctx context.Context, req core.EmbeddingRequest) (*core.
 	if len(texts) == 0 {
 		return nil, fmt.Errorf("embedding input must contain at least one text")
 	}
+	switch req.EncodingFormat {
+	case "", "float":
+	default:
+		return nil, fmt.Errorf("embed: unsupported encoding_format %q; Cohere embeddings return float vectors", req.EncodingFormat)
+	}
+	if req.Dimensions != nil {
+		return nil, fmt.Errorf("embed: dimensions are not supported by Cohere embeddings")
+	}
+	if req.User != "" {
+		return nil, fmt.Errorf("embed: user is not supported by Cohere embeddings")
+	}
 
 	cohReq := cohereEmbedRequest{
 		Texts:     texts,

--- a/providers/cohere/cohere.go
+++ b/providers/cohere/cohere.go
@@ -32,6 +32,7 @@ var (
 	_ core.Provider          = (*Provider)(nil)
 	_ core.StreamProvider    = (*Provider)(nil)
 	_ core.ProxiableProvider = (*Provider)(nil)
+	_ core.EmbeddingProvider = (*Provider)(nil)
 )
 
 // New creates a new Cohere provider.
@@ -315,4 +316,102 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 	}()
 
 	return ch, nil
+}
+
+type cohereEmbedRequest struct {
+	Texts     []string `json:"texts"`
+	Model     string   `json:"model"`
+	InputType string   `json:"input_type"`
+}
+
+type cohereEmbedResponse struct {
+	ID         string      `json:"id"`
+	Embeddings [][]float64 `json:"embeddings"`
+	Texts      []string    `json:"texts"`
+	Meta       struct {
+		BilledUnits struct {
+			InputTokens int `json:"input_tokens"`
+		} `json:"billed_units"`
+	} `json:"meta"`
+}
+
+// Embed sends an embedding request to Cohere's /v1/embed endpoint.
+func (p *Provider) Embed(ctx context.Context, req core.EmbeddingRequest) (*core.EmbeddingResponse, error) {
+	var texts []string
+	switch v := req.Input.(type) {
+	case string:
+		texts = []string{v}
+	case []string:
+		texts = v
+	case []interface{}:
+		for _, item := range v {
+			if s, ok := item.(string); ok {
+				texts = append(texts, s)
+			}
+		}
+	default:
+		return nil, fmt.Errorf("unsupported input type: %T", req.Input)
+	}
+
+	cohReq := cohereEmbedRequest{
+		Texts:     texts,
+		Model:     req.Model,
+		InputType: "search_document",
+	}
+
+	bodyReader, _, release, err := core.JSONBodyReader(cohReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal embed request: %w", err)
+	}
+	defer release()
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, p.baseURL+"/v1/embed", bodyReader)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create embed request: %w", err)
+	}
+	httpReq.Header.Set("Authorization", "Bearer "+p.apiKey)
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	httpResp, err := p.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("embed request failed: %w", err)
+	}
+	defer func() { _ = httpResp.Body.Close() }()
+
+	respBody, err := io.ReadAll(httpResp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read embed response: %w", err)
+	}
+
+	if httpResp.StatusCode != http.StatusOK {
+		var errResp cohereErrorResponse
+		if json.Unmarshal(respBody, &errResp) == nil && errResp.Message != "" {
+			return nil, fmt.Errorf("cohere embed API error (%d): %s", httpResp.StatusCode, errResp.Message)
+		}
+		return nil, fmt.Errorf("cohere embed API error (%d): %s", httpResp.StatusCode, string(respBody))
+	}
+
+	var cohResp cohereEmbedResponse
+	if err := json.Unmarshal(respBody, &cohResp); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal embed response: %w", err)
+	}
+
+	data := make([]core.Embedding, len(cohResp.Embeddings))
+	for i, emb := range cohResp.Embeddings {
+		data[i] = core.Embedding{
+			Object:    "embedding",
+			Embedding: emb,
+			Index:     i,
+		}
+	}
+
+	return &core.EmbeddingResponse{
+		Object: "list",
+		Data:   data,
+		Model:  req.Model,
+		Usage: core.EmbeddingUsage{
+			PromptTokens: cohResp.Meta.BilledUnits.InputTokens,
+			TotalTokens:  cohResp.Meta.BilledUnits.InputTokens,
+		},
+	}, nil
 }

--- a/providers/cohere/cohere.go
+++ b/providers/cohere/cohere.go
@@ -67,6 +67,13 @@ func (p *Provider) SupportedModels() []string {
 		"command-r",
 		"command-light",
 		"command",
+		"embed-v4.0",
+		"embed-english-v3.0",
+		"embed-multilingual-v3.0",
+		"embed-english-light-v3.0",
+		"embed-multilingual-light-v3.0",
+		"embed-english-v2.0",
+		"embed-multilingual-v2.0",
 	}
 }
 
@@ -344,13 +351,18 @@ func (p *Provider) Embed(ctx context.Context, req core.EmbeddingRequest) (*core.
 	case []string:
 		texts = v
 	case []interface{}:
-		for _, item := range v {
-			if s, ok := item.(string); ok {
-				texts = append(texts, s)
+		for i, item := range v {
+			s, ok := item.(string)
+			if !ok {
+				return nil, fmt.Errorf("unsupported input type at input[%d]: %T; expected string", i, item)
 			}
+			texts = append(texts, s)
 		}
 	default:
 		return nil, fmt.Errorf("unsupported input type: %T", req.Input)
+	}
+	if len(texts) == 0 {
+		return nil, fmt.Errorf("embedding input must contain at least one text")
 	}
 
 	cohReq := cohereEmbedRequest{

--- a/providers/cohere/cohere_test.go
+++ b/providers/cohere/cohere_test.go
@@ -2,10 +2,15 @@ package cohere
 
 import (
 	"context"
-	"github.com/ferro-labs/ai-gateway/providers/core"
+	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
+	"strings"
 	"testing"
+
+	"github.com/ferro-labs/ai-gateway/providers/core"
 )
 
 func TestNewCohere(t *testing.T) {
@@ -24,14 +29,15 @@ func TestCohereProvider_SupportedModels(t *testing.T) {
 	if len(models) == 0 {
 		t.Error("SupportedModels() returned empty")
 	}
-	found := false
+	wantModels := []string{"command-r-plus", "embed-v4.0", "embed-english-v3.0", "embed-multilingual-v3.0"}
+	found := map[string]bool{}
 	for _, m := range models {
-		if m == "command-r-plus" {
-			found = true
-		}
+		found[m] = true
 	}
-	if !found {
-		t.Error("command-r-plus not found")
+	for _, want := range wantModels {
+		if !found[want] {
+			t.Errorf("%s not found", want)
+		}
 	}
 }
 
@@ -61,6 +67,11 @@ func TestCohereProvider_Models(t *testing.T) {
 func TestCohereProvider_CompleteStream_Interface(_ *testing.T) {
 	p, _ := New("test-key", "")
 	var _ core.StreamProvider = p
+}
+
+func TestCohereProvider_EmbeddingProvider_Interface(_ *testing.T) {
+	p, _ := New("test-key", "")
+	var _ core.EmbeddingProvider = p
 }
 
 func TestCohereProvider_CompleteStream_MockSSE(t *testing.T) {
@@ -101,5 +112,212 @@ func TestCohereProvider_CompleteStream_MockSSE(t *testing.T) {
 	}
 	if chunks[2].Choices[0].FinishReason != "COMPLETE" {
 		t.Errorf("finish_reason = %q, want COMPLETE", chunks[2].Choices[0].FinishReason)
+	}
+}
+
+func TestCohereProvider_Embed_StringInput_MockHTTP(t *testing.T) {
+	const apiKey = "test-key"
+	seenRequest := false
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenRequest = true
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %q, want POST", r.Method)
+		}
+		if r.URL.Path != "/v1/embed" {
+			t.Errorf("request path = %q, want /v1/embed", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer "+apiKey {
+			t.Errorf("Authorization = %q, want Bearer %s", got, apiKey)
+		}
+
+		var got cohereEmbedRequest
+		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+			t.Errorf("failed to decode request: %v", err)
+		}
+		if got.Model != "embed-english-v3.0" {
+			t.Errorf("model = %q, want embed-english-v3.0", got.Model)
+		}
+		if !reflect.DeepEqual(got.Texts, []string{"hello"}) {
+			t.Errorf("texts = %#v, want [hello]", got.Texts)
+		}
+		if got.InputType != "search_document" {
+			t.Errorf("input_type = %q, want search_document", got.InputType)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, `{"id":"embed-1","embeddings":[[0.1,0.2]],"texts":["hello"],"meta":{"billed_units":{"input_tokens":3}}}`)
+	}))
+	defer srv.Close()
+
+	p, _ := New(apiKey, srv.URL)
+	resp, err := p.Embed(context.Background(), core.EmbeddingRequest{
+		Model: "embed-english-v3.0",
+		Input: "hello",
+	})
+	if err != nil {
+		t.Fatalf("Embed() error: %v", err)
+	}
+	if !seenRequest {
+		t.Fatal("expected test server to receive request")
+	}
+	if resp.Object != "list" {
+		t.Errorf("Object = %q, want list", resp.Object)
+	}
+	if resp.Model != "embed-english-v3.0" {
+		t.Errorf("Model = %q, want embed-english-v3.0", resp.Model)
+	}
+	if len(resp.Data) != 1 {
+		t.Fatalf("Data length = %d, want 1", len(resp.Data))
+	}
+	if resp.Data[0].Object != "embedding" {
+		t.Errorf("Data[0].Object = %q, want embedding", resp.Data[0].Object)
+	}
+	if resp.Data[0].Index != 0 {
+		t.Errorf("Data[0].Index = %d, want 0", resp.Data[0].Index)
+	}
+	if !reflect.DeepEqual(resp.Data[0].Embedding, []float64{0.1, 0.2}) {
+		t.Errorf("Data[0].Embedding = %#v, want [0.1 0.2]", resp.Data[0].Embedding)
+	}
+	if resp.Usage.PromptTokens != 3 || resp.Usage.TotalTokens != 3 {
+		t.Errorf("Usage = %+v, want prompt_tokens=3 total_tokens=3", resp.Usage)
+	}
+}
+
+func TestCohereProvider_Embed_StringSliceInput_MockHTTP(t *testing.T) {
+	var gotTexts []string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/embed" {
+			t.Errorf("request path = %q, want /v1/embed", r.URL.Path)
+		}
+
+		var got cohereEmbedRequest
+		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+			t.Errorf("failed to decode request: %v", err)
+		}
+		gotTexts = got.Texts
+		if got.Model != "embed-multilingual-v3.0" {
+			t.Errorf("model = %q, want embed-multilingual-v3.0", got.Model)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, `{"id":"embed-2","embeddings":[[0.1,0.2],[0.3,0.4]],"texts":["hello","there"],"meta":{"billed_units":{"input_tokens":5}}}`)
+	}))
+	defer srv.Close()
+
+	p, _ := New("test-key", srv.URL)
+	resp, err := p.Embed(context.Background(), core.EmbeddingRequest{
+		Model: "embed-multilingual-v3.0",
+		Input: []string{"hello", "there"},
+	})
+	if err != nil {
+		t.Fatalf("Embed() error: %v", err)
+	}
+	if !reflect.DeepEqual(gotTexts, []string{"hello", "there"}) {
+		t.Errorf("texts = %#v, want [hello there]", gotTexts)
+	}
+	if len(resp.Data) != 2 {
+		t.Fatalf("Data length = %d, want 2", len(resp.Data))
+	}
+	for i := range resp.Data {
+		if resp.Data[i].Index != i {
+			t.Errorf("Data[%d].Index = %d, want %d", i, resp.Data[i].Index, i)
+		}
+	}
+	if resp.Usage.PromptTokens != 5 || resp.Usage.TotalTokens != 5 {
+		t.Errorf("Usage = %+v, want prompt_tokens=5 total_tokens=5", resp.Usage)
+	}
+}
+
+func TestCohereProvider_Embed_InvalidInputType(t *testing.T) {
+	p, _ := New("test-key", "")
+	badInputs := []struct {
+		name  string
+		input interface{}
+	}{
+		{"nil", nil},
+		{"integer", 42},
+		{"float", 3.14},
+		{"bool", true},
+		{"map", map[string]string{"hello": "there"}},
+	}
+
+	for _, tc := range badInputs {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := p.Embed(context.Background(), core.EmbeddingRequest{
+				Model: "embed-english-v3.0",
+				Input: tc.input,
+			})
+			if err == nil {
+				t.Fatalf("Embed() with Input=%T: expected error, got nil", tc.input)
+			}
+			if !strings.Contains(err.Error(), "unsupported input type") {
+				t.Errorf("error = %q, want unsupported input type", err.Error())
+			}
+		})
+	}
+}
+
+func TestCohereProvider_Embed_SliceWithNonStringElement(t *testing.T) {
+	p, _ := New("test-key", "")
+	_, err := p.Embed(context.Background(), core.EmbeddingRequest{
+		Model: "embed-english-v3.0",
+		Input: []interface{}{"valid", 99, "also-valid"},
+	})
+	if err == nil {
+		t.Fatal("expected error for []interface{} with non-string element, got nil")
+	}
+	if !strings.Contains(err.Error(), "input[1]") || !strings.Contains(err.Error(), "expected string") {
+		t.Errorf("error = %q, want offending index and expected type", err.Error())
+	}
+}
+
+func TestCohereProvider_Embed_EmptyInput(t *testing.T) {
+	p, _ := New("test-key", "")
+	inputs := []struct {
+		name  string
+		input interface{}
+	}{
+		{"empty string slice", []string{}},
+		{"empty interface slice", []interface{}{}},
+	}
+
+	for _, tc := range inputs {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := p.Embed(context.Background(), core.EmbeddingRequest{
+				Model: "embed-english-v3.0",
+				Input: tc.input,
+			})
+			if err == nil {
+				t.Fatal("expected error for empty input, got nil")
+			}
+			if !strings.Contains(err.Error(), "at least one text") {
+				t.Errorf("error = %q, want at least one text", err.Error())
+			}
+		})
+	}
+}
+
+func TestCohereProvider_Embed_UpstreamNon2xxError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = io.WriteString(w, `{"message":"rate limited"}`)
+	}))
+	defer srv.Close()
+
+	p, _ := New("test-key", srv.URL)
+	_, err := p.Embed(context.Background(), core.EmbeddingRequest{
+		Model: "embed-english-v3.0",
+		Input: "hello",
+	})
+	if err == nil {
+		t.Fatal("expected upstream error, got nil")
+	}
+	if !strings.Contains(err.Error(), "cohere embed API error (429): rate limited") {
+		t.Errorf("error = %q, want cohere embed API error (429): rate limited", err.Error())
 	}
 }

--- a/providers/cohere/cohere_test.go
+++ b/providers/cohere/cohere_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"reflect"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/ferro-labs/ai-gateway/providers/core"
@@ -298,6 +299,66 @@ func TestCohereProvider_Embed_EmptyInput(t *testing.T) {
 				t.Errorf("error = %q, want at least one text", err.Error())
 			}
 		})
+	}
+}
+
+func TestCohereProvider_Embed_UnsupportedOptionalFields(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	dimensions := 256
+	p, _ := New("test-key", srv.URL)
+	tests := []struct {
+		name    string
+		req     core.EmbeddingRequest
+		wantErr string
+	}{
+		{
+			name: "unsupported encoding format",
+			req: core.EmbeddingRequest{
+				Model:          "embed-english-v3.0",
+				Input:          "hello",
+				EncodingFormat: "base64",
+			},
+			wantErr: "unsupported encoding_format",
+		},
+		{
+			name: "dimensions",
+			req: core.EmbeddingRequest{
+				Model:      "embed-english-v3.0",
+				Input:      "hello",
+				Dimensions: &dimensions,
+			},
+			wantErr: "dimensions are not supported",
+		},
+		{
+			name: "user",
+			req: core.EmbeddingRequest{
+				Model: "embed-english-v3.0",
+				Input: "hello",
+				User:  "user-123",
+			},
+			wantErr: "user is not supported",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := p.Embed(context.Background(), tc.req)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("error = %q, want %q", err.Error(), tc.wantErr)
+			}
+		})
+	}
+	if got := atomic.LoadInt32(&calls); got != 0 {
+		t.Fatalf("upstream calls = %d, want 0", got)
 	}
 }
 

--- a/providers/databricks/databricks.go
+++ b/providers/databricks/databricks.go
@@ -32,6 +32,7 @@ type Provider struct {
 var (
 	_ core.Provider          = (*Provider)(nil)
 	_ core.StreamProvider    = (*Provider)(nil)
+	_ core.EmbeddingProvider = (*Provider)(nil)
 	_ core.ProxiableProvider = (*Provider)(nil)
 )
 
@@ -55,6 +56,7 @@ func New(apiKey, baseURL string) (*Provider, error) {
 func normalizeBaseURL(baseURL string) string {
 	baseURL = strings.TrimRight(strings.TrimSpace(baseURL), "/")
 	baseURL = strings.TrimSuffix(baseURL, "/chat/completions")
+	baseURL = strings.TrimSuffix(baseURL, "/embeddings")
 	baseURL = strings.TrimSuffix(baseURL, "/models")
 	if !strings.Contains(baseURL, "/serving-endpoints") {
 		baseURL += "/serving-endpoints"
@@ -81,11 +83,13 @@ func (p *Provider) SupportedModels() []string {
 		"databricks-gemini-2-5-pro",
 		"databricks-gpt-oss-120b",
 		"databricks-llama-4-maverick",
+		"databricks-bge-large-en",
+		"databricks-gte-large-en",
 	}
 }
 
 // SupportsModel returns true for any Databricks serving endpoint name.
-func (p *Provider) SupportsModel(_ string) bool { return true }
+func (p *Provider) SupportsModel(model string) bool { return strings.TrimSpace(model) != "" }
 
 // Models returns structured model metadata.
 func (p *Provider) Models() []core.ModelInfo {
@@ -105,6 +109,21 @@ type response struct {
 	Model   string        `json:"model"`
 	Choices []core.Choice `json:"choices"`
 	Usage   core.Usage    `json:"usage"`
+}
+
+type embeddingRequest struct {
+	Model          string      `json:"model"`
+	Input          interface{} `json:"input"`
+	EncodingFormat string      `json:"encoding_format,omitempty"`
+	Dimensions     *int        `json:"dimensions,omitempty"`
+	User           string      `json:"user,omitempty"`
+}
+
+type embeddingResponse struct {
+	Object string              `json:"object"`
+	Data   []core.Embedding    `json:"data"`
+	Model  string              `json:"model"`
+	Usage  core.EmbeddingUsage `json:"usage"`
 }
 
 type errorDetail struct {
@@ -182,6 +201,108 @@ func (p *Provider) Complete(ctx context.Context, req core.Request) (*core.Respon
 		Choices:  pResp.Choices,
 		Usage:    pResp.Usage,
 	}, nil
+}
+
+// Embed sends an OpenAI-compatible embedding request to Databricks model serving.
+func (p *Provider) Embed(ctx context.Context, req core.EmbeddingRequest) (*core.EmbeddingResponse, error) {
+	input, err := normalizeEmbeddingInput(req.Input)
+	if err != nil {
+		return nil, err
+	}
+	if req.EncodingFormat != "" && req.EncodingFormat != "float" {
+		return nil, fmt.Errorf("embed: unsupported encoding_format %q; valid value is \"float\"", req.EncodingFormat)
+	}
+
+	pReq := embeddingRequest{
+		Model:          req.Model,
+		Input:          input,
+		EncodingFormat: req.EncodingFormat,
+		Dimensions:     req.Dimensions,
+		User:           req.User,
+	}
+
+	bodyReader, _, release, err := core.JSONBodyReader(pReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal embedding request: %w", err)
+	}
+	defer release()
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, p.baseURL+"/embeddings", bodyReader)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	httpReq.Header.Set("Authorization", "Bearer "+p.apiKey)
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	httpResp, err := p.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer func() { _ = httpResp.Body.Close() }()
+
+	respBody, err := io.ReadAll(httpResp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+	if httpResp.StatusCode < http.StatusOK || httpResp.StatusCode >= http.StatusMultipleChoices {
+		var errResp errorResponse
+		if json.Unmarshal(respBody, &errResp) == nil && errResp.Error.Message != "" {
+			return nil, fmt.Errorf("databricks API error (%d): %s", httpResp.StatusCode, errResp.Error.Message)
+		}
+		return nil, fmt.Errorf("databricks API error (%d): %s", httpResp.StatusCode, string(respBody))
+	}
+
+	var pResp embeddingResponse
+	if err := json.Unmarshal(respBody, &pResp); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal embedding response: %w", err)
+	}
+
+	return &core.EmbeddingResponse{
+		Object: pResp.Object,
+		Data:   pResp.Data,
+		Model:  pResp.Model,
+		Usage:  pResp.Usage,
+	}, nil
+}
+
+func normalizeEmbeddingInput(input interface{}) (interface{}, error) {
+	switch v := input.(type) {
+	case string:
+		if strings.TrimSpace(v) == "" {
+			return nil, fmt.Errorf("embed: Input must not be empty")
+		}
+		return v, nil
+	case []string:
+		if len(v) == 0 {
+			return nil, fmt.Errorf("embed: Input must not be an empty array")
+		}
+		for i, s := range v {
+			if strings.TrimSpace(s) == "" {
+				return nil, fmt.Errorf("embed: Input[%d] must not be empty", i)
+			}
+		}
+		return v, nil
+	case []interface{}:
+		if len(v) == 0 {
+			return nil, fmt.Errorf("embed: Input must not be an empty array")
+		}
+		strs := make([]string, 0, len(v))
+		for i, item := range v {
+			s, ok := item.(string)
+			if !ok {
+				return nil, fmt.Errorf("embed: Input[%d] is %T, want string", i, item)
+			}
+			if strings.TrimSpace(s) == "" {
+				return nil, fmt.Errorf("embed: Input[%d] must not be empty", i)
+			}
+			strs = append(strs, s)
+		}
+		return strs, nil
+	case nil:
+		return nil, fmt.Errorf("embed: Input must not be nil")
+	default:
+		return nil, fmt.Errorf("embed: unsupported Input type %T; want string or []string", input)
+	}
 }
 
 // CompleteStream sends a streaming chat completion request to Databricks.

--- a/providers/databricks/databricks_test.go
+++ b/providers/databricks/databricks_test.go
@@ -2,9 +2,12 @@ package databricks
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/ferro-labs/ai-gateway/providers/core"
@@ -40,6 +43,18 @@ func TestDatabricksProvider_SupportedModels(t *testing.T) {
 	if !found {
 		t.Error("databricks-claude-sonnet-4-5 not found")
 	}
+	for _, want := range []string{"databricks-bge-large-en", "databricks-gte-large-en"} {
+		foundEmbedding := false
+		for _, m := range models {
+			if m == want {
+				foundEmbedding = true
+				break
+			}
+		}
+		if !foundEmbedding {
+			t.Errorf("%s not found", want)
+		}
+	}
 }
 
 func TestDatabricksProvider_SupportsModel(t *testing.T) {
@@ -49,6 +64,15 @@ func TestDatabricksProvider_SupportsModel(t *testing.T) {
 	}
 	if !p.SupportsModel("custom-endpoint-name") {
 		t.Error("passthrough: expected all models to return true")
+	}
+	if p.SupportsModel("") {
+		t.Error("empty model should not be supported")
+	}
+	if p.SupportsModel("  ") {
+		t.Error("blank model should not be supported")
+	}
+	if !p.SupportsModel("databricks-bge-large-en") {
+		t.Error("expected databricks-bge-large-en to be supported")
 	}
 }
 
@@ -65,6 +89,11 @@ func TestDatabricksProvider_Models(t *testing.T) {
 func TestDatabricksProvider_CompleteStream_Interface(_ *testing.T) {
 	p, _ := New("test-key", "https://dbc.example.com")
 	var _ core.StreamProvider = p
+}
+
+func TestDatabricksProvider_Embed_Interface(_ *testing.T) {
+	p, _ := New("test-key", "https://dbc.example.com")
+	var _ core.EmbeddingProvider = p
 }
 
 func TestDatabricksProvider_AuthHeaders(t *testing.T) {
@@ -143,5 +172,176 @@ func TestDatabricksProvider_Complete_MockHTTP(t *testing.T) {
 	}
 	if len(resp.Choices) == 0 {
 		t.Error("expected at least one choice")
+	}
+}
+
+func TestDatabricksProvider_Embed_StringInput_MockHTTP(t *testing.T) {
+	testDatabricksEmbedSuccess(t, "hello world")
+}
+
+func TestDatabricksProvider_Embed_StringSliceInput_MockHTTP(t *testing.T) {
+	testDatabricksEmbedSuccess(t, []string{"hello", "world"})
+}
+
+func TestDatabricksProvider_Embed_InterfaceSliceInput_MockHTTP(t *testing.T) {
+	testDatabricksEmbedSuccess(t, []interface{}{"hello", "world"})
+}
+
+func TestDatabricksProvider_Embed_InvalidInput(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	p, _ := New("test-key", srv.URL)
+	badInputs := []struct {
+		name  string
+		input interface{}
+	}{
+		{"nil", nil},
+		{"integer", 42},
+		{"empty-string", ""},
+		{"blank-string", "  "},
+		{"empty-string-slice", []string{}},
+		{"empty-interface-slice", []interface{}{}},
+		{"empty-string-slice-member", []string{"ok", ""}},
+		{"blank-string-slice-member", []string{"ok", "  "}},
+		{"empty-interface-slice-member", []interface{}{"ok", ""}},
+		{"blank-interface-slice-member", []interface{}{"ok", "  "}},
+		{"non-string-array-member", []interface{}{"ok", 42}},
+	}
+	for _, tc := range badInputs {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := p.Embed(context.Background(), core.EmbeddingRequest{
+				Model: "databricks-bge-large-en",
+				Input: tc.input,
+			})
+			if err == nil {
+				t.Fatalf("Embed() error = nil, want error")
+			}
+		})
+	}
+	if got := atomic.LoadInt32(&calls); got != 0 {
+		t.Fatalf("upstream calls = %d, want 0", got)
+	}
+}
+
+func TestDatabricksProvider_Embed_UpstreamError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/serving-endpoints/embeddings" {
+			t.Errorf("path = %q, want /serving-endpoints/embeddings", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = w.Write([]byte(`{"error":{"message":"serving endpoint unavailable","type":"bad_gateway"}}`))
+	}))
+	defer srv.Close()
+
+	p, _ := New("test-key", srv.URL)
+	_, err := p.Embed(context.Background(), core.EmbeddingRequest{
+		Model: "databricks-bge-large-en",
+		Input: "hello",
+	})
+	if err == nil {
+		t.Fatal("Embed() error = nil, want upstream error")
+	}
+	if !strings.Contains(err.Error(), "serving endpoint unavailable") {
+		t.Fatalf("error = %v, want serving endpoint unavailable message", err)
+	}
+}
+
+func testDatabricksEmbedSuccess(t *testing.T, input interface{}) {
+	t.Helper()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+		if r.URL.Path != "/serving-endpoints/embeddings" {
+			t.Errorf("path = %q, want /serving-endpoints/embeddings", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != testBearerAPIKey {
+			t.Errorf("Authorization = %q, want %s", got, testBearerAPIKey)
+		}
+		if got := r.Header.Get("Content-Type"); got != "application/json" {
+			t.Errorf("Content-Type = %q, want application/json", got)
+		}
+
+		var body map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode request body: %v", err)
+		}
+		if got := body["model"]; got != "databricks-bge-large-en" {
+			t.Errorf("model = %v, want databricks-bge-large-en", got)
+		}
+		assertDatabricksEmbeddingInput(t, body["input"], input)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"object":"list","data":[{"object":"embedding","embedding":[0.1,0.2],"index":0},{"object":"embedding","embedding":[0.3,0.4],"index":1}],"model":"databricks-bge-large-en","usage":{"prompt_tokens":4,"total_tokens":4}}`))
+	}))
+	defer srv.Close()
+
+	p, _ := New("test-key", srv.URL)
+	resp, err := p.Embed(context.Background(), core.EmbeddingRequest{
+		Model: "databricks-bge-large-en",
+		Input: input,
+	})
+	if err != nil {
+		t.Fatalf("Embed() error: %v", err)
+	}
+	if resp.Object != "list" {
+		t.Errorf("Object = %q, want list", resp.Object)
+	}
+	if resp.Model != "databricks-bge-large-en" {
+		t.Errorf("Model = %q, want databricks-bge-large-en", resp.Model)
+	}
+	if len(resp.Data) != 2 {
+		t.Fatalf("Data length = %d, want 2", len(resp.Data))
+	}
+	if resp.Data[0].Object != "embedding" || resp.Data[0].Index != 0 || !reflect.DeepEqual(resp.Data[0].Embedding, []float64{0.1, 0.2}) {
+		t.Errorf("Data[0] = %+v, want mapped embedding at index 0", resp.Data[0])
+	}
+	if resp.Data[1].Object != "embedding" || resp.Data[1].Index != 1 || !reflect.DeepEqual(resp.Data[1].Embedding, []float64{0.3, 0.4}) {
+		t.Errorf("Data[1] = %+v, want mapped embedding at index 1", resp.Data[1])
+	}
+	if resp.Usage.PromptTokens != 4 || resp.Usage.TotalTokens != 4 {
+		t.Errorf("Usage = %+v, want prompt_tokens=4 total_tokens=4", resp.Usage)
+	}
+}
+
+func assertDatabricksEmbeddingInput(t *testing.T, got interface{}, want interface{}) {
+	t.Helper()
+
+	switch w := want.(type) {
+	case string:
+		if got != w {
+			t.Errorf("input = %#v, want %q", got, w)
+		}
+	case []string:
+		gotSlice, ok := got.([]interface{})
+		if !ok {
+			t.Fatalf("input = %T, want JSON array", got)
+		}
+		if len(gotSlice) != len(w) {
+			t.Fatalf("input length = %d, want %d", len(gotSlice), len(w))
+		}
+		for i := range w {
+			if gotSlice[i] != w[i] {
+				t.Errorf("input[%d] = %#v, want %q", i, gotSlice[i], w[i])
+			}
+		}
+	case []interface{}:
+		gotSlice, ok := got.([]interface{})
+		if !ok {
+			t.Fatalf("input = %T, want JSON array", got)
+		}
+		if !reflect.DeepEqual(gotSlice, w) {
+			t.Errorf("input = %#v, want %#v", gotSlice, w)
+		}
+	default:
+		t.Fatalf("unsupported expected input type %T", want)
 	}
 }

--- a/providers/fireworks/embedding.go
+++ b/providers/fireworks/embedding.go
@@ -1,0 +1,115 @@
+package fireworks
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/ferro-labs/ai-gateway/providers/core"
+)
+
+type embeddingRequest struct {
+	Model          string      `json:"model"`
+	Input          interface{} `json:"input"`
+	EncodingFormat string      `json:"encoding_format,omitempty"`
+	Dimensions     *int        `json:"dimensions,omitempty"`
+	User           string      `json:"user,omitempty"`
+}
+
+type embeddingResponse struct {
+	Object string              `json:"object"`
+	Data   []core.Embedding    `json:"data"`
+	Model  string              `json:"model"`
+	Usage  core.EmbeddingUsage `json:"usage"`
+}
+
+// Embed sends an OpenAI-compatible embedding request to Fireworks AI.
+func (p *Provider) Embed(ctx context.Context, req core.EmbeddingRequest) (*core.EmbeddingResponse, error) {
+	input, err := normalizeEmbeddingInput(req.Input)
+	if err != nil {
+		return nil, err
+	}
+	if req.EncodingFormat != "" && req.EncodingFormat != "float" {
+		return nil, fmt.Errorf("embed: unsupported encoding_format %q; valid value is \"float\"", req.EncodingFormat)
+	}
+
+	pReq := embeddingRequest{
+		Model:          req.Model,
+		Input:          input,
+		EncodingFormat: req.EncodingFormat,
+		Dimensions:     req.Dimensions,
+		User:           req.User,
+	}
+	bodyReader, _, release, err := core.JSONBodyReader(pReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal embedding request: %w", err)
+	}
+	defer release()
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, p.baseURL+"/v1/embeddings", bodyReader)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	httpReq.Header.Set("Authorization", "Bearer "+p.apiKey)
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	httpResp, err := p.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer func() { _ = httpResp.Body.Close() }()
+
+	respBody, err := io.ReadAll(httpResp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+	if httpResp.StatusCode < http.StatusOK || httpResp.StatusCode >= http.StatusMultipleChoices {
+		var errResp errorResponse
+		if json.Unmarshal(respBody, &errResp) == nil && errResp.Error.Message != "" {
+			return nil, fmt.Errorf("fireworks API error (%d): %s", httpResp.StatusCode, errResp.Error.Message)
+		}
+		return nil, fmt.Errorf("fireworks API error (%d): %s", httpResp.StatusCode, string(respBody))
+	}
+
+	var pResp embeddingResponse
+	if err := json.Unmarshal(respBody, &pResp); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal embedding response: %w", err)
+	}
+	return &core.EmbeddingResponse{
+		Object: pResp.Object,
+		Data:   pResp.Data,
+		Model:  pResp.Model,
+		Usage:  pResp.Usage,
+	}, nil
+}
+
+func normalizeEmbeddingInput(input interface{}) (interface{}, error) {
+	switch v := input.(type) {
+	case string:
+		return v, nil
+	case []string:
+		if len(v) == 0 {
+			return nil, fmt.Errorf("embed: Input must not be an empty array")
+		}
+		return v, nil
+	case []interface{}:
+		if len(v) == 0 {
+			return nil, fmt.Errorf("embed: Input must not be an empty array")
+		}
+		strs := make([]string, 0, len(v))
+		for i, item := range v {
+			s, ok := item.(string)
+			if !ok {
+				return nil, fmt.Errorf("embed: Input[%d] is %T, want string", i, item)
+			}
+			strs = append(strs, s)
+		}
+		return strs, nil
+	case nil:
+		return nil, fmt.Errorf("embed: Input must not be nil")
+	default:
+		return nil, fmt.Errorf("embed: unsupported Input type %T; want string or []string", input)
+	}
+}

--- a/providers/fireworks/fireworks.go
+++ b/providers/fireworks/fireworks.go
@@ -34,6 +34,7 @@ type Provider struct {
 var (
 	_ core.Provider          = (*Provider)(nil)
 	_ core.StreamProvider    = (*Provider)(nil)
+	_ core.EmbeddingProvider = (*Provider)(nil)
 	_ core.ProxiableProvider = (*Provider)(nil)
 	_ core.DiscoveryProvider = (*Provider)(nil)
 )
@@ -76,6 +77,13 @@ func (p *Provider) SupportedModels() []string {
 		"accounts/fireworks/models/firefunction-v2",
 		"accounts/fireworks/models/qwen2p5-72b-instruct",
 		"accounts/fireworks/models/deepseek-v3",
+		"accounts/fireworks/models/qwen3-embedding-0p6b",
+		"accounts/fireworks/models/qwen3-embedding-4b",
+		"fireworks_ai/nomic-ai/nomic-embed-text-v1",
+		"fireworks_ai/nomic-ai/nomic-embed-text-v1.5",
+		"fireworks_ai/WhereIsAI/UAE-Large-V1",
+		"fireworks_ai/thenlper/gte-base",
+		"fireworks_ai/thenlper/gte-large",
 	}
 }
 

--- a/providers/fireworks/fireworks_test.go
+++ b/providers/fireworks/fireworks_test.go
@@ -16,6 +16,7 @@ const (
 	testAPIKey              = "test-key"
 	testBearerAPIKey        = "Bearer test-key"
 	testChatCompletionsPath = "/chat/completions"
+	testEmbeddingModel      = "accounts/fireworks/models/qwen3-embedding-0p6b"
 )
 
 func TestNewFireworks(t *testing.T) {
@@ -153,16 +154,16 @@ func TestFireworksProvider_SupportedModels_Embeddings(t *testing.T) {
 	models := p.SupportedModels()
 	found := false
 	for _, m := range models {
-		if m == "accounts/fireworks/models/qwen3-embedding-0p6b" {
+		if m == testEmbeddingModel {
 			found = true
 			break
 		}
 	}
 	if !found {
-		t.Fatalf("embedding model %q not found in SupportedModels()", "accounts/fireworks/models/qwen3-embedding-0p6b")
+		t.Fatalf("embedding model %q not found in SupportedModels()", testEmbeddingModel)
 	}
-	if !p.SupportsModel("accounts/fireworks/models/qwen3-embedding-0p6b") {
-		t.Fatalf("SupportsModel(%q) = false, want true", "accounts/fireworks/models/qwen3-embedding-0p6b")
+	if !p.SupportsModel(testEmbeddingModel) {
+		t.Fatalf("SupportsModel(%q) = false, want true", testEmbeddingModel)
 	}
 }
 
@@ -196,7 +197,7 @@ func TestFireworksProvider_Embed_InvalidInput(t *testing.T) {
 	for _, tc := range badInputs {
 		t.Run(tc.name, func(t *testing.T) {
 			_, err := p.Embed(context.Background(), core.EmbeddingRequest{
-				Model: "accounts/fireworks/models/qwen3-embedding-0p6b",
+				Model: testEmbeddingModel,
 				Input: tc.input,
 			})
 			if err == nil {
@@ -222,7 +223,7 @@ func TestFireworksProvider_Embed_UpstreamError(t *testing.T) {
 
 	p, _ := New("test-key", srv.URL)
 	_, err := p.Embed(context.Background(), core.EmbeddingRequest{
-		Model: "accounts/fireworks/models/qwen3-embedding-0p6b",
+		Model: testEmbeddingModel,
 		Input: "hello",
 	})
 	if err == nil {
@@ -254,20 +255,20 @@ func testFireworksEmbedSuccess(t *testing.T, input interface{}) {
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 			t.Fatalf("failed to decode request body: %v", err)
 		}
-		if got := body["model"]; got != "accounts/fireworks/models/qwen3-embedding-0p6b" {
-			t.Errorf("model = %v, want accounts/fireworks/models/qwen3-embedding-0p6b", got)
+		if got := body["model"]; got != testEmbeddingModel {
+			t.Errorf("model = %v, want %s", got, testEmbeddingModel)
 		}
 		assertFireworksEmbeddingInput(t, body["input"], input)
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`{"object":"list","data":[{"object":"embedding","embedding":[0.1,0.2],"index":0},{"object":"embedding","embedding":[0.3,0.4],"index":1}],"model":"accounts/fireworks/models/qwen3-embedding-0p6b","usage":{"prompt_tokens":3,"total_tokens":3}}`))
+		_, _ = w.Write([]byte(`{"object":"list","data":[{"object":"embedding","embedding":[0.1,0.2],"index":0},{"object":"embedding","embedding":[0.3,0.4],"index":1}],"model":"` + testEmbeddingModel + `","usage":{"prompt_tokens":3,"total_tokens":3}}`))
 	}))
 	defer srv.Close()
 
 	p, _ := New("test-key", srv.URL)
 	resp, err := p.Embed(context.Background(), core.EmbeddingRequest{
-		Model: "accounts/fireworks/models/qwen3-embedding-0p6b",
+		Model: testEmbeddingModel,
 		Input: input,
 	})
 	if err != nil {
@@ -276,8 +277,8 @@ func testFireworksEmbedSuccess(t *testing.T, input interface{}) {
 	if resp.Object != "list" {
 		t.Errorf("Object = %q, want list", resp.Object)
 	}
-	if resp.Model != "accounts/fireworks/models/qwen3-embedding-0p6b" {
-		t.Errorf("Model = %q, want accounts/fireworks/models/qwen3-embedding-0p6b", resp.Model)
+	if resp.Model != testEmbeddingModel {
+		t.Errorf("Model = %q, want %s", resp.Model, testEmbeddingModel)
 	}
 	if len(resp.Data) != 2 {
 		t.Fatalf("Data length = %d, want 2", len(resp.Data))

--- a/providers/fireworks/fireworks_test.go
+++ b/providers/fireworks/fireworks_test.go
@@ -2,9 +2,13 @@ package fireworks
 
 import (
 	"context"
+	"encoding/json"
 	"github.com/ferro-labs/ai-gateway/providers/core"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
+	"strings"
+	"sync/atomic"
 	"testing"
 )
 
@@ -136,5 +140,181 @@ func TestFireworksProvider_Complete_MockHTTP(t *testing.T) {
 	}
 	if len(resp.Choices) == 0 {
 		t.Error("expected at least one choice")
+	}
+}
+
+func TestFireworksProvider_Embed_Interface(_ *testing.T) {
+	p, _ := New("test-key", "")
+	var _ core.EmbeddingProvider = p
+}
+
+func TestFireworksProvider_SupportedModels_Embeddings(t *testing.T) {
+	p, _ := New("test-key", "")
+	models := p.SupportedModels()
+	found := false
+	for _, m := range models {
+		if m == "accounts/fireworks/models/qwen3-embedding-0p6b" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("embedding model %q not found in SupportedModels()", "accounts/fireworks/models/qwen3-embedding-0p6b")
+	}
+	if !p.SupportsModel("accounts/fireworks/models/qwen3-embedding-0p6b") {
+		t.Fatalf("SupportsModel(%q) = false, want true", "accounts/fireworks/models/qwen3-embedding-0p6b")
+	}
+}
+
+func TestFireworksProvider_Embed_StringInput_MockHTTP(t *testing.T) {
+	testFireworksEmbedSuccess(t, "hello world")
+}
+
+func TestFireworksProvider_Embed_StringSliceInput_MockHTTP(t *testing.T) {
+	testFireworksEmbedSuccess(t, []string{"hello", "world"})
+}
+
+func TestFireworksProvider_Embed_InvalidInput(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	p, _ := New("test-key", srv.URL)
+	badInputs := []struct {
+		name  string
+		input interface{}
+	}{
+		{"nil", nil},
+		{"integer", 42},
+		{"empty-string-slice", []string{}},
+		{"empty-interface-slice", []interface{}{}},
+		{"non-string-array-member", []interface{}{"ok", 42}},
+	}
+	for _, tc := range badInputs {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := p.Embed(context.Background(), core.EmbeddingRequest{
+				Model: "accounts/fireworks/models/qwen3-embedding-0p6b",
+				Input: tc.input,
+			})
+			if err == nil {
+				t.Fatalf("Embed() error = nil, want error")
+			}
+		})
+	}
+	if got := atomic.LoadInt32(&calls); got != 0 {
+		t.Fatalf("upstream calls = %d, want 0", got)
+	}
+}
+
+func TestFireworksProvider_Embed_UpstreamError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/embeddings" {
+			t.Errorf("path = %q, want /v1/embeddings", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"error":{"message":"rate limited","type":"rate_limit"}}`))
+	}))
+	defer srv.Close()
+
+	p, _ := New("test-key", srv.URL)
+	_, err := p.Embed(context.Background(), core.EmbeddingRequest{
+		Model: "accounts/fireworks/models/qwen3-embedding-0p6b",
+		Input: "hello",
+	})
+	if err == nil {
+		t.Fatal("Embed() error = nil, want upstream error")
+	}
+	if !strings.Contains(err.Error(), "rate limited") {
+		t.Fatalf("error = %v, want rate limited message", err)
+	}
+}
+
+func testFireworksEmbedSuccess(t *testing.T, input interface{}) {
+	t.Helper()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+		if r.URL.Path != "/v1/embeddings" {
+			t.Errorf("path = %q, want /v1/embeddings", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-key" {
+			t.Errorf("Authorization = %q, want Bearer test-key", got)
+		}
+		if got := r.Header.Get("Content-Type"); got != "application/json" {
+			t.Errorf("Content-Type = %q, want application/json", got)
+		}
+
+		var body map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode request body: %v", err)
+		}
+		if got := body["model"]; got != "accounts/fireworks/models/qwen3-embedding-0p6b" {
+			t.Errorf("model = %v, want accounts/fireworks/models/qwen3-embedding-0p6b", got)
+		}
+		assertFireworksEmbeddingInput(t, body["input"], input)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"object":"list","data":[{"object":"embedding","embedding":[0.1,0.2],"index":0},{"object":"embedding","embedding":[0.3,0.4],"index":1}],"model":"accounts/fireworks/models/qwen3-embedding-0p6b","usage":{"prompt_tokens":3,"total_tokens":3}}`))
+	}))
+	defer srv.Close()
+
+	p, _ := New("test-key", srv.URL)
+	resp, err := p.Embed(context.Background(), core.EmbeddingRequest{
+		Model: "accounts/fireworks/models/qwen3-embedding-0p6b",
+		Input: input,
+	})
+	if err != nil {
+		t.Fatalf("Embed() error: %v", err)
+	}
+	if resp.Object != "list" {
+		t.Errorf("Object = %q, want list", resp.Object)
+	}
+	if resp.Model != "accounts/fireworks/models/qwen3-embedding-0p6b" {
+		t.Errorf("Model = %q, want accounts/fireworks/models/qwen3-embedding-0p6b", resp.Model)
+	}
+	if len(resp.Data) != 2 {
+		t.Fatalf("Data length = %d, want 2", len(resp.Data))
+	}
+	if resp.Data[0].Object != "embedding" || resp.Data[0].Index != 0 || !reflect.DeepEqual(resp.Data[0].Embedding, []float64{0.1, 0.2}) {
+		t.Errorf("Data[0] = %+v, want mapped embedding at index 0", resp.Data[0])
+	}
+	if resp.Data[1].Index != 1 || !reflect.DeepEqual(resp.Data[1].Embedding, []float64{0.3, 0.4}) {
+		t.Errorf("Data[1] = %+v, want mapped embedding at index 1", resp.Data[1])
+	}
+	if resp.Usage.PromptTokens != 3 || resp.Usage.TotalTokens != 3 {
+		t.Errorf("Usage = %+v, want prompt=3 total=3", resp.Usage)
+	}
+}
+
+func assertFireworksEmbeddingInput(t *testing.T, got interface{}, want interface{}) {
+	t.Helper()
+
+	switch w := want.(type) {
+	case string:
+		if got != w {
+			t.Fatalf("input = %#v, want %q", got, w)
+		}
+	case []string:
+		arr, ok := got.([]interface{})
+		if !ok {
+			t.Fatalf("input type = %T, want JSON array", got)
+		}
+		if len(arr) != len(w) {
+			t.Fatalf("input length = %d, want %d", len(arr), len(w))
+		}
+		for i := range w {
+			if arr[i] != w[i] {
+				t.Fatalf("input[%d] = %#v, want %q", i, arr[i], w[i])
+			}
+		}
+	default:
+		t.Fatalf("unsupported test input type %T", want)
 	}
 }

--- a/providers/gemini/gemini.go
+++ b/providers/gemini/gemini.go
@@ -31,6 +31,7 @@ type Provider struct {
 var (
 	_ core.Provider          = (*Provider)(nil)
 	_ core.StreamProvider    = (*Provider)(nil)
+	_ core.EmbeddingProvider = (*Provider)(nil)
 	_ core.ProxiableProvider = (*Provider)(nil)
 )
 
@@ -68,12 +69,24 @@ func (p *Provider) SupportedModels() []string {
 		"gemini-2.0-flash-lite",
 		"gemini-1.5-pro",
 		"gemini-1.5-flash",
+		"gemini-embedding-001",
+		"text-embedding-004",
+		"embedding-001",
 	}
 }
 
-// SupportsModel returns true if the model matches the Gemini prefix.
+// SupportsModel returns true if the model is a known Gemini chat or embedding model.
 func (p *Provider) SupportsModel(model string) bool {
-	return strings.HasPrefix(model, "gemini-")
+	model = strings.TrimPrefix(model, "models/")
+	if strings.HasPrefix(model, "gemini-") {
+		return true
+	}
+	switch model {
+	case "text-embedding-004", "embedding-001":
+		return true
+	default:
+		return false
+	}
 }
 
 // Models returns structured model metadata.
@@ -122,6 +135,30 @@ type geminiErrorDetail struct {
 
 type geminiErrorResponse struct {
 	Error geminiErrorDetail `json:"error"`
+}
+
+type geminiEmbeddingContent struct {
+	Parts []geminiPart `json:"parts"`
+}
+
+type geminiBatchEmbedContentRequest struct {
+	Model                string                 `json:"model"`
+	Content              geminiEmbeddingContent `json:"content"`
+	OutputDimensionality *int                   `json:"outputDimensionality,omitempty"`
+}
+
+type geminiBatchEmbedRequest struct {
+	Requests []geminiBatchEmbedContentRequest `json:"requests"`
+}
+
+type geminiBatchEmbedResponse struct {
+	Embeddings []struct {
+		Values []float64 `json:"values"`
+	} `json:"embeddings"`
+	UsageMetadata struct {
+		PromptTokenCount int `json:"promptTokenCount"`
+		TotalTokenCount  int `json:"totalTokenCount"`
+	} `json:"usageMetadata"`
 }
 
 type geminiStreamResponse struct {
@@ -199,6 +236,127 @@ func buildRequest(req core.Request) (geminiRequest, error) {
 		}
 	}
 	return r, nil
+}
+
+func embeddingInputs(input interface{}) ([]string, error) {
+	switch v := input.(type) {
+	case string:
+		return []string{v}, nil
+	case []string:
+		if len(v) == 0 {
+			return nil, fmt.Errorf("embed: Input must not be an empty array")
+		}
+		return v, nil
+	case []interface{}:
+		if len(v) == 0 {
+			return nil, fmt.Errorf("embed: Input must not be an empty array")
+		}
+		texts := make([]string, 0, len(v))
+		for i, item := range v {
+			s, ok := item.(string)
+			if !ok {
+				return nil, fmt.Errorf("embed: Input[%d] is %T, want string", i, item)
+			}
+			texts = append(texts, s)
+		}
+		return texts, nil
+	case nil:
+		return nil, fmt.Errorf("embed: Input must not be nil")
+	default:
+		return nil, fmt.Errorf("embed: unsupported Input type %T; want string or []string", input)
+	}
+}
+
+func geminiModelResource(model string) string {
+	model = strings.TrimPrefix(model, "models/")
+	return "models/" + model
+}
+
+// Embed sends a text embedding request to Gemini's batchEmbedContents endpoint.
+func (p *Provider) Embed(ctx context.Context, req core.EmbeddingRequest) (*core.EmbeddingResponse, error) {
+	if req.EncodingFormat != "" && req.EncodingFormat != "float" {
+		return nil, fmt.Errorf("embed: unsupported encoding_format %q; valid value is \"float\"", req.EncodingFormat)
+	}
+	texts, err := embeddingInputs(req.Input)
+	if err != nil {
+		return nil, err
+	}
+
+	model := strings.TrimPrefix(req.Model, "models/")
+	modelResource := geminiModelResource(req.Model)
+	geminiReq := geminiBatchEmbedRequest{
+		Requests: make([]geminiBatchEmbedContentRequest, 0, len(texts)),
+	}
+	for _, text := range texts {
+		geminiReq.Requests = append(geminiReq.Requests, geminiBatchEmbedContentRequest{
+			Model:                modelResource,
+			Content:              geminiEmbeddingContent{Parts: []geminiPart{{Text: text}}},
+			OutputDimensionality: req.Dimensions,
+		})
+	}
+
+	bodyReader, _, release, err := core.JSONBodyReader(geminiReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal embed request: %w", err)
+	}
+	defer release()
+
+	url := fmt.Sprintf("%s/v1beta/models/%s:batchEmbedContents?key=%s", p.baseURL, model, p.apiKey)
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bodyReader)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create embed request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	httpResp, err := p.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("embed request failed: %w", err)
+	}
+	defer func() { _ = httpResp.Body.Close() }()
+
+	respBody, err := io.ReadAll(httpResp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read embed response: %w", err)
+	}
+
+	if httpResp.StatusCode != http.StatusOK {
+		var errResp geminiErrorResponse
+		if json.Unmarshal(respBody, &errResp) == nil && errResp.Error.Message != "" {
+			return nil, fmt.Errorf("gemini embed API error (%d): %s", httpResp.StatusCode, errResp.Error.Message)
+		}
+		return nil, fmt.Errorf("gemini embed API error (%d): %s", httpResp.StatusCode, string(respBody))
+	}
+
+	var geminiResp geminiBatchEmbedResponse
+	if err := json.Unmarshal(respBody, &geminiResp); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal embed response: %w", err)
+	}
+	if len(geminiResp.Embeddings) != len(texts) {
+		return nil, fmt.Errorf("gemini embed API returned %d embeddings for %d inputs", len(geminiResp.Embeddings), len(texts))
+	}
+
+	data := make([]core.Embedding, len(geminiResp.Embeddings))
+	for i, embedding := range geminiResp.Embeddings {
+		data[i] = core.Embedding{
+			Object:    "embedding",
+			Embedding: embedding.Values,
+			Index:     i,
+		}
+	}
+
+	totalTokens := geminiResp.UsageMetadata.TotalTokenCount
+	if totalTokens == 0 {
+		totalTokens = geminiResp.UsageMetadata.PromptTokenCount
+	}
+	return &core.EmbeddingResponse{
+		Object: "list",
+		Data:   data,
+		Model:  req.Model,
+		Usage: core.EmbeddingUsage{
+			PromptTokens: geminiResp.UsageMetadata.PromptTokenCount,
+			TotalTokens:  totalTokens,
+		},
+	}, nil
 }
 
 // Complete sends a chat completion request to Gemini.

--- a/providers/gemini/gemini_test.go
+++ b/providers/gemini/gemini_test.go
@@ -2,10 +2,13 @@ package gemini
 
 import (
 	"context"
-	"github.com/ferro-labs/ai-gateway/providers/core"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
+
+	"github.com/ferro-labs/ai-gateway/providers/core"
 )
 
 func TestNewGemini(t *testing.T) {
@@ -25,13 +28,20 @@ func TestGeminiProvider_SupportedModels(t *testing.T) {
 		t.Error("SupportedModels() returned empty")
 	}
 	found := false
+	foundEmbedding := false
 	for _, m := range models {
 		if m == "gemini-2.0-flash" {
 			found = true
 		}
+		if m == "gemini-embedding-001" {
+			foundEmbedding = true
+		}
 	}
 	if !found {
 		t.Error("gemini-2.0-flash not found")
+	}
+	if !foundEmbedding {
+		t.Error("gemini-embedding-001 not found")
 	}
 }
 
@@ -42,6 +52,9 @@ func TestGeminiProvider_SupportsModel(t *testing.T) {
 	}
 	if p.SupportsModel("gpt-4o") {
 		t.Error("gemini should not support gpt-4o")
+	}
+	if !p.SupportsModel("text-embedding-004") {
+		t.Error("expected text-embedding-004 to be supported")
 	}
 }
 
@@ -58,6 +71,140 @@ func TestGeminiProvider_Models(t *testing.T) {
 func TestGeminiProvider_CompleteStream_Interface(_ *testing.T) {
 	p, _ := New("test-key", "")
 	var _ core.StreamProvider = p
+}
+
+func TestGeminiProvider_Embed_Interface(_ *testing.T) {
+	p, _ := New("test-key", "")
+	var _ core.EmbeddingProvider = p
+}
+
+func TestGeminiProvider_Embed_BatchSuccess(t *testing.T) {
+	dimensions := 64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+		if r.URL.Path != "/v1beta/models/gemini-embedding-001:batchEmbedContents" {
+			t.Errorf("request path = %q, want /v1beta/models/gemini-embedding-001:batchEmbedContents", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("key"); got != "test-key" {
+			t.Errorf("key query = %q, want test-key", got)
+		}
+		var body struct {
+			Requests []struct {
+				Model   string `json:"model"`
+				Content struct {
+					Parts []struct {
+						Text string `json:"text"`
+					} `json:"parts"`
+				} `json:"content"`
+				OutputDimensionality *int `json:"outputDimensionality"`
+			} `json:"requests"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		if len(body.Requests) != 2 {
+			t.Fatalf("requests len = %d, want 2", len(body.Requests))
+		}
+		if body.Requests[0].Model != "models/gemini-embedding-001" || body.Requests[0].Content.Parts[0].Text != "first" {
+			t.Errorf("first request = %+v", body.Requests[0])
+		}
+		if body.Requests[1].Content.Parts[0].Text != "second" {
+			t.Errorf("second text = %q, want second", body.Requests[1].Content.Parts[0].Text)
+		}
+		if body.Requests[0].OutputDimensionality == nil || *body.Requests[0].OutputDimensionality != dimensions {
+			t.Errorf("outputDimensionality = %v, want %d", body.Requests[0].OutputDimensionality, dimensions)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"embeddings":[{"values":[0.1,0.2]},{"values":[0.3,0.4]}],"usageMetadata":{"promptTokenCount":7,"totalTokenCount":7}}`))
+	}))
+	defer srv.Close()
+
+	p, _ := New("test-key", srv.URL)
+	resp, err := p.Embed(context.Background(), core.EmbeddingRequest{
+		Model:      "gemini-embedding-001",
+		Input:      []string{"first", "second"},
+		Dimensions: &dimensions,
+	})
+	if err != nil {
+		t.Fatalf("Embed() error: %v", err)
+	}
+	if resp.Object != "list" || resp.Model != "gemini-embedding-001" {
+		t.Errorf("response metadata = (%q, %q)", resp.Object, resp.Model)
+	}
+	if len(resp.Data) != 2 || resp.Data[0].Index != 0 || resp.Data[1].Index != 1 {
+		t.Fatalf("response data = %+v", resp.Data)
+	}
+	if resp.Data[0].Embedding[0] != 0.1 || resp.Data[1].Embedding[1] != 0.4 {
+		t.Errorf("embeddings = %+v", resp.Data)
+	}
+	if resp.Usage.PromptTokens != 7 || resp.Usage.TotalTokens != 7 {
+		t.Errorf("usage = %+v, want 7 prompt/total", resp.Usage)
+	}
+}
+
+func TestGeminiProvider_Embed_StringInput(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Requests []struct {
+				Content struct {
+					Parts []struct {
+						Text string `json:"text"`
+					} `json:"parts"`
+				} `json:"content"`
+			} `json:"requests"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		if len(body.Requests) != 1 || body.Requests[0].Content.Parts[0].Text != "hello" {
+			t.Fatalf("request body = %+v", body)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"embeddings":[{"values":[1,2,3]}]}`))
+	}))
+	defer srv.Close()
+
+	p, _ := New("test-key", srv.URL)
+	resp, err := p.Embed(context.Background(), core.EmbeddingRequest{
+		Model: "text-embedding-004",
+		Input: "hello",
+	})
+	if err != nil {
+		t.Fatalf("Embed() error: %v", err)
+	}
+	if len(resp.Data) != 1 || resp.Data[0].Embedding[2] != 3 {
+		t.Errorf("response data = %+v", resp.Data)
+	}
+}
+
+func TestGeminiProvider_Embed_InvalidInput(t *testing.T) {
+	p, _ := New("test-key", "")
+	_, err := p.Embed(context.Background(), core.EmbeddingRequest{
+		Model: "gemini-embedding-001",
+		Input: []interface{}{"ok", 123},
+	})
+	if err == nil || !strings.Contains(err.Error(), "Input[1]") {
+		t.Fatalf("Embed() error = %v, want invalid input error", err)
+	}
+}
+
+func TestGeminiProvider_Embed_UpstreamError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":{"message":"bad embedding request"}}`))
+	}))
+	defer srv.Close()
+
+	p, _ := New("test-key", srv.URL)
+	_, err := p.Embed(context.Background(), core.EmbeddingRequest{
+		Model: "gemini-embedding-001",
+		Input: "hello",
+	})
+	if err == nil || !strings.Contains(err.Error(), "bad embedding request") {
+		t.Fatalf("Embed() error = %v, want upstream error", err)
+	}
 }
 
 func TestGeminiProvider_CompleteStream_MockSSE(t *testing.T) {

--- a/providers/mistral/embedding.go
+++ b/providers/mistral/embedding.go
@@ -1,0 +1,115 @@
+package mistral
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/ferro-labs/ai-gateway/providers/core"
+)
+
+type embeddingRequest struct {
+	Model          string      `json:"model"`
+	Input          interface{} `json:"input"`
+	EncodingFormat string      `json:"encoding_format,omitempty"`
+	Dimensions     *int        `json:"dimensions,omitempty"`
+	User           string      `json:"user,omitempty"`
+}
+
+type embeddingResponse struct {
+	Object string              `json:"object"`
+	Data   []core.Embedding    `json:"data"`
+	Model  string              `json:"model"`
+	Usage  core.EmbeddingUsage `json:"usage"`
+}
+
+// Embed sends an OpenAI-compatible embedding request to Mistral.
+func (p *Provider) Embed(ctx context.Context, req core.EmbeddingRequest) (*core.EmbeddingResponse, error) {
+	input, err := normalizeEmbeddingInput(req.Input)
+	if err != nil {
+		return nil, err
+	}
+	if req.EncodingFormat != "" && req.EncodingFormat != "float" {
+		return nil, fmt.Errorf("embed: unsupported encoding_format %q; valid value is \"float\"", req.EncodingFormat)
+	}
+
+	pReq := embeddingRequest{
+		Model:          req.Model,
+		Input:          input,
+		EncodingFormat: req.EncodingFormat,
+		Dimensions:     req.Dimensions,
+		User:           req.User,
+	}
+	bodyReader, _, release, err := core.JSONBodyReader(pReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal embedding request: %w", err)
+	}
+	defer release()
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, p.baseURL+"/v1/embeddings", bodyReader)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	httpReq.Header.Set("Authorization", "Bearer "+p.apiKey)
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	httpResp, err := p.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer func() { _ = httpResp.Body.Close() }()
+
+	respBody, err := io.ReadAll(httpResp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+	if httpResp.StatusCode < http.StatusOK || httpResp.StatusCode >= http.StatusMultipleChoices {
+		var errResp errorResponse
+		if json.Unmarshal(respBody, &errResp) == nil && errResp.Error.Message != "" {
+			return nil, fmt.Errorf("mistral API error (%d): %s", httpResp.StatusCode, errResp.Error.Message)
+		}
+		return nil, fmt.Errorf("mistral API error (%d): %s", httpResp.StatusCode, string(respBody))
+	}
+
+	var pResp embeddingResponse
+	if err := json.Unmarshal(respBody, &pResp); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal embedding response: %w", err)
+	}
+	return &core.EmbeddingResponse{
+		Object: pResp.Object,
+		Data:   pResp.Data,
+		Model:  pResp.Model,
+		Usage:  pResp.Usage,
+	}, nil
+}
+
+func normalizeEmbeddingInput(input interface{}) (interface{}, error) {
+	switch v := input.(type) {
+	case string:
+		return v, nil
+	case []string:
+		if len(v) == 0 {
+			return nil, fmt.Errorf("embed: Input must not be an empty array")
+		}
+		return v, nil
+	case []interface{}:
+		if len(v) == 0 {
+			return nil, fmt.Errorf("embed: Input must not be an empty array")
+		}
+		strs := make([]string, 0, len(v))
+		for i, item := range v {
+			s, ok := item.(string)
+			if !ok {
+				return nil, fmt.Errorf("embed: Input[%d] is %T, want string", i, item)
+			}
+			strs = append(strs, s)
+		}
+		return strs, nil
+	case nil:
+		return nil, fmt.Errorf("embed: Input must not be nil")
+	default:
+		return nil, fmt.Errorf("embed: unsupported Input type %T; want string or []string", input)
+	}
+}

--- a/providers/mistral/mistral.go
+++ b/providers/mistral/mistral.go
@@ -33,6 +33,7 @@ type Provider struct {
 var (
 	_ core.Provider          = (*Provider)(nil)
 	_ core.StreamProvider    = (*Provider)(nil)
+	_ core.EmbeddingProvider = (*Provider)(nil)
 	_ core.ProxiableProvider = (*Provider)(nil)
 )
 
@@ -68,6 +69,9 @@ func (p *Provider) SupportedModels() []string {
 		"mistral-small-latest",
 		"open-mistral-nemo",
 		"codestral-latest",
+		"mistral-embed",
+		"codestral-embed",
+		"codestral-embed-2505",
 	}
 }
 

--- a/providers/mistral/mistral_test.go
+++ b/providers/mistral/mistral_test.go
@@ -12,6 +12,8 @@ import (
 	"testing"
 )
 
+const testEmbeddingModel = "mistral-embed"
+
 func TestNewMistral(t *testing.T) {
 	p, err := New("test-key", "")
 	if err != nil {
@@ -113,16 +115,16 @@ func TestMistralProvider_SupportedModels_Embeddings(t *testing.T) {
 	models := p.SupportedModels()
 	found := false
 	for _, m := range models {
-		if m == "mistral-embed" {
+		if m == testEmbeddingModel {
 			found = true
 			break
 		}
 	}
 	if !found {
-		t.Fatalf("embedding model %q not found in SupportedModels()", "mistral-embed")
+		t.Fatalf("embedding model %q not found in SupportedModels()", testEmbeddingModel)
 	}
-	if !p.SupportsModel("mistral-embed") {
-		t.Fatalf("SupportsModel(%q) = false, want true", "mistral-embed")
+	if !p.SupportsModel(testEmbeddingModel) {
+		t.Fatalf("SupportsModel(%q) = false, want true", testEmbeddingModel)
 	}
 }
 
@@ -156,7 +158,7 @@ func TestMistralProvider_Embed_InvalidInput(t *testing.T) {
 	for _, tc := range badInputs {
 		t.Run(tc.name, func(t *testing.T) {
 			_, err := p.Embed(context.Background(), core.EmbeddingRequest{
-				Model: "mistral-embed",
+				Model: testEmbeddingModel,
 				Input: tc.input,
 			})
 			if err == nil {
@@ -182,7 +184,7 @@ func TestMistralProvider_Embed_UpstreamError(t *testing.T) {
 
 	p, _ := New("test-key", srv.URL)
 	_, err := p.Embed(context.Background(), core.EmbeddingRequest{
-		Model: "mistral-embed",
+		Model: testEmbeddingModel,
 		Input: "hello",
 	})
 	if err == nil {
@@ -214,20 +216,20 @@ func testMistralEmbedSuccess(t *testing.T, input interface{}) {
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 			t.Fatalf("failed to decode request body: %v", err)
 		}
-		if got := body["model"]; got != "mistral-embed" {
-			t.Errorf("model = %v, want mistral-embed", got)
+		if got := body["model"]; got != testEmbeddingModel {
+			t.Errorf("model = %v, want %s", got, testEmbeddingModel)
 		}
 		assertMistralEmbeddingInput(t, body["input"], input)
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`{"object":"list","data":[{"object":"embedding","embedding":[0.1,0.2],"index":0},{"object":"embedding","embedding":[0.3,0.4],"index":1}],"model":"mistral-embed","usage":{"prompt_tokens":3,"total_tokens":3}}`))
+		_, _ = w.Write([]byte(`{"object":"list","data":[{"object":"embedding","embedding":[0.1,0.2],"index":0},{"object":"embedding","embedding":[0.3,0.4],"index":1}],"model":"` + testEmbeddingModel + `","usage":{"prompt_tokens":3,"total_tokens":3}}`))
 	}))
 	defer srv.Close()
 
 	p, _ := New("test-key", srv.URL)
 	resp, err := p.Embed(context.Background(), core.EmbeddingRequest{
-		Model: "mistral-embed",
+		Model: testEmbeddingModel,
 		Input: input,
 	})
 	if err != nil {
@@ -236,8 +238,8 @@ func testMistralEmbedSuccess(t *testing.T, input interface{}) {
 	if resp.Object != "list" {
 		t.Errorf("Object = %q, want list", resp.Object)
 	}
-	if resp.Model != "mistral-embed" {
-		t.Errorf("Model = %q, want mistral-embed", resp.Model)
+	if resp.Model != testEmbeddingModel {
+		t.Errorf("Model = %q, want %s", resp.Model, testEmbeddingModel)
 	}
 	if len(resp.Data) != 2 {
 		t.Fatalf("Data length = %d, want 2", len(resp.Data))

--- a/providers/mistral/mistral_test.go
+++ b/providers/mistral/mistral_test.go
@@ -2,9 +2,13 @@ package mistral
 
 import (
 	"context"
+	"encoding/json"
 	"github.com/ferro-labs/ai-gateway/providers/core"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
+	"strings"
+	"sync/atomic"
 	"testing"
 )
 
@@ -96,5 +100,181 @@ func TestMistralProvider_CompleteStream_MockSSE(t *testing.T) {
 	}
 	if chunks[2].Choices[0].Delta.Content != " there" {
 		t.Errorf("delta content = %q, want ' there'", chunks[2].Choices[0].Delta.Content)
+	}
+}
+
+func TestMistralProvider_Embed_Interface(_ *testing.T) {
+	p, _ := New("test-key", "")
+	var _ core.EmbeddingProvider = p
+}
+
+func TestMistralProvider_SupportedModels_Embeddings(t *testing.T) {
+	p, _ := New("test-key", "")
+	models := p.SupportedModels()
+	found := false
+	for _, m := range models {
+		if m == "mistral-embed" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("embedding model %q not found in SupportedModels()", "mistral-embed")
+	}
+	if !p.SupportsModel("mistral-embed") {
+		t.Fatalf("SupportsModel(%q) = false, want true", "mistral-embed")
+	}
+}
+
+func TestMistralProvider_Embed_StringInput_MockHTTP(t *testing.T) {
+	testMistralEmbedSuccess(t, "hello world")
+}
+
+func TestMistralProvider_Embed_StringSliceInput_MockHTTP(t *testing.T) {
+	testMistralEmbedSuccess(t, []string{"hello", "world"})
+}
+
+func TestMistralProvider_Embed_InvalidInput(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	p, _ := New("test-key", srv.URL)
+	badInputs := []struct {
+		name  string
+		input interface{}
+	}{
+		{"nil", nil},
+		{"integer", 42},
+		{"empty-string-slice", []string{}},
+		{"empty-interface-slice", []interface{}{}},
+		{"non-string-array-member", []interface{}{"ok", 42}},
+	}
+	for _, tc := range badInputs {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := p.Embed(context.Background(), core.EmbeddingRequest{
+				Model: "mistral-embed",
+				Input: tc.input,
+			})
+			if err == nil {
+				t.Fatalf("Embed() error = nil, want error")
+			}
+		})
+	}
+	if got := atomic.LoadInt32(&calls); got != 0 {
+		t.Fatalf("upstream calls = %d, want 0", got)
+	}
+}
+
+func TestMistralProvider_Embed_UpstreamError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/embeddings" {
+			t.Errorf("path = %q, want /v1/embeddings", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"error":{"message":"rate limited","type":"rate_limit"}}`))
+	}))
+	defer srv.Close()
+
+	p, _ := New("test-key", srv.URL)
+	_, err := p.Embed(context.Background(), core.EmbeddingRequest{
+		Model: "mistral-embed",
+		Input: "hello",
+	})
+	if err == nil {
+		t.Fatal("Embed() error = nil, want upstream error")
+	}
+	if !strings.Contains(err.Error(), "rate limited") {
+		t.Fatalf("error = %v, want rate limited message", err)
+	}
+}
+
+func testMistralEmbedSuccess(t *testing.T, input interface{}) {
+	t.Helper()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+		if r.URL.Path != "/v1/embeddings" {
+			t.Errorf("path = %q, want /v1/embeddings", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-key" {
+			t.Errorf("Authorization = %q, want Bearer test-key", got)
+		}
+		if got := r.Header.Get("Content-Type"); got != "application/json" {
+			t.Errorf("Content-Type = %q, want application/json", got)
+		}
+
+		var body map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode request body: %v", err)
+		}
+		if got := body["model"]; got != "mistral-embed" {
+			t.Errorf("model = %v, want mistral-embed", got)
+		}
+		assertMistralEmbeddingInput(t, body["input"], input)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"object":"list","data":[{"object":"embedding","embedding":[0.1,0.2],"index":0},{"object":"embedding","embedding":[0.3,0.4],"index":1}],"model":"mistral-embed","usage":{"prompt_tokens":3,"total_tokens":3}}`))
+	}))
+	defer srv.Close()
+
+	p, _ := New("test-key", srv.URL)
+	resp, err := p.Embed(context.Background(), core.EmbeddingRequest{
+		Model: "mistral-embed",
+		Input: input,
+	})
+	if err != nil {
+		t.Fatalf("Embed() error: %v", err)
+	}
+	if resp.Object != "list" {
+		t.Errorf("Object = %q, want list", resp.Object)
+	}
+	if resp.Model != "mistral-embed" {
+		t.Errorf("Model = %q, want mistral-embed", resp.Model)
+	}
+	if len(resp.Data) != 2 {
+		t.Fatalf("Data length = %d, want 2", len(resp.Data))
+	}
+	if resp.Data[0].Object != "embedding" || resp.Data[0].Index != 0 || !reflect.DeepEqual(resp.Data[0].Embedding, []float64{0.1, 0.2}) {
+		t.Errorf("Data[0] = %+v, want mapped embedding at index 0", resp.Data[0])
+	}
+	if resp.Data[1].Index != 1 || !reflect.DeepEqual(resp.Data[1].Embedding, []float64{0.3, 0.4}) {
+		t.Errorf("Data[1] = %+v, want mapped embedding at index 1", resp.Data[1])
+	}
+	if resp.Usage.PromptTokens != 3 || resp.Usage.TotalTokens != 3 {
+		t.Errorf("Usage = %+v, want prompt=3 total=3", resp.Usage)
+	}
+}
+
+func assertMistralEmbeddingInput(t *testing.T, got interface{}, want interface{}) {
+	t.Helper()
+
+	switch w := want.(type) {
+	case string:
+		if got != w {
+			t.Fatalf("input = %#v, want %q", got, w)
+		}
+	case []string:
+		arr, ok := got.([]interface{})
+		if !ok {
+			t.Fatalf("input type = %T, want JSON array", got)
+		}
+		if len(arr) != len(w) {
+			t.Fatalf("input length = %d, want %d", len(arr), len(w))
+		}
+		for i := range w {
+			if arr[i] != w[i] {
+				t.Fatalf("input[%d] = %#v, want %q", i, arr[i], w[i])
+			}
+		}
+	default:
+		t.Fatalf("unsupported test input type %T", want)
 	}
 }

--- a/providers/names.go
+++ b/providers/names.go
@@ -21,6 +21,7 @@ import (
 	novitapkg "github.com/ferro-labs/ai-gateway/providers/novita"
 	nvidianimpkg "github.com/ferro-labs/ai-gateway/providers/nvidia_nim"
 	ollamapkg "github.com/ferro-labs/ai-gateway/providers/ollama"
+	ollamacloudpkg "github.com/ferro-labs/ai-gateway/providers/ollama_cloud"
 	openaipkg "github.com/ferro-labs/ai-gateway/providers/openai"
 	openrouterpkg "github.com/ferro-labs/ai-gateway/providers/openrouter"
 	perplexitypkg "github.com/ferro-labs/ai-gateway/providers/perplexity"
@@ -108,6 +109,9 @@ const (
 	// NameOllama is the canonical name for the Ollama (local) provider.
 	NameOllama = ollamapkg.Name
 
+	// NameOllamaCloud is the canonical name for the Ollama Cloud provider.
+	NameOllamaCloud = ollamacloudpkg.Name
+
 	// NameDatabricks is the canonical name for the Databricks provider.
 	NameDatabricks = databrickspkg.Name
 
@@ -161,6 +165,7 @@ func AllProviderNames() []string {
 		NameNovita,
 		NameNVIDIANIM,
 		NameOllama,
+		NameOllamaCloud,
 		NameOpenAI,
 		NameOpenRouter,
 		NamePerplexity,

--- a/providers/novita/embedding.go
+++ b/providers/novita/embedding.go
@@ -1,0 +1,115 @@
+package novita
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/ferro-labs/ai-gateway/providers/core"
+)
+
+type embeddingRequest struct {
+	Model          string      `json:"model"`
+	Input          interface{} `json:"input"`
+	EncodingFormat string      `json:"encoding_format,omitempty"`
+	Dimensions     *int        `json:"dimensions,omitempty"`
+	User           string      `json:"user,omitempty"`
+}
+
+type embeddingResponse struct {
+	Object string              `json:"object"`
+	Data   []core.Embedding    `json:"data"`
+	Model  string              `json:"model"`
+	Usage  core.EmbeddingUsage `json:"usage"`
+}
+
+// Embed sends an OpenAI-compatible embedding request to Novita.
+func (p *Provider) Embed(ctx context.Context, req core.EmbeddingRequest) (*core.EmbeddingResponse, error) {
+	input, err := normalizeEmbeddingInput(req.Input)
+	if err != nil {
+		return nil, err
+	}
+	if req.EncodingFormat != "" && req.EncodingFormat != "float" {
+		return nil, fmt.Errorf("embed: unsupported encoding_format %q; valid value is \"float\"", req.EncodingFormat)
+	}
+
+	pReq := embeddingRequest{
+		Model:          req.Model,
+		Input:          input,
+		EncodingFormat: req.EncodingFormat,
+		Dimensions:     req.Dimensions,
+		User:           req.User,
+	}
+	bodyReader, _, release, err := core.JSONBodyReader(pReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal embedding request: %w", err)
+	}
+	defer release()
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, p.baseURL+"/embeddings", bodyReader)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	httpReq.Header.Set("Authorization", "Bearer "+p.apiKey)
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	httpResp, err := p.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer func() { _ = httpResp.Body.Close() }()
+
+	respBody, err := io.ReadAll(httpResp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+	if httpResp.StatusCode < http.StatusOK || httpResp.StatusCode >= http.StatusMultipleChoices {
+		var errResp errorResponse
+		if json.Unmarshal(respBody, &errResp) == nil && errResp.Error.Message != "" {
+			return nil, fmt.Errorf("novita API error (%d): %s", httpResp.StatusCode, errResp.Error.Message)
+		}
+		return nil, fmt.Errorf("novita API error (%d): %s", httpResp.StatusCode, string(respBody))
+	}
+
+	var pResp embeddingResponse
+	if err := json.Unmarshal(respBody, &pResp); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal embedding response: %w", err)
+	}
+	return &core.EmbeddingResponse{
+		Object: pResp.Object,
+		Data:   pResp.Data,
+		Model:  pResp.Model,
+		Usage:  pResp.Usage,
+	}, nil
+}
+
+func normalizeEmbeddingInput(input interface{}) (interface{}, error) {
+	switch v := input.(type) {
+	case string:
+		return v, nil
+	case []string:
+		if len(v) == 0 {
+			return nil, fmt.Errorf("embed: Input must not be an empty array")
+		}
+		return v, nil
+	case []interface{}:
+		if len(v) == 0 {
+			return nil, fmt.Errorf("embed: Input must not be an empty array")
+		}
+		strs := make([]string, 0, len(v))
+		for i, item := range v {
+			s, ok := item.(string)
+			if !ok {
+				return nil, fmt.Errorf("embed: Input[%d] is %T, want string", i, item)
+			}
+			strs = append(strs, s)
+		}
+		return strs, nil
+	case nil:
+		return nil, fmt.Errorf("embed: Input must not be nil")
+	default:
+		return nil, fmt.Errorf("embed: unsupported Input type %T; want string or []string", input)
+	}
+}

--- a/providers/novita/novita.go
+++ b/providers/novita/novita.go
@@ -34,6 +34,7 @@ type Provider struct {
 var (
 	_ core.Provider          = (*Provider)(nil)
 	_ core.StreamProvider    = (*Provider)(nil)
+	_ core.EmbeddingProvider = (*Provider)(nil)
 	_ core.DiscoveryProvider = (*Provider)(nil)
 	_ core.ProxiableProvider = (*Provider)(nil)
 )
@@ -71,6 +72,9 @@ func (p *Provider) SupportedModels() []string {
 		"minimax/minimax-m2.1",
 		"qwen/qwen3-vl-235b-a22b-thinking",
 		"zai-org/glm-4.7",
+		"baai/bge-m3",
+		"qwen/qwen3-embedding-0.6b",
+		"qwen/qwen3-embedding-8b",
 	}
 }
 

--- a/providers/novita/novita_test.go
+++ b/providers/novita/novita_test.go
@@ -13,7 +13,10 @@ import (
 	"github.com/ferro-labs/ai-gateway/providers/core"
 )
 
-const testBearerAPIKey = "Bearer test-key"
+const (
+	testBearerAPIKey   = "Bearer test-key"
+	testEmbeddingModel = "baai/bge-m3"
+)
 
 func TestNewNovita(t *testing.T) {
 	p, err := New("test-key", "")
@@ -150,16 +153,16 @@ func TestNovitaProvider_SupportedModels_Embeddings(t *testing.T) {
 	models := p.SupportedModels()
 	found := false
 	for _, m := range models {
-		if m == "baai/bge-m3" {
+		if m == testEmbeddingModel {
 			found = true
 			break
 		}
 	}
 	if !found {
-		t.Fatalf("embedding model %q not found in SupportedModels()", "baai/bge-m3")
+		t.Fatalf("embedding model %q not found in SupportedModels()", testEmbeddingModel)
 	}
-	if !p.SupportsModel("baai/bge-m3") {
-		t.Fatalf("SupportsModel(%q) = false, want true", "baai/bge-m3")
+	if !p.SupportsModel(testEmbeddingModel) {
+		t.Fatalf("SupportsModel(%q) = false, want true", testEmbeddingModel)
 	}
 }
 
@@ -193,7 +196,7 @@ func TestNovitaProvider_Embed_InvalidInput(t *testing.T) {
 	for _, tc := range badInputs {
 		t.Run(tc.name, func(t *testing.T) {
 			_, err := p.Embed(context.Background(), core.EmbeddingRequest{
-				Model: "baai/bge-m3",
+				Model: testEmbeddingModel,
 				Input: tc.input,
 			})
 			if err == nil {
@@ -219,7 +222,7 @@ func TestNovitaProvider_Embed_UpstreamError(t *testing.T) {
 
 	p, _ := New("test-key", srv.URL)
 	_, err := p.Embed(context.Background(), core.EmbeddingRequest{
-		Model: "baai/bge-m3",
+		Model: testEmbeddingModel,
 		Input: "hello",
 	})
 	if err == nil {
@@ -251,20 +254,20 @@ func testNovitaEmbedSuccess(t *testing.T, input interface{}) {
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 			t.Fatalf("failed to decode request body: %v", err)
 		}
-		if got := body["model"]; got != "baai/bge-m3" {
-			t.Errorf("model = %v, want baai/bge-m3", got)
+		if got := body["model"]; got != testEmbeddingModel {
+			t.Errorf("model = %v, want %s", got, testEmbeddingModel)
 		}
 		assertNovitaEmbeddingInput(t, body["input"], input)
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`{"object":"list","data":[{"object":"embedding","embedding":[0.1,0.2],"index":0},{"object":"embedding","embedding":[0.3,0.4],"index":1}],"model":"baai/bge-m3","usage":{"prompt_tokens":3,"total_tokens":3}}`))
+		_, _ = w.Write([]byte(`{"object":"list","data":[{"object":"embedding","embedding":[0.1,0.2],"index":0},{"object":"embedding","embedding":[0.3,0.4],"index":1}],"model":"` + testEmbeddingModel + `","usage":{"prompt_tokens":3,"total_tokens":3}}`))
 	}))
 	defer srv.Close()
 
 	p, _ := New("test-key", srv.URL)
 	resp, err := p.Embed(context.Background(), core.EmbeddingRequest{
-		Model: "baai/bge-m3",
+		Model: testEmbeddingModel,
 		Input: input,
 	})
 	if err != nil {
@@ -273,8 +276,8 @@ func testNovitaEmbedSuccess(t *testing.T, input interface{}) {
 	if resp.Object != "list" {
 		t.Errorf("Object = %q, want list", resp.Object)
 	}
-	if resp.Model != "baai/bge-m3" {
-		t.Errorf("Model = %q, want baai/bge-m3", resp.Model)
+	if resp.Model != testEmbeddingModel {
+		t.Errorf("Model = %q, want %s", resp.Model, testEmbeddingModel)
 	}
 	if len(resp.Data) != 2 {
 		t.Fatalf("Data length = %d, want 2", len(resp.Data))

--- a/providers/novita/novita_test.go
+++ b/providers/novita/novita_test.go
@@ -2,8 +2,12 @@ package novita
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
+	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/ferro-labs/ai-gateway/providers/core"
@@ -133,5 +137,181 @@ func TestNovitaProvider_Complete_MockHTTP(t *testing.T) {
 	}
 	if len(resp.Choices) == 0 {
 		t.Error("expected at least one choice")
+	}
+}
+
+func TestNovitaProvider_Embed_Interface(_ *testing.T) {
+	p, _ := New("test-key", "")
+	var _ core.EmbeddingProvider = p
+}
+
+func TestNovitaProvider_SupportedModels_Embeddings(t *testing.T) {
+	p, _ := New("test-key", "")
+	models := p.SupportedModels()
+	found := false
+	for _, m := range models {
+		if m == "baai/bge-m3" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("embedding model %q not found in SupportedModels()", "baai/bge-m3")
+	}
+	if !p.SupportsModel("baai/bge-m3") {
+		t.Fatalf("SupportsModel(%q) = false, want true", "baai/bge-m3")
+	}
+}
+
+func TestNovitaProvider_Embed_StringInput_MockHTTP(t *testing.T) {
+	testNovitaEmbedSuccess(t, "hello world")
+}
+
+func TestNovitaProvider_Embed_StringSliceInput_MockHTTP(t *testing.T) {
+	testNovitaEmbedSuccess(t, []string{"hello", "world"})
+}
+
+func TestNovitaProvider_Embed_InvalidInput(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	p, _ := New("test-key", srv.URL)
+	badInputs := []struct {
+		name  string
+		input interface{}
+	}{
+		{"nil", nil},
+		{"integer", 42},
+		{"empty-string-slice", []string{}},
+		{"empty-interface-slice", []interface{}{}},
+		{"non-string-array-member", []interface{}{"ok", 42}},
+	}
+	for _, tc := range badInputs {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := p.Embed(context.Background(), core.EmbeddingRequest{
+				Model: "baai/bge-m3",
+				Input: tc.input,
+			})
+			if err == nil {
+				t.Fatalf("Embed() error = nil, want error")
+			}
+		})
+	}
+	if got := atomic.LoadInt32(&calls); got != 0 {
+		t.Fatalf("upstream calls = %d, want 0", got)
+	}
+}
+
+func TestNovitaProvider_Embed_UpstreamError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/embeddings" {
+			t.Errorf("path = %q, want /embeddings", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"error":{"message":"rate limited","type":"rate_limit"}}`))
+	}))
+	defer srv.Close()
+
+	p, _ := New("test-key", srv.URL)
+	_, err := p.Embed(context.Background(), core.EmbeddingRequest{
+		Model: "baai/bge-m3",
+		Input: "hello",
+	})
+	if err == nil {
+		t.Fatal("Embed() error = nil, want upstream error")
+	}
+	if !strings.Contains(err.Error(), "rate limited") {
+		t.Fatalf("error = %v, want rate limited message", err)
+	}
+}
+
+func testNovitaEmbedSuccess(t *testing.T, input interface{}) {
+	t.Helper()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+		if r.URL.Path != "/embeddings" {
+			t.Errorf("path = %q, want /embeddings", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-key" {
+			t.Errorf("Authorization = %q, want Bearer test-key", got)
+		}
+		if got := r.Header.Get("Content-Type"); got != "application/json" {
+			t.Errorf("Content-Type = %q, want application/json", got)
+		}
+
+		var body map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode request body: %v", err)
+		}
+		if got := body["model"]; got != "baai/bge-m3" {
+			t.Errorf("model = %v, want baai/bge-m3", got)
+		}
+		assertNovitaEmbeddingInput(t, body["input"], input)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"object":"list","data":[{"object":"embedding","embedding":[0.1,0.2],"index":0},{"object":"embedding","embedding":[0.3,0.4],"index":1}],"model":"baai/bge-m3","usage":{"prompt_tokens":3,"total_tokens":3}}`))
+	}))
+	defer srv.Close()
+
+	p, _ := New("test-key", srv.URL)
+	resp, err := p.Embed(context.Background(), core.EmbeddingRequest{
+		Model: "baai/bge-m3",
+		Input: input,
+	})
+	if err != nil {
+		t.Fatalf("Embed() error: %v", err)
+	}
+	if resp.Object != "list" {
+		t.Errorf("Object = %q, want list", resp.Object)
+	}
+	if resp.Model != "baai/bge-m3" {
+		t.Errorf("Model = %q, want baai/bge-m3", resp.Model)
+	}
+	if len(resp.Data) != 2 {
+		t.Fatalf("Data length = %d, want 2", len(resp.Data))
+	}
+	if resp.Data[0].Object != "embedding" || resp.Data[0].Index != 0 || !reflect.DeepEqual(resp.Data[0].Embedding, []float64{0.1, 0.2}) {
+		t.Errorf("Data[0] = %+v, want mapped embedding at index 0", resp.Data[0])
+	}
+	if resp.Data[1].Index != 1 || !reflect.DeepEqual(resp.Data[1].Embedding, []float64{0.3, 0.4}) {
+		t.Errorf("Data[1] = %+v, want mapped embedding at index 1", resp.Data[1])
+	}
+	if resp.Usage.PromptTokens != 3 || resp.Usage.TotalTokens != 3 {
+		t.Errorf("Usage = %+v, want prompt=3 total=3", resp.Usage)
+	}
+}
+
+func assertNovitaEmbeddingInput(t *testing.T, got interface{}, want interface{}) {
+	t.Helper()
+
+	switch w := want.(type) {
+	case string:
+		if got != w {
+			t.Fatalf("input = %#v, want %q", got, w)
+		}
+	case []string:
+		arr, ok := got.([]interface{})
+		if !ok {
+			t.Fatalf("input type = %T, want JSON array", got)
+		}
+		if len(arr) != len(w) {
+			t.Fatalf("input length = %d, want %d", len(arr), len(w))
+		}
+		for i := range w {
+			if arr[i] != w[i] {
+				t.Fatalf("input[%d] = %#v, want %q", i, arr[i], w[i])
+			}
+		}
+	default:
+		t.Fatalf("unsupported test input type %T", want)
 	}
 }

--- a/providers/ollama_cloud/ollama_cloud.go
+++ b/providers/ollama_cloud/ollama_cloud.go
@@ -1,0 +1,551 @@
+// Package ollama_cloud provides a client for the Ollama Cloud API.
+package ollama_cloud
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	providerhttp "github.com/ferro-labs/ai-gateway/internal/httpclient"
+	"github.com/ferro-labs/ai-gateway/providers/core"
+)
+
+const (
+	// Name is the canonical provider identifier.
+	Name           = "ollama-cloud"
+	defaultBaseURL = "https://ollama.com"
+)
+
+var defaultModels = []string{
+	"gpt-oss:120b",
+	"gpt-oss:20b",
+	"qwen3-coder:480b",
+	"deepseek-v3.1:671b",
+}
+
+// Provider implements the Ollama Cloud API client.
+type Provider struct {
+	name       string
+	apiKey     string
+	baseURL    string
+	httpClient *http.Client
+
+	mu         sync.RWMutex
+	models     []string
+	discovered []string
+}
+
+// Compile-time interface assertions.
+var (
+	_ core.Provider          = (*Provider)(nil)
+	_ core.StreamProvider    = (*Provider)(nil)
+	_ core.DiscoveryProvider = (*Provider)(nil)
+)
+
+// New creates a new Ollama Cloud provider.
+func New(apiKey, baseURL string, models []string) (*Provider, error) {
+	apiKey = strings.TrimSpace(apiKey)
+	if apiKey == "" {
+		return nil, fmt.Errorf("ollama-cloud: api key is required")
+	}
+
+	baseURL = strings.TrimSpace(baseURL)
+	if baseURL == "" {
+		baseURL = defaultBaseURL
+	}
+	baseURL = strings.TrimRight(baseURL, "/")
+	u, err := url.Parse(baseURL)
+	if err != nil || (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
+		return nil, fmt.Errorf("ollama-cloud: invalid base URL %q: must be http or https with a host", baseURL)
+	}
+
+	models = normalizeModels(models)
+	if len(models) == 0 {
+		models = append([]string(nil), defaultModels...)
+	}
+
+	return &Provider{
+		name:       Name,
+		apiKey:     apiKey,
+		baseURL:    baseURL,
+		httpClient: providerhttp.ForProvider(Name),
+		models:     models,
+	}, nil
+}
+
+// Name implements core.Provider.
+func (p *Provider) Name() string { return p.name }
+
+// SupportedModels returns the configured and discovered models.
+func (p *Provider) SupportedModels() []string {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return combineModels(p.models, p.discovered)
+}
+
+// SupportsModel returns true if model is configured or has been discovered.
+func (p *Provider) SupportsModel(model string) bool {
+	model = strings.TrimSpace(model)
+	model = strings.TrimPrefix(model, Name+"/")
+	if model == "" {
+		return false
+	}
+
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	for _, supported := range combineModels(p.models, p.discovered) {
+		if model == supported {
+			return true
+		}
+	}
+	return false
+}
+
+// Models returns structured model metadata.
+func (p *Provider) Models() []core.ModelInfo {
+	return core.ModelsFromList(p.name, p.SupportedModels())
+}
+
+// Complete sends a non-streaming chat request to Ollama Cloud.
+func (p *Provider) Complete(ctx context.Context, req core.Request) (*core.Response, error) {
+	apiReq := buildChatRequest(req, false)
+	bodyReader, _, release, err := core.JSONBodyReader(apiReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+	defer release()
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, p.baseURL+"/api/chat", bodyReader)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	p.setHeaders(httpReq)
+
+	httpResp, err := p.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer func() { _ = httpResp.Body.Close() }()
+
+	respBody, err := io.ReadAll(httpResp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+	if httpResp.StatusCode != http.StatusOK {
+		return nil, apiError(httpResp.StatusCode, respBody)
+	}
+
+	var apiResp chatResponse
+	if err := json.Unmarshal(respBody, &apiResp); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
+	}
+	if apiResp.Error != "" {
+		return nil, fmt.Errorf("ollama-cloud API error: %s", apiResp.Error)
+	}
+
+	return &core.Response{
+		Object:   "chat.completion",
+		Created:  parseCreatedAt(apiResp.CreatedAt),
+		Model:    apiResp.Model,
+		Provider: p.name,
+		Choices: []core.Choice{
+			{
+				Index:        0,
+				Message:      apiResp.Message.toCore(),
+				FinishReason: apiResp.DoneReason,
+			},
+		},
+		Usage: usageFromCounts(apiResp.PromptEvalCount, apiResp.EvalCount),
+	}, nil
+}
+
+// CompleteStream sends a streaming chat request to Ollama Cloud.
+func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan core.StreamChunk, error) {
+	apiReq := buildChatRequest(req, true)
+	bodyReader, _, release, err := core.JSONBodyReader(apiReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+	defer release()
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, p.baseURL+"/api/chat", bodyReader)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	p.setHeaders(httpReq)
+
+	httpResp, err := p.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+
+	if httpResp.StatusCode != http.StatusOK {
+		defer func() { _ = httpResp.Body.Close() }()
+		respBody, _ := io.ReadAll(httpResp.Body)
+		return nil, apiError(httpResp.StatusCode, respBody)
+	}
+
+	ch := make(chan core.StreamChunk)
+	go func() {
+		defer close(ch)
+		defer func() { _ = httpResp.Body.Close() }()
+
+		scanner := bufio.NewScanner(httpResp.Body)
+		scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+		for scanner.Scan() {
+			line := strings.TrimSpace(scanner.Text())
+			if line == "" {
+				continue
+			}
+
+			var apiResp chatResponse
+			if err := json.Unmarshal([]byte(line), &apiResp); err != nil {
+				ch <- core.StreamChunk{Error: fmt.Errorf("failed to unmarshal stream chunk: %w", err)}
+				return
+			}
+			if apiResp.Error != "" {
+				ch <- core.StreamChunk{Error: fmt.Errorf("ollama-cloud API error: %s", apiResp.Error)}
+				return
+			}
+
+			ch <- streamChunkFromResponse(apiResp)
+		}
+		if err := scanner.Err(); err != nil {
+			ch <- core.StreamChunk{Error: err}
+		}
+	}()
+
+	return ch, nil
+}
+
+// DiscoverModels fetches the live Ollama Cloud model list.
+func (p *Provider) DiscoverModels(ctx context.Context) ([]core.ModelInfo, error) {
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, p.baseURL+"/api/tags", nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	httpReq.Header.Set("Authorization", "Bearer "+p.apiKey)
+
+	httpResp, err := p.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer func() { _ = httpResp.Body.Close() }()
+
+	respBody, err := io.ReadAll(httpResp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+	if httpResp.StatusCode != http.StatusOK {
+		return nil, apiError(httpResp.StatusCode, respBody)
+	}
+
+	var tags tagsResponse
+	if err := json.Unmarshal(respBody, &tags); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal models response: %w", err)
+	}
+
+	seen := make(map[string]struct{}, len(tags.Models))
+	modelIDs := make([]string, 0, len(tags.Models))
+	models := make([]core.ModelInfo, 0, len(tags.Models))
+	for _, m := range tags.Models {
+		id := strings.TrimSpace(m.Name)
+		if id == "" {
+			id = strings.TrimSpace(m.Model)
+		}
+		if id == "" {
+			continue
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		modelIDs = append(modelIDs, id)
+		models = append(models, core.ModelInfo{
+			ID:      id,
+			Object:  "model",
+			Created: parseCreatedAt(m.ModifiedAt),
+			OwnedBy: p.name,
+		})
+	}
+
+	p.mu.Lock()
+	p.discovered = modelIDs
+	p.mu.Unlock()
+
+	return models, nil
+}
+
+func (p *Provider) setHeaders(req *http.Request) {
+	req.Header.Set("Authorization", "Bearer "+p.apiKey)
+	req.Header.Set("Content-Type", "application/json")
+}
+
+type chatRequest struct {
+	Model    string         `json:"model"`
+	Messages []core.Message `json:"messages"`
+	Stream   bool           `json:"stream"`
+	Options  *chatOptions   `json:"options,omitempty"`
+	Tools    []core.Tool    `json:"tools,omitempty"`
+}
+
+type chatOptions struct {
+	Temperature *float64 `json:"temperature,omitempty"`
+	TopP        *float64 `json:"top_p,omitempty"`
+	NumPredict  *int     `json:"num_predict,omitempty"`
+}
+
+type chatResponse struct {
+	Model           string        `json:"model"`
+	CreatedAt       string        `json:"created_at"`
+	Message         nativeMessage `json:"message"`
+	Done            bool          `json:"done"`
+	DoneReason      string        `json:"done_reason"`
+	PromptEvalCount *int          `json:"prompt_eval_count"`
+	EvalCount       *int          `json:"eval_count"`
+	Error           string        `json:"error"`
+}
+
+type nativeMessage struct {
+	Role      string           `json:"role,omitempty"`
+	Content   string           `json:"content,omitempty"`
+	ToolCalls []nativeToolCall `json:"tool_calls,omitempty"`
+}
+
+type nativeToolCall struct {
+	ID       string             `json:"id,omitempty"`
+	Type     string             `json:"type,omitempty"`
+	Function nativeFunctionCall `json:"function"`
+}
+
+type nativeFunctionCall struct {
+	Name      string          `json:"name"`
+	Arguments json.RawMessage `json:"arguments,omitempty"`
+}
+
+type tagsResponse struct {
+	Models []struct {
+		Name       string `json:"name"`
+		Model      string `json:"model"`
+		ModifiedAt string `json:"modified_at"`
+	} `json:"models"`
+}
+
+func buildChatRequest(req core.Request, stream bool) chatRequest {
+	var maxTokens *int
+	if req.MaxCompletionTokens != nil {
+		maxTokens = req.MaxCompletionTokens
+	} else {
+		maxTokens = req.MaxTokens
+	}
+
+	var options *chatOptions
+	if req.Temperature != nil || req.TopP != nil || maxTokens != nil {
+		options = &chatOptions{
+			Temperature: req.Temperature,
+			TopP:        req.TopP,
+			NumPredict:  maxTokens,
+		}
+	}
+
+	return chatRequest{
+		Model:    req.Model,
+		Messages: req.Messages,
+		Stream:   stream,
+		Options:  options,
+		Tools:    req.Tools,
+	}
+}
+
+func streamChunkFromResponse(apiResp chatResponse) core.StreamChunk {
+	chunk := core.StreamChunk{
+		Object:  "chat.completion.chunk",
+		Created: parseCreatedAt(apiResp.CreatedAt),
+		Model:   apiResp.Model,
+	}
+	choice := core.StreamChoice{
+		Index: 0,
+		Delta: core.MessageDelta{
+			Role:      apiResp.Message.Role,
+			Content:   apiResp.Message.Content,
+			ToolCalls: apiResp.Message.toCore().ToolCalls,
+		},
+		FinishReason: apiResp.DoneReason,
+	}
+	if apiResp.Message.Role != "" || apiResp.Message.Content != "" || len(apiResp.Message.ToolCalls) > 0 || apiResp.Done || apiResp.DoneReason != "" {
+		chunk.Choices = append(chunk.Choices, choice)
+	}
+	if apiResp.PromptEvalCount != nil || apiResp.EvalCount != nil {
+		usage := usageFromCounts(apiResp.PromptEvalCount, apiResp.EvalCount)
+		chunk.Usage = &usage
+	}
+	return chunk
+}
+
+func (m nativeMessage) toCore() core.Message {
+	msg := core.Message{
+		Role:    m.Role,
+		Content: m.Content,
+	}
+	if len(m.ToolCalls) == 0 {
+		return msg
+	}
+
+	msg.ToolCalls = make([]core.ToolCall, 0, len(m.ToolCalls))
+	for _, tc := range m.ToolCalls {
+		callType := tc.Type
+		if callType == "" {
+			callType = "function"
+		}
+		msg.ToolCalls = append(msg.ToolCalls, core.ToolCall{
+			ID:   tc.ID,
+			Type: callType,
+			Function: core.FunctionCall{
+				Name:      tc.Function.Name,
+				Arguments: rawArgumentsString(tc.Function.Arguments),
+			},
+		})
+	}
+	return msg
+}
+
+func usageFromCounts(promptEvalCount, evalCount *int) core.Usage {
+	usage := core.Usage{}
+	if promptEvalCount != nil {
+		usage.PromptTokens = *promptEvalCount
+	}
+	if evalCount != nil {
+		usage.CompletionTokens = *evalCount
+	}
+	usage.TotalTokens = usage.PromptTokens + usage.CompletionTokens
+	return usage
+}
+
+func parseCreatedAt(value string) int64 {
+	if value == "" {
+		return 0
+	}
+	t, err := time.Parse(time.RFC3339Nano, value)
+	if err != nil {
+		return 0
+	}
+	return t.Unix()
+}
+
+func rawArgumentsString(raw json.RawMessage) string {
+	if len(raw) == 0 || string(raw) == "null" {
+		return ""
+	}
+
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		return s
+	}
+
+	var compacted bytes.Buffer
+	if err := json.Compact(&compacted, raw); err == nil {
+		return compacted.String()
+	}
+	return string(raw)
+}
+
+func apiError(statusCode int, body []byte) error {
+	msg := parseErrorMessage(body)
+	if msg == "" {
+		msg = http.StatusText(statusCode)
+	}
+	if msg == "" {
+		msg = "unexpected response"
+	}
+	return fmt.Errorf("ollama-cloud API error (%d): %s", statusCode, msg)
+}
+
+func parseErrorMessage(body []byte) string {
+	body = bytes.TrimSpace(body)
+	if len(body) == 0 {
+		return ""
+	}
+
+	var envelope struct {
+		Error   json.RawMessage `json:"error"`
+		Message string          `json:"message"`
+	}
+	if err := json.Unmarshal(body, &envelope); err == nil {
+		if len(envelope.Error) > 0 && string(envelope.Error) != "null" {
+			var errString string
+			if err := json.Unmarshal(envelope.Error, &errString); err == nil {
+				return errString
+			}
+			var errObject struct {
+				Message string `json:"message"`
+				Type    string `json:"type"`
+				Code    string `json:"code"`
+			}
+			if err := json.Unmarshal(envelope.Error, &errObject); err == nil {
+				if errObject.Message != "" {
+					return errObject.Message
+				}
+				if errObject.Type != "" {
+					return errObject.Type
+				}
+				if errObject.Code != "" {
+					return errObject.Code
+				}
+			}
+		}
+		if envelope.Message != "" {
+			return envelope.Message
+		}
+	}
+
+	msg := string(body)
+	if len(msg) > 4096 {
+		msg = msg[:4096]
+	}
+	return msg
+}
+
+func normalizeModels(models []string) []string {
+	out := make([]string, 0, len(models))
+	seen := make(map[string]struct{}, len(models))
+	for _, model := range models {
+		model = strings.TrimSpace(model)
+		if model == "" {
+			continue
+		}
+		if _, ok := seen[model]; ok {
+			continue
+		}
+		seen[model] = struct{}{}
+		out = append(out, model)
+	}
+	return out
+}
+
+func combineModels(primary, secondary []string) []string {
+	out := make([]string, 0, len(primary)+len(secondary))
+	seen := make(map[string]struct{}, len(primary)+len(secondary))
+	for _, model := range primary {
+		if _, ok := seen[model]; ok {
+			continue
+		}
+		seen[model] = struct{}{}
+		out = append(out, model)
+	}
+	for _, model := range secondary {
+		if _, ok := seen[model]; ok {
+			continue
+		}
+		seen[model] = struct{}{}
+		out = append(out, model)
+	}
+	return out
+}

--- a/providers/ollama_cloud/ollama_cloud.go
+++ b/providers/ollama_cloud/ollama_cloud.go
@@ -1,5 +1,5 @@
-// Package ollama_cloud provides a client for the Ollama Cloud API.
-package ollama_cloud
+// Package ollamacloud provides a client for the Ollama Cloud API.
+package ollamacloud
 
 import (
 	"bufio"

--- a/providers/ollama_cloud/ollama_cloud_test.go
+++ b/providers/ollama_cloud/ollama_cloud_test.go
@@ -13,6 +13,12 @@ import (
 	"github.com/ferro-labs/ai-gateway/providers/core"
 )
 
+const (
+	testAuthHeader  = "Bearer test-key"
+	testCloudModel  = "gpt-oss:20b"
+	testCloudAPIKey = "test-key"
+)
+
 func TestNewValidationAndDefaults(t *testing.T) {
 	if _, err := New("", "", nil); err == nil {
 		t.Fatal("expected empty API key to be rejected")
@@ -66,52 +72,11 @@ func TestCompleteSendsAuthAndMapsResponse(t *testing.T) {
 		if r.URL.Path != "/api/chat" {
 			t.Errorf("path = %s, want /api/chat", r.URL.Path)
 		}
-		if got := r.Header.Get("Authorization"); got != "Bearer test-key" {
-			t.Errorf("Authorization = %q, want Bearer test-key", got)
-		}
-		if got := r.Header.Get("Content-Type"); !strings.Contains(got, "application/json") {
-			t.Errorf("Content-Type = %q, want application/json", got)
-		}
-
-		var body struct {
-			Model    string         `json:"model"`
-			Messages []core.Message `json:"messages"`
-			Stream   bool           `json:"stream"`
-			Options  *struct {
-				Temperature *float64 `json:"temperature"`
-				TopP        *float64 `json:"top_p"`
-				NumPredict  *int     `json:"num_predict"`
-			} `json:"options"`
-			Tools []core.Tool `json:"tools"`
-		}
-		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-			t.Fatalf("failed to decode request body: %v", err)
-		}
-		if body.Model != "gpt-oss:20b" {
-			t.Errorf("model = %q, want gpt-oss:20b", body.Model)
-		}
-		if body.Stream {
-			t.Error("stream = true, want false")
-		}
-		if len(body.Messages) != 1 || body.Messages[0].Role != "user" || body.Messages[0].Content != "hello" {
-			t.Errorf("messages = %#v, want user hello", body.Messages)
-		}
-		if body.Options == nil || body.Options.NumPredict == nil || *body.Options.NumPredict != 8 {
-			t.Fatalf("num_predict = %#v, want 8", body.Options)
-		}
-		if body.Options.Temperature == nil || *body.Options.Temperature != 0.25 {
-			t.Fatalf("temperature = %#v, want 0.25", body.Options.Temperature)
-		}
-		if body.Options.TopP == nil || *body.Options.TopP != 0.9 {
-			t.Fatalf("top_p = %#v, want 0.9", body.Options.TopP)
-		}
-		if len(body.Tools) != 1 || body.Tools[0].Function.Name != "lookup" {
-			t.Fatalf("tools = %#v, want lookup tool", body.Tools)
-		}
+		assertCompleteRequest(t, r)
 
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{
-			"model":"gpt-oss:20b",
+			"model":"` + testCloudModel + `",
 			"created_at":"` + created + `",
 			"message":{"role":"assistant","content":"hi there"},
 			"done":true,
@@ -122,14 +87,14 @@ func TestCompleteSendsAuthAndMapsResponse(t *testing.T) {
 	}))
 	defer server.Close()
 
-	p, err := New("test-key", server.URL, []string{"gpt-oss:20b"})
+	p, err := New(testCloudAPIKey, server.URL, []string{testCloudModel})
 	if err != nil {
 		t.Fatalf("New returned error: %v", err)
 	}
 
 	temp, topP, maxTokens, maxCompletionTokens := 0.25, 0.9, 99, 8
 	resp, err := p.Complete(context.Background(), core.Request{
-		Model: "gpt-oss:20b",
+		Model: testCloudModel,
 		Messages: []core.Message{
 			{Role: "user", Content: "hello"},
 		},
@@ -148,8 +113,8 @@ func TestCompleteSendsAuthAndMapsResponse(t *testing.T) {
 	if resp.Provider != Name {
 		t.Fatalf("provider = %q, want %q", resp.Provider, Name)
 	}
-	if resp.Model != "gpt-oss:20b" {
-		t.Fatalf("model = %q, want gpt-oss:20b", resp.Model)
+	if resp.Model != testCloudModel {
+		t.Fatalf("model = %q, want %s", resp.Model, testCloudModel)
 	}
 	if resp.Created != mustUnix(t, created) {
 		t.Fatalf("created = %d, want %d", resp.Created, mustUnix(t, created))
@@ -168,6 +133,53 @@ func TestCompleteSendsAuthAndMapsResponse(t *testing.T) {
 	}
 }
 
+func assertCompleteRequest(t *testing.T, r *http.Request) {
+	t.Helper()
+
+	if got := r.Header.Get("Authorization"); got != testAuthHeader {
+		t.Errorf("Authorization = %q, want %s", got, testAuthHeader)
+	}
+	if got := r.Header.Get("Content-Type"); !strings.Contains(got, "application/json") {
+		t.Errorf("Content-Type = %q, want application/json", got)
+	}
+
+	var body struct {
+		Model    string         `json:"model"`
+		Messages []core.Message `json:"messages"`
+		Stream   bool           `json:"stream"`
+		Options  *struct {
+			Temperature *float64 `json:"temperature"`
+			TopP        *float64 `json:"top_p"`
+			NumPredict  *int     `json:"num_predict"`
+		} `json:"options"`
+		Tools []core.Tool `json:"tools"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		t.Fatalf("failed to decode request body: %v", err)
+	}
+	if body.Model != testCloudModel {
+		t.Errorf("model = %q, want %s", body.Model, testCloudModel)
+	}
+	if body.Stream {
+		t.Error("stream = true, want false")
+	}
+	if len(body.Messages) != 1 || body.Messages[0].Role != "user" || body.Messages[0].Content != "hello" {
+		t.Errorf("messages = %#v, want user hello", body.Messages)
+	}
+	if body.Options == nil || body.Options.NumPredict == nil || *body.Options.NumPredict != 8 {
+		t.Fatalf("num_predict = %#v, want 8", body.Options)
+	}
+	if body.Options.Temperature == nil || *body.Options.Temperature != 0.25 {
+		t.Fatalf("temperature = %#v, want 0.25", body.Options.Temperature)
+	}
+	if body.Options.TopP == nil || *body.Options.TopP != 0.9 {
+		t.Fatalf("top_p = %#v, want 0.9", body.Options.TopP)
+	}
+	if len(body.Tools) != 1 || body.Tools[0].Function.Name != "lookup" {
+		t.Fatalf("tools = %#v, want lookup tool", body.Tools)
+	}
+}
+
 func TestCompleteNon200Error(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusBadRequest)
@@ -175,12 +187,12 @@ func TestCompleteNon200Error(t *testing.T) {
 	}))
 	defer server.Close()
 
-	p, err := New("test-key", server.URL, []string{"gpt-oss:20b"})
+	p, err := New(testCloudAPIKey, server.URL, []string{testCloudModel})
 	if err != nil {
 		t.Fatalf("New returned error: %v", err)
 	}
 
-	_, err = p.Complete(context.Background(), core.Request{Model: "gpt-oss:20b"})
+	_, err = p.Complete(context.Background(), core.Request{Model: testCloudModel})
 	if err == nil {
 		t.Fatal("expected Complete to return an error")
 	}
@@ -194,8 +206,8 @@ func TestCompleteStreamParsesNDJSONAndFinalUsage(t *testing.T) {
 		if r.URL.Path != "/api/chat" {
 			t.Errorf("path = %s, want /api/chat", r.URL.Path)
 		}
-		if got := r.Header.Get("Authorization"); got != "Bearer test-key" {
-			t.Errorf("Authorization = %q, want Bearer test-key", got)
+		if got := r.Header.Get("Authorization"); got != testAuthHeader {
+			t.Errorf("Authorization = %q, want %s", got, testAuthHeader)
 		}
 
 		var body struct {
@@ -209,19 +221,19 @@ func TestCompleteStreamParsesNDJSONAndFinalUsage(t *testing.T) {
 		}
 
 		w.Header().Set("Content-Type", "application/x-ndjson")
-		_, _ = w.Write([]byte(`{"model":"gpt-oss:20b","created_at":"2025-01-02T03:04:05Z","message":{"role":"assistant","content":"hel"},"done":false}` + "\n"))
-		_, _ = w.Write([]byte(`{"model":"gpt-oss:20b","message":{"role":"assistant","content":"lo"},"done":false}` + "\n"))
-		_, _ = w.Write([]byte(`{"model":"gpt-oss:20b","done":true,"done_reason":"stop","prompt_eval_count":3,"eval_count":2}` + "\n"))
+		_, _ = w.Write([]byte(`{"model":"` + testCloudModel + `","created_at":"2025-01-02T03:04:05Z","message":{"role":"assistant","content":"hel"},"done":false}` + "\n"))
+		_, _ = w.Write([]byte(`{"model":"` + testCloudModel + `","message":{"role":"assistant","content":"lo"},"done":false}` + "\n"))
+		_, _ = w.Write([]byte(`{"model":"` + testCloudModel + `","done":true,"done_reason":"stop","prompt_eval_count":3,"eval_count":2}` + "\n"))
 	}))
 	defer server.Close()
 
-	p, err := New("test-key", server.URL, []string{"gpt-oss:20b"})
+	p, err := New(testCloudAPIKey, server.URL, []string{testCloudModel})
 	if err != nil {
 		t.Fatalf("New returned error: %v", err)
 	}
 
 	ch, err := p.CompleteStream(context.Background(), core.Request{
-		Model:    "gpt-oss:20b",
+		Model:    testCloudModel,
 		Messages: []core.Message{{Role: "user", Content: "hello"}},
 	})
 	if err != nil {

--- a/providers/ollama_cloud/ollama_cloud_test.go
+++ b/providers/ollama_cloud/ollama_cloud_test.go
@@ -1,0 +1,338 @@
+package ollama_cloud
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ferro-labs/ai-gateway/providers/core"
+)
+
+func TestNewValidationAndDefaults(t *testing.T) {
+	if _, err := New("", "", nil); err == nil {
+		t.Fatal("expected empty API key to be rejected")
+	}
+	if _, err := New("   ", "", nil); err == nil {
+		t.Fatal("expected whitespace API key to be rejected")
+	}
+
+	for _, baseURL := range []string{"ftp://example.com", "http://", "example.com", "://bad"} {
+		if _, err := New("test-key", baseURL, nil); err == nil {
+			t.Fatalf("expected invalid base URL %q to be rejected", baseURL)
+		}
+	}
+
+	p, err := New(" test-key ", "", nil)
+	if err != nil {
+		t.Fatalf("New returned error: %v", err)
+	}
+	if p.apiKey != "test-key" {
+		t.Fatalf("api key was not trimmed, got %q", p.apiKey)
+	}
+	if p.baseURL != defaultBaseURL {
+		t.Fatalf("default base URL = %q, want %q", p.baseURL, defaultBaseURL)
+	}
+	wantModels := []string{"gpt-oss:120b", "gpt-oss:20b", "qwen3-coder:480b", "deepseek-v3.1:671b"}
+	if !reflect.DeepEqual(p.SupportedModels(), wantModels) {
+		t.Fatalf("default models = %#v, want %#v", p.SupportedModels(), wantModels)
+	}
+	if _, ok := any(p).(core.ProxiableProvider); ok {
+		t.Fatal("ollama-cloud must not implement core.ProxiableProvider")
+	}
+
+	p, err = New("test-key", "https://example.com///", []string{" custom ", "", "custom"})
+	if err != nil {
+		t.Fatalf("New with custom URL returned error: %v", err)
+	}
+	if p.baseURL != "https://example.com" {
+		t.Fatalf("base URL = %q, want trimmed URL", p.baseURL)
+	}
+	if !reflect.DeepEqual(p.SupportedModels(), []string{"custom"}) {
+		t.Fatalf("custom models = %#v, want [custom]", p.SupportedModels())
+	}
+}
+
+func TestCompleteSendsAuthAndMapsResponse(t *testing.T) {
+	created := "2025-01-02T03:04:05Z"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+		if r.URL.Path != "/api/chat" {
+			t.Errorf("path = %s, want /api/chat", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-key" {
+			t.Errorf("Authorization = %q, want Bearer test-key", got)
+		}
+		if got := r.Header.Get("Content-Type"); !strings.Contains(got, "application/json") {
+			t.Errorf("Content-Type = %q, want application/json", got)
+		}
+
+		var body struct {
+			Model    string         `json:"model"`
+			Messages []core.Message `json:"messages"`
+			Stream   bool           `json:"stream"`
+			Options  *struct {
+				Temperature *float64 `json:"temperature"`
+				TopP        *float64 `json:"top_p"`
+				NumPredict  *int     `json:"num_predict"`
+			} `json:"options"`
+			Tools []core.Tool `json:"tools"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode request body: %v", err)
+		}
+		if body.Model != "gpt-oss:20b" {
+			t.Errorf("model = %q, want gpt-oss:20b", body.Model)
+		}
+		if body.Stream {
+			t.Error("stream = true, want false")
+		}
+		if len(body.Messages) != 1 || body.Messages[0].Role != "user" || body.Messages[0].Content != "hello" {
+			t.Errorf("messages = %#v, want user hello", body.Messages)
+		}
+		if body.Options == nil || body.Options.NumPredict == nil || *body.Options.NumPredict != 8 {
+			t.Fatalf("num_predict = %#v, want 8", body.Options)
+		}
+		if body.Options.Temperature == nil || *body.Options.Temperature != 0.25 {
+			t.Fatalf("temperature = %#v, want 0.25", body.Options.Temperature)
+		}
+		if body.Options.TopP == nil || *body.Options.TopP != 0.9 {
+			t.Fatalf("top_p = %#v, want 0.9", body.Options.TopP)
+		}
+		if len(body.Tools) != 1 || body.Tools[0].Function.Name != "lookup" {
+			t.Fatalf("tools = %#v, want lookup tool", body.Tools)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"model":"gpt-oss:20b",
+			"created_at":"` + created + `",
+			"message":{"role":"assistant","content":"hi there"},
+			"done":true,
+			"done_reason":"stop",
+			"prompt_eval_count":11,
+			"eval_count":7
+		}`))
+	}))
+	defer server.Close()
+
+	p, err := New("test-key", server.URL, []string{"gpt-oss:20b"})
+	if err != nil {
+		t.Fatalf("New returned error: %v", err)
+	}
+
+	temp, topP, maxTokens, maxCompletionTokens := 0.25, 0.9, 99, 8
+	resp, err := p.Complete(context.Background(), core.Request{
+		Model: "gpt-oss:20b",
+		Messages: []core.Message{
+			{Role: "user", Content: "hello"},
+		},
+		Temperature:         &temp,
+		TopP:                &topP,
+		MaxTokens:           &maxTokens,
+		MaxCompletionTokens: &maxCompletionTokens,
+		Tools: []core.Tool{
+			{Type: "function", Function: core.Function{Name: "lookup"}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Complete returned error: %v", err)
+	}
+
+	if resp.Provider != Name {
+		t.Fatalf("provider = %q, want %q", resp.Provider, Name)
+	}
+	if resp.Model != "gpt-oss:20b" {
+		t.Fatalf("model = %q, want gpt-oss:20b", resp.Model)
+	}
+	if resp.Created != mustUnix(t, created) {
+		t.Fatalf("created = %d, want %d", resp.Created, mustUnix(t, created))
+	}
+	if len(resp.Choices) != 1 {
+		t.Fatalf("choices length = %d, want 1", len(resp.Choices))
+	}
+	if resp.Choices[0].Message.Role != "assistant" || resp.Choices[0].Message.Content != "hi there" {
+		t.Fatalf("message = %#v, want assistant hi there", resp.Choices[0].Message)
+	}
+	if resp.Choices[0].FinishReason != "stop" {
+		t.Fatalf("finish reason = %q, want stop", resp.Choices[0].FinishReason)
+	}
+	if resp.Usage.PromptTokens != 11 || resp.Usage.CompletionTokens != 7 || resp.Usage.TotalTokens != 18 {
+		t.Fatalf("usage = %#v, want 11/7/18", resp.Usage)
+	}
+}
+
+func TestCompleteNon200Error(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":{"message":"model is required"}}`))
+	}))
+	defer server.Close()
+
+	p, err := New("test-key", server.URL, []string{"gpt-oss:20b"})
+	if err != nil {
+		t.Fatalf("New returned error: %v", err)
+	}
+
+	_, err = p.Complete(context.Background(), core.Request{Model: "gpt-oss:20b"})
+	if err == nil {
+		t.Fatal("expected Complete to return an error")
+	}
+	if got := err.Error(); !strings.Contains(got, "400") || !strings.Contains(got, "model is required") {
+		t.Fatalf("error = %q, want status code and response message", got)
+	}
+}
+
+func TestCompleteStreamParsesNDJSONAndFinalUsage(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/chat" {
+			t.Errorf("path = %s, want /api/chat", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-key" {
+			t.Errorf("Authorization = %q, want Bearer test-key", got)
+		}
+
+		var body struct {
+			Stream bool `json:"stream"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode request body: %v", err)
+		}
+		if !body.Stream {
+			t.Fatal("stream = false, want true")
+		}
+
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		_, _ = w.Write([]byte(`{"model":"gpt-oss:20b","created_at":"2025-01-02T03:04:05Z","message":{"role":"assistant","content":"hel"},"done":false}` + "\n"))
+		_, _ = w.Write([]byte(`{"model":"gpt-oss:20b","message":{"role":"assistant","content":"lo"},"done":false}` + "\n"))
+		_, _ = w.Write([]byte(`{"model":"gpt-oss:20b","done":true,"done_reason":"stop","prompt_eval_count":3,"eval_count":2}` + "\n"))
+	}))
+	defer server.Close()
+
+	p, err := New("test-key", server.URL, []string{"gpt-oss:20b"})
+	if err != nil {
+		t.Fatalf("New returned error: %v", err)
+	}
+
+	ch, err := p.CompleteStream(context.Background(), core.Request{
+		Model:    "gpt-oss:20b",
+		Messages: []core.Message{{Role: "user", Content: "hello"}},
+	})
+	if err != nil {
+		t.Fatalf("CompleteStream returned error: %v", err)
+	}
+
+	var chunks []core.StreamChunk
+	for chunk := range ch {
+		if chunk.Error != nil {
+			t.Fatalf("stream chunk error: %v", chunk.Error)
+		}
+		chunks = append(chunks, chunk)
+	}
+	if len(chunks) != 3 {
+		t.Fatalf("chunks length = %d, want 3", len(chunks))
+	}
+	if chunks[0].Choices[0].Delta.Role != "assistant" || chunks[0].Choices[0].Delta.Content != "hel" {
+		t.Fatalf("first delta = %#v, want assistant hel", chunks[0].Choices[0].Delta)
+	}
+	if chunks[1].Choices[0].Delta.Content != "lo" {
+		t.Fatalf("second delta content = %q, want lo", chunks[1].Choices[0].Delta.Content)
+	}
+	if chunks[2].Choices[0].FinishReason != "stop" {
+		t.Fatalf("final finish reason = %q, want stop", chunks[2].Choices[0].FinishReason)
+	}
+	if chunks[2].Usage == nil {
+		t.Fatal("final usage is nil")
+	}
+	if chunks[2].Usage.PromptTokens != 3 || chunks[2].Usage.CompletionTokens != 2 || chunks[2].Usage.TotalTokens != 5 {
+		t.Fatalf("final usage = %#v, want 3/2/5", *chunks[2].Usage)
+	}
+}
+
+func TestDiscoverModelsParsesTagsAndUpdatesSupportsModel(t *testing.T) {
+	firstModified := "2025-02-03T04:05:06Z"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("method = %s, want GET", r.Method)
+		}
+		if r.URL.Path != "/api/tags" {
+			t.Errorf("path = %s, want /api/tags", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-key" {
+			t.Errorf("Authorization = %q, want Bearer test-key", got)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"models": [
+				{"name":"gpt-oss:20b","modified_at":"` + firstModified + `"},
+				{"model":"qwen3-coder:480b","modified_at":"2025-02-04T04:05:06.123Z"},
+				{"name":"gpt-oss:20b","modified_at":"2025-02-05T04:05:06Z"}
+			]
+		}`))
+	}))
+	defer server.Close()
+
+	p, err := New("test-key", server.URL, []string{"configured:model"})
+	if err != nil {
+		t.Fatalf("New returned error: %v", err)
+	}
+
+	models, err := p.DiscoverModels(context.Background())
+	if err != nil {
+		t.Fatalf("DiscoverModels returned error: %v", err)
+	}
+	if len(models) != 2 {
+		t.Fatalf("models length = %d, want 2", len(models))
+	}
+	if models[0].ID != "gpt-oss:20b" || models[0].Object != "model" || models[0].OwnedBy != Name {
+		t.Fatalf("first model = %#v, want gpt-oss:20b model owned by %s", models[0], Name)
+	}
+	if models[0].Created != mustUnix(t, firstModified) {
+		t.Fatalf("first created = %d, want %d", models[0].Created, mustUnix(t, firstModified))
+	}
+	if models[1].ID != "qwen3-coder:480b" {
+		t.Fatalf("second model ID = %q, want qwen3-coder:480b", models[1].ID)
+	}
+	if !p.SupportsModel("qwen3-coder:480b") {
+		t.Fatal("SupportsModel should include discovered model")
+	}
+	if !p.SupportsModel("ollama-cloud/qwen3-coder:480b") {
+		t.Fatal("SupportsModel should accept ollama-cloud-prefixed discovered model")
+	}
+}
+
+func TestSupportsModel(t *testing.T) {
+	p, err := New("test-key", "https://example.com", []string{"gpt-oss:20b"})
+	if err != nil {
+		t.Fatalf("New returned error: %v", err)
+	}
+
+	if !p.SupportsModel("gpt-oss:20b") {
+		t.Fatal("SupportsModel(gpt-oss:20b) = false, want true")
+	}
+	if !p.SupportsModel("ollama-cloud/gpt-oss:20b") {
+		t.Fatal("SupportsModel(ollama-cloud/gpt-oss:20b) = false, want true")
+	}
+	if p.SupportsModel("gpt-4o") {
+		t.Fatal("SupportsModel(gpt-4o) = true, want false")
+	}
+	if p.SupportsModel("other/gpt-oss:20b") {
+		t.Fatal("SupportsModel(other/gpt-oss:20b) = true, want false")
+	}
+}
+
+func mustUnix(t *testing.T, value string) int64 {
+	t.Helper()
+	parsed, err := time.Parse(time.RFC3339Nano, value)
+	if err != nil {
+		t.Fatalf("failed to parse time %q: %v", value, err)
+	}
+	return parsed.Unix()
+}

--- a/providers/ollama_cloud/ollama_cloud_test.go
+++ b/providers/ollama_cloud/ollama_cloud_test.go
@@ -1,4 +1,4 @@
-package ollama_cloud
+package ollamacloud
 
 import (
 	"context"

--- a/providers/providers_list.go
+++ b/providers/providers_list.go
@@ -98,7 +98,7 @@ var allProviders = []ProviderEntry{
 	},
 	{
 		ID:           NameBedrock,
-		Capabilities: []string{CapabilityChat, CapabilityStream, CapabilityProxy},
+		Capabilities: []string{CapabilityChat, CapabilityStream, CapabilityEmbed, CapabilityProxy},
 		// All Bedrock env mappings are optional because the provider can be
 		// configured in two different ways:
 		//   1. Instance-role / credential-chain auth: only AWS_REGION is set.
@@ -161,7 +161,7 @@ var allProviders = []ProviderEntry{
 	},
 	{
 		ID:           NameDatabricks,
-		Capabilities: []string{CapabilityChat, CapabilityStream, CapabilityProxy},
+		Capabilities: []string{CapabilityChat, CapabilityStream, CapabilityEmbed, CapabilityProxy},
 		EnvMappings: []EnvMapping{
 			{CfgKeyAPIKey, "DATABRICKS_TOKEN", true},
 			{CfgKeyBaseURL, "DATABRICKS_HOST", true},
@@ -194,7 +194,7 @@ var allProviders = []ProviderEntry{
 	},
 	{
 		ID:           NameFireworks,
-		Capabilities: []string{CapabilityChat, CapabilityStream, CapabilityDiscovery, CapabilityProxy},
+		Capabilities: []string{CapabilityChat, CapabilityStream, CapabilityEmbed, CapabilityDiscovery, CapabilityProxy},
 		EnvMappings: []EnvMapping{
 			{CfgKeyAPIKey, "FIREWORKS_API_KEY", true},
 			{CfgKeyBaseURL, "FIREWORKS_BASE_URL", false},
@@ -205,7 +205,7 @@ var allProviders = []ProviderEntry{
 	},
 	{
 		ID:           NameGemini,
-		Capabilities: []string{CapabilityChat, CapabilityStream, CapabilityProxy},
+		Capabilities: []string{CapabilityChat, CapabilityStream, CapabilityEmbed, CapabilityProxy},
 		EnvMappings: []EnvMapping{
 			{CfgKeyAPIKey, "GEMINI_API_KEY", true},
 			{CfgKeyBaseURL, "GEMINI_BASE_URL", false},
@@ -238,7 +238,7 @@ var allProviders = []ProviderEntry{
 	},
 	{
 		ID:           NameMistral,
-		Capabilities: []string{CapabilityChat, CapabilityStream, CapabilityProxy},
+		Capabilities: []string{CapabilityChat, CapabilityStream, CapabilityEmbed, CapabilityProxy},
 		EnvMappings: []EnvMapping{
 			{CfgKeyAPIKey, "MISTRAL_API_KEY", true},
 			{CfgKeyBaseURL, "MISTRAL_BASE_URL", false},
@@ -260,7 +260,7 @@ var allProviders = []ProviderEntry{
 	},
 	{
 		ID:           NameNovita,
-		Capabilities: []string{CapabilityChat, CapabilityStream, CapabilityDiscovery, CapabilityProxy},
+		Capabilities: []string{CapabilityChat, CapabilityStream, CapabilityEmbed, CapabilityDiscovery, CapabilityProxy},
 		EnvMappings: []EnvMapping{
 			{CfgKeyAPIKey, "NOVITA_API_KEY", true},
 			{CfgKeyBaseURL, "NOVITA_BASE_URL", false},
@@ -390,7 +390,7 @@ var allProviders = []ProviderEntry{
 	},
 	{
 		ID:           NameTogether,
-		Capabilities: []string{CapabilityChat, CapabilityStream, CapabilityProxy},
+		Capabilities: []string{CapabilityChat, CapabilityStream, CapabilityEmbed, CapabilityProxy},
 		EnvMappings: []EnvMapping{
 			{CfgKeyAPIKey, "TOGETHER_API_KEY", true},
 			{CfgKeyBaseURL, "TOGETHER_BASE_URL", false},
@@ -401,7 +401,7 @@ var allProviders = []ProviderEntry{
 	},
 	{
 		ID:           NameVertexAI,
-		Capabilities: []string{CapabilityChat, CapabilityStream, CapabilityProxy},
+		Capabilities: []string{CapabilityChat, CapabilityStream, CapabilityEmbed, CapabilityProxy},
 		// project_id is the gate: if unset, skip silently.
 		// region plus one of api_key / service_account_json are required once
 		// project_id is present.

--- a/providers/providers_list.go
+++ b/providers/providers_list.go
@@ -24,6 +24,7 @@ import (
 	novitapkg "github.com/ferro-labs/ai-gateway/providers/novita"
 	nvidianimpkg "github.com/ferro-labs/ai-gateway/providers/nvidia_nim"
 	ollamapkg "github.com/ferro-labs/ai-gateway/providers/ollama"
+	ollamacloudpkg "github.com/ferro-labs/ai-gateway/providers/ollama_cloud"
 	openaipkg "github.com/ferro-labs/ai-gateway/providers/openai"
 	openrouterpkg "github.com/ferro-labs/ai-gateway/providers/openrouter"
 	perplexitypkg "github.com/ferro-labs/ai-gateway/providers/perplexity"
@@ -293,6 +294,22 @@ var allProviders = []ProviderEntry{
 				models = strings.Split(m, ",")
 			}
 			return ollamapkg.New(cfg[CfgKeyHost], models)
+		},
+	},
+	{
+		ID:           NameOllamaCloud,
+		Capabilities: []string{CapabilityChat, CapabilityStream, CapabilityDiscovery},
+		EnvMappings: []EnvMapping{
+			{CfgKeyAPIKey, "OLLAMA_API_KEY", true},
+			{CfgKeyBaseURL, "OLLAMA_CLOUD_BASE_URL", false},
+			{CfgKeyModels, "OLLAMA_CLOUD_MODELS", false},
+		},
+		Build: func(cfg ProviderConfig) (Provider, error) {
+			var models []string
+			if m := cfg[CfgKeyModels]; m != "" {
+				models = strings.Split(m, ",")
+			}
+			return ollamacloudpkg.New(cfg[CfgKeyAPIKey], cfg[CfgKeyBaseURL], models)
 		},
 	},
 	{

--- a/providers/providers_list.go
+++ b/providers/providers_list.go
@@ -149,7 +149,7 @@ var allProviders = []ProviderEntry{
 	},
 	{
 		ID:           NameCohere,
-		Capabilities: []string{CapabilityChat, CapabilityStream, CapabilityProxy},
+		Capabilities: []string{CapabilityChat, CapabilityStream, CapabilityProxy, CapabilityEmbed},
 		EnvMappings: []EnvMapping{
 			{CfgKeyAPIKey, "COHERE_API_KEY", true},
 			{CfgKeyBaseURL, "COHERE_BASE_URL", false},

--- a/providers/stability_test.go
+++ b/providers/stability_test.go
@@ -52,6 +52,11 @@ type providerNameStabilityCase struct {
 }
 
 func providerNameStabilityCases() []providerNameStabilityCase {
+	cases := providerNameStabilityCoreCases()
+	return append(cases, providerNameStabilityExtensionCases()...)
+}
+
+func providerNameStabilityCoreCases() []providerNameStabilityCase {
 	return []providerNameStabilityCase{
 		{
 			wantName: NameAI21,
@@ -218,6 +223,11 @@ func providerNameStabilityCases() []providerNameStabilityCase {
 				return p
 			},
 		},
+	}
+}
+
+func providerNameStabilityExtensionCases() []providerNameStabilityCase {
+	return []providerNameStabilityCase{
 		{
 			wantName: NameMistral,
 			build: func(t *testing.T) Provider {

--- a/providers/stability_test.go
+++ b/providers/stability_test.go
@@ -21,6 +21,7 @@ import (
 	novitapkg "github.com/ferro-labs/ai-gateway/providers/novita"
 	nvidianimpkg "github.com/ferro-labs/ai-gateway/providers/nvidia_nim"
 	ollamapkg "github.com/ferro-labs/ai-gateway/providers/ollama"
+	ollamacloudpkg "github.com/ferro-labs/ai-gateway/providers/ollama_cloud"
 	openaipkg "github.com/ferro-labs/ai-gateway/providers/openai"
 	openrouterpkg "github.com/ferro-labs/ai-gateway/providers/openrouter"
 	perplexitypkg "github.com/ferro-labs/ai-gateway/providers/perplexity"
@@ -268,6 +269,17 @@ func providerNameStabilityCases() []providerNameStabilityCase {
 				p, err := ollamapkg.New("http://localhost:11434", nil)
 				if err != nil {
 					t.Fatalf("NewOllama: %v", err)
+				}
+				return p
+			},
+		},
+		{
+			wantName: NameOllamaCloud,
+			build: func(t *testing.T) Provider {
+				t.Helper()
+				p, err := ollamacloudpkg.New(testAPIKey, "", []string{"gpt-oss:20b"})
+				if err != nil {
+					t.Fatalf("NewOllamaCloud: %v", err)
 				}
 				return p
 			},

--- a/providers/stability_test.go
+++ b/providers/stability_test.go
@@ -466,6 +466,21 @@ func TestProviderCapabilitiesNotEmpty(t *testing.T) {
 	}
 }
 
+// TestProviderEmbedCapabilityMatchesInterface keeps factory metadata aligned
+// with the optional EmbeddingProvider interface used by /v1/embeddings routing.
+func TestProviderEmbedCapabilityMatchesInterface(t *testing.T) {
+	for _, tc := range providerNameStabilityCases() {
+		t.Run(tc.wantName, func(t *testing.T) {
+			p := tc.build(t)
+			_, implements := p.(EmbeddingProvider)
+			declares := ProviderHasCapability(tc.wantName, CapabilityEmbed)
+			if implements != declares {
+				t.Errorf("provider %q embed capability mismatch: implements EmbeddingProvider=%v, declares %q=%v", tc.wantName, implements, CapabilityEmbed, declares)
+			}
+		})
+	}
+}
+
 // TestProviderEnvMappingsHaveRequiredKey verifies that each provider entry has
 // a configured? gate: either at least one EnvMapping with Required=true, or a
 // ConfiguredFn (used for providers whose gate is an OR across multiple env vars,

--- a/providers/together/embedding.go
+++ b/providers/together/embedding.go
@@ -1,0 +1,115 @@
+package together
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/ferro-labs/ai-gateway/providers/core"
+)
+
+type embeddingRequest struct {
+	Model          string      `json:"model"`
+	Input          interface{} `json:"input"`
+	EncodingFormat string      `json:"encoding_format,omitempty"`
+	Dimensions     *int        `json:"dimensions,omitempty"`
+	User           string      `json:"user,omitempty"`
+}
+
+type embeddingResponse struct {
+	Object string              `json:"object"`
+	Data   []core.Embedding    `json:"data"`
+	Model  string              `json:"model"`
+	Usage  core.EmbeddingUsage `json:"usage"`
+}
+
+// Embed sends an OpenAI-compatible embedding request to Together AI.
+func (p *Provider) Embed(ctx context.Context, req core.EmbeddingRequest) (*core.EmbeddingResponse, error) {
+	input, err := normalizeEmbeddingInput(req.Input)
+	if err != nil {
+		return nil, err
+	}
+	if req.EncodingFormat != "" && req.EncodingFormat != "float" {
+		return nil, fmt.Errorf("embed: unsupported encoding_format %q; valid value is \"float\"", req.EncodingFormat)
+	}
+
+	pReq := embeddingRequest{
+		Model:          req.Model,
+		Input:          input,
+		EncodingFormat: req.EncodingFormat,
+		Dimensions:     req.Dimensions,
+		User:           req.User,
+	}
+	bodyReader, _, release, err := core.JSONBodyReader(pReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal embedding request: %w", err)
+	}
+	defer release()
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, p.baseURL+"/v1/embeddings", bodyReader) //nolint:gosec // baseURL validated in New()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	httpReq.Header.Set("Authorization", "Bearer "+p.apiKey)
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	httpResp, err := p.httpClient.Do(httpReq) //nolint:gosec // baseURL validated in New()
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer func() { _ = httpResp.Body.Close() }()
+
+	respBody, err := io.ReadAll(httpResp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+	if httpResp.StatusCode < http.StatusOK || httpResp.StatusCode >= http.StatusMultipleChoices {
+		var errResp errorResponse
+		if json.Unmarshal(respBody, &errResp) == nil && errResp.Error.Message != "" {
+			return nil, fmt.Errorf("together API error (%d): %s", httpResp.StatusCode, errResp.Error.Message)
+		}
+		return nil, fmt.Errorf("together API error (%d): %s", httpResp.StatusCode, string(respBody))
+	}
+
+	var pResp embeddingResponse
+	if err := json.Unmarshal(respBody, &pResp); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal embedding response: %w", err)
+	}
+	return &core.EmbeddingResponse{
+		Object: pResp.Object,
+		Data:   pResp.Data,
+		Model:  pResp.Model,
+		Usage:  pResp.Usage,
+	}, nil
+}
+
+func normalizeEmbeddingInput(input interface{}) (interface{}, error) {
+	switch v := input.(type) {
+	case string:
+		return v, nil
+	case []string:
+		if len(v) == 0 {
+			return nil, fmt.Errorf("embed: Input must not be an empty array")
+		}
+		return v, nil
+	case []interface{}:
+		if len(v) == 0 {
+			return nil, fmt.Errorf("embed: Input must not be an empty array")
+		}
+		strs := make([]string, 0, len(v))
+		for i, item := range v {
+			s, ok := item.(string)
+			if !ok {
+				return nil, fmt.Errorf("embed: Input[%d] is %T, want string", i, item)
+			}
+			strs = append(strs, s)
+		}
+		return strs, nil
+	case nil:
+		return nil, fmt.Errorf("embed: Input must not be nil")
+	default:
+		return nil, fmt.Errorf("embed: unsupported Input type %T; want string or []string", input)
+	}
+}

--- a/providers/together/together.go
+++ b/providers/together/together.go
@@ -34,6 +34,7 @@ type Provider struct {
 var (
 	_ core.Provider          = (*Provider)(nil)
 	_ core.StreamProvider    = (*Provider)(nil)
+	_ core.EmbeddingProvider = (*Provider)(nil)
 	_ core.ProxiableProvider = (*Provider)(nil)
 )
 
@@ -73,6 +74,10 @@ func (p *Provider) SupportedModels() []string {
 		"meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo",
 		"mistralai/Mixtral-8x7B-Instruct-v0.1",
 		"Qwen/Qwen2.5-72B-Instruct-Turbo",
+		"BAAI/bge-base-en-v1.5",
+		"baai/bge-base-en-v1.5",
+		"together-ai-embedding-up-to-150m",
+		"together-ai-embedding-151m-to-350m",
 	}
 }
 

--- a/providers/together/together_test.go
+++ b/providers/together/together_test.go
@@ -15,6 +15,8 @@ import (
 	"github.com/ferro-labs/ai-gateway/providers/core"
 )
 
+const testEmbeddingModel = "BAAI/bge-base-en-v1.5"
+
 func TestNewTogether(t *testing.T) {
 	p, err := New("test-key", "")
 	if err != nil {
@@ -142,16 +144,16 @@ func TestTogetherProvider_SupportedModels_Embeddings(t *testing.T) {
 	models := p.SupportedModels()
 	found := false
 	for _, m := range models {
-		if m == "BAAI/bge-base-en-v1.5" {
+		if m == testEmbeddingModel {
 			found = true
 			break
 		}
 	}
 	if !found {
-		t.Fatalf("embedding model %q not found in SupportedModels()", "BAAI/bge-base-en-v1.5")
+		t.Fatalf("embedding model %q not found in SupportedModels()", testEmbeddingModel)
 	}
-	if !p.SupportsModel("BAAI/bge-base-en-v1.5") {
-		t.Fatalf("SupportsModel(%q) = false, want true", "BAAI/bge-base-en-v1.5")
+	if !p.SupportsModel(testEmbeddingModel) {
+		t.Fatalf("SupportsModel(%q) = false, want true", testEmbeddingModel)
 	}
 }
 
@@ -185,7 +187,7 @@ func TestTogetherProvider_Embed_InvalidInput(t *testing.T) {
 	for _, tc := range badInputs {
 		t.Run(tc.name, func(t *testing.T) {
 			_, err := p.Embed(context.Background(), core.EmbeddingRequest{
-				Model: "BAAI/bge-base-en-v1.5",
+				Model: testEmbeddingModel,
 				Input: tc.input,
 			})
 			if err == nil {
@@ -211,7 +213,7 @@ func TestTogetherProvider_Embed_UpstreamError(t *testing.T) {
 
 	p, _ := New("test-key", srv.URL)
 	_, err := p.Embed(context.Background(), core.EmbeddingRequest{
-		Model: "BAAI/bge-base-en-v1.5",
+		Model: testEmbeddingModel,
 		Input: "hello",
 	})
 	if err == nil {
@@ -243,20 +245,20 @@ func testTogetherEmbedSuccess(t *testing.T, input interface{}) {
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 			t.Fatalf("failed to decode request body: %v", err)
 		}
-		if got := body["model"]; got != "BAAI/bge-base-en-v1.5" {
-			t.Errorf("model = %v, want BAAI/bge-base-en-v1.5", got)
+		if got := body["model"]; got != testEmbeddingModel {
+			t.Errorf("model = %v, want %s", got, testEmbeddingModel)
 		}
 		assertTogetherEmbeddingInput(t, body["input"], input)
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`{"object":"list","data":[{"object":"embedding","embedding":[0.1,0.2],"index":0},{"object":"embedding","embedding":[0.3,0.4],"index":1}],"model":"BAAI/bge-base-en-v1.5","usage":{"prompt_tokens":3,"total_tokens":3}}`))
+		_, _ = w.Write([]byte(`{"object":"list","data":[{"object":"embedding","embedding":[0.1,0.2],"index":0},{"object":"embedding","embedding":[0.3,0.4],"index":1}],"model":"` + testEmbeddingModel + `","usage":{"prompt_tokens":3,"total_tokens":3}}`))
 	}))
 	defer srv.Close()
 
 	p, _ := New("test-key", srv.URL)
 	resp, err := p.Embed(context.Background(), core.EmbeddingRequest{
-		Model: "BAAI/bge-base-en-v1.5",
+		Model: testEmbeddingModel,
 		Input: input,
 	})
 	if err != nil {
@@ -265,8 +267,8 @@ func testTogetherEmbedSuccess(t *testing.T, input interface{}) {
 	if resp.Object != "list" {
 		t.Errorf("Object = %q, want list", resp.Object)
 	}
-	if resp.Model != "BAAI/bge-base-en-v1.5" {
-		t.Errorf("Model = %q, want BAAI/bge-base-en-v1.5", resp.Model)
+	if resp.Model != testEmbeddingModel {
+		t.Errorf("Model = %q, want %s", resp.Model, testEmbeddingModel)
 	}
 	if len(resp.Data) != 2 {
 		t.Fatalf("Data length = %d, want 2", len(resp.Data))

--- a/providers/together/together_test.go
+++ b/providers/together/together_test.go
@@ -2,9 +2,13 @@ package together
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"reflect"
+	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -127,3 +131,179 @@ func TestTogetherProvider_Complete_Integration(t *testing.T) {
 }
 
 func intPtr(i int) *int { return &i }
+
+func TestTogetherProvider_Embed_Interface(_ *testing.T) {
+	p, _ := New("test-key", "")
+	var _ core.EmbeddingProvider = p
+}
+
+func TestTogetherProvider_SupportedModels_Embeddings(t *testing.T) {
+	p, _ := New("test-key", "")
+	models := p.SupportedModels()
+	found := false
+	for _, m := range models {
+		if m == "BAAI/bge-base-en-v1.5" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("embedding model %q not found in SupportedModels()", "BAAI/bge-base-en-v1.5")
+	}
+	if !p.SupportsModel("BAAI/bge-base-en-v1.5") {
+		t.Fatalf("SupportsModel(%q) = false, want true", "BAAI/bge-base-en-v1.5")
+	}
+}
+
+func TestTogetherProvider_Embed_StringInput_MockHTTP(t *testing.T) {
+	testTogetherEmbedSuccess(t, "hello world")
+}
+
+func TestTogetherProvider_Embed_StringSliceInput_MockHTTP(t *testing.T) {
+	testTogetherEmbedSuccess(t, []string{"hello", "world"})
+}
+
+func TestTogetherProvider_Embed_InvalidInput(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	p, _ := New("test-key", srv.URL)
+	badInputs := []struct {
+		name  string
+		input interface{}
+	}{
+		{"nil", nil},
+		{"integer", 42},
+		{"empty-string-slice", []string{}},
+		{"empty-interface-slice", []interface{}{}},
+		{"non-string-array-member", []interface{}{"ok", 42}},
+	}
+	for _, tc := range badInputs {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := p.Embed(context.Background(), core.EmbeddingRequest{
+				Model: "BAAI/bge-base-en-v1.5",
+				Input: tc.input,
+			})
+			if err == nil {
+				t.Fatalf("Embed() error = nil, want error")
+			}
+		})
+	}
+	if got := atomic.LoadInt32(&calls); got != 0 {
+		t.Fatalf("upstream calls = %d, want 0", got)
+	}
+}
+
+func TestTogetherProvider_Embed_UpstreamError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/embeddings" {
+			t.Errorf("path = %q, want /v1/embeddings", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"error":{"message":"rate limited","type":"rate_limit"}}`))
+	}))
+	defer srv.Close()
+
+	p, _ := New("test-key", srv.URL)
+	_, err := p.Embed(context.Background(), core.EmbeddingRequest{
+		Model: "BAAI/bge-base-en-v1.5",
+		Input: "hello",
+	})
+	if err == nil {
+		t.Fatal("Embed() error = nil, want upstream error")
+	}
+	if !strings.Contains(err.Error(), "rate limited") {
+		t.Fatalf("error = %v, want rate limited message", err)
+	}
+}
+
+func testTogetherEmbedSuccess(t *testing.T, input interface{}) {
+	t.Helper()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+		if r.URL.Path != "/v1/embeddings" {
+			t.Errorf("path = %q, want /v1/embeddings", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-key" {
+			t.Errorf("Authorization = %q, want Bearer test-key", got)
+		}
+		if got := r.Header.Get("Content-Type"); got != "application/json" {
+			t.Errorf("Content-Type = %q, want application/json", got)
+		}
+
+		var body map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode request body: %v", err)
+		}
+		if got := body["model"]; got != "BAAI/bge-base-en-v1.5" {
+			t.Errorf("model = %v, want BAAI/bge-base-en-v1.5", got)
+		}
+		assertTogetherEmbeddingInput(t, body["input"], input)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"object":"list","data":[{"object":"embedding","embedding":[0.1,0.2],"index":0},{"object":"embedding","embedding":[0.3,0.4],"index":1}],"model":"BAAI/bge-base-en-v1.5","usage":{"prompt_tokens":3,"total_tokens":3}}`))
+	}))
+	defer srv.Close()
+
+	p, _ := New("test-key", srv.URL)
+	resp, err := p.Embed(context.Background(), core.EmbeddingRequest{
+		Model: "BAAI/bge-base-en-v1.5",
+		Input: input,
+	})
+	if err != nil {
+		t.Fatalf("Embed() error: %v", err)
+	}
+	if resp.Object != "list" {
+		t.Errorf("Object = %q, want list", resp.Object)
+	}
+	if resp.Model != "BAAI/bge-base-en-v1.5" {
+		t.Errorf("Model = %q, want BAAI/bge-base-en-v1.5", resp.Model)
+	}
+	if len(resp.Data) != 2 {
+		t.Fatalf("Data length = %d, want 2", len(resp.Data))
+	}
+	if resp.Data[0].Object != "embedding" || resp.Data[0].Index != 0 || !reflect.DeepEqual(resp.Data[0].Embedding, []float64{0.1, 0.2}) {
+		t.Errorf("Data[0] = %+v, want mapped embedding at index 0", resp.Data[0])
+	}
+	if resp.Data[1].Index != 1 || !reflect.DeepEqual(resp.Data[1].Embedding, []float64{0.3, 0.4}) {
+		t.Errorf("Data[1] = %+v, want mapped embedding at index 1", resp.Data[1])
+	}
+	if resp.Usage.PromptTokens != 3 || resp.Usage.TotalTokens != 3 {
+		t.Errorf("Usage = %+v, want prompt=3 total=3", resp.Usage)
+	}
+}
+
+func assertTogetherEmbeddingInput(t *testing.T, got interface{}, want interface{}) {
+	t.Helper()
+
+	switch w := want.(type) {
+	case string:
+		if got != w {
+			t.Fatalf("input = %#v, want %q", got, w)
+		}
+	case []string:
+		arr, ok := got.([]interface{})
+		if !ok {
+			t.Fatalf("input type = %T, want JSON array", got)
+		}
+		if len(arr) != len(w) {
+			t.Fatalf("input length = %d, want %d", len(arr), len(w))
+		}
+		for i := range w {
+			if arr[i] != w[i] {
+				t.Fatalf("input[%d] = %#v, want %q", i, arr[i], w[i])
+			}
+		}
+	default:
+		t.Fatalf("unsupported test input type %T", want)
+	}
+}

--- a/providers/vertex_ai/vertex_ai.go
+++ b/providers/vertex_ai/vertex_ai.go
@@ -41,6 +41,7 @@ type Provider struct {
 var (
 	_ core.Provider          = (*Provider)(nil)
 	_ core.StreamProvider    = (*Provider)(nil)
+	_ core.EmbeddingProvider = (*Provider)(nil)
 	_ core.ProxiableProvider = (*Provider)(nil)
 )
 
@@ -111,11 +112,23 @@ func (p *Provider) SupportedModels() []string {
 		"gemini-2.5-pro",
 		"gemini-2.5-flash",
 		"gemini-2.0-flash",
+		"gemini-embedding-001",
+		"text-embedding-005",
+		"text-embedding-004",
+		"text-multilingual-embedding-002",
+		"textembedding-gecko@003",
+		"textembedding-gecko-multilingual@001",
 	}
 }
 
-// SupportsModel returns true for any model — Vertex AI validates model names.
-func (p *Provider) SupportsModel(_ string) bool { return true }
+// SupportsModel returns true for known Vertex AI chat and text embedding model families.
+func (p *Provider) SupportsModel(model string) bool {
+	model = vertexAIModelID(model)
+	return strings.HasPrefix(model, "gemini-") ||
+		strings.HasPrefix(model, "text-embedding-") ||
+		strings.HasPrefix(model, "textembedding-gecko") ||
+		strings.HasPrefix(model, "text-multilingual-embedding-")
+}
 
 // Models returns structured model metadata.
 func (p *Provider) Models() []core.ModelInfo {
@@ -144,8 +157,50 @@ type vertexAIError struct {
 	} `json:"error"`
 }
 
+type vertexAIEmbeddingRequest struct {
+	Instances  []vertexAIEmbeddingInstance  `json:"instances"`
+	Parameters *vertexAIEmbeddingParameters `json:"parameters,omitempty"`
+}
+
+type vertexAIEmbeddingInstance struct {
+	Content string `json:"content"`
+}
+
+type vertexAIEmbeddingParameters struct {
+	OutputDimensionality *int `json:"outputDimensionality,omitempty"`
+}
+
+type vertexAIEmbeddingPrediction struct {
+	Embeddings struct {
+		Values     []float64 `json:"values"`
+		Statistics struct {
+			TokenCount      int `json:"token_count"`
+			TokenCountCamel int `json:"tokenCount"`
+		} `json:"statistics"`
+	} `json:"embeddings"`
+	Values    []float64 `json:"values"`
+	Embedding []float64 `json:"embedding"`
+}
+
+type vertexAIEmbeddingResponse struct {
+	Predictions []vertexAIEmbeddingPrediction `json:"predictions"`
+	Metadata    struct {
+		TokenMetadata struct {
+			InputTokenCount struct {
+				TotalTokens int `json:"totalTokens"`
+			} `json:"inputTokenCount"`
+		} `json:"tokenMetadata"`
+	} `json:"metadata"`
+}
+
 func (p *Provider) endpoint() string {
 	return p.baseURL + "/chat/completions"
+}
+
+func (p *Provider) predictionEndpoint(model string) string {
+	baseURL := strings.TrimRight(p.baseURL, "/")
+	baseURL = strings.TrimSuffix(baseURL, "/endpoints/openapi")
+	return fmt.Sprintf("%s/publishers/google/models/%s:predict", baseURL, vertexAIModelID(model))
 }
 
 func (p *Provider) authorizeRequest(req *http.Request) error {
@@ -162,6 +217,156 @@ func (p *Provider) authorizeRequest(req *http.Request) error {
 	}
 	req.Header.Set("Authorization", "Bearer "+tok.AccessToken)
 	return nil
+}
+
+func vertexAIEmbeddingInputs(input interface{}) ([]string, error) {
+	switch v := input.(type) {
+	case string:
+		return []string{v}, nil
+	case []string:
+		if len(v) == 0 {
+			return nil, fmt.Errorf("embed: Input must not be an empty array")
+		}
+		return v, nil
+	case []interface{}:
+		if len(v) == 0 {
+			return nil, fmt.Errorf("embed: Input must not be an empty array")
+		}
+		texts := make([]string, 0, len(v))
+		for i, item := range v {
+			s, ok := item.(string)
+			if !ok {
+				return nil, fmt.Errorf("embed: Input[%d] is %T, want string", i, item)
+			}
+			texts = append(texts, s)
+		}
+		return texts, nil
+	case nil:
+		return nil, fmt.Errorf("embed: Input must not be nil")
+	default:
+		return nil, fmt.Errorf("embed: unsupported Input type %T; want string or []string", input)
+	}
+}
+
+func vertexAIModelID(model string) string {
+	model = strings.TrimPrefix(model, "publishers/google/models/")
+	model = strings.TrimPrefix(model, "models/")
+	return model
+}
+
+func isVertexAITextEmbeddingModel(model string) bool {
+	model = vertexAIModelID(model)
+	return model == "gemini-embedding-001" ||
+		strings.HasPrefix(model, "text-embedding-") ||
+		strings.HasPrefix(model, "textembedding-gecko") ||
+		strings.HasPrefix(model, "text-multilingual-embedding-")
+}
+
+func vertexAIEmbeddingValues(prediction vertexAIEmbeddingPrediction) ([]float64, int) {
+	values := prediction.Embeddings.Values
+	if values == nil {
+		values = prediction.Values
+	}
+	if values == nil {
+		values = prediction.Embedding
+	}
+	tokenCount := prediction.Embeddings.Statistics.TokenCount
+	if tokenCount == 0 {
+		tokenCount = prediction.Embeddings.Statistics.TokenCountCamel
+	}
+	return values, tokenCount
+}
+
+// Embed sends a text embedding request to Vertex AI's publisher model predict endpoint.
+func (p *Provider) Embed(ctx context.Context, req core.EmbeddingRequest) (*core.EmbeddingResponse, error) {
+	if !isVertexAITextEmbeddingModel(req.Model) {
+		return nil, fmt.Errorf("embed: unsupported Vertex AI text embedding model %q", req.Model)
+	}
+	if req.EncodingFormat != "" && req.EncodingFormat != "float" {
+		return nil, fmt.Errorf("embed: unsupported encoding_format %q; valid value is \"float\"", req.EncodingFormat)
+	}
+	texts, err := vertexAIEmbeddingInputs(req.Input)
+	if err != nil {
+		return nil, err
+	}
+
+	vertexReq := vertexAIEmbeddingRequest{
+		Instances: make([]vertexAIEmbeddingInstance, 0, len(texts)),
+	}
+	for _, text := range texts {
+		vertexReq.Instances = append(vertexReq.Instances, vertexAIEmbeddingInstance{Content: text})
+	}
+	if req.Dimensions != nil {
+		vertexReq.Parameters = &vertexAIEmbeddingParameters{OutputDimensionality: req.Dimensions}
+	}
+
+	bodyReader, _, release, err := core.JSONBodyReader(vertexReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal embed request: %w", err)
+	}
+	defer release()
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, p.predictionEndpoint(req.Model), bodyReader)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create embed request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	if err := p.authorizeRequest(httpReq); err != nil {
+		return nil, err
+	}
+
+	httpResp, err := p.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("embed request failed: %w", err)
+	}
+	defer func() { _ = httpResp.Body.Close() }()
+
+	respBody, err := io.ReadAll(httpResp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read embed response: %w", err)
+	}
+
+	if httpResp.StatusCode != http.StatusOK {
+		var errResp vertexAIError
+		if json.Unmarshal(respBody, &errResp) == nil && errResp.Error.Message != "" {
+			return nil, fmt.Errorf("vertex ai embed API error (%d): %s", httpResp.StatusCode, errResp.Error.Message)
+		}
+		return nil, fmt.Errorf("vertex ai embed API error (%d): %s", httpResp.StatusCode, string(respBody))
+	}
+
+	var vertexResp vertexAIEmbeddingResponse
+	if err := json.Unmarshal(respBody, &vertexResp); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal embed response: %w", err)
+	}
+	if len(vertexResp.Predictions) != len(texts) {
+		return nil, fmt.Errorf("vertex ai embed API returned %d embeddings for %d inputs", len(vertexResp.Predictions), len(texts))
+	}
+
+	data := make([]core.Embedding, len(vertexResp.Predictions))
+	promptTokens := vertexResp.Metadata.TokenMetadata.InputTokenCount.TotalTokens
+	statisticsTokens := 0
+	for i, prediction := range vertexResp.Predictions {
+		values, tokenCount := vertexAIEmbeddingValues(prediction)
+		data[i] = core.Embedding{
+			Object:    "embedding",
+			Embedding: values,
+			Index:     i,
+		}
+		statisticsTokens += tokenCount
+	}
+	if promptTokens == 0 {
+		promptTokens = statisticsTokens
+	}
+
+	return &core.EmbeddingResponse{
+		Object: "list",
+		Data:   data,
+		Model:  req.Model,
+		Usage: core.EmbeddingUsage{
+			PromptTokens: promptTokens,
+			TotalTokens:  promptTokens,
+		},
+	}, nil
 }
 
 // Complete sends a chat completion request to Vertex AI.

--- a/providers/vertex_ai/vertex_ai_test.go
+++ b/providers/vertex_ai/vertex_ai_test.go
@@ -11,11 +11,13 @@ import (
 	"github.com/ferro-labs/ai-gateway/providers/core"
 )
 
+const testAPIKey = "test-key"
+
 func TestNewVertexAI_APIKeyMode(t *testing.T) {
 	p, err := New(Options{
 		ProjectID: "demo-project",
 		Region:    "us-central1",
-		APIKey:    "test-key",
+		APIKey:    testAPIKey,
 	})
 	if err != nil {
 		t.Fatalf("New() error: %v", err)
@@ -29,14 +31,14 @@ func TestNewVertexAI_APIKeyMode(t *testing.T) {
 }
 
 func TestNewVertexAI_RequiresProjectID(t *testing.T) {
-	_, err := New(Options{Region: "us-central1", APIKey: "test-key"})
+	_, err := New(Options{Region: "us-central1", APIKey: testAPIKey})
 	if err == nil {
 		t.Fatal("expected error for missing project_id")
 	}
 }
 
 func TestNewVertexAI_RequiresRegion(t *testing.T) {
-	_, err := New(Options{ProjectID: "demo-project", APIKey: "test-key"})
+	_, err := New(Options{ProjectID: "demo-project", APIKey: testAPIKey})
 	if err == nil {
 		t.Fatal("expected error for missing region")
 	}
@@ -64,11 +66,11 @@ func TestVertexAIProvider_AuthHeaders_APIKey(t *testing.T) {
 	p, _ := New(Options{
 		ProjectID: "demo-project",
 		Region:    "us-central1",
-		APIKey:    "test-key",
+		APIKey:    testAPIKey,
 	})
 	headers := p.AuthHeaders()
-	if headers["x-goog-api-key"] != "test-key" {
-		t.Errorf("x-goog-api-key = %q, want test-key", headers["x-goog-api-key"])
+	if headers["x-goog-api-key"] != testAPIKey {
+		t.Errorf("x-goog-api-key = %q, want %s", headers["x-goog-api-key"], testAPIKey)
 	}
 }
 
@@ -76,7 +78,7 @@ func TestVertexAIProvider_SupportedModels(t *testing.T) {
 	p, _ := New(Options{
 		ProjectID: "demo-project",
 		Region:    "us-central1",
-		APIKey:    "test-key",
+		APIKey:    testAPIKey,
 	})
 	models := p.SupportedModels()
 	found := map[string]bool{}
@@ -97,7 +99,7 @@ func TestVertexAIProvider_CompleteStream_Interface(_ *testing.T) {
 	p, _ := New(Options{
 		ProjectID: "demo-project",
 		Region:    "us-central1",
-		APIKey:    "test-key",
+		APIKey:    testAPIKey,
 	})
 	var _ core.StreamProvider = p
 }
@@ -106,7 +108,7 @@ func TestVertexAIProvider_Embed_Interface(_ *testing.T) {
 	p, _ := New(Options{
 		ProjectID: "demo-project",
 		Region:    "us-central1",
-		APIKey:    "test-key",
+		APIKey:    testAPIKey,
 	})
 	var _ core.EmbeddingProvider = p
 }
@@ -121,8 +123,8 @@ func TestVertexAIProvider_Embed_BatchSuccess_APIKey(t *testing.T) {
 		if r.URL.Path != wantPath {
 			t.Errorf("request path = %q, want %s", r.URL.Path, wantPath)
 		}
-		if got := r.Header.Get("x-goog-api-key"); got != "test-key" {
-			t.Errorf("x-goog-api-key = %q, want test-key", got)
+		if got := r.Header.Get("x-goog-api-key"); got != testAPIKey {
+			t.Errorf("x-goog-api-key = %q, want %s", got, testAPIKey)
 		}
 		var body struct {
 			Instances []struct {

--- a/providers/vertex_ai/vertex_ai_test.go
+++ b/providers/vertex_ai/vertex_ai_test.go
@@ -2,8 +2,10 @@ package vertexai
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/ferro-labs/ai-gateway/providers/core"
@@ -70,6 +72,27 @@ func TestVertexAIProvider_AuthHeaders_APIKey(t *testing.T) {
 	}
 }
 
+func TestVertexAIProvider_SupportedModels(t *testing.T) {
+	p, _ := New(Options{
+		ProjectID: "demo-project",
+		Region:    "us-central1",
+		APIKey:    "test-key",
+	})
+	models := p.SupportedModels()
+	found := map[string]bool{}
+	for _, model := range models {
+		found[model] = true
+	}
+	for _, want := range []string{"gemini-2.5-flash", "text-embedding-005", "textembedding-gecko@003", "gemini-embedding-001"} {
+		if !found[want] {
+			t.Errorf("SupportedModels() missing %q", want)
+		}
+		if !p.SupportsModel(want) {
+			t.Errorf("SupportsModel(%q) = false, want true", want)
+		}
+	}
+}
+
 func TestVertexAIProvider_CompleteStream_Interface(_ *testing.T) {
 	p, _ := New(Options{
 		ProjectID: "demo-project",
@@ -77,6 +100,160 @@ func TestVertexAIProvider_CompleteStream_Interface(_ *testing.T) {
 		APIKey:    "test-key",
 	})
 	var _ core.StreamProvider = p
+}
+
+func TestVertexAIProvider_Embed_Interface(_ *testing.T) {
+	p, _ := New(Options{
+		ProjectID: "demo-project",
+		Region:    "us-central1",
+		APIKey:    "test-key",
+	})
+	var _ core.EmbeddingProvider = p
+}
+
+func TestVertexAIProvider_Embed_BatchSuccess_APIKey(t *testing.T) {
+	dimensions := 256
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		wantPath := "/v1/projects/demo-project/locations/us-central1/publishers/google/models/text-embedding-005:predict"
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+		if r.URL.Path != wantPath {
+			t.Errorf("request path = %q, want %s", r.URL.Path, wantPath)
+		}
+		if got := r.Header.Get("x-goog-api-key"); got != "test-key" {
+			t.Errorf("x-goog-api-key = %q, want test-key", got)
+		}
+		var body struct {
+			Instances []struct {
+				Content string `json:"content"`
+			} `json:"instances"`
+			Parameters struct {
+				OutputDimensionality *int `json:"outputDimensionality"`
+			} `json:"parameters"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		if len(body.Instances) != 2 || body.Instances[0].Content != "first" || body.Instances[1].Content != "second" {
+			t.Fatalf("instances = %+v, want first/second", body.Instances)
+		}
+		if body.Parameters.OutputDimensionality == nil || *body.Parameters.OutputDimensionality != dimensions {
+			t.Errorf("outputDimensionality = %v, want %d", body.Parameters.OutputDimensionality, dimensions)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"predictions":[{"embeddings":{"values":[0.1,0.2],"statistics":{"token_count":2}}},{"embeddings":{"values":[0.3,0.4],"statistics":{"token_count":3}}}]}`))
+	}))
+	defer srv.Close()
+
+	p, _ := New(Options{
+		ProjectID: "demo-project",
+		Region:    "us-central1",
+		APIKey:    "test-key",
+	})
+	p.SetBaseURL(srv.URL + "/v1/projects/demo-project/locations/us-central1/endpoints/openapi")
+
+	resp, err := p.Embed(context.Background(), core.EmbeddingRequest{
+		Model:      "text-embedding-005",
+		Input:      []string{"first", "second"},
+		Dimensions: &dimensions,
+	})
+	if err != nil {
+		t.Fatalf("Embed() error: %v", err)
+	}
+	if resp.Object != "list" || resp.Model != "text-embedding-005" {
+		t.Errorf("response metadata = (%q, %q)", resp.Object, resp.Model)
+	}
+	if len(resp.Data) != 2 || resp.Data[0].Index != 0 || resp.Data[1].Index != 1 {
+		t.Fatalf("response data = %+v", resp.Data)
+	}
+	if resp.Data[0].Embedding[0] != 0.1 || resp.Data[1].Embedding[1] != 0.4 {
+		t.Errorf("embeddings = %+v", resp.Data)
+	}
+	if resp.Usage.PromptTokens != 5 || resp.Usage.TotalTokens != 5 {
+		t.Errorf("usage = %+v, want 5 prompt/total", resp.Usage)
+	}
+}
+
+func TestVertexAIProvider_Embed_StringInput(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/publishers/google/models/textembedding-gecko@003:predict" {
+			t.Errorf("request path = %q, want /publishers/google/models/textembedding-gecko@003:predict", r.URL.Path)
+		}
+		var body struct {
+			Instances []struct {
+				Content string `json:"content"`
+			} `json:"instances"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		if len(body.Instances) != 1 || body.Instances[0].Content != "hello" {
+			t.Fatalf("instances = %+v, want hello", body.Instances)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"predictions":[{"embeddings":{"values":[1,2,3],"statistics":{"tokenCount":4}}}]}`))
+	}))
+	defer srv.Close()
+
+	p, _ := New(Options{
+		ProjectID: "demo-project",
+		Region:    "us-central1",
+		APIKey:    "test-key",
+	})
+	p.SetBaseURL(srv.URL)
+
+	resp, err := p.Embed(context.Background(), core.EmbeddingRequest{
+		Model: "textembedding-gecko@003",
+		Input: "hello",
+	})
+	if err != nil {
+		t.Fatalf("Embed() error: %v", err)
+	}
+	if len(resp.Data) != 1 || resp.Data[0].Embedding[2] != 3 {
+		t.Errorf("response data = %+v", resp.Data)
+	}
+	if resp.Usage.TotalTokens != 4 {
+		t.Errorf("usage = %+v, want total_tokens 4", resp.Usage)
+	}
+}
+
+func TestVertexAIProvider_Embed_InvalidInput(t *testing.T) {
+	p, _ := New(Options{
+		ProjectID: "demo-project",
+		Region:    "us-central1",
+		APIKey:    "test-key",
+	})
+	_, err := p.Embed(context.Background(), core.EmbeddingRequest{
+		Model: "text-embedding-005",
+		Input: []interface{}{"ok", 123},
+	})
+	if err == nil || !strings.Contains(err.Error(), "Input[1]") {
+		t.Fatalf("Embed() error = %v, want invalid input error", err)
+	}
+}
+
+func TestVertexAIProvider_Embed_UpstreamError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":{"message":"bad predict request"}}`))
+	}))
+	defer srv.Close()
+
+	p, _ := New(Options{
+		ProjectID: "demo-project",
+		Region:    "us-central1",
+		APIKey:    "test-key",
+	})
+	p.SetBaseURL(srv.URL)
+
+	_, err := p.Embed(context.Background(), core.EmbeddingRequest{
+		Model: "text-embedding-005",
+		Input: "hello",
+	})
+	if err == nil || !strings.Contains(err.Error(), "bad predict request") {
+		t.Fatalf("Embed() error = %v, want upstream error", err)
+	}
 }
 
 func TestVertexAIProvider_Complete_MockHTTP(t *testing.T) {


### PR DESCRIPTION
## Summary

Release v1.0.5 adds first-class Ollama Cloud support, expands `/v1/embeddings` coverage across built-in text embedding providers, and updates release/catalog documentation while keeping the gateway's public API OpenAI-compatible for end users.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] New provider
- [ ] New plugin
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Performance improvement
- [x] Refactor / code quality
- [x] Documentation / comments only
- [ ] CI / tooling

## Related issues

Fixes #94

## Changes

- Added `ollama-cloud` as a first-class provider, separate from local `ollama`, using Ollama Cloud's documented `/api/chat` and `/api/tags` APIs with Bearer token auth.
- Added Ollama Cloud streaming, model discovery, config examples, Docker env comments, README provider listing, and `ollama-cloud/*` catalog entries with `null` token pricing.
- Expanded `EmbeddingProvider` support for Bedrock, Cohere, Databricks, Fireworks, Gemini, Mistral, Novita, Together, and Vertex AI text embedding flows.
- Added package-local embedding tests for auth/path mapping, string and array input, invalid input, upstream errors, response vector mapping, and token usage.
- Added a provider registry guardrail that keeps `CapabilityEmbed` aligned with actual `core.EmbeddingProvider` implementations.
- Added release notes for v1.0.5 and implementation docs for Ollama Cloud and embedding-provider expansion.

## Testing

- [x] Existing tests pass (`go test ./...`)
- [x] New unit tests added (if applicable)
- [ ] Manually tested against a live provider (if provider change)

Additional validation run locally:

```bash
go test -count=1 ./providers/bedrock/... ./providers/cohere/... ./providers/databricks/... ./providers/fireworks/... ./providers/gemini/... ./providers/mistral/... ./providers/novita/... ./providers/together/... ./providers/vertex_ai/... ./providers
go test -count=1 ./...
make build
git diff --check
git push -u origin release/v1.0.5
```

## Provider checklist (fill in only for new/updated providers)

- [x] Provider file at `providers/<id>/<id>.go`
- [x] Test file at `providers/<id>/<id>_test.go`
- [x] `ProviderEntry` added to `providers/providers_list.go`
- [x] Name constant added to `providers/names.go`
- [x] Models added to `models/catalog.json`
- [x] `AllowedTools`, `MaxCallDepth` and streaming tested

Notes:

- `AllowedTools` and `MaxCallDepth` are not applicable to the Ollama Cloud provider or embedding-only provider updates.
- Streaming coverage was added for Ollama Cloud; embedding providers are non-streaming by endpoint design.
- Bedrock and Vertex AI multimodal/image embeddings are intentionally deferred because `core.EmbeddingRequest` currently models text input only.

## Plugin checklist (fill in only for new/updated plugins)

- [ ] Plugin file at `internal/plugins/<name>/`
- [ ] `Stage` (before/after request) correctly set
- [ ] Test coverage added
- [ ] Example config documented

Not applicable; this PR does not add or update plugins.

## Breaking change notes

None. Existing OpenAI-compatible gateway routes and provider IDs remain backward compatible.

## Screenshots / output (optional)

```text
ok   github.com/ferro-labs/ai-gateway/providers/bedrock
ok   github.com/ferro-labs/ai-gateway/providers/cohere
ok   github.com/ferro-labs/ai-gateway/providers/databricks
ok   github.com/ferro-labs/ai-gateway/providers/fireworks
ok   github.com/ferro-labs/ai-gateway/providers/gemini
ok   github.com/ferro-labs/ai-gateway/providers/mistral
ok   github.com/ferro-labs/ai-gateway/providers/novita
ok   github.com/ferro-labs/ai-gateway/providers/together
ok   github.com/ferro-labs/ai-gateway/providers/vertex_ai
Pre-push checks passed
```
