### PR TITLE
fix: allow large SSE data lines in provider streams

### DIFF
--- a/providers/ai21/ai21.go
+++ b/providers/ai21/ai21.go
@@ -2,7 +2,6 @@
 package ai21
 
 import (
-	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -332,7 +331,7 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 		defer close(ch)
 		defer func() { _ = httpResp.Body.Close() }()
 
-		scanner := bufio.NewScanner(httpResp.Body)
+		scanner := core.NewSSEScanner(httpResp.Body)
 		for scanner.Scan() {
 			line := scanner.Text()
 			if !strings.HasPrefix(line, "data: ") {

--- a/providers/anthropic/anthropic.go
+++ b/providers/anthropic/anthropic.go
@@ -2,7 +2,6 @@
 package anthropic
 
 import (
-	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -313,7 +312,7 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 		defer func() { _ = httpResp.Body.Close() }()
 
 		var msgID, model string
-		scanner := bufio.NewScanner(httpResp.Body)
+		scanner := core.NewSSEScanner(httpResp.Body)
 		for scanner.Scan() {
 			line := scanner.Text()
 			if !strings.HasPrefix(line, "data: ") {

--- a/providers/azure_foundry/azure_foundry.go
+++ b/providers/azure_foundry/azure_foundry.go
@@ -2,7 +2,6 @@
 package azurefoundry
 
 import (
-	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -219,7 +218,7 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 		defer close(ch)
 		defer func() { _ = httpResp.Body.Close() }()
 
-		scanner := bufio.NewScanner(httpResp.Body)
+		scanner := core.NewSSEScanner(httpResp.Body)
 		for scanner.Scan() {
 			line := scanner.Text()
 			if !strings.HasPrefix(line, "data: ") {

--- a/providers/azure_openai/azure_openai.go
+++ b/providers/azure_openai/azure_openai.go
@@ -2,7 +2,6 @@
 package azureopenai
 
 import (
-	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -224,7 +223,7 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 		defer close(ch)
 		defer func() { _ = httpResp.Body.Close() }()
 
-		scanner := bufio.NewScanner(httpResp.Body)
+		scanner := core.NewSSEScanner(httpResp.Body)
 		for scanner.Scan() {
 			line := scanner.Text()
 			if !strings.HasPrefix(line, "data: ") {

--- a/providers/cerebras/cerebras.go
+++ b/providers/cerebras/cerebras.go
@@ -2,7 +2,6 @@
 package cerebras
 
 import (
-	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -223,7 +222,7 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 		defer close(ch)
 		defer func() { _ = httpResp.Body.Close() }()
 
-		scanner := bufio.NewScanner(httpResp.Body)
+		scanner := core.NewSSEScanner(httpResp.Body)
 		for scanner.Scan() {
 			line := scanner.Text()
 			if !strings.HasPrefix(line, "data: ") {

--- a/providers/cloudflare/cloudflare.go
+++ b/providers/cloudflare/cloudflare.go
@@ -2,7 +2,6 @@
 package cloudflare
 
 import (
-	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -221,7 +220,7 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 		defer close(ch)
 		defer func() { _ = httpResp.Body.Close() }()
 
-		scanner := bufio.NewScanner(httpResp.Body)
+		scanner := core.NewSSEScanner(httpResp.Body)
 		for scanner.Scan() {
 			line := scanner.Text()
 			if !strings.HasPrefix(line, "data: ") {

--- a/providers/cohere/cohere.go
+++ b/providers/cohere/cohere.go
@@ -2,7 +2,6 @@
 package cohere
 
 import (
-	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -272,7 +271,7 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 		defer close(ch)
 		defer func() { _ = httpResp.Body.Close() }()
 
-		scanner := bufio.NewScanner(httpResp.Body)
+		scanner := core.NewSSEScanner(httpResp.Body)
 		for scanner.Scan() {
 			line := scanner.Text()
 			if !strings.HasPrefix(line, "data: ") {

--- a/providers/core/sse_scanner.go
+++ b/providers/core/sse_scanner.go
@@ -1,0 +1,19 @@
+package core
+
+import (
+	"bufio"
+	"io"
+)
+
+const (
+	sseScannerInitialBufferSize = 64 * 1024
+	sseScannerMaxTokenSize      = 1024 * 1024
+)
+
+// NewSSEScanner returns a scanner sized for large SSE data lines, such as
+// tool-call payloads and long reasoning traces.
+func NewSSEScanner(r io.Reader) *bufio.Scanner {
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, sseScannerInitialBufferSize), sseScannerMaxTokenSize)
+	return scanner
+}

--- a/providers/core/sse_scanner_test.go
+++ b/providers/core/sse_scanner_test.go
@@ -1,0 +1,21 @@
+package core
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNewSSEScannerAllowsLargeDataLine(t *testing.T) {
+	payload := "data: " + strings.Repeat("x", 70*1024)
+	scanner := NewSSEScanner(strings.NewReader(payload + "\n\n"))
+
+	if !scanner.Scan() {
+		t.Fatalf("expected scanner to read oversized SSE line, err=%v", scanner.Err())
+	}
+	if got := scanner.Text(); got != payload {
+		t.Fatalf("scanner read %d bytes, want %d", len(got), len(payload))
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("scanner error: %v", err)
+	}
+}

--- a/providers/databricks/databricks.go
+++ b/providers/databricks/databricks.go
@@ -2,7 +2,6 @@
 package databricks
 
 import (
-	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -348,7 +347,7 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 		defer close(ch)
 		defer func() { _ = httpResp.Body.Close() }()
 
-		scanner := bufio.NewScanner(httpResp.Body)
+		scanner := core.NewSSEScanner(httpResp.Body)
 		for scanner.Scan() {
 			line := scanner.Text()
 			if !strings.HasPrefix(line, "data: ") {

--- a/providers/deepinfra/deepinfra.go
+++ b/providers/deepinfra/deepinfra.go
@@ -2,7 +2,6 @@
 package deepinfra
 
 import (
-	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -214,8 +213,7 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 		defer close(ch)
 		defer func() { _ = httpResp.Body.Close() }()
 
-		scanner := bufio.NewScanner(httpResp.Body)
-		scanner.Buffer(make([]byte, 64*1024), 1024*1024) // allow up to 1 MB per SSE line
+		scanner := core.NewSSEScanner(httpResp.Body)
 		for scanner.Scan() {
 			line := scanner.Text()
 			if !strings.HasPrefix(line, "data: ") {

--- a/providers/deepseek/deepseek.go
+++ b/providers/deepseek/deepseek.go
@@ -2,7 +2,6 @@
 package deepseek
 
 import (
-	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -221,7 +220,7 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 		defer close(ch)
 		defer func() { _ = httpResp.Body.Close() }()
 
-		scanner := bufio.NewScanner(httpResp.Body)
+		scanner := core.NewSSEScanner(httpResp.Body)
 		for scanner.Scan() {
 			line := scanner.Text()
 			if !strings.HasPrefix(line, "data: ") {

--- a/providers/fireworks/fireworks.go
+++ b/providers/fireworks/fireworks.go
@@ -2,7 +2,6 @@
 package fireworks
 
 import (
-	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -239,7 +238,7 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 		defer close(ch)
 		defer func() { _ = httpResp.Body.Close() }()
 
-		scanner := bufio.NewScanner(httpResp.Body)
+		scanner := core.NewSSEScanner(httpResp.Body)
 		for scanner.Scan() {
 			line := scanner.Text()
 			if !strings.HasPrefix(line, "data: ") {

--- a/providers/gemini/gemini.go
+++ b/providers/gemini/gemini.go
@@ -2,7 +2,6 @@
 package gemini
 
 import (
-	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -465,7 +464,7 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 		defer close(ch)
 		defer func() { _ = httpResp.Body.Close() }()
 
-		scanner := bufio.NewScanner(httpResp.Body)
+		scanner := core.NewSSEScanner(httpResp.Body)
 		for scanner.Scan() {
 			line := scanner.Text()
 			if !strings.HasPrefix(line, "data: ") {

--- a/providers/groq/groq.go
+++ b/providers/groq/groq.go
@@ -2,7 +2,6 @@
 package groq
 
 import (
-	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -223,7 +222,7 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 		defer close(ch)
 		defer func() { _ = httpResp.Body.Close() }()
 
-		scanner := bufio.NewScanner(httpResp.Body)
+		scanner := core.NewSSEScanner(httpResp.Body)
 		for scanner.Scan() {
 			line := scanner.Text()
 			if !strings.HasPrefix(line, "data: ") {

--- a/providers/hugging_face/hugging_face.go
+++ b/providers/hugging_face/hugging_face.go
@@ -2,7 +2,6 @@
 package huggingface
 
 import (
-	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -219,7 +218,7 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 		defer close(ch)
 		defer func() { _ = httpResp.Body.Close() }()
 
-		scanner := bufio.NewScanner(httpResp.Body)
+		scanner := core.NewSSEScanner(httpResp.Body)
 		for scanner.Scan() {
 			line := scanner.Text()
 			if !strings.HasPrefix(line, "data: ") {

--- a/providers/mistral/mistral.go
+++ b/providers/mistral/mistral.go
@@ -2,7 +2,6 @@
 package mistral
 
 import (
-	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -227,7 +226,7 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 		defer close(ch)
 		defer func() { _ = httpResp.Body.Close() }()
 
-		scanner := bufio.NewScanner(httpResp.Body)
+		scanner := core.NewSSEScanner(httpResp.Body)
 		for scanner.Scan() {
 			line := scanner.Text()
 			if !strings.HasPrefix(line, "data: ") {

--- a/providers/moonshot/moonshot.go
+++ b/providers/moonshot/moonshot.go
@@ -2,7 +2,6 @@
 package moonshot
 
 import (
-	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -214,8 +213,7 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 		defer close(ch)
 		defer func() { _ = httpResp.Body.Close() }()
 
-		scanner := bufio.NewScanner(httpResp.Body)
-		scanner.Buffer(make([]byte, 64*1024), 1024*1024) // allow up to 1 MB per SSE line
+		scanner := core.NewSSEScanner(httpResp.Body)
 		for scanner.Scan() {
 			line := scanner.Text()
 			if !strings.HasPrefix(line, "data: ") {

--- a/providers/novita/novita.go
+++ b/providers/novita/novita.go
@@ -2,7 +2,6 @@
 package novita
 
 import (
-	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -226,7 +225,7 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 		defer close(ch)
 		defer func() { _ = httpResp.Body.Close() }()
 
-		scanner := bufio.NewScanner(httpResp.Body)
+		scanner := core.NewSSEScanner(httpResp.Body)
 		for scanner.Scan() {
 			line := scanner.Text()
 			if !strings.HasPrefix(line, "data: ") {

--- a/providers/nvidia_nim/nvidia_nim.go
+++ b/providers/nvidia_nim/nvidia_nim.go
@@ -2,7 +2,6 @@
 package nvidianim
 
 import (
-	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -215,8 +214,7 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 		defer close(ch)
 		defer func() { _ = httpResp.Body.Close() }()
 
-		scanner := bufio.NewScanner(httpResp.Body)
-		scanner.Buffer(make([]byte, 64*1024), 1024*1024) // allow up to 1 MB per SSE line
+		scanner := core.NewSSEScanner(httpResp.Body)
 		for scanner.Scan() {
 			line := scanner.Text()
 			if !strings.HasPrefix(line, "data: ") {

--- a/providers/ollama/ollama.go
+++ b/providers/ollama/ollama.go
@@ -2,7 +2,6 @@
 package ollama
 
 import (
-	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -206,7 +205,7 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 		defer close(ch)
 		defer func() { _ = httpResp.Body.Close() }()
 
-		scanner := bufio.NewScanner(httpResp.Body)
+		scanner := core.NewSSEScanner(httpResp.Body)
 		for scanner.Scan() {
 			line := scanner.Text()
 			if !strings.HasPrefix(line, "data: ") {

--- a/providers/ollama_cloud/ollama_cloud.go
+++ b/providers/ollama_cloud/ollama_cloud.go
@@ -2,7 +2,6 @@
 package ollamacloud
 
 import (
-	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -198,8 +197,7 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 		defer close(ch)
 		defer func() { _ = httpResp.Body.Close() }()
 
-		scanner := bufio.NewScanner(httpResp.Body)
-		scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+		scanner := core.NewSSEScanner(httpResp.Body)
 		for scanner.Scan() {
 			line := strings.TrimSpace(scanner.Text())
 			if line == "" {

--- a/providers/openrouter/openrouter.go
+++ b/providers/openrouter/openrouter.go
@@ -2,7 +2,6 @@
 package openrouter
 
 import (
-	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -223,7 +222,7 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 		defer close(ch)
 		defer func() { _ = httpResp.Body.Close() }()
 
-		scanner := bufio.NewScanner(httpResp.Body)
+		scanner := core.NewSSEScanner(httpResp.Body)
 		for scanner.Scan() {
 			line := scanner.Text()
 			if !strings.HasPrefix(line, "data: ") {

--- a/providers/perplexity/perplexity.go
+++ b/providers/perplexity/perplexity.go
@@ -2,7 +2,6 @@
 package perplexity
 
 import (
-	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -226,7 +225,7 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 		defer close(ch)
 		defer func() { _ = httpResp.Body.Close() }()
 
-		scanner := bufio.NewScanner(httpResp.Body)
+		scanner := core.NewSSEScanner(httpResp.Body)
 		for scanner.Scan() {
 			line := scanner.Text()
 			if !strings.HasPrefix(line, "data: ") {

--- a/providers/qwen/qwen.go
+++ b/providers/qwen/qwen.go
@@ -2,7 +2,6 @@
 package qwen
 
 import (
-	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -214,8 +213,7 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 		defer close(ch)
 		defer func() { _ = httpResp.Body.Close() }()
 
-		scanner := bufio.NewScanner(httpResp.Body)
-		scanner.Buffer(make([]byte, 64*1024), 1024*1024) // allow up to 1 MB per SSE line
+		scanner := core.NewSSEScanner(httpResp.Body)
 		for scanner.Scan() {
 			line := scanner.Text()
 			if !strings.HasPrefix(line, "data: ") {

--- a/providers/replicate/replicate.go
+++ b/providers/replicate/replicate.go
@@ -2,7 +2,6 @@
 package replicate
 
 import (
-	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -417,8 +416,7 @@ func (p *Provider) readStream(ctx context.Context, body io.ReadCloser, ch chan<-
 	defer close(ch)
 	defer func() { _ = body.Close() }()
 
-	scanner := bufio.NewScanner(body)
-	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+	scanner := core.NewSSEScanner(body)
 
 	event := eventMessage
 	var data strings.Builder

--- a/providers/sambanova/sambanova.go
+++ b/providers/sambanova/sambanova.go
@@ -2,7 +2,6 @@
 package sambanova
 
 import (
-	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -214,8 +213,7 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 		defer close(ch)
 		defer func() { _ = httpResp.Body.Close() }()
 
-		scanner := bufio.NewScanner(httpResp.Body)
-		scanner.Buffer(make([]byte, 64*1024), 1024*1024) // allow up to 1 MB per SSE line
+		scanner := core.NewSSEScanner(httpResp.Body)
 		for scanner.Scan() {
 			line := scanner.Text()
 			if !strings.HasPrefix(line, "data: ") {

--- a/providers/together/together.go
+++ b/providers/together/together.go
@@ -2,7 +2,6 @@
 package together
 
 import (
-	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -228,7 +227,7 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 		defer close(ch)
 		defer func() { _ = httpResp.Body.Close() }()
 
-		scanner := bufio.NewScanner(httpResp.Body)
+		scanner := core.NewSSEScanner(httpResp.Body)
 		for scanner.Scan() {
 			line := scanner.Text()
 			if !strings.HasPrefix(line, "data: ") {

--- a/providers/vertex_ai/vertex_ai.go
+++ b/providers/vertex_ai/vertex_ai.go
@@ -2,7 +2,6 @@
 package vertexai
 
 import (
-	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -484,7 +483,7 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 		defer close(ch)
 		defer func() { _ = httpResp.Body.Close() }()
 
-		scanner := bufio.NewScanner(httpResp.Body)
+		scanner := core.NewSSEScanner(httpResp.Body)
 		for scanner.Scan() {
 			line := scanner.Text()
 			if !strings.HasPrefix(line, "data: ") {

--- a/providers/xai/xai.go
+++ b/providers/xai/xai.go
@@ -2,7 +2,6 @@
 package xai
 
 import (
-	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -223,7 +222,7 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 		defer close(ch)
 		defer func() { _ = httpResp.Body.Close() }()
 
-		scanner := bufio.NewScanner(httpResp.Body)
+		scanner := core.NewSSEScanner(httpResp.Body)
 		for scanner.Scan() {
 			line := scanner.Text()
 			if !strings.HasPrefix(line, "data: ") {


### PR DESCRIPTION
Fixes #129.

## Summary
- add a shared `core.NewSSEScanner` helper with a 1 MB max SSE token size
- switch provider stream parsers to use the shared scanner so large `data:` lines do not hit `bufio.Scanner`'s default 64 KB token limit
- add a regression test for an SSE data line larger than 64 KB

## Tests
- `go test ./providers/core -run TestNewSSEScannerAllowsLargeDataLine -count=1`
- `git diff --check`