### PR TITLE
fix: handling across unresolvable models

### DIFF
--- a/internal/strategies/costoptimized.go
+++ b/internal/strategies/costoptimized.go
@@ -80,7 +80,10 @@ func (c *CostOptimized) Execute(ctx context.Context, req providers.Request) (*pr
 		best = &candidates[0]
 	}
 
-	p, _ := c.lookup(best.target.VirtualKey)
+	p, ok := c.lookup(best.target.VirtualKey)
+	if !ok {
+		return nil, fmt.Errorf("cost optimized routing: provider not found: %s", best.target.VirtualKey)
+	}
 	resp, err := p.Complete(ctx, req)
 	if err != nil {
 		return nil, err

--- a/internal/strategies/costoptimized_test.go
+++ b/internal/strategies/costoptimized_test.go
@@ -96,6 +96,23 @@ func TestCostOptimized_SkipsUnsupportedModel(t *testing.T) {
 	}
 }
 
+func TestCostOptimized_UnresolvableSelectedTargetReturnsError(t *testing.T) {
+	mp := &mockProvider{name: "cheap", models: []string{"gpt-4o"}, resp: &providers.Response{ID: "cheap"}}
+	s := NewCostOptimized(
+		[]Target{{VirtualKey: "cheap"}},
+		lookupMissingAfterFirstHit(mp),
+		buildCatalog(),
+	)
+
+	_, err := s.Execute(context.Background(), providers.Request{
+		Model:    "gpt-4o",
+		Messages: []providers.Message{{Role: "user", Content: "hi"}},
+	})
+	if err == nil {
+		t.Fatal("expected error when selected provider is no longer resolvable")
+	}
+}
+
 func TestCostOptimized_NoTargets(t *testing.T) {
 	s := NewCostOptimized(nil, newLookup(), models.Catalog{})
 	_, err := s.Execute(context.Background(), providers.Request{Model: "gpt-4o"})

--- a/internal/strategies/leastlatency.go
+++ b/internal/strategies/leastlatency.go
@@ -67,7 +67,10 @@ func (l *LeastLatency) Execute(ctx context.Context, req providers.Request) (*pro
 		// Round-robin through unseen providers to gather latency samples for each
 		// before settling on the best-known option.
 		pick := unseen[rand.Intn(len(unseen))] //nolint:gosec
-		p, _ := l.lookup(pick.target.VirtualKey)
+		p, ok := l.lookup(pick.target.VirtualKey)
+		if !ok {
+			return nil, fmt.Errorf("least latency based routing: provider not found: %s", pick.target.VirtualKey)
+		}
 		resp, err := p.Complete(ctx, req)
 		if err != nil {
 			return nil, err
@@ -84,7 +87,10 @@ func (l *LeastLatency) Execute(ctx context.Context, req providers.Request) (*pro
 		}
 	}
 
-	p, _ := l.lookup(best.target.VirtualKey)
+	p, ok := l.lookup(best.target.VirtualKey)
+	if !ok {
+		return nil, fmt.Errorf("least latency based routing: provider not found: %s", best.target.VirtualKey)
+	}
 	resp, err := p.Complete(ctx, req)
 	if err != nil {
 		return nil, err

--- a/internal/strategies/leastlatency_test.go
+++ b/internal/strategies/leastlatency_test.go
@@ -62,6 +62,39 @@ func TestLeastLatency_SkipsUnsupportedModel(t *testing.T) {
 	}
 }
 
+func TestLeastLatency_UnresolvableUnseenTargetReturnsError(t *testing.T) {
+	mp := &mockProvider{name: "p1", models: []string{"gpt-4o"}, resp: &providers.Response{ID: "ok"}}
+
+	tr := latency.New(10)
+	s := NewLeastLatency(
+		[]Target{{VirtualKey: "p1"}},
+		lookupMissingAfterFirstHit(mp),
+		tr,
+	)
+
+	_, err := s.Execute(context.Background(), providers.Request{Model: "gpt-4o"})
+	if err == nil {
+		t.Fatal("expected error when selected unseen provider is no longer resolvable")
+	}
+}
+
+func TestLeastLatency_UnresolvableSampledTargetReturnsError(t *testing.T) {
+	mp := &mockProvider{name: "p1", models: []string{"gpt-4o"}, resp: &providers.Response{ID: "ok"}}
+
+	tr := latency.New(10)
+	tr.Record("p1", 20*time.Millisecond)
+	s := NewLeastLatency(
+		[]Target{{VirtualKey: "p1"}},
+		lookupMissingAfterFirstHit(mp),
+		tr,
+	)
+
+	_, err := s.Execute(context.Background(), providers.Request{Model: "gpt-4o"})
+	if err == nil {
+		t.Fatal("expected error when selected sampled provider is no longer resolvable")
+	}
+}
+
 func TestLeastLatency_NoTargets(t *testing.T) {
 	tr := latency.New(10)
 	s := NewLeastLatency(nil, newLookup(), tr)

--- a/internal/strategies/loadbalance.go
+++ b/internal/strategies/loadbalance.go
@@ -48,7 +48,10 @@ func (lb *LoadBalance) Execute(ctx context.Context, req providers.Request) (*pro
 		return nil, err
 	}
 
-	p, _ := lb.lookup(target.VirtualKey)
+	p, ok := lb.lookup(target.VirtualKey)
+	if !ok {
+		return nil, fmt.Errorf("load balancing based routing: provider not found: %s", target.VirtualKey)
+	}
 	resp, err := p.Complete(ctx, req)
 	if err != nil {
 		return nil, err

--- a/internal/strategies/strategy_test.go
+++ b/internal/strategies/strategy_test.go
@@ -43,6 +43,20 @@ func newLookup(pp ...providers.Provider) ProviderLookup {
 	}
 }
 
+func lookupMissingAfterFirstHit(p providers.Provider) ProviderLookup {
+	calls := 0
+	return func(name string) (providers.Provider, bool) {
+		if name != p.Name() {
+			return nil, false
+		}
+		calls++
+		if calls == 1 {
+			return p, true
+		}
+		return nil, false
+	}
+}
+
 func TestSingle_Execute(t *testing.T) {
 	mp := &mockProvider{name: "a", models: []string{"gpt-4o"}, resp: &providers.Response{ID: "ok"}}
 	s := NewSingle(Target{VirtualKey: "a"}, newLookup(mp))
@@ -382,6 +396,19 @@ func TestLoadBalance_MissingProvider(t *testing.T) {
 	_, err := lb.Execute(context.Background(), providers.Request{Model: "gpt-4o", Messages: []providers.Message{{Role: "user", Content: "hi"}}})
 	if err == nil {
 		t.Fatal("expected error when provider is not registered")
+	}
+}
+
+func TestLoadBalance_UnresolvableSelectedTargetReturnsError(t *testing.T) {
+	mp := &mockProvider{name: "a", models: []string{"gpt-4o"}, resp: &providers.Response{ID: "a"}}
+	lb := NewLoadBalance(
+		[]Target{{VirtualKey: "a", Weight: 100}},
+		lookupMissingAfterFirstHit(mp),
+	)
+
+	_, err := lb.Execute(context.Background(), providers.Request{Model: "gpt-4o", Messages: []providers.Message{{Role: "user", Content: "hi"}}})
+	if err == nil {
+		t.Fatal("expected error when selected provider is no longer resolvable")
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes nil-pointer panics in `least-latency`, `cost-optimized`, and `loadbalance` routing when a selected target can no longer be resolved before dispatch. The strategies now return routing errors instead of dereferencing a nil provider, with focused regression coverage for the affected paths.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] New provider
- [ ] New plugin
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Performance improvement
- [ ] Refactor / code quality
- [ ] Documentation / comments only
- [ ] CI / tooling

## Related issues

Fixes #130 

## Changes

- Check the second provider lookup in `loadbalance` before calling `Complete`.
- Check the second provider lookup in `cost-optimized` before calling `Complete`.
- Check both least-latency dispatch paths:
  - unseen-provider sampling path;
  - already-sampled best-provider path.
- Return strategy-specific provider-not-found errors instead of panicking when a target becomes unresolvable.
- Add focused regression tests that simulate a provider resolving during compatibility filtering and disappearing before dispatch.

## Files changed

- `internal/strategies/loadbalance.go`
- `internal/strategies/costoptimized.go`
- `internal/strategies/leastlatency.go`
- `internal/strategies/strategy_test.go`
- `internal/strategies/costoptimized_test.go`
- `internal/strategies/leastlatency_test.go`

## Testing

- [ ] Existing tests pass (`go test ./...`)
- [x] New unit tests added (if applicable)
- [ ] Manually tested against a live provider (if provider change)

Additional coverage added for:

- load-balance selected target becoming unresolvable before dispatch;
- cost-optimized selected target becoming unresolvable before dispatch;
- least-latency unseen sampled target becoming unresolvable before dispatch;
- least-latency already-sampled best target becoming unresolvable before dispatch.