### PR TITLE
fix: release v1.1.1 — stability hotfix (C1/C2/C3/C4 + H5/H7 + #126)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,10 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Generate release notes
+        env:
+          # Used by scripts/generate_release_notes.sh to query the GitHub
+          # compare API for the per-PR author list (Contributors section).
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: bash scripts/generate_release_notes.sh "${GITHUB_REF_NAME}" "${RUNNER_TEMP}/release-notes.md"
 
       - name: Run GoReleaser
@@ -68,6 +72,8 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Generate release notes
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: bash scripts/generate_release_notes.sh "${GITHUB_REF_NAME}" "${RUNNER_TEMP}/release-notes.md"
 
       - name: Send Discord notification

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,43 @@ All notable changes to Ferro Labs AI Gateway are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.1] — 2026-05-31
+
+Stability hotfix. No new features, no API breaks. Fixes every issue labelled [`release-1.1.1`](https://github.com/ferro-labs/ai-gateway/issues?q=label%3Arelease-1.1.1) plus three additional CRITICAL bugs found in the post-v1.1.0 engine audit (shutdown panic, runtime-discovery data race, streaming goroutine/body leak). Adds a `goleak` + `-race` concurrency stress harness so these regressions can't recur silently.
+
+### Fixed
+
+- **Send on closed channel panic during shutdown** (issue [#127](https://github.com/ferro-labs/ai-gateway/issues/127)): `Gateway.Close()` previously called `close(g.hookDispatchQ)` while `publishEvent` could still be enqueuing dispatches; the producer's `select`/`default` arm guards a *full* channel but not a *closed* one, so production crashed under shutdown-under-load. `Close()` now cancels a shutdown context instead; producers select on it before sending; workers drain any queued events before exiting; `Close()` waits up to 5s for workers via a `WaitGroup` (never blocks indefinitely so a panicking hook can't wedge shutdown). Stress-tested with 50 concurrent `Route()` callers racing `Close()` under `-race`.
+- **Data race in provider lookup vs runtime discovery / config reload** (issue [#128](https://github.com/ferro-labs/ai-gateway/issues/128)): the lookup closure built in `getStrategy` read `g.providers` and `g.circuitBreakers` without holding `g.mu`, racing `RegisterProvider` and `ReloadConfig` (which reassigns `circuitBreakers` wholesale). Closure now takes `g.mu.RLock` for its body; verified `Route` (`gateway.go:330`) and `RouteStream` (`gateway.go:1108`) release the gateway lock before strategy execution so the lock-in-closure cannot recursively deadlock against a writer. Stress-tested with 20 concurrent `Route()` callers racing a mutator goroutine that reassigns both maps under `-race`.
+- **Streaming goroutine and HTTP body leak on client disconnect**: `streamwrap.Meter` previously blocked forever on `out <- chunk` when the consumer (typically the HTTP handler) stopped reading because the client disconnected. The `Meter` goroutine, the upstream provider goroutine (blocked on its next send to `src`), and the provider's HTTP response body all leaked. `Meter` now selects on `ctx.Done()` for every send and every read from `src`; on cancel it drains `src` so the upstream goroutine can finish its in-flight write and exit. Emits a single `gateway.request.failed` event with a new `client_canceled` `provider_errors` metric label so budgets and observability still see the request and dashboards can separate client disconnects from real provider errors.
+- **MCP registry/executor and plugin-manager races** (issue [#131](https://github.com/ferro-labs/ai-gateway/issues/131), PR [#172](https://github.com/ferro-labs/ai-gateway/pull/172)): `Route`/`RouteStream` now snapshot `g.mcpRegistry` / `g.mcpExecutor` under `g.mu.RLock` instead of reading the fields after the lock is released, eliminating a race against `ReloadConfig`. `plugin.Manager` gets its own `sync.RWMutex` around the `before`/`after`/`onErr` slices so registrations during reload are safe vs concurrent execution.
+- **Streaming aborts on SSE lines larger than 64 KB** (issue [#129](https://github.com/ferro-labs/ai-gateway/issues/129), PR [#153](https://github.com/ferro-labs/ai-gateway/pull/153)): added shared `providers/core/sse_scanner.go` with a `Buffer(_, 1 MiB)` helper and applied it to the 9 stream-capable providers that were missing it. Tools, long reasoning blocks, and large embedded payloads no longer truncate the stream.
+- **Nil-pointer panic in `least-latency` / `cost-optimized` / `loadbalance` when a target is unresolvable at dispatch** (issue [#130](https://github.com/ferro-labs/ai-gateway/issues/130), PR [#156](https://github.com/ferro-labs/ai-gateway/pull/156)): all three strategies now return a routing error when the selected target can no longer be resolved between candidate-building and dispatch, instead of dereferencing a nil provider.
+- **`cost-optimized` routing treated `null`-priced catalog entries as $0** (issue [#126](https://github.com/ferro-labs/ai-gateway/issues/126), PR [#155](https://github.com/ferro-labs/ai-gateway/pull/155); originally scoped for v1.1.2, pulled forward because the fix was ready). Unpriced candidates no longer silently win cheapest-provider selection in a mixed pool. Behavior is governed by the new `strategy.unpriced_strategy` knob (see *Added*); the default preserves the historical fallback ranking for pools where every candidate is priced.
+
+### Added
+
+- **`strategy.unpriced_strategy` config knob** for `cost-optimized` routing: `fallback` (default — prefer priced candidates, then first compatible unpriced target), `skip` (reject unpriced candidates), or `allow` (legacy behavior — treat missing prices as zero cost). Validated at config load.
+- **`providers/core/sse_scanner.go`**: shared `NewSSEScanner(r)` helper returning a `*bufio.Scanner` pre-configured with a 1 MiB line buffer. New stream providers should call it instead of repeating the buffer setup.
+- **`provider_errors{err="client_canceled"}` metric label**: distinguishes streaming requests cancelled by the client from real provider errors. Existing `provider_error` and `circuit_open` labels are unchanged.
+- **Stress / leak test harness**: `internal/streamwrap/wrap_leak_test.go` (goroutine-leak check + client-disconnect + natural-end-of-stream cases) and `gateway_stress_test.go` (`TestStress_ShutdownUnderLoad_NoPanic`, `TestStress_ReloadUnderLoad_NoRace`). Both use `go.uber.org/goleak` and run under `-race`.
+
+### Changed
+
+- **`Gateway.Close()`** now drains the hook-dispatch queue and waits up to 5 seconds for hook workers to finish in-flight dispatches before returning. The hook channel is no longer closed by `Close()` — workers exit via the new shutdown context. Calling `Close()` more than once remains safe (idempotent).
+- **`go.uber.org/goleak`** promoted from an indirect to a direct dependency, used by the new stress and leak tests.
+
+### Documentation
+
+- `README.md` and the YAML/JSON example configs document the new `strategy.unpriced_strategy` knob under the *Routing strategies* section.
+
+### Notes
+
+- All public `release-1.1.1` issues — [#126](https://github.com/ferro-labs/ai-gateway/issues/126), [#127](https://github.com/ferro-labs/ai-gateway/issues/127), [#128](https://github.com/ferro-labs/ai-gateway/issues/128), [#129](https://github.com/ferro-labs/ai-gateway/issues/129), [#130](https://github.com/ferro-labs/ai-gateway/issues/130), [#131](https://github.com/ferro-labs/ai-gateway/issues/131) — are closed by this release.
+- A separate GitHub Security Advisory accompanies this tag for the streaming-disconnect fix; check the Security tab for the GHSA ID and CVSS scoring.
+
+---
+
 ## [1.1.0] — 2026-05-24
 
 Adds opt-in OpenTelemetry tracing. Off by default — a zero-allocation no-op until an OTLP endpoint or exporter is configured.

--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ Full methodology, raw results, and flamegraph analysis:
 
 - **8 routing strategies:** single, fallback, load balance, least latency, cost-optimized, content-based, A/B test, conditional
 - Provider failover with configurable retry policies and status code filters
+- Cost-optimized routing can explicitly fallback, skip, or allow providers with unknown catalog prices
 - Per-request model aliases (`fast → gpt-4o-mini`, `smart → claude-3-5-sonnet`)
 
 ### 🔌 Providers (30)
@@ -278,6 +279,8 @@ Full annotated example — copy to `config.yaml` and customize:
 strategy:
   mode: fallback  # single | fallback | loadbalance | conditional
                   # least-latency | cost-optimized | content-based | ab-test
+  # cost-optimized only: fallback (default) | skip | allow
+  # unpriced_strategy: fallback
 
 # Provider targets (tried in order for fallback mode)
 targets:

--- a/config.example.json
+++ b/config.example.json
@@ -1,6 +1,7 @@
 {
   "strategy": {
     "mode": "fallback",
+    "_unpriced_strategy_comment": "cost-optimized only: fallback (default) | skip | allow",
     "_comment": "mode: single | fallback | loadbalance | conditional | content-based | ab-test | least-latency | cost-optimized"
   },
   "_conditional_example": {

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -3,6 +3,10 @@
 
 strategy:
   mode: fallback  # single | fallback | loadbalance | conditional | content-based | ab-test | least-latency | cost-optimized
+  # For cost-optimized mode only: fallback (default) | skip | allow.
+  # fallback prefers priced candidates, then first compatible unpriced target.
+  # skip rejects unpriced candidates; allow treats missing prices as zero cost.
+  # unpriced_strategy: fallback
 
 # --- conditional routing example ---
 # strategy:

--- a/config.go
+++ b/config.go
@@ -118,6 +118,9 @@ type TracingConfig struct {
 type StrategyConfig struct {
 	Mode       StrategyMode `json:"mode" yaml:"mode"`
 	Conditions []Condition  `json:"conditions,omitempty" yaml:"conditions,omitempty"` // For conditional routing
+	// UnpricedStrategy controls how cost-optimized routing treats providers with
+	// missing catalog pricing: "fallback" (default), "skip", or "allow".
+	UnpricedStrategy string `json:"unpriced_strategy,omitempty" yaml:"unpriced_strategy,omitempty"`
 	// ContentConditions defines rules for the content-based routing strategy.
 	// Rules are evaluated in order; the first match wins.
 	ContentConditions []ContentCondition `json:"content_conditions,omitempty" yaml:"content_conditions,omitempty"`

--- a/config_load.go
+++ b/config_load.go
@@ -67,6 +67,14 @@ func ValidateConfig(cfg Config) error {
 		return fmt.Errorf("ab-test strategy requires at least one ab_variant")
 	}
 
+	if mode == ModeCostOptimized {
+		switch cfg.Strategy.UnpricedStrategy {
+		case "", "fallback", "skip", "allow":
+		default:
+			return fmt.Errorf("cost-optimized unpriced_strategy must be one of fallback, skip, allow")
+		}
+	}
+
 	if mode == ModeLoadBalance {
 		var sum float64
 		for _, t := range cfg.Targets {

--- a/config_load_test.go
+++ b/config_load_test.go
@@ -28,6 +28,24 @@ func TestLoadConfig_Valid(t *testing.T) {
 	}
 }
 
+func TestLoadConfig_CostOptimizedUnpricedStrategy(t *testing.T) {
+	data := `{
+		"strategy": {"mode": "cost-optimized", "unpriced_strategy": "skip"},
+		"targets": [
+			{"virtual_key": "openai-key"}
+		]
+	}`
+	path := writeTempFile(t, "config.json", data)
+
+	cfg, err := LoadConfig(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Strategy.UnpricedStrategy != "skip" {
+		t.Errorf("expected unpriced_strategy %q, got %q", "skip", cfg.Strategy.UnpricedStrategy)
+	}
+}
+
 func TestLoadConfig_NonExistentFile(t *testing.T) {
 	_, err := LoadConfig("/tmp/does-not-exist-config-12345.json")
 	if err == nil {
@@ -103,6 +121,36 @@ func TestValidateConfig_UnknownStrategy(t *testing.T) {
 	}
 	if err := ValidateConfig(cfg); err == nil {
 		t.Fatal("expected error for unknown strategy")
+	}
+}
+
+func TestValidateConfig_CostOptimizedUnpricedStrategy(t *testing.T) {
+	tests := []struct {
+		name              string
+		unpricedStrategy  string
+		wantValidationErr bool
+	}{
+		{name: "default"},
+		{name: "fallback", unpricedStrategy: "fallback"},
+		{name: "skip", unpricedStrategy: "skip"},
+		{name: "allow", unpricedStrategy: "allow"},
+		{name: "invalid", unpricedStrategy: "free", wantValidationErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := Config{
+				Strategy: StrategyConfig{Mode: ModeCostOptimized, UnpricedStrategy: tt.unpricedStrategy},
+				Targets:  []Target{{VirtualKey: "key1"}},
+			}
+			err := ValidateConfig(cfg)
+			if tt.wantValidationErr && err == nil {
+				t.Fatal("expected validation error")
+			}
+			if !tt.wantValidationErr && err != nil {
+				t.Fatalf("unexpected validation error: %v", err)
+			}
+		})
 	}
 }
 

--- a/gateway.go
+++ b/gateway.go
@@ -59,6 +59,9 @@ type Gateway struct {
 	hooks            []EventHookFunc
 	hookSnapshot     atomic.Value
 	hookDispatchQ    chan hookDispatch
+	hookWorkersDone  sync.WaitGroup
+	shutdownCtx      context.Context
+	shutdownCancel   context.CancelFunc
 	circuitBreakers  map[string]*circuitbreaker.CircuitBreaker
 	discoveredModels map[string][]providers.ModelInfo
 	latencyTracker   *latency.Tracker
@@ -123,6 +126,7 @@ func New(cfg Config) (*Gateway, error) {
 		hookDispatchQ: make(chan hookDispatch, hookDispatchQueueSize),
 		obs:           observability.NoOp(),
 	}
+	gw.shutdownCtx, gw.shutdownCancel = context.WithCancel(context.Background())
 	gw.hookSnapshot.Store([]EventHookFunc{})
 	gw.startHookWorkers()
 
@@ -613,6 +617,27 @@ func (g *Gateway) publishEvent(ctx context.Context, event events.HookEvent) {
 			hook:  hook,
 		}
 
+		// Bias toward the shutdown check first so we never race a Close()
+		// that has already cancelled. Once shutdownCtx is Done we drop the
+		// event rather than risk a send on what used to be a closed channel
+		// (we no longer close hookDispatchQ — workers exit via shutdownCtx).
+		// The nil-shutdownCtx branch supports a handful of unit tests that
+		// build Gateway literals directly without going through New().
+		if g.shutdownCtx != nil {
+			select {
+			case <-g.shutdownCtx.Done():
+				return
+			default:
+			}
+			select {
+			case g.hookDispatchQ <- dispatch:
+			case <-g.shutdownCtx.Done():
+				return
+			default:
+				metrics.HookEventsDroppedTotal.WithLabelValues(event.Subject).Inc()
+			}
+			continue
+		}
 		select {
 		case g.hookDispatchQ <- dispatch:
 		default:
@@ -637,9 +662,25 @@ func (g *Gateway) startHookWorkers() {
 	}
 
 	for range workerCount {
+		g.hookWorkersDone.Add(1)
 		go func() {
-			for dispatch := range g.hookDispatchQ {
-				runHookDispatch(dispatch)
+			defer g.hookWorkersDone.Done()
+			for {
+				select {
+				case <-g.shutdownCtx.Done():
+					// Best-effort drain anything queued before exiting so we
+					// don't lose events that were already enqueued.
+					for {
+						select {
+						case dispatch := <-g.hookDispatchQ:
+							runHookDispatch(dispatch)
+						default:
+							return
+						}
+					}
+				case dispatch := <-g.hookDispatchQ:
+					runHookDispatch(dispatch)
+				}
 			}
 		}()
 	}
@@ -772,7 +813,17 @@ func (g *Gateway) getStrategy() (strategies.Strategy, error) {
 	}
 
 	// Provider lookup with transparent circuit-breaker wrapping.
+	//
+	// The closure is captured into the strategy and invoked later from the
+	// request hot path, AFTER Route/RouteStream have released g.mu. It
+	// therefore needs its own RLock to coordinate with RegisterProvider and
+	// ReloadConfig (which reassigns circuitBreakers wholesale, line 707).
+	// Safe under sync.RWMutex because the calling paths drop the lock before
+	// strategy execution — see gateway.go:330 (Route) and
+	// gateway.go:1108 (RouteStream).
 	lookup := func(name string) (providers.Provider, bool) {
+		g.mu.RLock()
+		defer g.mu.RUnlock()
 		p, ok := g.providers[name]
 		if !ok {
 			return nil, false
@@ -1603,9 +1654,26 @@ func (g *Gateway) FindStreamingByModel(model string) (providers.StreamProvider, 
 }
 
 // Close cleans up resources.
+//
+// Cancels the gateway shutdown context (which signals hook workers to drain
+// and exit) and waits up to 5s for the workers to finish so in-flight hook
+// dispatches are not abruptly killed. Returns nil even if the worker drain
+// times out — Close must never block indefinitely (a panicking hook could
+// otherwise wedge shutdown).
+//
+// Safe to call multiple times; subsequent calls are no-ops.
 func (g *Gateway) Close() error {
 	g.closeOnce.Do(func() {
-		close(g.hookDispatchQ)
+		g.shutdownCancel()
+		done := make(chan struct{})
+		go func() {
+			g.hookWorkersDone.Wait()
+			close(done)
+		}()
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+		}
 	})
 	return nil
 }

--- a/gateway.go
+++ b/gateway.go
@@ -816,7 +816,7 @@ func (g *Gateway) getStrategy() (strategies.Strategy, error) {
 		if len(targets) == 0 {
 			return nil, fmt.Errorf("no targets configured for cost-optimized strategy")
 		}
-		s = strategies.NewCostOptimized(targets, lookup, g.catalog)
+		s = strategies.NewCostOptimized(targets, lookup, g.catalog, g.config.Strategy.UnpricedStrategy)
 	case ModeConditional:
 		if len(g.config.Strategy.Conditions) == 0 {
 			return nil, fmt.Errorf("no conditions configured for conditional strategy")

--- a/gateway.go
+++ b/gateway.go
@@ -325,6 +325,8 @@ func (g *Gateway) Route(ctx context.Context, req providers.Request) (*providers.
 	strategyMode := string(g.config.Strategy.Mode)
 	obs := g.obs
 	obsEventsActive := g.obsEventsActive
+	mcpRegistrySnapshot := g.mcpRegistry
+	mcpExecutorSnapshot := g.mcpExecutor
 	g.mu.RUnlock()
 	ctx, span := obs.StartRequestSpan(ctx, observability.RequestAttrs{
 		Operation:       "chat",
@@ -365,8 +367,8 @@ func (g *Gateway) Route(ctx context.Context, req providers.Request) (*providers.
 
 	// Inject MCP tool definitions into the request when servers are ready.
 	var mcpTools []mcp.Tool
-	if g.mcpRegistry != nil {
-		mcpTools = g.mcpRegistry.AllTools()
+	if mcpRegistrySnapshot != nil {
+		mcpTools = mcpRegistrySnapshot.AllTools()
 	}
 	if len(mcpTools) > 0 {
 		// Build a set of tool names already present in the request so we do not
@@ -460,15 +462,15 @@ func (g *Gateway) Route(ctx context.Context, req providers.Request) (*providers.
 	// Agentic MCP tool-call loop. Runs only when MCP is active and the LLM
 	// returned tool_calls. Each iteration executes the tools and re-contacts
 	// the LLM until no more tool_calls are present or the depth limit is hit.
-	if g.mcpExecutor != nil && len(mcpTools) > 0 {
+	if mcpExecutorSnapshot != nil && len(mcpTools) > 0 {
 		depth := 0
 		trace.WithRegion(ctx, "gateway.route.mcp.loop", func() {
-			for g.mcpExecutor.ShouldContinueLoop(resp, depth) {
+			for mcpExecutorSnapshot.ShouldContinueLoop(resp, depth) {
 				depth++
 
 				// ResolvePendingToolCalls returns the assistant message (with tool_calls)
 				// plus one tool-result message per call — append all at once.
-				toolMsgs, toolErr := g.mcpExecutor.ResolvePendingToolCalls(ctx, resp)
+				toolMsgs, toolErr := mcpExecutorSnapshot.ResolvePendingToolCalls(ctx, resp)
 				if toolErr != nil {
 					err = fmt.Errorf("mcp tool execution at depth %d: %w", depth, toolErr)
 					return
@@ -989,6 +991,7 @@ func (g *Gateway) RouteStream(ctx context.Context, req providers.Request) (<-cha
 	strategyMode := string(g.config.Strategy.Mode)
 	obs := g.obs
 	obsEventsActive := g.obsEventsActive
+	mcpRegistrySnapshot := g.mcpRegistry
 	g.mu.RUnlock()
 	ctx, span := obs.StartRequestSpan(ctx, observability.RequestAttrs{
 		Operation:       "chat",
@@ -1012,9 +1015,7 @@ func (g *Gateway) RouteStream(ctx context.Context, req providers.Request) (<-cha
 	// MCP redirect: when tool servers are registered, the agentic loop must
 	// run to completion before any response is sent. Route() handles this
 	// entirely; we wrap its non-streaming result into a channel here.
-	g.mu.RLock()
-	hasMCP := g.mcpRegistry != nil && g.mcpRegistry.HasServers()
-	g.mu.RUnlock()
+	hasMCP := mcpRegistrySnapshot != nil && mcpRegistrySnapshot.HasServers()
 	if hasMCP {
 		// Do not force req.Stream = false here: let Route() capture the
 		// original stream flag via its own originalStream variable so that

--- a/gateway_race_test.go
+++ b/gateway_race_test.go
@@ -1,0 +1,205 @@
+package aigateway
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	internalmcp "github.com/ferro-labs/ai-gateway/internal/mcp"
+	"github.com/ferro-labs/ai-gateway/providers"
+)
+
+// freshMockProvider returns a new *providers.Response on every call, avoiding
+// the shared-pointer data race that would occur if multiple goroutines mutate
+// a single response returned by the default mockProvider.
+type freshMockProvider struct {
+	name   string
+	models []string
+}
+
+func (p *freshMockProvider) Name() string                  { return p.name }
+func (p *freshMockProvider) SupportedModels() []string     { return p.models }
+func (p *freshMockProvider) Models() []providers.ModelInfo { return nil }
+func (p *freshMockProvider) SupportsModel(model string) bool {
+	for _, m := range p.models {
+		if m == model {
+			return true
+		}
+	}
+	return false
+}
+func (p *freshMockProvider) Complete(_ context.Context, _ providers.Request) (*providers.Response, error) {
+	return &providers.Response{
+		ID:      "r1",
+		Choices: []providers.Choice{{Message: providers.Message{Role: "assistant", Content: "ok"}}},
+	}, nil
+}
+
+// TestRoute_MCPSnapshotIsolation verifies that Route uses the mcpRegistry /
+// mcpExecutor values captured at request entry, not whatever the live fields
+// contain later. Concretely: if the registry is nil when the snapshot is taken,
+// no MCP tool injection occurs even if a registry is installed after the lock
+// is released.
+func TestRoute_MCPSnapshotIsolation(t *testing.T) {
+	gw, err := New(Config{
+		Strategy: StrategyConfig{Mode: ModeSingle},
+		Targets:  []Target{{VirtualKey: "mock"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	gw.RegisterProvider(&freshMockProvider{
+		name:   "mock",
+		models: []string{"gpt-4o"},
+	})
+
+	// mcpRegistry is nil at this point — snapshot taken inside Route will be nil.
+	resp, err := gw.Route(context.Background(), providers.Request{
+		Model:    "gpt-4o",
+		Messages: []providers.Message{{Role: "user", Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("Route() error: %v", err)
+	}
+	if len(resp.Choices) == 0 {
+		t.Fatal("expected at least one choice")
+	}
+	// No MCP tools should have been injected (registry was nil at snapshot time).
+	if len(resp.Choices[0].Message.ToolCalls) != 0 {
+		t.Errorf("unexpected tool calls: %v", resp.Choices[0].Message.ToolCalls)
+	}
+}
+
+// TestRoute_MCPFieldsSnapshotRace verifies that concurrent writes to
+// g.mcpRegistry / g.mcpExecutor (under g.mu.Lock) do not race with Route's
+// reads of those fields.
+//
+// Before the fix, Route read g.mcpRegistry and g.mcpExecutor after releasing
+// g.mu, so a concurrent writer could replace the pointers mid-flight.  The
+// fix snapshots both fields inside the initial g.mu.RLock block.
+//
+// Run with: go test -race -run TestRoute_MCPFieldsSnapshotRace .
+func TestRoute_MCPFieldsSnapshotRace(t *testing.T) {
+	gw, err := New(Config{
+		Strategy: StrategyConfig{Mode: ModeSingle},
+		Targets:  []Target{{VirtualKey: "mock"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	gw.RegisterProvider(&freshMockProvider{
+		name:   "mock",
+		models: []string{"gpt-4o"},
+	})
+
+	req := providers.Request{
+		Model:    "gpt-4o",
+		Messages: []providers.Message{{Role: "user", Content: "hi"}},
+	}
+
+	var wg sync.WaitGroup
+	const iters = 300
+
+	// Writer: toggles mcpRegistry/mcpExecutor under the gateway lock, exactly
+	// as ReloadConfig does (but without touching any other field, so we isolate
+	// only the MCP snapshot race).
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iters; i++ {
+			gw.mu.Lock()
+			reg := internalmcp.NewRegistry()
+			gw.mcpRegistry = reg
+			gw.mcpExecutor = internalmcp.NewExecutor(reg, 5, nil)
+			gw.mu.Unlock()
+
+			gw.mu.Lock()
+			gw.mcpRegistry = nil
+			gw.mcpExecutor = nil
+			gw.mu.Unlock()
+		}
+	}()
+
+	// Readers: call Route concurrently with the writer.
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iters; j++ {
+				_, _ = gw.Route(context.Background(), req)
+			}
+		}()
+	}
+
+	wg.Wait()
+}
+
+// TestRouteStream_MCPRegistrySnapshotRace verifies that RouteStream's
+// mcpRegistry snapshot (taken inside the initial g.mu.RLock block) does not
+// race with concurrent writes to g.mcpRegistry.
+//
+// The old code acquired a *second* g.mu.RLock just for the hasMCP check; the
+// fix collapses it into the first lock block so the field is read exactly once,
+// under the same lock that protects all other request-entry snapshots.
+func TestRouteStream_MCPRegistrySnapshotRace(t *testing.T) {
+	ch := make(chan providers.StreamChunk)
+	close(ch)
+
+	gw, err := New(Config{
+		Strategy: StrategyConfig{Mode: ModeSingle},
+		Targets:  []Target{{VirtualKey: "mock-stream"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	gw.RegisterProvider(&mockStreamProvider{
+		mockProvider: mockProvider{
+			name:   "mock-stream",
+			models: []string{"gpt-4o"},
+		},
+		streamCh: ch,
+	})
+
+	req := providers.Request{
+		Model:    "gpt-4o",
+		Stream:   true,
+		Messages: []providers.Message{{Role: "user", Content: "hi"}},
+	}
+
+	var wg sync.WaitGroup
+	const iters = 300
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iters; i++ {
+			gw.mu.Lock()
+			reg := internalmcp.NewRegistry()
+			gw.mcpRegistry = reg
+			gw.mcpExecutor = internalmcp.NewExecutor(reg, 5, nil)
+			gw.mu.Unlock()
+
+			gw.mu.Lock()
+			gw.mcpRegistry = nil
+			gw.mcpExecutor = nil
+			gw.mu.Unlock()
+		}
+	}()
+
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iters; j++ {
+				out, err := gw.RouteStream(context.Background(), req)
+				if err != nil {
+					continue
+				}
+				for range out { //nolint:revive
+				}
+			}
+		}()
+	}
+
+	wg.Wait()
+}

--- a/gateway_stress_test.go
+++ b/gateway_stress_test.go
@@ -1,0 +1,225 @@
+package aigateway
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/ferro-labs/ai-gateway/internal/circuitbreaker"
+	"github.com/ferro-labs/ai-gateway/providers"
+	"go.uber.org/goleak"
+)
+
+// stressStubProvider returns a fresh *providers.Response on every Complete
+// call. The shared-pointer mockProvider in gateway_test.go is unsafe under
+// concurrent Route() — gateway.go:519 writes OverheadMs on the returned
+// pointer, so two parallel callers racing on the same pointer trips the race
+// detector with a fixture-level race that has nothing to do with the bugs
+// these tests are checking for.
+type stressStubProvider struct {
+	name   string
+	models []string
+}
+
+func (s *stressStubProvider) Name() string                  { return s.name }
+func (s *stressStubProvider) SupportedModels() []string     { return s.models }
+func (s *stressStubProvider) Models() []providers.ModelInfo { return nil }
+func (s *stressStubProvider) SupportsModel(model string) bool {
+	for _, m := range s.models {
+		if m == model {
+			return true
+		}
+	}
+	return false
+}
+func (s *stressStubProvider) Complete(_ context.Context, _ providers.Request) (*providers.Response, error) {
+	return &providers.Response{ID: "ok", Provider: s.name, Model: "gpt-4o"}, nil
+}
+
+// stressGoleak applies a goroutine-leak check at the end of each stress test.
+// We can't use TestMain here because gateway_test.go runs many other tests in
+// the same package that intentionally leak goroutines (e.g. hook workers from
+// gateways that the test never Closes). Per-test goleak with IgnoreCurrent
+// catches NEW leaks introduced by the test under inspection.
+func stressGoleak(t *testing.T) {
+	t.Helper()
+	opts := []goleak.Option{
+		goleak.IgnoreCurrent(),
+		// stdlib HTTP/2 connection pool keeps a readLoop goroutine alive
+		// until the transport's idle timeout. The catalog loader inside
+		// gateway.New() opens one. It is not a gateway leak; ignore it.
+		goleak.IgnoreTopFunction("net/http.(*http2ClientConn).readLoop"),
+		goleak.IgnoreTopFunction("internal/poll.runtime_pollWait"),
+	}
+	t.Cleanup(func() {
+		// Give any in-flight goroutines a brief grace window to exit. Without
+		// this, a perfectly-correct goroutine that is mid-return when the
+		// check runs can be flagged.
+		deadline := time.Now().Add(2 * time.Second)
+		var err error
+		for time.Now().Before(deadline) {
+			if err = goleak.Find(opts...); err == nil {
+				return
+			}
+			time.Sleep(20 * time.Millisecond)
+		}
+		if err != nil {
+			t.Fatalf("goroutine leak detected: %v", err)
+		}
+	})
+}
+
+// TestStress_ShutdownUnderLoad_NoPanic is the C1 regression: pre-fix, calling
+// Close() while publishEvent goroutines were in flight produced a hard panic
+// (send on closed channel). The fix replaces close(hookDispatchQ) with a
+// cancellation-context pattern. Run with -race to catch any reintroduction.
+func TestStress_ShutdownUnderLoad_NoPanic(t *testing.T) {
+	stressGoleak(t)
+
+	gw, err := New(Config{
+		Strategy: StrategyConfig{Mode: ModeSingle},
+		Targets:  []Target{{VirtualKey: "stub"}},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	gw.RegisterProvider(&stressStubProvider{name: "stub", models: []string{"gpt-4o"}})
+	// At least one hook so hasHooks() returns true and publishEvent actually
+	// enqueues into hookDispatchQ on every Route call.
+	gw.AddHook(func(_ context.Context, _ string, _ map[string]interface{}) {})
+
+	const workers = 50
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+
+	for range workers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			req := providers.Request{
+				Model:    "gpt-4o",
+				Messages: []providers.Message{{Role: "user", Content: "hi"}},
+			}
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				// Ignore errors — the gateway may legitimately return errors
+				// after Close(). The test only fails on PANIC.
+				_, _ = gw.Route(context.Background(), req)
+			}
+		}()
+	}
+
+	// Let load build up, then shut down hard.
+	time.Sleep(100 * time.Millisecond)
+	if err := gw.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	close(stop)
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("workers did not exit within 5s of Close()")
+	}
+
+	// Idempotency: a second Close must not panic either.
+	if err := gw.Close(); err != nil {
+		t.Fatalf("second Close: %v", err)
+	}
+}
+
+// TestStress_ReloadUnderLoad_NoRace is the C2 regression: pre-fix, the lookup
+// closure inside getStrategy read g.providers and g.circuitBreakers without
+// holding g.mu, racing ReloadConfig (which reassigns circuitBreakers
+// wholesale at line ~707) and RegisterProvider (writes g.providers under
+// Lock). Must be run with -race.
+func TestStress_ReloadUnderLoad_NoRace(t *testing.T) {
+	stressGoleak(t)
+
+	gw, err := New(Config{
+		Strategy: StrategyConfig{Mode: ModeSingle},
+		Targets:  []Target{{VirtualKey: "stub"}},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer func() { _ = gw.Close() }()
+
+	gw.RegisterProvider(&stressStubProvider{name: "stub", models: []string{"gpt-4o"}})
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+
+	// Request workload: 20 goroutines hammering Route through the strategy
+	// (which invokes the lookup closure on every call).
+	const workers = 20
+	for range workers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			req := providers.Request{
+				Model:    "gpt-4o",
+				Messages: []providers.Message{{Role: "user", Content: "hi"}},
+			}
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				_, _ = gw.Route(context.Background(), req)
+			}
+		}()
+	}
+
+	// Mutator: races provider/circuit-breaker writes vs the lookup reads.
+	// Uses the same write paths the gateway uses in production (Register +
+	// direct map mutation via g.mu) so the race is real, not synthetic.
+	wg.Add(1)
+	var mutations atomic.Int64
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			gw.mu.Lock()
+			gw.circuitBreakers["stub"] = circuitbreaker.New(5, 1, time.Second)
+			gw.providers["stub"] = &stressStubProvider{name: "stub", models: []string{"gpt-4o"}}
+			gw.mu.Unlock()
+			mutations.Add(1)
+			time.Sleep(time.Microsecond)
+		}
+	}()
+
+	time.Sleep(300 * time.Millisecond)
+	close(stop)
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("workers did not exit within 5s")
+	}
+
+	if mutations.Load() < 10 {
+		t.Fatalf("mutator only ran %d times — test is not exercising the race", mutations.Load())
+	}
+}

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -81,6 +81,8 @@ func counterValue(t *testing.T, c prometheus.Counter) float64 {
 	return m.GetCounter().GetValue()
 }
 
+func ptrFloat64(v float64) *float64 { return &v }
+
 func TestGateway_Route_Single(t *testing.T) {
 	gw, _ := New(Config{
 		Strategy: StrategyConfig{Mode: ModeSingle},
@@ -132,6 +134,83 @@ func TestGateway_Route_Fallback(t *testing.T) {
 	}
 	if resp.ID != "fallback-ok" {
 		t.Errorf("got ID %q, want fallback-ok", resp.ID)
+	}
+}
+
+func TestGateway_Route_CostOptimizedPassesUnpricedStrategy(t *testing.T) {
+	tests := []struct {
+		name             string
+		unpricedStrategy string
+		wantProvider     string
+	}{
+		{
+			name:             "skip routes to priced provider",
+			unpricedStrategy: "skip",
+			wantProvider:     "priced",
+		},
+		{
+			name:             "allow routes to unpriced provider",
+			unpricedStrategy: "allow",
+			wantProvider:     "unpriced",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gw, err := New(Config{
+				Strategy: StrategyConfig{
+					Mode:             ModeCostOptimized,
+					UnpricedStrategy: tt.unpricedStrategy,
+				},
+				Targets: []Target{
+					{VirtualKey: "unpriced"},
+					{VirtualKey: "priced"},
+				},
+			})
+			if err != nil {
+				t.Fatalf("New: %v", err)
+			}
+			gw.catalog = models.Catalog{
+				"unpriced/gpt-4o": {
+					Provider: "unpriced",
+					ModelID:  "gpt-4o",
+					Mode:     models.ModeChat,
+					Pricing:  models.Pricing{},
+				},
+				"priced/gpt-4o": {
+					Provider: "priced",
+					ModelID:  "gpt-4o",
+					Mode:     models.ModeChat,
+					Pricing: models.Pricing{
+						InputPerMTokens: ptrFloat64(1.0),
+					},
+				},
+			}
+			gw.RegisterProvider(&mockProvider{
+				name:   "unpriced",
+				models: []string{"gpt-4o"},
+				resp:   &providers.Response{ID: "unpriced", Model: "gpt-4o"},
+			})
+			gw.RegisterProvider(&mockProvider{
+				name:   "priced",
+				models: []string{"gpt-4o"},
+				resp:   &providers.Response{ID: "priced", Model: "gpt-4o"},
+			})
+
+			resp, err := gw.Route(context.Background(), providers.Request{
+				Model:    "gpt-4o",
+				Messages: []providers.Message{{Role: "user", Content: "hello"}},
+			})
+			if err != nil {
+				t.Fatalf("Route: %v", err)
+			}
+			if resp.Provider != tt.wantProvider {
+				t.Fatalf("got provider %q, want %q", resp.Provider, tt.wantProvider)
+			}
+			if resp.ID != tt.wantProvider {
+				t.Fatalf("got response ID %q, want %q", resp.ID, tt.wantProvider)
+			}
+		})
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.43.0
 	go.opentelemetry.io/otel/sdk v1.43.0
 	go.opentelemetry.io/otel/trace v1.43.0
+	go.uber.org/goleak v1.3.0
 	golang.org/x/oauth2 v0.35.0
 	gopkg.in/yaml.v3 v3.0.1
 	modernc.org/sqlite v1.46.1

--- a/internal/strategies/costoptimized.go
+++ b/internal/strategies/costoptimized.go
@@ -80,7 +80,10 @@ func (c *CostOptimized) Execute(ctx context.Context, req providers.Request) (*pr
 		best = &candidates[0]
 	}
 
-	p, _ := c.lookup(best.target.VirtualKey)
+	p, ok := c.lookup(best.target.VirtualKey)
+	if !ok {
+		return nil, fmt.Errorf("cost optimized routing: provider not found: %s", best.target.VirtualKey)
+	}
 	resp, err := p.Complete(ctx, req)
 	if err != nil {
 		return nil, err

--- a/internal/strategies/costoptimized.go
+++ b/internal/strategies/costoptimized.go
@@ -9,17 +9,34 @@ import (
 )
 
 // CostOptimized routes to the cheapest compatible provider based on estimated
-// input cost from the model catalog. When catalog pricing is unavailable for
-// all candidates, the first compatible provider is used as a fallback.
+// input cost from the model catalog. By default, unpriced candidates are used
+// only when no compatible provider has known pricing.
 type CostOptimized struct {
-	targets []Target
-	lookup  ProviderLookup
-	catalog models.Catalog
+	targets          []Target
+	lookup           ProviderLookup
+	catalog          models.Catalog
+	unpricedStrategy unpricedStrategy
+}
+
+type unpricedStrategy string
+
+const (
+	unpricedStrategyFallback unpricedStrategy = "fallback"
+	unpricedStrategySkip     unpricedStrategy = "skip"
+	unpricedStrategyAllow    unpricedStrategy = "allow"
+)
+
+type priced struct {
+	target   Target
+	costUSD  float64
+	hasPrice bool
+	isModel  bool
 }
 
 // NewCostOptimized creates a new cost-optimized strategy.
-func NewCostOptimized(targets []Target, lookup ProviderLookup, catalog models.Catalog) *CostOptimized {
-	return &CostOptimized{targets: targets, lookup: lookup, catalog: catalog}
+func NewCostOptimized(targets []Target, lookup ProviderLookup, catalog models.Catalog, unpricedStrategyConfig ...string) *CostOptimized {
+	strategy := newUnpricedStrategy(unpricedStrategyConfig...)
+	return &CostOptimized{targets: targets, lookup: lookup, catalog: catalog, unpricedStrategy: strategy}
 }
 
 // Execute selects the provider with the lowest estimated input cost for the
@@ -36,13 +53,6 @@ func (c *CostOptimized) Execute(ctx context.Context, req providers.Request) (*pr
 		promptChars += len(msg.Content)
 	}
 	estimatedPromptTokens := promptChars/4 + 1
-
-	type priced struct {
-		target   Target
-		costUSD  float64
-		hasPrice bool
-	}
-
 	var candidates []priced
 	for _, t := range c.targets {
 		p, ok := c.lookup(t.VirtualKey)
@@ -55,7 +65,8 @@ func (c *CostOptimized) Execute(ctx context.Context, req providers.Request) (*pr
 		candidates = append(candidates, priced{
 			target:   t,
 			costUSD:  result.InputUSD,
-			hasPrice: result.ModelFound,
+			hasPrice: result.Priced,
+			isModel:  result.ModelFound,
 		})
 	}
 
@@ -63,21 +74,13 @@ func (c *CostOptimized) Execute(ctx context.Context, req providers.Request) (*pr
 		return nil, fmt.Errorf("no provider supports model %s", req.Model)
 	}
 
-	// Among providers with catalog pricing, pick the cheapest.
-	var best *priced
-	for i := range candidates {
-		entry := &candidates[i]
-		if !entry.hasPrice {
-			continue
-		}
-		if best == nil || entry.costUSD < best.costUSD {
-			best = entry
-		}
-	}
-
-	// No pricing found — fall back to the first compatible provider.
-	if best == nil {
-		best = &candidates[0]
+	// Unpriced candidates are providers that support the model but do not have
+	// usable input-token pricing in the catalog. The mode controls whether those
+	// candidates are excluded, used only when nothing is priced, or treated as
+	// normal zero-cost candidates.
+	best, err := selectCostOptimizedCandidate(candidates, c.unpricedStrategy, req.Model)
+	if err != nil {
+		return nil, err
 	}
 
 	p, ok := c.lookup(best.target.VirtualKey)
@@ -89,4 +92,54 @@ func (c *CostOptimized) Execute(ctx context.Context, req providers.Request) (*pr
 		return nil, err
 	}
 	return responseWithProvider(resp, best.target.VirtualKey), nil
+}
+
+func newUnpricedStrategy(config ...string) unpricedStrategy {
+	if len(config) == 0 {
+		return unpricedStrategyFallback
+	}
+	return parseUnpricedStrategy(config[0])
+}
+
+func parseUnpricedStrategy(strategy string) unpricedStrategy {
+	switch unpricedStrategy(strategy) {
+	case unpricedStrategySkip, unpricedStrategyAllow:
+		return unpricedStrategy(strategy)
+	default:
+		return unpricedStrategyFallback
+	}
+}
+
+func (s unpricedStrategy) ranksUnpricedCandidates() bool {
+	return s == unpricedStrategyAllow
+}
+
+func (s unpricedStrategy) requiresPricedCandidate() bool {
+	return s == unpricedStrategySkip
+}
+
+func selectCostOptimizedCandidate(candidates []priced, strategy unpricedStrategy, model string) (*priced, error) {
+	var best *priced
+	for i := range candidates {
+		candidate := &candidates[i]
+		if !candidate.isModel {
+			continue
+		}
+		if !strategy.ranksUnpricedCandidates() && !candidate.hasPrice {
+			continue
+		}
+		if best == nil || candidate.costUSD < best.costUSD {
+			best = candidate
+		}
+	}
+
+	if best != nil {
+		return best, nil
+	} else if strategy.requiresPricedCandidate() {
+		// No cataloged/priced candidate is selectable; return an error.
+		return nil, fmt.Errorf("no priced provider supports model %s", model)
+	}
+	// Preserve historical fallback behavior: when no cataloged/priced candidate
+	// is selectable, fallback and allow route to the first compatible target.
+	return &candidates[0], nil
 }

--- a/internal/strategies/costoptimized_test.go
+++ b/internal/strategies/costoptimized_test.go
@@ -96,6 +96,23 @@ func TestCostOptimized_SkipsUnsupportedModel(t *testing.T) {
 	}
 }
 
+func TestCostOptimized_UnresolvableSelectedTargetReturnsError(t *testing.T) {
+	mp := &mockProvider{name: "cheap", models: []string{"gpt-4o"}, resp: &providers.Response{ID: "cheap"}}
+	s := NewCostOptimized(
+		[]Target{{VirtualKey: "cheap"}},
+		lookupMissingAfterFirstHit(mp),
+		buildCatalog(),
+	)
+
+	_, err := s.Execute(context.Background(), providers.Request{
+		Model:    "gpt-4o",
+		Messages: []providers.Message{{Role: "user", Content: "hi"}},
+	})
+	if err == nil {
+		t.Fatal("expected error when selected provider is no longer resolvable")
+	}
+}
+
 func TestCostOptimized_NoTargets(t *testing.T) {
 	s := NewCostOptimized(nil, newLookup(), models.Catalog{})
 	_, err := s.Execute(context.Background(), providers.Request{Model: "gpt-4o"})

--- a/internal/strategies/costoptimized_test.go
+++ b/internal/strategies/costoptimized_test.go
@@ -76,6 +76,211 @@ func TestCostOptimized_FallsBackWhenNoPricing(t *testing.T) {
 	}
 }
 
+func TestCostOptimized_SkipsUnpricedCatalogEntryWhenPricedCandidateExists(t *testing.T) {
+	unpriced := &mockProvider{name: "unpriced", models: []string{"gpt-4o"}, resp: &providers.Response{ID: "unpriced"}}
+	priced := &mockProvider{name: "priced", models: []string{"gpt-4o"}, resp: &providers.Response{ID: "priced"}}
+
+	catalog := models.Catalog{
+		"unpriced/gpt-4o": {
+			Provider: "unpriced",
+			ModelID:  "gpt-4o",
+			Mode:     models.ModeChat,
+			Pricing:  models.Pricing{},
+		},
+		"priced/gpt-4o": {
+			Provider: "priced",
+			ModelID:  "gpt-4o",
+			Mode:     models.ModeChat,
+			Pricing: models.Pricing{
+				InputPerMTokens:  ptrF(1.0),
+				OutputPerMTokens: ptrF(2.0),
+			},
+		},
+	}
+	targets := []Target{{VirtualKey: "unpriced"}, {VirtualKey: "priced"}}
+	s := NewCostOptimized(targets, newLookup(unpriced, priced), catalog)
+
+	resp, err := s.Execute(context.Background(), providers.Request{
+		Model:    "gpt-4o",
+		Messages: []providers.Message{{Role: "user", Content: "hello"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.ID != "priced" {
+		t.Errorf("expected priced provider, got %q", resp.ID)
+	}
+}
+
+func TestCostOptimized_DoesNotRankOutputOnlyPricingAsFreeInput(t *testing.T) {
+	outputOnly := &mockProvider{name: "output-only", models: []string{"gpt-4o"}, resp: &providers.Response{ID: "output-only"}}
+	priced := &mockProvider{name: "priced", models: []string{"gpt-4o"}, resp: &providers.Response{ID: "priced"}}
+
+	catalog := models.Catalog{
+		"output-only/gpt-4o": {
+			Provider: "output-only",
+			ModelID:  "gpt-4o",
+			Mode:     models.ModeChat,
+			Pricing: models.Pricing{
+				OutputPerMTokens: ptrF(2.0),
+			},
+		},
+		"priced/gpt-4o": {
+			Provider: "priced",
+			ModelID:  "gpt-4o",
+			Mode:     models.ModeChat,
+			Pricing: models.Pricing{
+				InputPerMTokens:  ptrF(1.0),
+				OutputPerMTokens: ptrF(2.0),
+			},
+		},
+	}
+	targets := []Target{{VirtualKey: "output-only"}, {VirtualKey: "priced"}}
+	s := NewCostOptimized(targets, newLookup(outputOnly, priced), catalog)
+
+	resp, err := s.Execute(context.Background(), providers.Request{
+		Model:    "gpt-4o",
+		Messages: []providers.Message{{Role: "user", Content: "hello"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.ID != "priced" {
+		t.Errorf("expected priced provider, got %q", resp.ID)
+	}
+}
+
+func TestCostOptimized_FallsBackToFirstCompatibleWhenAllCandidatesUnpriced(t *testing.T) {
+	first := &mockProvider{name: "first", models: []string{"gpt-4o"}, resp: &providers.Response{ID: "first"}}
+	second := &mockProvider{name: "second", models: []string{"gpt-4o"}, resp: &providers.Response{ID: "second"}}
+
+	catalog := models.Catalog{
+		"first/gpt-4o": {
+			Provider: "first",
+			ModelID:  "gpt-4o",
+			Mode:     models.ModeChat,
+			Pricing:  models.Pricing{},
+		},
+		"second/gpt-4o": {
+			Provider: "second",
+			ModelID:  "gpt-4o",
+			Mode:     models.ModeChat,
+			Pricing:  models.Pricing{},
+		},
+	}
+	targets := []Target{{VirtualKey: "first"}, {VirtualKey: "second"}}
+	s := NewCostOptimized(targets, newLookup(first, second), catalog)
+
+	resp, err := s.Execute(context.Background(), providers.Request{
+		Model:    "gpt-4o",
+		Messages: []providers.Message{{Role: "user", Content: "hello"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.ID != "first" {
+		t.Errorf("expected first compatible provider fallback, got %q", resp.ID)
+	}
+}
+
+func TestCostOptimized_InvalidUnpricedStrategyFallsBackToFirstCompatible(t *testing.T) {
+	first := &mockProvider{name: "first", models: []string{"gpt-4o"}, resp: &providers.Response{ID: "first"}}
+	second := &mockProvider{name: "second", models: []string{"gpt-4o"}, resp: &providers.Response{ID: "second"}}
+
+	catalog := models.Catalog{
+		"first/gpt-4o": {
+			Provider: "first",
+			ModelID:  "gpt-4o",
+			Mode:     models.ModeChat,
+			Pricing:  models.Pricing{},
+		},
+		"second/gpt-4o": {
+			Provider: "second",
+			ModelID:  "gpt-4o",
+			Mode:     models.ModeChat,
+			Pricing:  models.Pricing{},
+		},
+	}
+	targets := []Target{{VirtualKey: "first"}, {VirtualKey: "second"}}
+	s := NewCostOptimized(targets, newLookup(first, second), catalog, "unknown")
+
+	resp, err := s.Execute(context.Background(), providers.Request{
+		Model:    "gpt-4o",
+		Messages: []providers.Message{{Role: "user", Content: "hello"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.ID != "first" {
+		t.Errorf("expected invalid unpriced strategy to use fallback mode, got %q", resp.ID)
+	}
+}
+
+func TestCostOptimized_AllowTreatsUnpricedAsZeroCost(t *testing.T) {
+	priced := &mockProvider{name: "priced", models: []string{"gpt-4o"}, resp: &providers.Response{ID: "priced"}}
+	unpriced := &mockProvider{name: "unpriced", models: []string{"gpt-4o"}, resp: &providers.Response{ID: "unpriced"}}
+
+	catalog := models.Catalog{
+		"priced/gpt-4o": {
+			Provider: "priced",
+			ModelID:  "gpt-4o",
+			Mode:     models.ModeChat,
+			Pricing: models.Pricing{
+				InputPerMTokens: ptrF(1.0),
+			},
+		},
+		"unpriced/gpt-4o": {
+			Provider: "unpriced",
+			ModelID:  "gpt-4o",
+			Mode:     models.ModeChat,
+			Pricing:  models.Pricing{},
+		},
+	}
+	targets := []Target{{VirtualKey: "priced"}, {VirtualKey: "unpriced"}}
+	s := NewCostOptimized(targets, newLookup(priced, unpriced), catalog, "allow")
+
+	resp, err := s.Execute(context.Background(), providers.Request{
+		Model:    "gpt-4o",
+		Messages: []providers.Message{{Role: "user", Content: "hello"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.ID != "unpriced" {
+		t.Errorf("expected allow mode to pick zero-cost unpriced provider, got %q", resp.ID)
+	}
+}
+
+func TestCostOptimized_SkipErrorsWhenAllCandidatesUnpriced(t *testing.T) {
+	first := &mockProvider{name: "first", models: []string{"gpt-4o"}, resp: &providers.Response{ID: "first"}}
+	second := &mockProvider{name: "second", models: []string{"gpt-4o"}, resp: &providers.Response{ID: "second"}}
+
+	catalog := models.Catalog{
+		"first/gpt-4o": {
+			Provider: "first",
+			ModelID:  "gpt-4o",
+			Mode:     models.ModeChat,
+			Pricing:  models.Pricing{},
+		},
+		"second/gpt-4o": {
+			Provider: "second",
+			ModelID:  "gpt-4o",
+			Mode:     models.ModeChat,
+			Pricing:  models.Pricing{},
+		},
+	}
+	targets := []Target{{VirtualKey: "first"}, {VirtualKey: "second"}}
+	s := NewCostOptimized(targets, newLookup(first, second), catalog, "skip")
+
+	_, err := s.Execute(context.Background(), providers.Request{
+		Model:    "gpt-4o",
+		Messages: []providers.Message{{Role: "user", Content: "hello"}},
+	})
+	if err == nil {
+		t.Fatal("expected error when skip mode has no priced candidates")
+	}
+}
+
 func TestCostOptimized_SkipsUnsupportedModel(t *testing.T) {
 	p1 := &mockProvider{name: "cheap", models: []string{"gpt-3.5-turbo"}, resp: &providers.Response{ID: "wrong"}}
 	p2 := &mockProvider{name: "expensive", models: []string{"gpt-4o"}, resp: &providers.Response{ID: "right"}}
@@ -110,6 +315,28 @@ func TestCostOptimized_UnresolvableSelectedTargetReturnsError(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("expected error when selected provider is no longer resolvable")
+	}
+}
+
+func TestCostOptimized_ErrorsWhenNoProviderSupportsModel(t *testing.T) {
+	p1 := &mockProvider{name: "cheap", models: []string{"gpt-3.5-turbo"}, resp: &providers.Response{ID: "wrong"}}
+	p2 := &mockProvider{name: "expensive", models: []string{"claude-3"}, resp: &providers.Response{ID: "wrong"}}
+
+	targets := []Target{{VirtualKey: "cheap"}, {VirtualKey: "expensive"}}
+	s := NewCostOptimized(targets, newLookup(p1, p2), buildCatalog())
+
+	_, err := s.Execute(context.Background(), providers.Request{
+		Model:    "gpt-4o",
+		Messages: []providers.Message{{Role: "user", Content: "hi"}},
+	})
+	if err == nil {
+		t.Fatal("expected error when no provider supports model")
+	}
+	if err.Error() != "no provider supports model gpt-4o" {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if p1.calls != 0 || p2.calls != 0 {
+		t.Errorf("providers should not be called, got cheap=%d expensive=%d", p1.calls, p2.calls)
 	}
 }
 

--- a/internal/strategies/leastlatency.go
+++ b/internal/strategies/leastlatency.go
@@ -67,7 +67,10 @@ func (l *LeastLatency) Execute(ctx context.Context, req providers.Request) (*pro
 		// Round-robin through unseen providers to gather latency samples for each
 		// before settling on the best-known option.
 		pick := unseen[rand.Intn(len(unseen))] //nolint:gosec
-		p, _ := l.lookup(pick.target.VirtualKey)
+		p, ok := l.lookup(pick.target.VirtualKey)
+		if !ok {
+			return nil, fmt.Errorf("least latency based routing: provider not found: %s", pick.target.VirtualKey)
+		}
 		resp, err := p.Complete(ctx, req)
 		if err != nil {
 			return nil, err
@@ -84,7 +87,10 @@ func (l *LeastLatency) Execute(ctx context.Context, req providers.Request) (*pro
 		}
 	}
 
-	p, _ := l.lookup(best.target.VirtualKey)
+	p, ok := l.lookup(best.target.VirtualKey)
+	if !ok {
+		return nil, fmt.Errorf("least latency based routing: provider not found: %s", best.target.VirtualKey)
+	}
 	resp, err := p.Complete(ctx, req)
 	if err != nil {
 		return nil, err

--- a/internal/strategies/leastlatency_test.go
+++ b/internal/strategies/leastlatency_test.go
@@ -62,6 +62,39 @@ func TestLeastLatency_SkipsUnsupportedModel(t *testing.T) {
 	}
 }
 
+func TestLeastLatency_UnresolvableUnseenTargetReturnsError(t *testing.T) {
+	mp := &mockProvider{name: "p1", models: []string{"gpt-4o"}, resp: &providers.Response{ID: "ok"}}
+
+	tr := latency.New(10)
+	s := NewLeastLatency(
+		[]Target{{VirtualKey: "p1"}},
+		lookupMissingAfterFirstHit(mp),
+		tr,
+	)
+
+	_, err := s.Execute(context.Background(), providers.Request{Model: "gpt-4o"})
+	if err == nil {
+		t.Fatal("expected error when selected unseen provider is no longer resolvable")
+	}
+}
+
+func TestLeastLatency_UnresolvableSampledTargetReturnsError(t *testing.T) {
+	mp := &mockProvider{name: "p1", models: []string{"gpt-4o"}, resp: &providers.Response{ID: "ok"}}
+
+	tr := latency.New(10)
+	tr.Record("p1", 20*time.Millisecond)
+	s := NewLeastLatency(
+		[]Target{{VirtualKey: "p1"}},
+		lookupMissingAfterFirstHit(mp),
+		tr,
+	)
+
+	_, err := s.Execute(context.Background(), providers.Request{Model: "gpt-4o"})
+	if err == nil {
+		t.Fatal("expected error when selected sampled provider is no longer resolvable")
+	}
+}
+
 func TestLeastLatency_NoTargets(t *testing.T) {
 	tr := latency.New(10)
 	s := NewLeastLatency(nil, newLookup(), tr)

--- a/internal/strategies/loadbalance.go
+++ b/internal/strategies/loadbalance.go
@@ -48,7 +48,10 @@ func (lb *LoadBalance) Execute(ctx context.Context, req providers.Request) (*pro
 		return nil, err
 	}
 
-	p, _ := lb.lookup(target.VirtualKey)
+	p, ok := lb.lookup(target.VirtualKey)
+	if !ok {
+		return nil, fmt.Errorf("load balancing based routing: provider not found: %s", target.VirtualKey)
+	}
 	resp, err := p.Complete(ctx, req)
 	if err != nil {
 		return nil, err

--- a/internal/strategies/strategy_test.go
+++ b/internal/strategies/strategy_test.go
@@ -43,6 +43,20 @@ func newLookup(pp ...providers.Provider) ProviderLookup {
 	}
 }
 
+func lookupMissingAfterFirstHit(p providers.Provider) ProviderLookup {
+	calls := 0
+	return func(name string) (providers.Provider, bool) {
+		if name != p.Name() {
+			return nil, false
+		}
+		calls++
+		if calls == 1 {
+			return p, true
+		}
+		return nil, false
+	}
+}
+
 func TestSingle_Execute(t *testing.T) {
 	mp := &mockProvider{name: "a", models: []string{"gpt-4o"}, resp: &providers.Response{ID: "ok"}}
 	s := NewSingle(Target{VirtualKey: "a"}, newLookup(mp))
@@ -382,6 +396,19 @@ func TestLoadBalance_MissingProvider(t *testing.T) {
 	_, err := lb.Execute(context.Background(), providers.Request{Model: "gpt-4o", Messages: []providers.Message{{Role: "user", Content: "hi"}}})
 	if err == nil {
 		t.Fatal("expected error when provider is not registered")
+	}
+}
+
+func TestLoadBalance_UnresolvableSelectedTargetReturnsError(t *testing.T) {
+	mp := &mockProvider{name: "a", models: []string{"gpt-4o"}, resp: &providers.Response{ID: "a"}}
+	lb := NewLoadBalance(
+		[]Target{{VirtualKey: "a", Weight: 100}},
+		lookupMissingAfterFirstHit(mp),
+	)
+
+	_, err := lb.Execute(context.Background(), providers.Request{Model: "gpt-4o", Messages: []providers.Message{{Role: "user", Content: "hi"}}})
+	if err == nil {
+		t.Fatal("expected error when selected provider is no longer resolvable")
 	}
 }
 

--- a/internal/streamwrap/wrap.go
+++ b/internal/streamwrap/wrap.go
@@ -87,29 +87,61 @@ func Meter(ctx context.Context, src <-chan providers.StreamChunk, start time.Tim
 		var streamErr error
 		var firstChunkAt time.Time
 		var lastChunkAt time.Time
+		clientCanceled := false
 
-		for chunk := range src {
-			now := time.Now()
-			if firstChunkAt.IsZero() {
-				firstChunkAt = now
-			}
-			lastChunkAt = now
+	loop:
+		for {
+			select {
+			case <-ctx.Done():
+				// Consumer (typically the HTTP handler) went away. Stop trying
+				// to forward chunks — out is almost certainly unread — but
+				// keep draining src so the upstream provider goroutine can
+				// finish its in-flight write to src and exit. The provider
+				// MUST close src eventually for this to terminate; that is
+				// the existing contract for every CompleteStream impl.
+				clientCanceled = true
+				streamErr = ctx.Err()
+				for range src { //nolint:revive
+				}
+				break loop
+			case chunk, ok := <-src:
+				if !ok {
+					break loop
+				}
+				now := time.Now()
+				if firstChunkAt.IsZero() {
+					firstChunkAt = now
+				}
+				lastChunkAt = now
 
-			// Capture the last non-zero usage block (the final OpenAI chunk with
-			// include_usage=true has TotalTokens > 0; other providers may set it
-			// differently).
-			if chunk.Usage != nil && (chunk.Usage.TotalTokens > 0 || chunk.Usage.PromptTokens > 0) {
-				usage = *chunk.Usage
-			}
-			if chunk.Error != nil {
-				streamErr = chunk.Error
-			}
-			out <- chunk
-			// Stop consuming src as soon as an error chunk is forwarded. If the
-			// provider does not close the channel promptly we would otherwise
-			// block here and never emit metrics or close out.
-			if streamErr != nil {
-				break
+				// Capture the last non-zero usage block (the final OpenAI chunk
+				// with include_usage=true has TotalTokens > 0; other providers
+				// may set it differently).
+				if chunk.Usage != nil && (chunk.Usage.TotalTokens > 0 || chunk.Usage.PromptTokens > 0) {
+					usage = *chunk.Usage
+				}
+				if chunk.Error != nil {
+					streamErr = chunk.Error
+				}
+
+				// Forward the chunk, but stop blocking if the consumer
+				// disconnects mid-send.
+				select {
+				case out <- chunk:
+				case <-ctx.Done():
+					clientCanceled = true
+					streamErr = ctx.Err()
+					for range src { //nolint:revive
+					}
+					break loop
+				}
+
+				// Stop consuming src as soon as an error chunk is forwarded.
+				// If the provider does not close src promptly we would
+				// otherwise block here and never emit metrics or close out.
+				if chunk.Error != nil {
+					break loop
+				}
 			}
 		}
 
@@ -125,7 +157,10 @@ func Meter(ctx context.Context, src <-chan providers.StreamChunk, start time.Tim
 
 		if streamErr != nil {
 			errType := "provider_error"
-			if errors.Is(streamErr, circuitbreaker.ErrCircuitOpen) {
+			switch {
+			case clientCanceled:
+				errType = "client_canceled"
+			case errors.Is(streamErr, circuitbreaker.ErrCircuitOpen):
 				errType = "circuit_open"
 			}
 			requestMetrics := metrics.ForRequest(meta.Provider, meta.Model)

--- a/internal/streamwrap/wrap_leak_test.go
+++ b/internal/streamwrap/wrap_leak_test.go
@@ -1,0 +1,147 @@
+package streamwrap
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/ferro-labs/ai-gateway/internal/events"
+	"github.com/ferro-labs/ai-gateway/internal/metrics"
+	"github.com/ferro-labs/ai-gateway/models"
+	"github.com/ferro-labs/ai-gateway/providers"
+	"go.uber.org/goleak"
+)
+
+// TestMain installs a package-wide goroutine-leak check. The Meter goroutine
+// MUST exit by the time the consumer-side channel closes — under any
+// termination condition (success, provider error, client disconnect,
+// consumer-stops-reading).
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m, goleak.IgnoreCurrent())
+}
+
+// TestMeter_ClientDisconnect_NoGoroutineLeak simulates the production failure
+// mode for C3: a slow producer (provider streaming chunks at ~10ms cadence)
+// and a consumer (the HTTP handler) that goes away mid-stream because the
+// client disconnected. Before the fix, the Meter goroutine blocks forever on
+// `out <- chunk`, the upstream goroutine blocks forever on its next send to
+// `src`, and the HTTP body never gets closed.
+func TestMeter_ClientDisconnect_NoGoroutineLeak(t *testing.T) {
+	src := make(chan providers.StreamChunk)
+
+	var producerExited atomic.Bool
+	go func() {
+		defer close(src)
+		defer producerExited.Store(true)
+		// Send 50 chunks at 10ms cadence. The consumer cancels at ~25ms, so
+		// the producer is still in the middle of streaming when cancel fires.
+		for range 50 {
+			select {
+			case src <- providers.StreamChunk{ID: "chunk"}:
+			case <-time.After(200 * time.Millisecond):
+				// Defensive: if Meter never reads from src, the producer
+				// should NOT itself leak. The C3 fix drains src on cancel,
+				// so this branch must never fire in a healthy run.
+				t.Errorf("producer write to src blocked > 200ms — Meter is not draining src on cancel")
+				return
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+	}()
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	var published atomic.Int32
+	var publishedSubject atomic.Value
+	publishFn := func(_ context.Context, event events.HookEvent) {
+		publishedSubject.Store(event.Subject)
+		published.Add(1)
+	}
+
+	out := Meter(ctx, src, time.Now(), MeterMeta{
+		Provider:  "openai",
+		Model:     "gpt-4o",
+		Catalog:   models.Catalog{},
+		PublishFn: publishFn,
+		TraceID:   "trace-disconnect",
+	})
+
+	// Consume 1 chunk, then disconnect.
+	<-out
+	time.AfterFunc(15*time.Millisecond, cancel)
+
+	// Wait for Meter to close `out`. Without the fix this hangs forever
+	// (caught by the goroutine-leak check, but the explicit timeout gives
+	// a clearer failure message).
+	done := make(chan struct{})
+	go func() {
+		for range out { //nolint:revive
+		}
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Meter did not close `out` within 2s of ctx cancel — goroutine leak")
+	}
+
+	// Producer must have been able to exit (src was drained, not abandoned).
+	deadline := time.Now().Add(1 * time.Second)
+	for !producerExited.Load() {
+		if time.Now().After(deadline) {
+			t.Fatal("producer goroutine did not exit within 1s — src was never drained")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	if published.Load() != 1 {
+		t.Fatalf("publish count = %d, want 1 (failed event for client disconnect)", published.Load())
+	}
+	if got := publishedSubject.Load(); got != "gateway.request.failed" {
+		t.Fatalf("published subject = %v, want gateway.request.failed", got)
+	}
+
+	// The client_canceled metric label MUST be incremented so dashboards can
+	// distinguish disconnects from real provider errors.
+	if v := counterValue(t, metrics.ProviderErrors.WithLabelValues("openai", "client_canceled")); v < 1 {
+		t.Fatalf("provider_errors{err=client_canceled} = %v, want >= 1", v)
+	}
+}
+
+// TestMeter_ConsumerStopsReading_NoLeak guards the inverse: if the consumer
+// simply stops reading without cancelling the ctx, Meter should still exit
+// once the producer closes `src`. (Sanity check that the new select did not
+// accidentally break the natural end-of-stream path.)
+func TestMeter_ConsumerStopsReading_NoLeak(t *testing.T) {
+	src := feed(
+		providers.StreamChunk{ID: "1"},
+		providers.StreamChunk{ID: "2"},
+		providers.StreamChunk{ID: "3"},
+	)
+
+	out := Meter(context.Background(), src, time.Now(), MeterMeta{
+		Provider: "openai",
+		Model:    "gpt-4o",
+		Catalog:  models.Catalog{},
+	})
+
+	// Read one, then stop. Meter's per-chunk send is buffered through the
+	// unbuffered `out`, so once we stop reading the next send blocks until
+	// the consumer drains the rest. The TEST drains the rest below — this
+	// case just confirms that close(src) flows through to close(out) without
+	// any leak even when the consumer is slow.
+	<-out
+
+	done := make(chan struct{})
+	go func() {
+		for range out { //nolint:revive
+		}
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Meter did not close `out` within 2s of src close — natural-EOS leak")
+	}
+}

--- a/models/calculator.go
+++ b/models/calculator.go
@@ -30,6 +30,8 @@ type CostResult struct {
 	// ModelFound is false when the catalog has no entry for the requested model.
 	// All cost fields will be zero in that case.
 	ModelFound bool
+	// Priced is false when the model has no input-token price.
+	Priced bool
 }
 
 // perM converts a nullable price-per-million-tokens to a cost for n tokens.
@@ -52,6 +54,8 @@ func Calculate(catalog Catalog, modelKey string, usage Usage) CostResult {
 
 	p := model.Pricing
 	r := CostResult{ModelFound: true}
+
+	r.Priced = p.InputPerMTokens != nil
 
 	switch model.Mode {
 	case ModeChat:

--- a/models/calculator_test.go
+++ b/models/calculator_test.go
@@ -48,6 +48,9 @@ func TestCalculateChatBasic(t *testing.T) {
 	if got.TotalUSD != 12.5 {
 		t.Errorf("TotalUSD: got %v, want 12.5", got.TotalUSD)
 	}
+	if !got.Priced {
+		t.Error("Priced should be true when token pricing is present")
+	}
 }
 
 func TestCalculateChatCacheAndReasoning(t *testing.T) {
@@ -111,6 +114,55 @@ func TestCalculateChatNilPricing(t *testing.T) {
 
 	if got.TotalUSD != 0 {
 		t.Errorf("TotalUSD: got %v, want 0 for all-nil pricing", got.TotalUSD)
+	}
+	if got.Priced {
+		t.Error("Priced should be false for all-nil pricing")
+	}
+}
+
+func TestCalculateChatOutputOnlyPricingIsNotInputPriced(t *testing.T) {
+	c := catalogWith("openai/output-only", Model{
+		Provider: "openai",
+		ModelID:  "output-only",
+		Mode:     ModeChat,
+		Pricing: Pricing{
+			OutputPerMTokens: ptr(15.0),
+		},
+	})
+
+	got := Calculate(c, "openai/output-only", Usage{
+		PromptTokens:     100_000,
+		CompletionTokens: 100_000,
+	})
+
+	if got.InputUSD != 0 {
+		t.Errorf("InputUSD: got %v, want 0 when input pricing is nil", got.InputUSD)
+	}
+	if got.OutputUSD != 1.5 {
+		t.Errorf("OutputUSD: got %v, want 1.5", got.OutputUSD)
+	}
+	if got.Priced {
+		t.Error("Priced should be false when input pricing is nil")
+	}
+}
+
+func TestCalculateChatZeroInputPriceIsPriced(t *testing.T) {
+	c := catalogWith("openai/free-input", Model{
+		Provider: "openai",
+		ModelID:  "free-input",
+		Mode:     ModeChat,
+		Pricing: Pricing{
+			InputPerMTokens: ptr(0),
+		},
+	})
+
+	got := Calculate(c, "openai/free-input", Usage{PromptTokens: 100_000})
+
+	if got.InputUSD != 0 {
+		t.Errorf("InputUSD: got %v, want 0 for explicit free input pricing", got.InputUSD)
+	}
+	if !got.Priced {
+		t.Error("Priced should be true when input pricing is explicitly zero")
 	}
 }
 
@@ -236,6 +288,9 @@ func TestCalculateModelNotFound(t *testing.T) {
 	}
 	if got.TotalUSD != 0 {
 		t.Errorf("TotalUSD: got %v, want 0 for unknown model", got.TotalUSD)
+	}
+	if got.Priced {
+		t.Error("Priced should be false for unknown model")
 	}
 }
 

--- a/plugin/manager.go
+++ b/plugin/manager.go
@@ -3,6 +3,7 @@ package plugin
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	"github.com/ferro-labs/ai-gateway/internal/logging"
 	"github.com/ferro-labs/ai-gateway/observability"
@@ -38,6 +39,7 @@ type Manager struct {
 	before []Plugin
 	after  []Plugin
 	onErr  []Plugin
+	mu     sync.RWMutex
 }
 
 // NewManager creates a new plugin manager.
@@ -47,6 +49,9 @@ func NewManager() *Manager {
 
 // Register registers a plugin at the given stage.
 func (m *Manager) Register(stage Stage, p Plugin) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	switch stage {
 	case StageBeforeRequest:
 		m.before = append(m.before, p)
@@ -64,7 +69,10 @@ func (m *Manager) Register(stage Stage, p Plugin) error {
 // RunBefore executes all before-request plugins. Returns an error if a plugin
 // rejects the request.
 func (m *Manager) RunBefore(ctx context.Context, pctx *Context) error {
-	for _, p := range m.before {
+	m.mu.RLock()
+	plugins := m.before
+	m.mu.RUnlock()
+	for _, p := range plugins {
 		err := m.executePlugin(ctx, p, pctx, string(StageBeforeRequest))
 		if err != nil {
 			if pctx.Reject {
@@ -92,7 +100,10 @@ func (m *Manager) RunBefore(ctx context.Context, pctx *Context) error {
 
 // RunAfter executes all after-request plugins.
 func (m *Manager) RunAfter(ctx context.Context, pctx *Context) error {
-	for _, p := range m.after {
+	m.mu.RLock()
+	plugins := m.after
+	m.mu.RUnlock()
+	for _, p := range plugins {
 		err := m.executePlugin(ctx, p, pctx, string(StageAfterRequest))
 		if pctx.Reject {
 			reason := pctx.Reason
@@ -117,7 +128,10 @@ func (m *Manager) RunAfter(ctx context.Context, pctx *Context) error {
 
 // RunOnError executes all on-error plugins.
 func (m *Manager) RunOnError(ctx context.Context, pctx *Context) {
-	for _, p := range m.onErr {
+	m.mu.RLock()
+	plugins := m.onErr
+	m.mu.RUnlock()
+	for _, p := range plugins {
 		if err := m.executePlugin(ctx, p, pctx, string(StageOnError)); err != nil {
 			logging.Logger.Warn("on-error plugin error", "plugin", p.Name(), "error", err)
 		}
@@ -154,5 +168,7 @@ func (m *Manager) executePlugin(ctx context.Context, p Plugin, pctx *Context, st
 
 // HasPlugins returns true if any plugins are registered.
 func (m *Manager) HasPlugins() bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
 	return len(m.before)+len(m.after)+len(m.onErr) > 0
 }

--- a/plugin/manager_race_test.go
+++ b/plugin/manager_race_test.go
@@ -1,0 +1,145 @@
+package plugin
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/ferro-labs/ai-gateway/providers"
+)
+
+// TestManager_ConcurrentRegisterAndRunBefore verifies that concurrent calls to
+// Register and RunBefore do not race. Requires -race to detect the defect: the
+// fix adds a lock to Register but RunBefore ranges over m.before without
+// holding m.mu.RLock(), so the goroutine scheduler can interleave a slice
+// grow (in Register) with the range read (in RunBefore).
+func TestManager_ConcurrentRegisterAndRunBefore(_ *testing.T) {
+	m := NewManager()
+	pctx := NewContext(&providers.Request{Model: "gpt-4o"})
+
+	var wg sync.WaitGroup
+	const n = 200
+
+	for i := 0; i < n; i++ {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			_ = m.Register(StageBeforeRequest, &mockPlugin{name: "p", typ: TypeGuardrail})
+		}()
+		go func() {
+			defer wg.Done()
+			_ = m.RunBefore(context.Background(), pctx)
+		}()
+	}
+	wg.Wait()
+}
+
+// TestManager_ConcurrentRegisterAndRunAfter is the same race check for
+// RunAfter / m.after.
+func TestManager_ConcurrentRegisterAndRunAfter(_ *testing.T) {
+	m := NewManager()
+	pctx := NewContext(&providers.Request{Model: "gpt-4o"})
+	pctx.Response = &providers.Response{ID: "r1"}
+
+	var wg sync.WaitGroup
+	const n = 200
+
+	for i := 0; i < n; i++ {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			_ = m.Register(StageAfterRequest, &mockPlugin{name: "p", typ: TypeLogging})
+		}()
+		go func() {
+			defer wg.Done()
+			_ = m.RunAfter(context.Background(), pctx)
+		}()
+	}
+	wg.Wait()
+}
+
+// TestManager_ConcurrentRegisterAndRunOnError is the same race check for
+// RunOnError / m.onErr.
+func TestManager_ConcurrentRegisterAndRunOnError(_ *testing.T) {
+	m := NewManager()
+	pctx := NewContext(&providers.Request{Model: "gpt-4o"})
+
+	var wg sync.WaitGroup
+	const n = 200
+
+	for i := 0; i < n; i++ {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			_ = m.Register(StageOnError, &mockPlugin{name: "p", typ: TypeLogging})
+		}()
+		go func() {
+			defer wg.Done()
+			m.RunOnError(context.Background(), pctx)
+		}()
+	}
+	wg.Wait()
+}
+
+// TestManager_ConcurrentRegisterAndHasPlugins checks that HasPlugins does not
+// race with concurrent Register calls (it reads all three slice lengths without
+// a lock).
+func TestManager_ConcurrentRegisterAndHasPlugins(_ *testing.T) {
+	m := NewManager()
+
+	var wg sync.WaitGroup
+	const n = 200
+
+	for i := 0; i < n; i++ {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			_ = m.Register(StageBeforeRequest, &mockPlugin{name: "p", typ: TypeGuardrail})
+		}()
+		go func() {
+			defer wg.Done()
+			_ = m.HasPlugins()
+		}()
+	}
+	wg.Wait()
+}
+
+// TestManager_ConcurrentAllReadersAndRegister fires RunBefore, RunAfter,
+// RunOnError, and HasPlugins simultaneously against concurrent Register calls.
+// This catches any reader–reader or reader–writer races that the individual
+// pairwise tests might miss under a specific schedule.
+func TestManager_ConcurrentAllReadersAndRegister(_ *testing.T) {
+	m := NewManager()
+	pctxBefore := NewContext(&providers.Request{Model: "gpt-4o"})
+	pctxAfter := NewContext(&providers.Request{Model: "gpt-4o"})
+	pctxAfter.Response = &providers.Response{ID: "r1"}
+	pctxErr := NewContext(&providers.Request{Model: "gpt-4o"})
+
+	var wg sync.WaitGroup
+	const n = 100
+
+	for i := 0; i < n; i++ {
+		wg.Add(5)
+		go func() {
+			defer wg.Done()
+			_ = m.Register(StageBeforeRequest, &mockPlugin{name: "p", typ: TypeGuardrail})
+		}()
+		go func() {
+			defer wg.Done()
+			_ = m.RunBefore(context.Background(), pctxBefore)
+		}()
+		go func() {
+			defer wg.Done()
+			_ = m.RunAfter(context.Background(), pctxAfter)
+		}()
+		go func() {
+			defer wg.Done()
+			m.RunOnError(context.Background(), pctxErr)
+		}()
+		go func() {
+			defer wg.Done()
+			_ = m.HasPlugins()
+		}()
+	}
+	wg.Wait()
+}

--- a/plugin/plugin_test.go
+++ b/plugin/plugin_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 	"testing"
 
 	"github.com/ferro-labs/ai-gateway/providers"
@@ -236,5 +237,82 @@ func TestManager_NoPlugins(t *testing.T) {
 	pctx := NewContext(&providers.Request{})
 	if err := m.RunBefore(context.Background(), pctx); err != nil {
 		t.Fatal(err)
+	}
+}
+
+// TestManager_Register_AllStages verifies that HasPlugins reports true once a
+// plugin is registered at any stage and that each stage is independent.
+func TestManager_Register_AllStages(t *testing.T) {
+	for _, stage := range []Stage{StageBeforeRequest, StageAfterRequest, StageOnError} {
+		m := NewManager()
+		if m.HasPlugins() {
+			t.Fatalf("stage %s: expected HasPlugins=false before register", stage)
+		}
+		if err := m.Register(stage, &mockPlugin{name: "p", typ: TypeGuardrail}); err != nil {
+			t.Fatalf("stage %s: Register() error: %v", stage, err)
+		}
+		if !m.HasPlugins() {
+			t.Errorf("stage %s: expected HasPlugins=true after register", stage)
+		}
+	}
+}
+
+// TestManager_RunBefore_SnapshotIsolation verifies that a plugin registered
+// after RunBefore takes its slice snapshot is not included in that run.
+// This checks the snapshot semantics introduced by the RLock fix.
+func TestManager_RunBefore_SnapshotIsolation(t *testing.T) {
+	m := NewManager()
+
+	// firstStarted is closed by the first plugin's Execute, proving that
+	// RunBefore has already taken the slice snapshot and entered the loop.
+	firstStarted := make(chan struct{})
+	gate := make(chan struct{})
+	secondCalled := false
+
+	var firstOnce sync.Once
+	_ = m.Register(StageBeforeRequest, &mockPlugin{
+		name: "first",
+		typ:  TypeGuardrail,
+		execFn: func(_ context.Context, _ *Context) error {
+			// Only coordinate on the first call; subsequent runs just pass through.
+			firstOnce.Do(func() {
+				close(firstStarted) // snapshot was taken; we are inside the loop
+				<-gate              // block until the test has registered the second plugin
+			})
+			return nil
+		},
+	})
+
+	done := make(chan error, 1)
+	go func() {
+		done <- m.RunBefore(context.Background(), NewContext(&providers.Request{Model: "gpt-4o"}))
+	}()
+
+	// Wait until the first plugin is executing — the snapshot is now fixed.
+	<-firstStarted
+
+	// Register a second plugin. Because the snapshot was already taken, this
+	// registration must not affect the current RunBefore call.
+	_ = m.Register(StageBeforeRequest, &mockPlugin{
+		name: "second",
+		typ:  TypeGuardrail,
+		execFn: func(_ context.Context, _ *Context) error {
+			secondCalled = true
+			return nil
+		},
+	})
+
+	close(gate) // let the first plugin finish
+	if err := <-done; err != nil {
+		t.Fatalf("RunBefore() error: %v", err)
+	}
+	if secondCalled {
+		t.Error("second plugin (registered after snapshot) must not be called in this run")
+	}
+
+	// A subsequent RunBefore takes a fresh snapshot that includes "second".
+	_ = m.RunBefore(context.Background(), NewContext(&providers.Request{Model: "gpt-4o"}))
+	if !secondCalled {
+		t.Error("subsequent RunBefore must execute the newly registered second plugin")
 	}
 }

--- a/providers/ai21/ai21.go
+++ b/providers/ai21/ai21.go
@@ -2,7 +2,6 @@
 package ai21
 
 import (
-	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -332,7 +331,7 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 		defer close(ch)
 		defer func() { _ = httpResp.Body.Close() }()
 
-		scanner := bufio.NewScanner(httpResp.Body)
+		scanner := core.NewSSEScanner(httpResp.Body)
 		for scanner.Scan() {
 			line := scanner.Text()
 			if !strings.HasPrefix(line, "data: ") {

--- a/providers/anthropic/anthropic.go
+++ b/providers/anthropic/anthropic.go
@@ -2,7 +2,6 @@
 package anthropic
 
 import (
-	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -313,7 +312,7 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 		defer func() { _ = httpResp.Body.Close() }()
 
 		var msgID, model string
-		scanner := bufio.NewScanner(httpResp.Body)
+		scanner := core.NewSSEScanner(httpResp.Body)
 		for scanner.Scan() {
 			line := scanner.Text()
 			if !strings.HasPrefix(line, "data: ") {

--- a/providers/azure_foundry/azure_foundry.go
+++ b/providers/azure_foundry/azure_foundry.go
@@ -2,7 +2,6 @@
 package azurefoundry
 
 import (
-	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -219,7 +218,7 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 		defer close(ch)
 		defer func() { _ = httpResp.Body.Close() }()
 
-		scanner := bufio.NewScanner(httpResp.Body)
+		scanner := core.NewSSEScanner(httpResp.Body)
 		for scanner.Scan() {
 			line := scanner.Text()
 			if !strings.HasPrefix(line, "data: ") {

--- a/providers/azure_openai/azure_openai.go
+++ b/providers/azure_openai/azure_openai.go
@@ -2,7 +2,6 @@
 package azureopenai
 
 import (
-	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -224,7 +223,7 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 		defer close(ch)
 		defer func() { _ = httpResp.Body.Close() }()
 
-		scanner := bufio.NewScanner(httpResp.Body)
+		scanner := core.NewSSEScanner(httpResp.Body)
 		for scanner.Scan() {
 			line := scanner.Text()
 			if !strings.HasPrefix(line, "data: ") {

--- a/providers/cerebras/cerebras.go
+++ b/providers/cerebras/cerebras.go
@@ -2,7 +2,6 @@
 package cerebras
 
 import (
-	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -223,7 +222,7 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 		defer close(ch)
 		defer func() { _ = httpResp.Body.Close() }()
 
-		scanner := bufio.NewScanner(httpResp.Body)
+		scanner := core.NewSSEScanner(httpResp.Body)
 		for scanner.Scan() {
 			line := scanner.Text()
 			if !strings.HasPrefix(line, "data: ") {

--- a/providers/cloudflare/cloudflare.go
+++ b/providers/cloudflare/cloudflare.go
@@ -2,7 +2,6 @@
 package cloudflare
 
 import (
-	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -221,7 +220,7 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 		defer close(ch)
 		defer func() { _ = httpResp.Body.Close() }()
 
-		scanner := bufio.NewScanner(httpResp.Body)
+		scanner := core.NewSSEScanner(httpResp.Body)
 		for scanner.Scan() {
 			line := scanner.Text()
 			if !strings.HasPrefix(line, "data: ") {

--- a/providers/cohere/cohere.go
+++ b/providers/cohere/cohere.go
@@ -2,7 +2,6 @@
 package cohere
 
 import (
-	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -272,7 +271,7 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 		defer close(ch)
 		defer func() { _ = httpResp.Body.Close() }()
 
-		scanner := bufio.NewScanner(httpResp.Body)
+		scanner := core.NewSSEScanner(httpResp.Body)
 		for scanner.Scan() {
 			line := scanner.Text()
 			if !strings.HasPrefix(line, "data: ") {

--- a/providers/core/sse_scanner.go
+++ b/providers/core/sse_scanner.go
@@ -1,0 +1,19 @@
+package core
+
+import (
+	"bufio"
+	"io"
+)
+
+const (
+	sseScannerInitialBufferSize = 64 * 1024
+	sseScannerMaxTokenSize      = 1024 * 1024
+)
+
+// NewSSEScanner returns a scanner sized for large SSE data lines, such as
+// tool-call payloads and long reasoning traces.
+func NewSSEScanner(r io.Reader) *bufio.Scanner {
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, sseScannerInitialBufferSize), sseScannerMaxTokenSize)
+	return scanner
+}

--- a/providers/core/sse_scanner_test.go
+++ b/providers/core/sse_scanner_test.go
@@ -1,0 +1,21 @@
+package core
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNewSSEScannerAllowsLargeDataLine(t *testing.T) {
+	payload := "data: " + strings.Repeat("x", 70*1024)
+	scanner := NewSSEScanner(strings.NewReader(payload + "\n\n"))
+
+	if !scanner.Scan() {
+		t.Fatalf("expected scanner to read oversized SSE line, err=%v", scanner.Err())
+	}
+	if got := scanner.Text(); got != payload {
+		t.Fatalf("scanner read %d bytes, want %d", len(got), len(payload))
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("scanner error: %v", err)
+	}
+}

--- a/providers/databricks/databricks.go
+++ b/providers/databricks/databricks.go
@@ -2,7 +2,6 @@
 package databricks
 
 import (
-	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -348,7 +347,7 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 		defer close(ch)
 		defer func() { _ = httpResp.Body.Close() }()
 
-		scanner := bufio.NewScanner(httpResp.Body)
+		scanner := core.NewSSEScanner(httpResp.Body)
 		for scanner.Scan() {
 			line := scanner.Text()
 			if !strings.HasPrefix(line, "data: ") {

--- a/providers/deepinfra/deepinfra.go
+++ b/providers/deepinfra/deepinfra.go
@@ -2,7 +2,6 @@
 package deepinfra
 
 import (
-	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -214,8 +213,7 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 		defer close(ch)
 		defer func() { _ = httpResp.Body.Close() }()
 
-		scanner := bufio.NewScanner(httpResp.Body)
-		scanner.Buffer(make([]byte, 64*1024), 1024*1024) // allow up to 1 MB per SSE line
+		scanner := core.NewSSEScanner(httpResp.Body)
 		for scanner.Scan() {
 			line := scanner.Text()
 			if !strings.HasPrefix(line, "data: ") {

--- a/providers/deepseek/deepseek.go
+++ b/providers/deepseek/deepseek.go
@@ -2,7 +2,6 @@
 package deepseek
 
 import (
-	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -221,7 +220,7 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 		defer close(ch)
 		defer func() { _ = httpResp.Body.Close() }()
 
-		scanner := bufio.NewScanner(httpResp.Body)
+		scanner := core.NewSSEScanner(httpResp.Body)
 		for scanner.Scan() {
 			line := scanner.Text()
 			if !strings.HasPrefix(line, "data: ") {

--- a/providers/fireworks/fireworks.go
+++ b/providers/fireworks/fireworks.go
@@ -2,7 +2,6 @@
 package fireworks
 
 import (
-	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -239,7 +238,7 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 		defer close(ch)
 		defer func() { _ = httpResp.Body.Close() }()
 
-		scanner := bufio.NewScanner(httpResp.Body)
+		scanner := core.NewSSEScanner(httpResp.Body)
 		for scanner.Scan() {
 			line := scanner.Text()
 			if !strings.HasPrefix(line, "data: ") {

--- a/providers/gemini/gemini.go
+++ b/providers/gemini/gemini.go
@@ -2,7 +2,6 @@
 package gemini
 
 import (
-	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -465,7 +464,7 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 		defer close(ch)
 		defer func() { _ = httpResp.Body.Close() }()
 
-		scanner := bufio.NewScanner(httpResp.Body)
+		scanner := core.NewSSEScanner(httpResp.Body)
 		for scanner.Scan() {
 			line := scanner.Text()
 			if !strings.HasPrefix(line, "data: ") {

--- a/providers/groq/groq.go
+++ b/providers/groq/groq.go
@@ -2,7 +2,6 @@
 package groq
 
 import (
-	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -223,7 +222,7 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 		defer close(ch)
 		defer func() { _ = httpResp.Body.Close() }()
 
-		scanner := bufio.NewScanner(httpResp.Body)
+		scanner := core.NewSSEScanner(httpResp.Body)
 		for scanner.Scan() {
 			line := scanner.Text()
 			if !strings.HasPrefix(line, "data: ") {

--- a/providers/hugging_face/hugging_face.go
+++ b/providers/hugging_face/hugging_face.go
@@ -2,7 +2,6 @@
 package huggingface
 
 import (
-	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -219,7 +218,7 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 		defer close(ch)
 		defer func() { _ = httpResp.Body.Close() }()
 
-		scanner := bufio.NewScanner(httpResp.Body)
+		scanner := core.NewSSEScanner(httpResp.Body)
 		for scanner.Scan() {
 			line := scanner.Text()
 			if !strings.HasPrefix(line, "data: ") {

--- a/providers/mistral/mistral.go
+++ b/providers/mistral/mistral.go
@@ -2,7 +2,6 @@
 package mistral
 
 import (
-	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -227,7 +226,7 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 		defer close(ch)
 		defer func() { _ = httpResp.Body.Close() }()
 
-		scanner := bufio.NewScanner(httpResp.Body)
+		scanner := core.NewSSEScanner(httpResp.Body)
 		for scanner.Scan() {
 			line := scanner.Text()
 			if !strings.HasPrefix(line, "data: ") {

--- a/providers/moonshot/moonshot.go
+++ b/providers/moonshot/moonshot.go
@@ -2,7 +2,6 @@
 package moonshot
 
 import (
-	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -214,8 +213,7 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 		defer close(ch)
 		defer func() { _ = httpResp.Body.Close() }()
 
-		scanner := bufio.NewScanner(httpResp.Body)
-		scanner.Buffer(make([]byte, 64*1024), 1024*1024) // allow up to 1 MB per SSE line
+		scanner := core.NewSSEScanner(httpResp.Body)
 		for scanner.Scan() {
 			line := scanner.Text()
 			if !strings.HasPrefix(line, "data: ") {

--- a/providers/novita/novita.go
+++ b/providers/novita/novita.go
@@ -2,7 +2,6 @@
 package novita
 
 import (
-	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -226,7 +225,7 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 		defer close(ch)
 		defer func() { _ = httpResp.Body.Close() }()
 
-		scanner := bufio.NewScanner(httpResp.Body)
+		scanner := core.NewSSEScanner(httpResp.Body)
 		for scanner.Scan() {
 			line := scanner.Text()
 			if !strings.HasPrefix(line, "data: ") {

--- a/providers/nvidia_nim/nvidia_nim.go
+++ b/providers/nvidia_nim/nvidia_nim.go
@@ -2,7 +2,6 @@
 package nvidianim
 
 import (
-	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -215,8 +214,7 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 		defer close(ch)
 		defer func() { _ = httpResp.Body.Close() }()
 
-		scanner := bufio.NewScanner(httpResp.Body)
-		scanner.Buffer(make([]byte, 64*1024), 1024*1024) // allow up to 1 MB per SSE line
+		scanner := core.NewSSEScanner(httpResp.Body)
 		for scanner.Scan() {
 			line := scanner.Text()
 			if !strings.HasPrefix(line, "data: ") {

--- a/providers/ollama/ollama.go
+++ b/providers/ollama/ollama.go
@@ -2,7 +2,6 @@
 package ollama
 
 import (
-	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -206,7 +205,7 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 		defer close(ch)
 		defer func() { _ = httpResp.Body.Close() }()
 
-		scanner := bufio.NewScanner(httpResp.Body)
+		scanner := core.NewSSEScanner(httpResp.Body)
 		for scanner.Scan() {
 			line := scanner.Text()
 			if !strings.HasPrefix(line, "data: ") {

--- a/providers/ollama_cloud/ollama_cloud.go
+++ b/providers/ollama_cloud/ollama_cloud.go
@@ -2,7 +2,6 @@
 package ollamacloud
 
 import (
-	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -198,8 +197,7 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 		defer close(ch)
 		defer func() { _ = httpResp.Body.Close() }()
 
-		scanner := bufio.NewScanner(httpResp.Body)
-		scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+		scanner := core.NewSSEScanner(httpResp.Body)
 		for scanner.Scan() {
 			line := strings.TrimSpace(scanner.Text())
 			if line == "" {

--- a/providers/openrouter/openrouter.go
+++ b/providers/openrouter/openrouter.go
@@ -2,7 +2,6 @@
 package openrouter
 
 import (
-	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -223,7 +222,7 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 		defer close(ch)
 		defer func() { _ = httpResp.Body.Close() }()
 
-		scanner := bufio.NewScanner(httpResp.Body)
+		scanner := core.NewSSEScanner(httpResp.Body)
 		for scanner.Scan() {
 			line := scanner.Text()
 			if !strings.HasPrefix(line, "data: ") {

--- a/providers/perplexity/perplexity.go
+++ b/providers/perplexity/perplexity.go
@@ -2,7 +2,6 @@
 package perplexity
 
 import (
-	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -226,7 +225,7 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 		defer close(ch)
 		defer func() { _ = httpResp.Body.Close() }()
 
-		scanner := bufio.NewScanner(httpResp.Body)
+		scanner := core.NewSSEScanner(httpResp.Body)
 		for scanner.Scan() {
 			line := scanner.Text()
 			if !strings.HasPrefix(line, "data: ") {

--- a/providers/qwen/qwen.go
+++ b/providers/qwen/qwen.go
@@ -2,7 +2,6 @@
 package qwen
 
 import (
-	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -214,8 +213,7 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 		defer close(ch)
 		defer func() { _ = httpResp.Body.Close() }()
 
-		scanner := bufio.NewScanner(httpResp.Body)
-		scanner.Buffer(make([]byte, 64*1024), 1024*1024) // allow up to 1 MB per SSE line
+		scanner := core.NewSSEScanner(httpResp.Body)
 		for scanner.Scan() {
 			line := scanner.Text()
 			if !strings.HasPrefix(line, "data: ") {

--- a/providers/replicate/replicate.go
+++ b/providers/replicate/replicate.go
@@ -2,7 +2,6 @@
 package replicate
 
 import (
-	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -417,8 +416,7 @@ func (p *Provider) readStream(ctx context.Context, body io.ReadCloser, ch chan<-
 	defer close(ch)
 	defer func() { _ = body.Close() }()
 
-	scanner := bufio.NewScanner(body)
-	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+	scanner := core.NewSSEScanner(body)
 
 	event := eventMessage
 	var data strings.Builder

--- a/providers/sambanova/sambanova.go
+++ b/providers/sambanova/sambanova.go
@@ -2,7 +2,6 @@
 package sambanova
 
 import (
-	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -214,8 +213,7 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 		defer close(ch)
 		defer func() { _ = httpResp.Body.Close() }()
 
-		scanner := bufio.NewScanner(httpResp.Body)
-		scanner.Buffer(make([]byte, 64*1024), 1024*1024) // allow up to 1 MB per SSE line
+		scanner := core.NewSSEScanner(httpResp.Body)
 		for scanner.Scan() {
 			line := scanner.Text()
 			if !strings.HasPrefix(line, "data: ") {

--- a/providers/together/together.go
+++ b/providers/together/together.go
@@ -2,7 +2,6 @@
 package together
 
 import (
-	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -228,7 +227,7 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 		defer close(ch)
 		defer func() { _ = httpResp.Body.Close() }()
 
-		scanner := bufio.NewScanner(httpResp.Body)
+		scanner := core.NewSSEScanner(httpResp.Body)
 		for scanner.Scan() {
 			line := scanner.Text()
 			if !strings.HasPrefix(line, "data: ") {

--- a/providers/vertex_ai/vertex_ai.go
+++ b/providers/vertex_ai/vertex_ai.go
@@ -2,7 +2,6 @@
 package vertexai
 
 import (
-	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -484,7 +483,7 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 		defer close(ch)
 		defer func() { _ = httpResp.Body.Close() }()
 
-		scanner := bufio.NewScanner(httpResp.Body)
+		scanner := core.NewSSEScanner(httpResp.Body)
 		for scanner.Scan() {
 			line := scanner.Text()
 			if !strings.HasPrefix(line, "data: ") {

--- a/providers/xai/xai.go
+++ b/providers/xai/xai.go
@@ -2,7 +2,6 @@
 package xai
 
 import (
-	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -223,7 +222,7 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 		defer close(ch)
 		defer func() { _ = httpResp.Body.Close() }()
 
-		scanner := bufio.NewScanner(httpResp.Body)
+		scanner := core.NewSSEScanner(httpResp.Body)
 		for scanner.Scan() {
 			line := scanner.Text()
 			if !strings.HasPrefix(line, "data: ") {

--- a/scripts/generate_release_notes.sh
+++ b/scripts/generate_release_notes.sh
@@ -8,6 +8,13 @@ if [[ $# -lt 1 || $# -gt 2 ]]; then
 fi
 
 tag="$1"
+# Tag-push events restrict who can push, but tag names are still
+# user-controlled — reject anything outside a semver-shaped allowlist
+# before interpolating into curl URLs, git arguments, or printf strings.
+if [[ ! "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.+-]+)?$ ]]; then
+  echo "refusing unexpected tag format: $tag" >&2
+  exit 1
+fi
 version="${tag#v}"
 output_file="${2:-}"
 repo_url="https://github.com/ferro-labs/ai-gateway"
@@ -51,6 +58,47 @@ if ! awk -v version="$version" '
 ' "$changelog_file" >"$tmp_file"; then
   echo "failed to extract release notes for $tag from $changelog_file" >&2
   exit 1
+fi
+
+# Append a Contributors section sourced from the GitHub compare API.
+# Skipped silently on any failure (no prev tag, missing curl/jq, API error,
+# rate limit) so the release always falls back to the CHANGELOG-only body.
+# Filters out chore:/docs:/ci: commits to keep the focus on feature/fix work.
+prev_tag=$(git tag --list 'v[0-9]*' --sort=-v:refname 2>/dev/null | grep -vFx "$tag" | head -n1 || true)
+
+if [[ -n "$prev_tag" ]] && command -v curl >/dev/null 2>&1 && command -v jq >/dev/null 2>&1; then
+  api_url="https://api.github.com/repos/ferro-labs/ai-gateway/compare/${prev_tag}...${tag}"
+  auth_header=()
+  if [[ -n "${GITHUB_TOKEN:-}" ]]; then
+    auth_header=(-H "Authorization: Bearer ${GITHUB_TOKEN}")
+  fi
+
+  contrib_file="$(mktemp)"
+  if curl -fsS "${auth_header[@]}" \
+       -H "Accept: application/vnd.github+json" \
+       "$api_url" 2>/dev/null \
+     | jq -r '
+         [
+           .commits[]
+           | select(.commit.message | test("^(chore|docs|ci)\\("; "i") | not)
+           | {
+               subject: (.commit.message | split("\n")[0]),
+               login:   (.author.login // .commit.author.name),
+             }
+         ]
+         | unique_by(.subject)
+         | .[]
+         | "* \(.subject) — @\(.login)"
+       ' 2>/dev/null > "$contrib_file"
+  then
+    if [[ -s "$contrib_file" ]]; then
+      {
+        printf '\n\n## Contributors\n\nThanks to everyone who shipped this release:\n\n'
+        cat "$contrib_file"
+      } >> "$tmp_file"
+    fi
+  fi
+  rm -f "$contrib_file"
 fi
 
 {


### PR DESCRIPTION
## Summary

Release rollup for **v1.1.1** — the stability hotfix tag in the post-v1.1.0 stabilization series. Fixes every public `release-1.1.1` issue plus three locally-tracked CRITICAL bugs (C1, C2, C3) discovered in the engine audit. Adds a `goleak` + `-race` stress harness so these regressions stay fixed.

No new features. No API changes (one new optional config knob — `strategy.unpriced_strategy` — defaulting to historical behavior). Cherry-picked one item forward from the v1.1.2 plan (#126 — cost-optimized routing for unpriced models) because its fix happened to be ready and shares test surface with H5.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Performance / reliability — eliminates a class of goroutine + HTTP body leaks
- [ ] Breaking change

## Related issues

Fixes the entire `release-1.1.1` label:

- Fixes #126 — cost-optimized routing treats null-priced models as $0 (pulled forward from v1.1.2)
- Fixes #127 — panic: send on closed hook-dispatch channel during shutdown (**C1**)
- Fixes #128 — data race: provider lookup reads maps without lock; races with runtime discovery (**C2**)
- Fixes #129 — streaming aborts on SSE lines > 64 KB (**C4**)
- Fixes #130 — nil-pointer panic in least-latency / cost-optimized / load-balance when a target resolves to nil (**H5**)
- Fixes #131 — unsynchronized reads of `mcpRegistry`/`mcpExecutor`/`config` race with `ReloadConfig`; `plugin.Manager` has no lock (**H7**)

- **C3** — streaming goroutine + HTTP body leak on client disconnect. Engineering fix is in this PR (`internal/streamwrap/wrap.go`). A GitHub Security Advisory will be published separately with the unauthenticated-DoS framing once v1.1.1 is tagged.

Reference: [`docs/coordination/stability-v1.1.x.md`](https://github.com/ferro-labs/ai-gateway-workspace/blob/main/docs/coordination/stability-v1.1.x.md) in the workspace meta-repo rolls up public + private status.

## Changes (per commit)

| Commit | Fix | Area |
|---|---|---|
| [`b4462f0`](https://github.com/ferro-labs/ai-gateway/pull/156) | **H5** — `least-latency` / `cost-optimized` / `loadbalance` now return a routing error when a selected target is unresolvable at dispatch instead of dereferencing a nil provider. | `internal/strategies/` |
| [`bd1e34b`](https://github.com/ferro-labs/ai-gateway/pull/153) | **C4** — shared `providers/core/sse_scanner.go` helper with `Buffer(_, 1 MiB)`; sweep across the 9 providers that previously aborted on SSE lines > 64 KiB. | `providers/core/` + all stream providers |
| [`d954206`](https://github.com/ferro-labs/ai-gateway/pull/155) | **#126** — `cost-optimized` no longer treats `null`-priced catalog entries as $0. New `strategy.unpriced_strategy` knob: `fallback` (default — prefer priced, then first compatible unpriced), `skip` (reject unpriced), `allow` (legacy zero-cost behavior). Config-level validation. | `internal/strategies/costoptimized.go`, `config.go`, `config_load.go` |
| [`20990b1`](https://github.com/ferro-labs/ai-gateway/pull/172) | **H7** — `Route`/`RouteStream` snapshot `g.mcpRegistry` / `g.mcpExecutor` under `g.mu.RLock` instead of reading the fields after the lock is released; `plugin.Manager` gets its own `sync.RWMutex` around the `before`/`after`/`onErr` slices. | `gateway.go`, `plugin/manager.go` |
| `46ddb82` | **C3** — `streamwrap.Meter` now selects on `ctx.Done()` for every send AND every read from `src`; on cancel it drains `src` so the upstream provider goroutine can exit and the HTTP body gets released. New `client_canceled` `provider_errors` metric label distinguishes disconnects from real provider errors. Emits one `failed` event so budgets / observability still see the request. | `internal/streamwrap/wrap.go` |
| `03df800` | **C1** — replaced `close(g.hookDispatchQ)` in `Close()` with a shutdown-context cancel. Producers select on `shutdownCtx.Done()` before sending; workers select on it and drain queued events before exiting; `Close()` waits up to 5s for workers via a `WaitGroup`. The select+default arm in `publishEvent` only guarded a FULL channel — a CLOSED channel send still panicked, which is what production hit. **C2** — the `lookup` closure built in `getStrategy()` now takes `g.mu.RLock()` for its body. Verified `Route` and `RouteStream` release the gateway lock before strategy execution (gateway.go:330 and gateway.go:1108), so the lock-in-closure cannot recursively deadlock against a Writer. | `gateway.go` |

### New stress harness (Phase 0 gate)

- `go.uber.org/goleak` promoted to a direct dependency (was indirect).
- `internal/streamwrap/wrap_leak_test.go` — `goleak.VerifyTestMain` + `TestMeter_ClientDisconnect_NoGoroutineLeak` (slow producer, mid-stream cancel; asserts no goroutine survives, producer exits, single failed event published, `client_canceled` metric +1) + `TestMeter_ConsumerStopsReading_NoLeak` (guards the natural close-of-src path so the new select doesn't break end-of-stream).
- `gateway_stress_test.go` — `TestStress_ShutdownUnderLoad_NoPanic` (50 workers hammering `Route` while `Close` fires) + `TestStress_ReloadUnderLoad_NoRace` (20 workers hammering `Route` while a mutator goroutine reassigns `g.providers` / `g.circuitBreakers` through the production write path). Both run under `-race`; both pass under the `stdlib http2 readLoop` ignore (the catalog loader's HTTPS transport keeps that goroutine alive — not a gateway leak).

## Testing

- [x] `go test -race ./...` — all 68 packages green
- [x] `go vet ./...` clean
- [x] `gofmt -l .` clean
- [x] New `goleak` + `-race` stress tests for C1, C2, C3 added and green
- [x] Existing tests untouched (the one direct-`Gateway{}`-literal test that depends on the unmodified-`publishEvent` path keeps working via a nil-`shutdownCtx` guard branch)
- [ ] Manual smoke against a live provider — not run for this PR (no provider behavior changes; the only behavior surface is shutdown / cancel paths and the cost-routing knob, all covered by unit + stress tests)

## Breaking change notes

None. `strategy.unpriced_strategy` defaults to `fallback`, which preserves the pre-#155 ranking semantics for any catalog where every candidate has a known price. The only user-visible behavior change is that an unpriced candidate is no longer silently chosen as the cheapest in a mixed pool — operators who relied on that can opt back in with `unpriced_strategy: allow`.

## New dependency

- `go.uber.org/goleak v1.3.0` — promoted from indirect to direct (used by the new stress + leak tests only).

## Post-merge / pre-tag actions

- [ ] Draft + publish the **C3 GHSA** with the unauthenticated-disconnect-DoS framing before cutting `v1.1.1`.
- [ ] Update `CHANGELOG.md` for `v1.1.1` (claim #126 here, not v1.1.2).
- [ ] Tag `v1.1.1` once the advisory is live.
- [ ] Flip status rows in [`docs/coordination/stability-v1.1.x.md`](https://github.com/ferro-labs/ai-gateway-workspace/blob/main/docs/coordination/stability-v1.1.x.md) for any items the release notes language changes.
