### PR TITLE
feat: add streaming support to the Replicate provider

### DIFF
--- a/providers/replicate/replicate.go
+++ b/providers/replicate/replicate.go
@@ -189,14 +189,7 @@ func (p *Provider) Complete(ctx context.Context, req core.Request) (*core.Respon
 
 	predReq := replicatePredictionRequest{Input: input}
 
-	modelPath := req.Model
-	for _, m := range p.textModels {
-		if ModelBaseName(m) == ModelBaseName(req.Model) {
-			modelPath = m
-			break
-		}
-	}
-
+	modelPath := p.resolveTextModel(req.Model)
 	var url string
 	if v := ModelVersion(modelPath); v != "" {
 		predReq.Version = v
@@ -422,7 +415,6 @@ func (p *Provider) readStream(ctx context.Context, body io.ReadCloser, ch chan<-
 	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
 
 	event := "message"
-	id := predictionID
 	var data strings.Builder
 	dispatch := func() bool {
 		if data.Len() == 0 && event == "message" {
@@ -433,7 +425,7 @@ func (p *Provider) readStream(ctx context.Context, body io.ReadCloser, ch chan<-
 		switch event {
 		case "output":
 			ch <- core.StreamChunk{
-				ID:    id,
+				ID:    predictionID,
 				Model: model,
 				Choices: []core.StreamChoice{{
 					Index: 0,
@@ -454,7 +446,7 @@ func (p *Provider) readStream(ctx context.Context, body io.ReadCloser, ch chan<-
 				}
 			}
 			ch <- core.StreamChunk{
-				ID:    id,
+				ID:    predictionID,
 				Model: model,
 				Choices: []core.StreamChoice{{
 					Index:        0,
@@ -480,7 +472,6 @@ func (p *Provider) readStream(ctx context.Context, body io.ReadCloser, ch chan<-
 				return
 			}
 			event = "message"
-			id = predictionID
 			data.Reset()
 			continue
 		}
@@ -489,10 +480,6 @@ func (p *Provider) readStream(ctx context.Context, body io.ReadCloser, ch chan<-
 		}
 		if value, ok := strings.CutPrefix(line, "event:"); ok {
 			event = strings.TrimSpace(value)
-			continue
-		}
-		if value, ok := strings.CutPrefix(line, "id:"); ok {
-			id = strings.TrimSpace(value)
 			continue
 		}
 		if value, ok := strings.CutPrefix(line, "data:"); ok {

--- a/providers/replicate/replicate.go
+++ b/providers/replicate/replicate.go
@@ -2,6 +2,7 @@
 package replicate
 
 import (
+	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -37,6 +38,7 @@ type Provider struct {
 // Compile-time interface assertions.
 var (
 	_ core.Provider          = (*Provider)(nil)
+	_ core.StreamProvider    = (*Provider)(nil)
 	_ core.ImageProvider     = (*Provider)(nil)
 	_ core.ProxiableProvider = (*Provider)(nil)
 )
@@ -132,10 +134,14 @@ func ModelVersion(path string) string {
 
 // Prediction represents a Replicate API prediction result.
 type Prediction struct {
-	ID     string      `json:"id"`
-	Status string      `json:"status"`
-	Output interface{} `json:"output"`
-	Error  string      `json:"error,omitempty"`
+	ID        string      `json:"id"`
+	Status    string      `json:"status"`
+	Output    interface{} `json:"output"`
+	Error     string      `json:"error,omitempty"`
+	StreamURL string      `json:"stream_url,omitempty"`
+	URLs      struct {
+		Stream string `json:"stream,omitempty"`
+	} `json:"urls,omitempty"`
 }
 
 type replicatePredictionInput struct {
@@ -147,6 +153,7 @@ type replicatePredictionInput struct {
 type replicatePredictionRequest struct {
 	Version string                   `json:"version,omitempty"`
 	Input   replicatePredictionInput `json:"input"`
+	Stream  bool                     `json:"stream,omitempty"`
 }
 
 type replicateImageInput struct {
@@ -235,6 +242,78 @@ func (p *Provider) Complete(ctx context.Context, req core.Request) (*core.Respon
 	}, nil
 }
 
+// CompleteStream submits a Replicate prediction with streaming enabled and
+// translates Replicate output SSE events into OpenAI-compatible stream chunks.
+func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan core.StreamChunk, error) {
+	var sb strings.Builder
+	for _, msg := range req.Messages {
+		sb.WriteString(msg.Role)
+		sb.WriteString(": ")
+		sb.WriteString(msg.Content)
+		sb.WriteString("\n")
+	}
+	sb.WriteString("assistant: ")
+
+	input := replicatePredictionInput{Prompt: sb.String()}
+	if req.MaxTokens != nil {
+		input.MaxTokens = *req.MaxTokens
+	}
+	if req.Temperature != nil {
+		input.Temperature = *req.Temperature
+	}
+
+	predReq := replicatePredictionRequest{Input: input, Stream: true}
+	modelPath := p.resolveTextModel(req.Model)
+
+	var url string
+	if v := ModelVersion(modelPath); v != "" {
+		predReq.Version = v
+		url = fmt.Sprintf("%s/predictions", p.baseURL)
+	} else {
+		url = fmt.Sprintf("%s/models/%s/predictions", p.baseURL, ModelBaseName(modelPath))
+	}
+
+	bodyReader, _, release, err := core.JSONBodyReader(predReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+	defer release()
+
+	pred, err := p.submitPrediction(ctx, url, bodyReader)
+	if err != nil {
+		return nil, err
+	}
+	streamURL := pred.URLs.Stream
+	if streamURL == "" {
+		streamURL = pred.StreamURL
+	}
+	if streamURL == "" {
+		return nil, fmt.Errorf("replicate prediction %s does not include a stream URL", pred.ID)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, streamURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create stream request: %w", err)
+	}
+	httpReq.Header.Set("Authorization", "Token "+p.apiKey)
+	httpReq.Header.Set("Accept", "text/event-stream")
+
+	httpResp, err := p.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("stream request failed: %w", err)
+	}
+
+	if httpResp.StatusCode != http.StatusOK {
+		defer func() { _ = httpResp.Body.Close() }()
+		respBody, _ := io.ReadAll(httpResp.Body)
+		return nil, fmt.Errorf("replicate stream error (%d): %s", httpResp.StatusCode, string(respBody))
+	}
+
+	ch := make(chan core.StreamChunk)
+	go p.readStream(ctx, httpResp.Body, ch, pred.ID, req.Model)
+	return ch, nil
+}
+
 // GenerateImage submits an image generation prediction and polls until done.
 func (p *Provider) GenerateImage(ctx context.Context, req core.ImageRequest) (*core.ImageResponse, error) {
 	input := replicateImageInput{Prompt: req.Prompt}
@@ -295,6 +374,138 @@ func (p *Provider) GenerateImage(ctx context.Context, req core.ImageRequest) (*c
 		Created: time.Now().Unix(),
 		Data:    images,
 	}, nil
+}
+
+func (p *Provider) resolveTextModel(model string) string {
+	for _, m := range p.textModels {
+		if ModelBaseName(m) == ModelBaseName(model) {
+			return m
+		}
+	}
+	return model
+}
+
+func (p *Provider) submitPrediction(ctx context.Context, url string, body io.Reader) (*Prediction, error) {
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	httpReq.Header.Set("Authorization", "Token "+p.apiKey)
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	httpResp, err := p.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer func() { _ = httpResp.Body.Close() }()
+
+	if httpResp.StatusCode != http.StatusCreated && httpResp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(httpResp.Body)
+		return nil, fmt.Errorf("replicate API error (%d): %s", httpResp.StatusCode, string(respBody))
+	}
+
+	var pred Prediction
+	if err := json.NewDecoder(httpResp.Body).Decode(&pred); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal prediction: %w", err)
+	}
+	if pred.Status == "failed" || pred.Status == "canceled" {
+		return nil, fmt.Errorf("replicate prediction %s: %s", pred.Status, pred.Error)
+	}
+	return &pred, nil
+}
+
+func (p *Provider) readStream(ctx context.Context, body io.ReadCloser, ch chan<- core.StreamChunk, predictionID, model string) {
+	defer close(ch)
+	defer func() { _ = body.Close() }()
+
+	scanner := bufio.NewScanner(body)
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+
+	event := "message"
+	id := predictionID
+	var data strings.Builder
+	dispatch := func() bool {
+		if data.Len() == 0 && event == "message" {
+			return true
+		}
+		payload := data.String()
+		payload = strings.TrimSuffix(payload, "\n")
+		switch event {
+		case "output":
+			ch <- core.StreamChunk{
+				ID:    id,
+				Model: model,
+				Choices: []core.StreamChoice{{
+					Index: 0,
+					Delta: core.MessageDelta{Content: payload},
+				}},
+			}
+		case "error":
+			ch <- core.StreamChunk{Error: fmt.Errorf("replicate stream error: %s", payload)}
+			return false
+		case "done":
+			if payload != "" && payload != "{}" {
+				var done struct {
+					Reason string `json:"reason"`
+				}
+				if json.Unmarshal([]byte(payload), &done) == nil && done.Reason != "" {
+					ch <- core.StreamChunk{Error: fmt.Errorf("replicate prediction finished with reason %q", done.Reason)}
+					return false
+				}
+			}
+			ch <- core.StreamChunk{
+				ID:    id,
+				Model: model,
+				Choices: []core.StreamChoice{{
+					Index:        0,
+					FinishReason: "stop",
+				}},
+			}
+			return false
+		}
+		return true
+	}
+
+	for scanner.Scan() {
+		select {
+		case <-ctx.Done():
+			ch <- core.StreamChunk{Error: ctx.Err()}
+			return
+		default:
+		}
+
+		line := scanner.Text()
+		if line == "" {
+			if !dispatch() {
+				return
+			}
+			event = "message"
+			id = predictionID
+			data.Reset()
+			continue
+		}
+		if strings.HasPrefix(line, ":") {
+			continue
+		}
+		if value, ok := strings.CutPrefix(line, "event:"); ok {
+			event = strings.TrimSpace(value)
+			continue
+		}
+		if value, ok := strings.CutPrefix(line, "id:"); ok {
+			id = strings.TrimSpace(value)
+			continue
+		}
+		if value, ok := strings.CutPrefix(line, "data:"); ok {
+			data.WriteString(strings.TrimPrefix(value, " "))
+			data.WriteByte('\n')
+		}
+	}
+	if data.Len() > 0 {
+		_ = dispatch()
+	}
+	if err := scanner.Err(); err != nil {
+		ch <- core.StreamChunk{Error: fmt.Errorf("stream read error: %w", err)}
+	}
 }
 
 // submitAndPoll submits a prediction and polls until it completes.

--- a/providers/replicate/replicate_test.go
+++ b/providers/replicate/replicate_test.go
@@ -3,11 +3,12 @@ package replicate
 import (
 	"context"
 	"encoding/json"
-	"github.com/ferro-labs/ai-gateway/providers/core"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/ferro-labs/ai-gateway/providers/core"
 )
 
 func TestNewReplicate(t *testing.T) {
@@ -226,6 +227,89 @@ func TestReplicateProvider_Complete_MockHTTP(t *testing.T) {
 	}
 	if resp.Choices[0].Message.Content != "Hello world" {
 		t.Errorf("content = %q, want 'Hello world'", resp.Choices[0].Message.Content)
+	}
+}
+
+func TestReplicateProvider_CompleteStream_Interface(_ *testing.T) {
+	p, _ := New("test-token", "", nil, nil)
+	var _ core.StreamProvider = p
+}
+
+func TestReplicateProvider_CompleteStream_MockSSE(t *testing.T) {
+	var gotPath string
+	var gotAuth string
+	var gotAccept string
+	var gotBody map[string]interface{}
+
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/models/test/model/predictions":
+			gotPath = r.URL.Path
+			gotAuth = r.Header.Get("Authorization")
+			if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+				t.Fatalf("decode prediction request: %v", err)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{
+				"id":"pred-stream",
+				"status":"starting",
+				"urls":{"stream":"` + srv.URL + `/stream"}
+			}`))
+		case "/stream":
+			gotAccept = r.Header.Get("Accept")
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("event: output\nid: 1\ndata: Hello\n\n" +
+				"event: output\nid: 2\ndata:  world\n\n" +
+				"event: done\ndata: {}\n\n"))
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	p, _ := New("test-token", srv.URL, []string{"test/model"}, nil)
+	ch, err := p.CompleteStream(context.Background(), core.Request{
+		Model:    "test/model",
+		Messages: []core.Message{{Role: "user", Content: "Hi"}},
+	})
+	if err != nil {
+		t.Fatalf("CompleteStream() error: %v", err)
+	}
+
+	var chunks []core.StreamChunk
+	for c := range ch {
+		if c.Error != nil {
+			t.Fatalf("stream chunk error: %v", c.Error)
+		}
+		chunks = append(chunks, c)
+	}
+
+	if gotPath != "/models/test/model/predictions" {
+		t.Fatalf("request path = %q, want /models/test/model/predictions", gotPath)
+	}
+	if gotAuth != "Token test-token" {
+		t.Fatalf("authorization = %q, want Token test-token", gotAuth)
+	}
+	if gotAccept != "text/event-stream" {
+		t.Fatalf("stream Accept = %q, want text/event-stream", gotAccept)
+	}
+	if gotBody["stream"] != true {
+		t.Fatalf("body[\"stream\"] = %v, want true", gotBody["stream"])
+	}
+	if len(chunks) != 3 {
+		t.Fatalf("got %d chunks, want 3: %+v", len(chunks), chunks)
+	}
+	if chunks[0].Choices[0].Delta.Content != "Hello" {
+		t.Fatalf("first chunk content = %q, want Hello", chunks[0].Choices[0].Delta.Content)
+	}
+	if chunks[1].Choices[0].Delta.Content != " world" {
+		t.Fatalf("second chunk content = %q, want ' world'", chunks[1].Choices[0].Delta.Content)
+	}
+	if chunks[2].Choices[0].FinishReason != "stop" {
+		t.Fatalf("final finish_reason = %q, want stop", chunks[2].Choices[0].FinishReason)
 	}
 }
 

--- a/providers/replicate/replicate_test.go
+++ b/providers/replicate/replicate_test.go
@@ -302,6 +302,11 @@ func TestReplicateProvider_CompleteStream_MockSSE(t *testing.T) {
 	if len(chunks) != 3 {
 		t.Fatalf("got %d chunks, want 3: %+v", len(chunks), chunks)
 	}
+	for i, chunk := range chunks {
+		if chunk.ID != "pred-stream" {
+			t.Fatalf("chunk %d ID = %q, want pred-stream", i, chunk.ID)
+		}
+	}
 	if chunks[0].Choices[0].Delta.Content != "Hello" {
 		t.Fatalf("first chunk content = %q, want Hello", chunks[0].Choices[0].Delta.Content)
 	}


### PR DESCRIPTION
## Summary

Adds streaming support to the Replicate provider.

This implements `CompleteStream` for `providers/replicate`, allowing Replicate-backed chat completions to work with OpenAI-compatible streaming requests.

## What Changed

- Added `core.StreamProvider` support for Replicate.
- Sends Replicate prediction requests with `stream: true`.
- Follows the returned Replicate stream URL from `urls.stream` or `stream_url`.
- Parses Replicate SSE events:
  - `output` events become streamed `StreamChunk` content.
  - `done` emits a final chunk with `finish_reason: "stop"`.
  - `error` emits a stream error chunk.
- Added mock SSE test coverage for Replicate streaming.

## Tests

```powershell
go test ./providers/replicate/...
go test ./...
```

Output:

```text
ok      github.com/ferro-labs/ai-gateway/providers/replicate    1.065s
```

## Related Issue

Belongs to: https://github.com/ferro-labs/ai-gateway/issues/46


