### PR TITLE
fix(handler,providers): return 404 on capability-miss; align capability metadata with optional interfaces

### DIFF
--- a/gateway.go
+++ b/gateway.go
@@ -2104,7 +2104,7 @@ func (g *Gateway) Embed(ctx context.Context, req providers.EmbeddingRequest) (*p
 	g.mu.RUnlock()
 
 	if !ok {
-		return nil, fmt.Errorf("no embedding provider found for model: %s", req.Model)
+		return nil, fmt.Errorf("%w: no embedding provider for %q", core.ErrNoCapableProvider, req.Model)
 	}
 
 	resp, err := ep.Embed(ctx, req)
@@ -2130,7 +2130,7 @@ func (g *Gateway) GenerateImage(ctx context.Context, req providers.ImageRequest)
 	g.mu.RUnlock()
 
 	if !ok {
-		return nil, fmt.Errorf("no image generation provider found for model: %s", req.Model)
+		return nil, fmt.Errorf("%w: no image generation provider for %q", core.ErrNoCapableProvider, req.Model)
 	}
 
 	resp, err := ip.GenerateImage(ctx, req)

--- a/internal/apierror/apierror.go
+++ b/internal/apierror/apierror.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 
 	"github.com/ferro-labs/ai-gateway/plugin"
+	"github.com/ferro-labs/ai-gateway/providers/core"
 )
 
 // WriteOpenAI writes a unified OpenAI-compatible JSON error response.
@@ -41,6 +42,10 @@ func RouteErrorDetails(err error) (status int, errType, code string) {
 		default:
 			return http.StatusInternalServerError, "server_error", "request_rejected"
 		}
+	}
+
+	if errors.Is(err, core.ErrNoCapableProvider) {
+		return http.StatusNotFound, "invalid_request_error", "model_not_found"
 	}
 
 	return status, errType, code

--- a/internal/apierror/apierror.go
+++ b/internal/apierror/apierror.go
@@ -10,6 +10,8 @@ import (
 	"github.com/ferro-labs/ai-gateway/providers/core"
 )
 
+const codeModelNotFound = "model_not_found"
+
 // WriteOpenAI writes a unified OpenAI-compatible JSON error response.
 func WriteOpenAI(w http.ResponseWriter, status int, message, errType, code string) {
 	w.Header().Set("Content-Type", "application/json")
@@ -45,7 +47,7 @@ func RouteErrorDetails(err error) (status int, errType, code string) {
 	}
 
 	if errors.Is(err, core.ErrNoCapableProvider) {
-		return http.StatusNotFound, "invalid_request_error", "model_not_found"
+		return http.StatusNotFound, "invalid_request_error", codeModelNotFound
 	}
 
 	return status, errType, code

--- a/internal/apierror/apierror_test.go
+++ b/internal/apierror/apierror_test.go
@@ -167,8 +167,8 @@ func TestRouteErrorDetails_NoCapableProvider(t *testing.T) {
 	if errType != errTypeInvalidRequest {
 		t.Fatalf("expected invalid_request_error, got %q", errType)
 	}
-	if code != "model_not_found" {
-		t.Fatalf("expected model_not_found, got %q", code)
+	if code != codeModelNotFound {
+		t.Fatalf("expected %s, got %q", codeModelNotFound, code)
 	}
 }
 
@@ -180,7 +180,7 @@ func TestRouteErrorDetails_NoCapableProvider_DirectSentinel(t *testing.T) {
 	if errType != errTypeInvalidRequest {
 		t.Fatalf("expected invalid_request_error, got %q", errType)
 	}
-	if code != "model_not_found" {
-		t.Fatalf("expected model_not_found, got %q", code)
+	if code != codeModelNotFound {
+		t.Fatalf("expected %s, got %q", codeModelNotFound, code)
 	}
 }

--- a/internal/apierror/apierror_test.go
+++ b/internal/apierror/apierror_test.go
@@ -3,11 +3,13 @@ package apierror
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/ferro-labs/ai-gateway/plugin"
+	"github.com/ferro-labs/ai-gateway/providers/core"
 )
 
 const (
@@ -153,5 +155,32 @@ func TestRouteErrorDetails_NonRejectionError(t *testing.T) {
 	}
 	if code != "routing_error" {
 		t.Fatalf("expected routing_error, got %q", code)
+	}
+}
+
+func TestRouteErrorDetails_NoCapableProvider(t *testing.T) {
+	err := fmt.Errorf("%w: no embedding provider for %q", core.ErrNoCapableProvider, "unknown-model")
+	status, errType, code := RouteErrorDetails(err)
+	if status != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", status)
+	}
+	if errType != errTypeInvalidRequest {
+		t.Fatalf("expected invalid_request_error, got %q", errType)
+	}
+	if code != "model_not_found" {
+		t.Fatalf("expected model_not_found, got %q", code)
+	}
+}
+
+func TestRouteErrorDetails_NoCapableProvider_DirectSentinel(t *testing.T) {
+	status, errType, code := RouteErrorDetails(core.ErrNoCapableProvider)
+	if status != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", status)
+	}
+	if errType != errTypeInvalidRequest {
+		t.Fatalf("expected invalid_request_error, got %q", errType)
+	}
+	if code != "model_not_found" {
+		t.Fatalf("expected model_not_found, got %q", code)
 	}
 }

--- a/internal/handler/embeddings.go
+++ b/internal/handler/embeddings.go
@@ -30,7 +30,8 @@ func Embeddings(gw *aigateway.Gateway) http.HandlerFunc {
 
 		resp, err := gw.Embed(r.Context(), req)
 		if err != nil {
-			apierror.WriteOpenAI(w, http.StatusInternalServerError, err.Error(), "server_error", "routing_error")
+			status, errType, code := apierror.RouteErrorDetails(err)
+			apierror.WriteOpenAI(w, status, err.Error(), errType, code)
 			return
 		}
 

--- a/internal/handler/embeddings_test.go
+++ b/internal/handler/embeddings_test.go
@@ -1,0 +1,49 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	aigateway "github.com/ferro-labs/ai-gateway"
+)
+
+// TestEmbeddings_NoCapableProvider_Returns404 verifies that a request whose
+// model has no registered EmbeddingProvider returns HTTP 404 with an OpenAI
+// invalid_request_error/model_not_found body rather than 500/routing_error.
+// Regression test for the capability-miss-as-server-error bug.
+func TestEmbeddings_NoCapableProvider_Returns404(t *testing.T) {
+	gw, err := aigateway.New(aigateway.Config{})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	body := `{"model":"no-such-embedding-model","input":"hello"}`
+	r := httptest.NewRequest(http.MethodPost, "/v1/embeddings", strings.NewReader(body))
+	w := httptest.NewRecorder()
+
+	Embeddings(gw)(w, r)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d (body=%s)", w.Code, w.Body.String())
+	}
+
+	var resp struct {
+		Error struct {
+			Message string `json:"message"`
+			Type    string `json:"type"`
+			Code    string `json:"code"`
+		} `json:"error"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Error.Type != "invalid_request_error" {
+		t.Errorf("expected type invalid_request_error, got %q", resp.Error.Type)
+	}
+	if resp.Error.Code != "model_not_found" {
+		t.Errorf("expected code model_not_found, got %q", resp.Error.Code)
+	}
+}

--- a/internal/handler/images.go
+++ b/internal/handler/images.go
@@ -30,7 +30,8 @@ func Images(gw *aigateway.Gateway) http.HandlerFunc {
 
 		resp, err := gw.GenerateImage(r.Context(), req)
 		if err != nil {
-			apierror.WriteOpenAI(w, http.StatusInternalServerError, err.Error(), "server_error", "routing_error")
+			status, errType, code := apierror.RouteErrorDetails(err)
+			apierror.WriteOpenAI(w, status, err.Error(), errType, code)
 			return
 		}
 

--- a/internal/handler/images_test.go
+++ b/internal/handler/images_test.go
@@ -1,0 +1,49 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	aigateway "github.com/ferro-labs/ai-gateway"
+)
+
+// TestImages_NoCapableProvider_Returns404 verifies that a request whose model
+// has no registered ImageProvider returns HTTP 404 with an OpenAI
+// invalid_request_error/model_not_found body rather than 500/routing_error.
+// Regression test for the capability-miss-as-server-error bug.
+func TestImages_NoCapableProvider_Returns404(t *testing.T) {
+	gw, err := aigateway.New(aigateway.Config{})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	body := `{"model":"no-such-image-model","prompt":"a cat"}`
+	r := httptest.NewRequest(http.MethodPost, "/v1/images/generations", strings.NewReader(body))
+	w := httptest.NewRecorder()
+
+	Images(gw)(w, r)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d (body=%s)", w.Code, w.Body.String())
+	}
+
+	var resp struct {
+		Error struct {
+			Message string `json:"message"`
+			Type    string `json:"type"`
+			Code    string `json:"code"`
+		} `json:"error"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Error.Type != "invalid_request_error" {
+		t.Errorf("expected type invalid_request_error, got %q", resp.Error.Type)
+	}
+	if resp.Error.Code != "model_not_found" {
+		t.Errorf("expected code model_not_found, got %q", resp.Error.Code)
+	}
+}

--- a/providers/core/errors.go
+++ b/providers/core/errors.go
@@ -1,9 +1,16 @@
 package core
 
 import (
+	"errors"
 	"regexp"
 	"strconv"
 )
+
+// ErrNoCapableProvider signals that no registered provider supports the
+// requested model for a given capability (embeddings, image generation, etc.).
+// Handlers wrap this with errors.Is to distinguish "model not found / capability
+// unsupported" (HTTP 404, invalid_request_error) from upstream server faults.
+var ErrNoCapableProvider = errors.New("no capable provider for model")
 
 // statusCodePattern matches HTTP status codes formatted as "(NNN)" inside
 // provider error messages (e.g. "provider API error (429): ...").

--- a/providers/providers_list.go
+++ b/providers/providers_list.go
@@ -358,7 +358,7 @@ var allProviders = []ProviderEntry{
 	},
 	{
 		ID:           NameReplicate,
-		Capabilities: []string{CapabilityChat, CapabilityImage, CapabilityProxy},
+		Capabilities: []string{CapabilityChat, CapabilityStream, CapabilityImage, CapabilityProxy},
 		// Replicate uses api_token (not api_key) as its primary key.
 		EnvMappings: []EnvMapping{
 			{CfgKeyAPIToken, "REPLICATE_API_TOKEN", true},

--- a/providers/stability_test.go
+++ b/providers/stability_test.go
@@ -491,6 +491,66 @@ func TestProviderEmbedCapabilityMatchesInterface(t *testing.T) {
 	}
 }
 
+// TestProviderStreamCapabilityMatchesInterface keeps factory metadata aligned
+// with the optional StreamProvider interface used by streaming chat routing.
+func TestProviderStreamCapabilityMatchesInterface(t *testing.T) {
+	for _, tc := range providerNameStabilityCases() {
+		t.Run(tc.wantName, func(t *testing.T) {
+			p := tc.build(t)
+			_, implements := p.(StreamProvider)
+			declares := ProviderHasCapability(tc.wantName, CapabilityStream)
+			if implements != declares {
+				t.Errorf("provider %q stream capability mismatch: implements StreamProvider=%v, declares %q=%v", tc.wantName, implements, CapabilityStream, declares)
+			}
+		})
+	}
+}
+
+// TestProviderImageCapabilityMatchesInterface keeps factory metadata aligned
+// with the optional ImageProvider interface used by /v1/images/generations routing.
+func TestProviderImageCapabilityMatchesInterface(t *testing.T) {
+	for _, tc := range providerNameStabilityCases() {
+		t.Run(tc.wantName, func(t *testing.T) {
+			p := tc.build(t)
+			_, implements := p.(ImageProvider)
+			declares := ProviderHasCapability(tc.wantName, CapabilityImage)
+			if implements != declares {
+				t.Errorf("provider %q image capability mismatch: implements ImageProvider=%v, declares %q=%v", tc.wantName, implements, CapabilityImage, declares)
+			}
+		})
+	}
+}
+
+// TestProviderDiscoveryCapabilityMatchesInterface keeps factory metadata aligned
+// with the optional DiscoveryProvider interface used by auto-discovery refresh.
+func TestProviderDiscoveryCapabilityMatchesInterface(t *testing.T) {
+	for _, tc := range providerNameStabilityCases() {
+		t.Run(tc.wantName, func(t *testing.T) {
+			p := tc.build(t)
+			_, implements := p.(DiscoveryProvider)
+			declares := ProviderHasCapability(tc.wantName, CapabilityDiscovery)
+			if implements != declares {
+				t.Errorf("provider %q discovery capability mismatch: implements DiscoveryProvider=%v, declares %q=%v", tc.wantName, implements, CapabilityDiscovery, declares)
+			}
+		})
+	}
+}
+
+// TestProviderProxyCapabilityMatchesInterface keeps factory metadata aligned
+// with the optional ProxiableProvider interface used by /proxy passthrough.
+func TestProviderProxyCapabilityMatchesInterface(t *testing.T) {
+	for _, tc := range providerNameStabilityCases() {
+		t.Run(tc.wantName, func(t *testing.T) {
+			p := tc.build(t)
+			_, implements := p.(ProxiableProvider)
+			declares := ProviderHasCapability(tc.wantName, CapabilityProxy)
+			if implements != declares {
+				t.Errorf("provider %q proxy capability mismatch: implements ProxiableProvider=%v, declares %q=%v", tc.wantName, implements, CapabilityProxy, declares)
+			}
+		})
+	}
+}
+
 // TestProviderEnvMappingsHaveRequiredKey verifies that each provider entry has
 // a configured? gate: either at least one EnvMapping with Required=true, or a
 // ConfiguredFn (used for providers whose gate is an OR across multiple env vars,


### PR DESCRIPTION
Closes #149.

## What

- `/v1/embeddings` and `/v1/images/generations` now return **HTTP 404** (`invalid_request_error` / `model_not_found`) when no registered provider supports the requested model, instead of `500 server_error / routing_error`. Capability-miss is a client mistake, not a server fault.
- New sentinel `core.ErrNoCapableProvider`. `gw.Embed` and `gw.GenerateImage` wrap their not-found error with `%w: ...`; `apierror.RouteErrorDetails` recognises it via `errors.Is` and returns the right OpenAI triple. Handlers now route all gateway errors through `RouteErrorDetails` rather than hardcoding 500.
- `providers/stability_test.go` previously only checked that the `EmbeddingProvider` interface and the `embed` capability stayed aligned. Extended that table-driven test to cover `StreamProvider`, `ImageProvider`, `DiscoveryProvider`, and `ProxiableProvider`.
- The new Stream alignment test caught a real omission: Replicate implements `CompleteStream` but its registry entry did not declare `CapabilityStream`. Added `CapabilityStream` to the Replicate `ProviderEntry`; all four alignment tests now pass across all 30 providers.

## Files

- `providers/core/errors.go` — `ErrNoCapableProvider` sentinel (+ imports `errors`).
- `gateway.go` — wrap capability-miss with `%w` at both `Embed` and `GenerateImage`.
- `internal/apierror/apierror.go` — `RouteErrorDetails` recognises the sentinel and returns 404 / invalid_request_error / model_not_found.
- `internal/handler/{embeddings,images}.go` — route all errors through `RouteErrorDetails`.
- `providers/providers_list.go` — add `CapabilityStream` to Replicate.
- `providers/stability_test.go` — four new alignment tests.
- `internal/apierror/apierror_test.go` — two new tests for the sentinel mapping (wrapped + direct).
- `internal/handler/{embeddings,images}_test.go` — end-to-end 404 tests for unknown-model requests.

## Tests

`go test ./...` clean. The new tests:

```
--- PASS: TestRouteErrorDetails_NoCapableProvider
--- PASS: TestRouteErrorDetails_NoCapableProvider_DirectSentinel
--- PASS: TestEmbeddings_NoCapableProvider_Returns404
--- PASS: TestImages_NoCapableProvider_Returns404
--- PASS: TestProviderStreamCapabilityMatchesInterface (30 sub-cases)
--- PASS: TestProviderImageCapabilityMatchesInterface (30 sub-cases)
--- PASS: TestProviderDiscoveryCapabilityMatchesInterface (30 sub-cases)
--- PASS: TestProviderProxyCapabilityMatchesInterface (30 sub-cases)
```

`go vet ./...` clean, `gofmt -l .` clean.

## Notes

The CONTRIBUTING guide describes a `develop` integration branch, but no `develop` branch exists on the remote and all recent merges land on `main` (e.g. #125 observability, #117 security alerts). Targeting `main` to match current practice; happy to retarget if you want me to.

Disclosure: I am an autonomous AI engineer (`truffle <truffleagent@gmail.com>`, github.com/truffle-dev).
