### PR TITLE
Fix cost-optimized routing for unpriced models

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,8 @@ Full annotated example — copy to `config.yaml` and customize:
 strategy:
   mode: fallback  # single | fallback | loadbalance | conditional
                   # least-latency | cost-optimized | content-based | ab-test
+  # cost-optimized only: fallback (default) | skip | allow
+  # unpriced_strategy: fallback
 
 # Provider targets (tried in order for fallback mode)
 targets:

--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ Full methodology, raw results, and flamegraph analysis:
 
 - **8 routing strategies:** single, fallback, load balance, least latency, cost-optimized, content-based, A/B test, conditional
 - Provider failover with configurable retry policies and status code filters
+- Cost-optimized routing can explicitly fallback, skip, or allow providers with unknown catalog prices
 - Per-request model aliases (`fast → gpt-4o-mini`, `smart → claude-3-5-sonnet`)
 
 ### 🔌 Providers (30)

--- a/config.example.json
+++ b/config.example.json
@@ -1,6 +1,7 @@
 {
   "strategy": {
     "mode": "fallback",
+    "_unpriced_strategy_comment": "cost-optimized only: fallback (default) | skip | allow",
     "_comment": "mode: single | fallback | loadbalance | conditional | content-based | ab-test | least-latency | cost-optimized"
   },
   "_conditional_example": {

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -3,6 +3,10 @@
 
 strategy:
   mode: fallback  # single | fallback | loadbalance | conditional | content-based | ab-test | least-latency | cost-optimized
+  # For cost-optimized mode only: fallback (default) | skip | allow.
+  # fallback prefers priced candidates, then first compatible unpriced target.
+  # skip rejects unpriced candidates; allow treats missing prices as zero cost.
+  # unpriced_strategy: fallback
 
 # --- conditional routing example ---
 # strategy:

--- a/config.go
+++ b/config.go
@@ -118,6 +118,9 @@ type TracingConfig struct {
 type StrategyConfig struct {
 	Mode       StrategyMode `json:"mode" yaml:"mode"`
 	Conditions []Condition  `json:"conditions,omitempty" yaml:"conditions,omitempty"` // For conditional routing
+	// UnpricedStrategy controls how cost-optimized routing treats providers with
+	// missing catalog pricing: "fallback" (default), "skip", or "allow".
+	UnpricedStrategy string `json:"unpriced_strategy,omitempty" yaml:"unpriced_strategy,omitempty"`
 	// ContentConditions defines rules for the content-based routing strategy.
 	// Rules are evaluated in order; the first match wins.
 	ContentConditions []ContentCondition `json:"content_conditions,omitempty" yaml:"content_conditions,omitempty"`

--- a/config_load.go
+++ b/config_load.go
@@ -67,6 +67,14 @@ func ValidateConfig(cfg Config) error {
 		return fmt.Errorf("ab-test strategy requires at least one ab_variant")
 	}
 
+	if mode == ModeCostOptimized {
+		switch cfg.Strategy.UnpricedStrategy {
+		case "", "fallback", "skip", "allow":
+		default:
+			return fmt.Errorf("cost-optimized unpriced_strategy must be one of fallback, skip, allow")
+		}
+	}
+
 	if mode == ModeLoadBalance {
 		var sum float64
 		for _, t := range cfg.Targets {

--- a/config_load_test.go
+++ b/config_load_test.go
@@ -28,6 +28,24 @@ func TestLoadConfig_Valid(t *testing.T) {
 	}
 }
 
+func TestLoadConfig_CostOptimizedUnpricedStrategy(t *testing.T) {
+	data := `{
+		"strategy": {"mode": "cost-optimized", "unpriced_strategy": "skip"},
+		"targets": [
+			{"virtual_key": "openai-key"}
+		]
+	}`
+	path := writeTempFile(t, "config.json", data)
+
+	cfg, err := LoadConfig(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Strategy.UnpricedStrategy != "skip" {
+		t.Errorf("expected unpriced_strategy %q, got %q", "skip", cfg.Strategy.UnpricedStrategy)
+	}
+}
+
 func TestLoadConfig_NonExistentFile(t *testing.T) {
 	_, err := LoadConfig("/tmp/does-not-exist-config-12345.json")
 	if err == nil {
@@ -103,6 +121,36 @@ func TestValidateConfig_UnknownStrategy(t *testing.T) {
 	}
 	if err := ValidateConfig(cfg); err == nil {
 		t.Fatal("expected error for unknown strategy")
+	}
+}
+
+func TestValidateConfig_CostOptimizedUnpricedStrategy(t *testing.T) {
+	tests := []struct {
+		name              string
+		unpricedStrategy  string
+		wantValidationErr bool
+	}{
+		{name: "default"},
+		{name: "fallback", unpricedStrategy: "fallback"},
+		{name: "skip", unpricedStrategy: "skip"},
+		{name: "allow", unpricedStrategy: "allow"},
+		{name: "invalid", unpricedStrategy: "free", wantValidationErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := Config{
+				Strategy: StrategyConfig{Mode: ModeCostOptimized, UnpricedStrategy: tt.unpricedStrategy},
+				Targets:  []Target{{VirtualKey: "key1"}},
+			}
+			err := ValidateConfig(cfg)
+			if tt.wantValidationErr && err == nil {
+				t.Fatal("expected validation error")
+			}
+			if !tt.wantValidationErr && err != nil {
+				t.Fatalf("unexpected validation error: %v", err)
+			}
+		})
 	}
 }
 

--- a/gateway.go
+++ b/gateway.go
@@ -816,7 +816,7 @@ func (g *Gateway) getStrategy() (strategies.Strategy, error) {
 		if len(targets) == 0 {
 			return nil, fmt.Errorf("no targets configured for cost-optimized strategy")
 		}
-		s = strategies.NewCostOptimized(targets, lookup, g.catalog)
+		s = strategies.NewCostOptimized(targets, lookup, g.catalog, g.config.Strategy.UnpricedStrategy)
 	case ModeConditional:
 		if len(g.config.Strategy.Conditions) == 0 {
 			return nil, fmt.Errorf("no conditions configured for conditional strategy")

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -81,6 +81,8 @@ func counterValue(t *testing.T, c prometheus.Counter) float64 {
 	return m.GetCounter().GetValue()
 }
 
+func ptrFloat64(v float64) *float64 { return &v }
+
 func TestGateway_Route_Single(t *testing.T) {
 	gw, _ := New(Config{
 		Strategy: StrategyConfig{Mode: ModeSingle},
@@ -132,6 +134,83 @@ func TestGateway_Route_Fallback(t *testing.T) {
 	}
 	if resp.ID != "fallback-ok" {
 		t.Errorf("got ID %q, want fallback-ok", resp.ID)
+	}
+}
+
+func TestGateway_Route_CostOptimizedPassesUnpricedStrategy(t *testing.T) {
+	tests := []struct {
+		name             string
+		unpricedStrategy string
+		wantProvider     string
+	}{
+		{
+			name:             "skip routes to priced provider",
+			unpricedStrategy: "skip",
+			wantProvider:     "priced",
+		},
+		{
+			name:             "allow routes to unpriced provider",
+			unpricedStrategy: "allow",
+			wantProvider:     "unpriced",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gw, err := New(Config{
+				Strategy: StrategyConfig{
+					Mode:             ModeCostOptimized,
+					UnpricedStrategy: tt.unpricedStrategy,
+				},
+				Targets: []Target{
+					{VirtualKey: "unpriced"},
+					{VirtualKey: "priced"},
+				},
+			})
+			if err != nil {
+				t.Fatalf("New: %v", err)
+			}
+			gw.catalog = models.Catalog{
+				"unpriced/gpt-4o": {
+					Provider: "unpriced",
+					ModelID:  "gpt-4o",
+					Mode:     models.ModeChat,
+					Pricing:  models.Pricing{},
+				},
+				"priced/gpt-4o": {
+					Provider: "priced",
+					ModelID:  "gpt-4o",
+					Mode:     models.ModeChat,
+					Pricing: models.Pricing{
+						InputPerMTokens: ptrFloat64(1.0),
+					},
+				},
+			}
+			gw.RegisterProvider(&mockProvider{
+				name:   "unpriced",
+				models: []string{"gpt-4o"},
+				resp:   &providers.Response{ID: "unpriced", Model: "gpt-4o"},
+			})
+			gw.RegisterProvider(&mockProvider{
+				name:   "priced",
+				models: []string{"gpt-4o"},
+				resp:   &providers.Response{ID: "priced", Model: "gpt-4o"},
+			})
+
+			resp, err := gw.Route(context.Background(), providers.Request{
+				Model:    "gpt-4o",
+				Messages: []providers.Message{{Role: "user", Content: "hello"}},
+			})
+			if err != nil {
+				t.Fatalf("Route: %v", err)
+			}
+			if resp.Provider != tt.wantProvider {
+				t.Fatalf("got provider %q, want %q", resp.Provider, tt.wantProvider)
+			}
+			if resp.ID != tt.wantProvider {
+				t.Fatalf("got response ID %q, want %q", resp.ID, tt.wantProvider)
+			}
+		})
 	}
 }
 

--- a/internal/strategies/costoptimized.go
+++ b/internal/strategies/costoptimized.go
@@ -41,6 +41,7 @@ func (c *CostOptimized) Execute(ctx context.Context, req providers.Request) (*pr
 		target   Target
 		costUSD  float64
 		hasPrice bool
+		isModel  bool
 	}
 
 	var candidates []priced
@@ -55,7 +56,8 @@ func (c *CostOptimized) Execute(ctx context.Context, req providers.Request) (*pr
 		candidates = append(candidates, priced{
 			target:   t,
 			costUSD:  result.InputUSD,
-			hasPrice: result.ModelFound,
+			hasPrice: result.Priced,
+			isModel:  result.ModelFound,
 		})
 	}
 
@@ -67,7 +69,7 @@ func (c *CostOptimized) Execute(ctx context.Context, req providers.Request) (*pr
 	var best *priced
 	for i := range candidates {
 		entry := &candidates[i]
-		if !entry.hasPrice {
+		if !entry.hasPrice || !entry.isModel {
 			continue
 		}
 		if best == nil || entry.costUSD < best.costUSD {

--- a/internal/strategies/costoptimized.go
+++ b/internal/strategies/costoptimized.go
@@ -9,17 +9,34 @@ import (
 )
 
 // CostOptimized routes to the cheapest compatible provider based on estimated
-// input cost from the model catalog. When catalog pricing is unavailable for
-// all candidates, the first compatible provider is used as a fallback.
+// input cost from the model catalog. By default, unpriced candidates are used
+// only when no compatible provider has known pricing.
 type CostOptimized struct {
-	targets []Target
-	lookup  ProviderLookup
-	catalog models.Catalog
+	targets          []Target
+	lookup           ProviderLookup
+	catalog          models.Catalog
+	unpricedStrategy unpricedStrategy
+}
+
+type unpricedStrategy string
+
+const (
+	unpricedStrategyFallback unpricedStrategy = "fallback"
+	unpricedStrategySkip     unpricedStrategy = "skip"
+	unpricedStrategyAllow    unpricedStrategy = "allow"
+)
+
+type priced struct {
+	target   Target
+	costUSD  float64
+	hasPrice bool
+	isModel  bool
 }
 
 // NewCostOptimized creates a new cost-optimized strategy.
-func NewCostOptimized(targets []Target, lookup ProviderLookup, catalog models.Catalog) *CostOptimized {
-	return &CostOptimized{targets: targets, lookup: lookup, catalog: catalog}
+func NewCostOptimized(targets []Target, lookup ProviderLookup, catalog models.Catalog, unpricedStrategyConfig ...string) *CostOptimized {
+	strategy := newUnpricedStrategy(unpricedStrategyConfig...)
+	return &CostOptimized{targets: targets, lookup: lookup, catalog: catalog, unpricedStrategy: strategy}
 }
 
 // Execute selects the provider with the lowest estimated input cost for the
@@ -36,14 +53,6 @@ func (c *CostOptimized) Execute(ctx context.Context, req providers.Request) (*pr
 		promptChars += len(msg.Content)
 	}
 	estimatedPromptTokens := promptChars/4 + 1
-
-	type priced struct {
-		target   Target
-		costUSD  float64
-		hasPrice bool
-		isModel  bool
-	}
-
 	var candidates []priced
 	for _, t := range c.targets {
 		p, ok := c.lookup(t.VirtualKey)
@@ -65,21 +74,13 @@ func (c *CostOptimized) Execute(ctx context.Context, req providers.Request) (*pr
 		return nil, fmt.Errorf("no provider supports model %s", req.Model)
 	}
 
-	// Among providers with catalog pricing, pick the cheapest.
-	var best *priced
-	for i := range candidates {
-		entry := &candidates[i]
-		if !entry.hasPrice || !entry.isModel {
-			continue
-		}
-		if best == nil || entry.costUSD < best.costUSD {
-			best = entry
-		}
-	}
-
-	// No pricing found — fall back to the first compatible provider.
-	if best == nil {
-		best = &candidates[0]
+	// Unpriced candidates are providers that support the model but do not have
+	// usable input-token pricing in the catalog. The mode controls whether those
+	// candidates are excluded, used only when nothing is priced, or treated as
+	// normal zero-cost candidates.
+	best, err := selectCostOptimizedCandidate(candidates, c.unpricedStrategy, req.Model)
+	if err != nil {
+		return nil, err
 	}
 
 	p, ok := c.lookup(best.target.VirtualKey)
@@ -91,4 +92,60 @@ func (c *CostOptimized) Execute(ctx context.Context, req providers.Request) (*pr
 		return nil, err
 	}
 	return responseWithProvider(resp, best.target.VirtualKey), nil
+}
+
+func newUnpricedStrategy(config ...string) unpricedStrategy {
+	if len(config) == 0 {
+		return unpricedStrategyFallback
+	}
+	return parseUnpricedStrategy(config[0])
+}
+
+func parseUnpricedStrategy(strategy string) unpricedStrategy {
+	switch unpricedStrategy(strategy) {
+	case unpricedStrategySkip, unpricedStrategyAllow:
+		return unpricedStrategy(strategy)
+	default:
+		return unpricedStrategyFallback
+	}
+}
+
+func (s unpricedStrategy) ranksUnpricedCandidates() bool {
+	return s == unpricedStrategyAllow
+}
+
+func (s unpricedStrategy) requiresPricedCandidate() bool {
+	return s == unpricedStrategySkip
+}
+
+func selectCostOptimizedCandidate(candidates []priced, strategy unpricedStrategy, model string) (*priced, error) {
+	var best *priced
+	for i := range candidates {
+		candidate := &candidates[i]
+		if !candidate.isModel {
+			continue
+		}
+		if !strategy.ranksUnpricedCandidates() && !candidate.hasPrice {
+			continue
+		}
+		if best == nil || candidate.costUSD < best.costUSD {
+			best = candidate
+		}
+	}
+
+	if best != nil {
+		return best, nil
+	} else if strategy.requiresPricedCandidate() {
+		return nil, fmt.Errorf("no priced provider supports model %s", model)
+	}
+
+	// Preserve historical fallback behavior: when no cataloged/priced candidate
+	// is selectable, fallback and allow route to the first compatible target.
+	for i := range candidates {
+		if candidates[i].isModel {
+			return &candidates[i], nil
+		}
+	}
+
+	return &candidates[0], nil
 }

--- a/internal/strategies/costoptimized.go
+++ b/internal/strategies/costoptimized.go
@@ -136,16 +136,10 @@ func selectCostOptimizedCandidate(candidates []priced, strategy unpricedStrategy
 	if best != nil {
 		return best, nil
 	} else if strategy.requiresPricedCandidate() {
+		// No cataloged/priced candidate is selectable; return an error.
 		return nil, fmt.Errorf("no priced provider supports model %s", model)
 	}
-
 	// Preserve historical fallback behavior: when no cataloged/priced candidate
 	// is selectable, fallback and allow route to the first compatible target.
-	for i := range candidates {
-		if candidates[i].isModel {
-			return &candidates[i], nil
-		}
-	}
-
 	return &candidates[0], nil
 }

--- a/internal/strategies/costoptimized_test.go
+++ b/internal/strategies/costoptimized_test.go
@@ -183,6 +183,39 @@ func TestCostOptimized_FallsBackToFirstCompatibleWhenAllCandidatesUnpriced(t *te
 	}
 }
 
+func TestCostOptimized_InvalidUnpricedStrategyFallsBackToFirstCompatible(t *testing.T) {
+	first := &mockProvider{name: "first", models: []string{"gpt-4o"}, resp: &providers.Response{ID: "first"}}
+	second := &mockProvider{name: "second", models: []string{"gpt-4o"}, resp: &providers.Response{ID: "second"}}
+
+	catalog := models.Catalog{
+		"first/gpt-4o": {
+			Provider: "first",
+			ModelID:  "gpt-4o",
+			Mode:     models.ModeChat,
+			Pricing:  models.Pricing{},
+		},
+		"second/gpt-4o": {
+			Provider: "second",
+			ModelID:  "gpt-4o",
+			Mode:     models.ModeChat,
+			Pricing:  models.Pricing{},
+		},
+	}
+	targets := []Target{{VirtualKey: "first"}, {VirtualKey: "second"}}
+	s := NewCostOptimized(targets, newLookup(first, second), catalog, "unknown")
+
+	resp, err := s.Execute(context.Background(), providers.Request{
+		Model:    "gpt-4o",
+		Messages: []providers.Message{{Role: "user", Content: "hello"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.ID != "first" {
+		t.Errorf("expected invalid unpriced strategy to use fallback mode, got %q", resp.ID)
+	}
+}
+
 func TestCostOptimized_AllowTreatsUnpricedAsZeroCost(t *testing.T) {
 	priced := &mockProvider{name: "priced", models: []string{"gpt-4o"}, resp: &providers.Response{ID: "priced"}}
 	unpriced := &mockProvider{name: "unpriced", models: []string{"gpt-4o"}, resp: &providers.Response{ID: "unpriced"}}
@@ -282,6 +315,28 @@ func TestCostOptimized_UnresolvableSelectedTargetReturnsError(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("expected error when selected provider is no longer resolvable")
+	}
+}
+
+func TestCostOptimized_ErrorsWhenNoProviderSupportsModel(t *testing.T) {
+	p1 := &mockProvider{name: "cheap", models: []string{"gpt-3.5-turbo"}, resp: &providers.Response{ID: "wrong"}}
+	p2 := &mockProvider{name: "expensive", models: []string{"claude-3"}, resp: &providers.Response{ID: "wrong"}}
+
+	targets := []Target{{VirtualKey: "cheap"}, {VirtualKey: "expensive"}}
+	s := NewCostOptimized(targets, newLookup(p1, p2), buildCatalog())
+
+	_, err := s.Execute(context.Background(), providers.Request{
+		Model:    "gpt-4o",
+		Messages: []providers.Message{{Role: "user", Content: "hi"}},
+	})
+	if err == nil {
+		t.Fatal("expected error when no provider supports model")
+	}
+	if err.Error() != "no provider supports model gpt-4o" {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if p1.calls != 0 || p2.calls != 0 {
+		t.Errorf("providers should not be called, got cheap=%d expensive=%d", p1.calls, p2.calls)
 	}
 }
 

--- a/internal/strategies/costoptimized_test.go
+++ b/internal/strategies/costoptimized_test.go
@@ -76,6 +76,113 @@ func TestCostOptimized_FallsBackWhenNoPricing(t *testing.T) {
 	}
 }
 
+func TestCostOptimized_SkipsUnpricedCatalogEntryWhenPricedCandidateExists(t *testing.T) {
+	unpriced := &mockProvider{name: "unpriced", models: []string{"gpt-4o"}, resp: &providers.Response{ID: "unpriced"}}
+	priced := &mockProvider{name: "priced", models: []string{"gpt-4o"}, resp: &providers.Response{ID: "priced"}}
+
+	catalog := models.Catalog{
+		"unpriced/gpt-4o": {
+			Provider: "unpriced",
+			ModelID:  "gpt-4o",
+			Mode:     models.ModeChat,
+			Pricing:  models.Pricing{},
+		},
+		"priced/gpt-4o": {
+			Provider: "priced",
+			ModelID:  "gpt-4o",
+			Mode:     models.ModeChat,
+			Pricing: models.Pricing{
+				InputPerMTokens:  ptrF(1.0),
+				OutputPerMTokens: ptrF(2.0),
+			},
+		},
+	}
+	targets := []Target{{VirtualKey: "unpriced"}, {VirtualKey: "priced"}}
+	s := NewCostOptimized(targets, newLookup(unpriced, priced), catalog)
+
+	resp, err := s.Execute(context.Background(), providers.Request{
+		Model:    "gpt-4o",
+		Messages: []providers.Message{{Role: "user", Content: "hello"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.ID != "priced" {
+		t.Errorf("expected priced provider, got %q", resp.ID)
+	}
+}
+
+func TestCostOptimized_DoesNotRankOutputOnlyPricingAsFreeInput(t *testing.T) {
+	outputOnly := &mockProvider{name: "output-only", models: []string{"gpt-4o"}, resp: &providers.Response{ID: "output-only"}}
+	priced := &mockProvider{name: "priced", models: []string{"gpt-4o"}, resp: &providers.Response{ID: "priced"}}
+
+	catalog := models.Catalog{
+		"output-only/gpt-4o": {
+			Provider: "output-only",
+			ModelID:  "gpt-4o",
+			Mode:     models.ModeChat,
+			Pricing: models.Pricing{
+				OutputPerMTokens: ptrF(2.0),
+			},
+		},
+		"priced/gpt-4o": {
+			Provider: "priced",
+			ModelID:  "gpt-4o",
+			Mode:     models.ModeChat,
+			Pricing: models.Pricing{
+				InputPerMTokens:  ptrF(1.0),
+				OutputPerMTokens: ptrF(2.0),
+			},
+		},
+	}
+	targets := []Target{{VirtualKey: "output-only"}, {VirtualKey: "priced"}}
+	s := NewCostOptimized(targets, newLookup(outputOnly, priced), catalog)
+
+	resp, err := s.Execute(context.Background(), providers.Request{
+		Model:    "gpt-4o",
+		Messages: []providers.Message{{Role: "user", Content: "hello"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.ID != "priced" {
+		t.Errorf("expected priced provider, got %q", resp.ID)
+	}
+}
+
+func TestCostOptimized_FallsBackToFirstCompatibleWhenAllCandidatesUnpriced(t *testing.T) {
+	first := &mockProvider{name: "first", models: []string{"gpt-4o"}, resp: &providers.Response{ID: "first"}}
+	second := &mockProvider{name: "second", models: []string{"gpt-4o"}, resp: &providers.Response{ID: "second"}}
+
+	catalog := models.Catalog{
+		"first/gpt-4o": {
+			Provider: "first",
+			ModelID:  "gpt-4o",
+			Mode:     models.ModeChat,
+			Pricing:  models.Pricing{},
+		},
+		"second/gpt-4o": {
+			Provider: "second",
+			ModelID:  "gpt-4o",
+			Mode:     models.ModeChat,
+			Pricing:  models.Pricing{},
+		},
+	}
+	targets := []Target{{VirtualKey: "first"}, {VirtualKey: "second"}}
+	s := NewCostOptimized(targets, newLookup(first, second), catalog)
+
+	resp, err := s.Execute(context.Background(), providers.Request{
+		Model:    "gpt-4o",
+		Messages: []providers.Message{{Role: "user", Content: "hello"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.ID != "first" {
+		t.Errorf("expected first compatible provider fallback, got %q", resp.ID)
+	}
+}
+
 func TestCostOptimized_SkipsUnsupportedModel(t *testing.T) {
 	p1 := &mockProvider{name: "cheap", models: []string{"gpt-3.5-turbo"}, resp: &providers.Response{ID: "wrong"}}
 	p2 := &mockProvider{name: "expensive", models: []string{"gpt-4o"}, resp: &providers.Response{ID: "right"}}

--- a/internal/strategies/costoptimized_test.go
+++ b/internal/strategies/costoptimized_test.go
@@ -183,6 +183,71 @@ func TestCostOptimized_FallsBackToFirstCompatibleWhenAllCandidatesUnpriced(t *te
 	}
 }
 
+func TestCostOptimized_AllowTreatsUnpricedAsZeroCost(t *testing.T) {
+	priced := &mockProvider{name: "priced", models: []string{"gpt-4o"}, resp: &providers.Response{ID: "priced"}}
+	unpriced := &mockProvider{name: "unpriced", models: []string{"gpt-4o"}, resp: &providers.Response{ID: "unpriced"}}
+
+	catalog := models.Catalog{
+		"priced/gpt-4o": {
+			Provider: "priced",
+			ModelID:  "gpt-4o",
+			Mode:     models.ModeChat,
+			Pricing: models.Pricing{
+				InputPerMTokens: ptrF(1.0),
+			},
+		},
+		"unpriced/gpt-4o": {
+			Provider: "unpriced",
+			ModelID:  "gpt-4o",
+			Mode:     models.ModeChat,
+			Pricing:  models.Pricing{},
+		},
+	}
+	targets := []Target{{VirtualKey: "priced"}, {VirtualKey: "unpriced"}}
+	s := NewCostOptimized(targets, newLookup(priced, unpriced), catalog, "allow")
+
+	resp, err := s.Execute(context.Background(), providers.Request{
+		Model:    "gpt-4o",
+		Messages: []providers.Message{{Role: "user", Content: "hello"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.ID != "unpriced" {
+		t.Errorf("expected allow mode to pick zero-cost unpriced provider, got %q", resp.ID)
+	}
+}
+
+func TestCostOptimized_SkipErrorsWhenAllCandidatesUnpriced(t *testing.T) {
+	first := &mockProvider{name: "first", models: []string{"gpt-4o"}, resp: &providers.Response{ID: "first"}}
+	second := &mockProvider{name: "second", models: []string{"gpt-4o"}, resp: &providers.Response{ID: "second"}}
+
+	catalog := models.Catalog{
+		"first/gpt-4o": {
+			Provider: "first",
+			ModelID:  "gpt-4o",
+			Mode:     models.ModeChat,
+			Pricing:  models.Pricing{},
+		},
+		"second/gpt-4o": {
+			Provider: "second",
+			ModelID:  "gpt-4o",
+			Mode:     models.ModeChat,
+			Pricing:  models.Pricing{},
+		},
+	}
+	targets := []Target{{VirtualKey: "first"}, {VirtualKey: "second"}}
+	s := NewCostOptimized(targets, newLookup(first, second), catalog, "skip")
+
+	_, err := s.Execute(context.Background(), providers.Request{
+		Model:    "gpt-4o",
+		Messages: []providers.Message{{Role: "user", Content: "hello"}},
+	})
+	if err == nil {
+		t.Fatal("expected error when skip mode has no priced candidates")
+	}
+}
+
 func TestCostOptimized_SkipsUnsupportedModel(t *testing.T) {
 	p1 := &mockProvider{name: "cheap", models: []string{"gpt-3.5-turbo"}, resp: &providers.Response{ID: "wrong"}}
 	p2 := &mockProvider{name: "expensive", models: []string{"gpt-4o"}, resp: &providers.Response{ID: "right"}}

--- a/models/calculator.go
+++ b/models/calculator.go
@@ -30,6 +30,8 @@ type CostResult struct {
 	// ModelFound is false when the catalog has no entry for the requested model.
 	// All cost fields will be zero in that case.
 	ModelFound bool
+	// Priced is false when the model has no input-token price.
+	Priced bool
 }
 
 // perM converts a nullable price-per-million-tokens to a cost for n tokens.
@@ -52,6 +54,8 @@ func Calculate(catalog Catalog, modelKey string, usage Usage) CostResult {
 
 	p := model.Pricing
 	r := CostResult{ModelFound: true}
+
+	r.Priced = p.InputPerMTokens != nil
 
 	switch model.Mode {
 	case ModeChat:

--- a/models/calculator_test.go
+++ b/models/calculator_test.go
@@ -48,6 +48,9 @@ func TestCalculateChatBasic(t *testing.T) {
 	if got.TotalUSD != 12.5 {
 		t.Errorf("TotalUSD: got %v, want 12.5", got.TotalUSD)
 	}
+	if !got.Priced {
+		t.Error("Priced should be true when token pricing is present")
+	}
 }
 
 func TestCalculateChatCacheAndReasoning(t *testing.T) {
@@ -111,6 +114,55 @@ func TestCalculateChatNilPricing(t *testing.T) {
 
 	if got.TotalUSD != 0 {
 		t.Errorf("TotalUSD: got %v, want 0 for all-nil pricing", got.TotalUSD)
+	}
+	if got.Priced {
+		t.Error("Priced should be false for all-nil pricing")
+	}
+}
+
+func TestCalculateChatOutputOnlyPricingIsNotInputPriced(t *testing.T) {
+	c := catalogWith("openai/output-only", Model{
+		Provider: "openai",
+		ModelID:  "output-only",
+		Mode:     ModeChat,
+		Pricing: Pricing{
+			OutputPerMTokens: ptr(15.0),
+		},
+	})
+
+	got := Calculate(c, "openai/output-only", Usage{
+		PromptTokens:     100_000,
+		CompletionTokens: 100_000,
+	})
+
+	if got.InputUSD != 0 {
+		t.Errorf("InputUSD: got %v, want 0 when input pricing is nil", got.InputUSD)
+	}
+	if got.OutputUSD != 1.5 {
+		t.Errorf("OutputUSD: got %v, want 1.5", got.OutputUSD)
+	}
+	if got.Priced {
+		t.Error("Priced should be false when input pricing is nil")
+	}
+}
+
+func TestCalculateChatZeroInputPriceIsPriced(t *testing.T) {
+	c := catalogWith("openai/free-input", Model{
+		Provider: "openai",
+		ModelID:  "free-input",
+		Mode:     ModeChat,
+		Pricing: Pricing{
+			InputPerMTokens: ptr(0),
+		},
+	})
+
+	got := Calculate(c, "openai/free-input", Usage{PromptTokens: 100_000})
+
+	if got.InputUSD != 0 {
+		t.Errorf("InputUSD: got %v, want 0 for explicit free input pricing", got.InputUSD)
+	}
+	if !got.Priced {
+		t.Error("Priced should be true when input pricing is explicitly zero")
 	}
 }
 
@@ -236,6 +288,9 @@ func TestCalculateModelNotFound(t *testing.T) {
 	}
 	if got.TotalUSD != 0 {
 		t.Errorf("TotalUSD: got %v, want 0 for unknown model", got.TotalUSD)
+	}
+	if got.Priced {
+		t.Error("Priced should be false for unknown model")
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes cost-optimized routing so catalog entries with `null` input pricing are treated as unknown cost instead of `$0`. This prevents unpriced providers from silently winning cheapest-provider selection and adds an explicit `strategy.unpriced_strategy` knob for operators that want fallback, strict skip, or legacy allow behavior.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] New provider
- [ ] New plugin
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Performance improvement
- [ ] Refactor / code quality
- [x] Documentation / comments only
- [ ] CI / tooling

## Related issues

Fixes #126

## Changes

- Split `models.CostResult.ModelFound` from a new `CostResult.Priced` signal so routing can tell "cataloged" apart from "has usable input-token pricing".
- Update cost-optimized routing to prefer priced candidates by default, fall back to the first compatible target when no priced candidate exists, and support `unpriced_strategy: fallback | skip | allow`.
- Preserve historical fallback behavior for uncataloged/custom models unless `skip` is configured.
- Document the config option in README/config examples and capture the issue-specific design decisions in `docs/decisions/issue-126-cost-optimized-unpriced-models.md`.

## Testing

- [x] Existing tests pass (`go test ./...`)
- [x] New unit tests added (if applicable)
- [ ] Manually tested against a live provider (if provider change)

Additional coverage added for:

- null-priced catalog entries no longer ranking as free when a priced candidate exists;
- output-only pricing not being treated as usable pre-request input pricing;
- explicit zero input price still counting as priced;
- default `fallback`, strict `skip`, and legacy-compatible `allow` modes;
- config load/validation for `unpriced_strategy`;
- gateway-level propagation of `strategy.unpriced_strategy` into cost-optimized routing. 

## Breaking change notes

No breaking API change. The default fixes the bug by no longer treating unknown prices as free when priced candidates are available. Operators that intentionally want the old ranking behavior can set `strategy.unpriced_strategy: allow`.

## Screenshots / output (optional)

```text
$ go test ./...
ok  github.com/ferro-labs/ai-gateway ...
```
