### PR TITLE
Fix/issue152

### DIFF
--- a/config.go
+++ b/config.go
@@ -221,6 +221,9 @@ type CircuitBreakerConfig struct {
 	// SuccessThreshold is the number of consecutive successes in half-open state
 	// required to close the circuit. Defaults to 1.
 	SuccessThreshold int `json:"success_threshold" yaml:"success_threshold"`
+	// MaxHalfThreshold is the maximum number of concurrent in-flight probes
+	// allowed while the circuit is half-open. Zero or negative values default to 1.
+	MaxHalfThreshold int `json:"max_half_threshold" yaml:"max_half_threshold"`
 	// Timeout is the duration the circuit stays open before transitioning to
 	// half-open (e.g. "30s"). Defaults to "30s".
 	Timeout string `json:"timeout" yaml:"timeout"`

--- a/config_load_test.go
+++ b/config_load_test.go
@@ -259,6 +259,62 @@ func TestValidateConfig_PrivacyLevel(t *testing.T) {
 	}
 }
 
+func TestLoadConfig_CircuitBreakerMaxHalfThreshold_JSON(t *testing.T) {
+	data := `{
+		"strategy": {"mode": "single"},
+		"targets": [{
+			"virtual_key": "openai",
+			"circuit_breaker": {
+				"failure_threshold": 5,
+				"success_threshold": 2,
+				"max_half_threshold": 3,
+				"timeout": "30s"
+			}
+		}]
+	}`
+	path := writeTempFile(t, "config.json", data)
+	cfg, err := LoadConfig(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	cb := cfg.Targets[0].CircuitBreaker
+	if cb == nil {
+		t.Fatal("expected CircuitBreaker config to be present")
+	}
+	if cb.MaxHalfThreshold != 3 {
+		t.Errorf("MaxHalfThreshold = %d, want 3", cb.MaxHalfThreshold)
+	}
+	if cb.FailureThreshold != 5 {
+		t.Errorf("FailureThreshold = %d, want 5", cb.FailureThreshold)
+	}
+}
+
+func TestLoadConfig_CircuitBreakerMaxHalfThreshold_YAML(t *testing.T) {
+	data := `
+strategy:
+  mode: single
+targets:
+  - virtual_key: anthropic
+    circuit_breaker:
+      failure_threshold: 3
+      success_threshold: 1
+      max_half_threshold: 2
+      timeout: 15s
+`
+	path := writeTempFile(t, "config.yaml", data)
+	cfg, err := LoadConfig(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	cb := cfg.Targets[0].CircuitBreaker
+	if cb == nil {
+		t.Fatal("expected CircuitBreaker config to be present")
+	}
+	if cb.MaxHalfThreshold != 2 {
+		t.Errorf("MaxHalfThreshold = %d, want 2", cb.MaxHalfThreshold)
+	}
+}
+
 func writeTempFile(t *testing.T, name, content string) string {
 	t.Helper()
 	dir := t.TempDir()

--- a/gateway.go
+++ b/gateway.go
@@ -1050,6 +1050,8 @@ func (p *cbProvider) Complete(ctx context.Context, req providers.Request) (*prov
 		if shouldRecordCircuitBreakerFailure(ctx, err) {
 			p.cb.RecordFailure()
 			metrics.CircuitBreakerState.WithLabelValues(p.name).Set(float64(p.cb.State()))
+		} else {
+			p.cb.ReleaseProbe()
 		}
 		return nil, err
 	}
@@ -1065,6 +1067,7 @@ func (p *cbProvider) CompleteStream(ctx context.Context, req providers.Request) 
 	}
 	sp, ok := p.Provider.(providers.StreamProvider)
 	if !ok {
+		p.cb.ReleaseProbe()
 		return nil, fmt.Errorf("provider %s does not support streaming", p.name)
 	}
 	ch, err := sp.CompleteStream(ctx, req)
@@ -1072,6 +1075,8 @@ func (p *cbProvider) CompleteStream(ctx context.Context, req providers.Request) 
 		if shouldRecordCircuitBreakerFailure(ctx, err) {
 			p.cb.RecordFailure()
 			metrics.CircuitBreakerState.WithLabelValues(p.name).Set(float64(p.cb.State()))
+		} else {
+			p.cb.ReleaseProbe()
 		}
 		return nil, err
 	}
@@ -1099,6 +1104,7 @@ func shouldRecordCircuitBreakerFailure(ctx context.Context, err error) bool {
 func recordStreamCircuitBreakerOutcome(ctx context.Context, cb *circuitbreaker.CircuitBreaker, name string, err error) {
 	if err != nil {
 		if !shouldRecordCircuitBreakerFailure(ctx, err) {
+			cb.ReleaseProbe()
 			return
 		}
 		cb.RecordFailure()

--- a/gateway.go
+++ b/gateway.go
@@ -1123,6 +1123,7 @@ func (g *Gateway) ensureCircuitBreakersLocked() {
 		g.circuitBreakers[t.VirtualKey] = circuitbreaker.New(
 			t.CircuitBreaker.FailureThreshold,
 			t.CircuitBreaker.SuccessThreshold,
+			t.CircuitBreaker.MaxHalfThreshold,
 			timeout,
 		)
 	}

--- a/gateway_stress_test.go
+++ b/gateway_stress_test.go
@@ -197,7 +197,7 @@ func TestStress_ReloadUnderLoad_NoRace(t *testing.T) {
 			default:
 			}
 			gw.mu.Lock()
-			gw.circuitBreakers["stub"] = circuitbreaker.New(5, 1, time.Second)
+			gw.circuitBreakers["stub"] = circuitbreaker.New(5, 1, 1, time.Second)
 			gw.providers["stub"] = &stressStubProvider{name: "stub", models: []string{"gpt-4o"}}
 			gw.mu.Unlock()
 			mutations.Add(1)

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -1212,6 +1212,78 @@ func TestShouldRecordCircuitBreakerFailure(t *testing.T) {
 	}
 }
 
+func TestGateway_CircuitBreaker_ReleasesHalfOpenProbeForIgnoredRateLimit(t *testing.T) {
+	var calls atomic.Int32
+	gw, err := New(Config{
+		Strategy: StrategyConfig{Mode: ModeSingle},
+		Targets: []Target{
+			{
+				VirtualKey: mockProviderName,
+				CircuitBreaker: &CircuitBreakerConfig{
+					FailureThreshold: 1,
+					SuccessThreshold: 1,
+					MaxHalfThreshold: 1,
+					Timeout:          "1ms",
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("New failed: %v", err)
+	}
+	gw.RegisterProvider(&mockProvider{
+		name:   mockProviderName,
+		models: []string{"gpt-4o"},
+		completeFn: func(context.Context, providers.Request) (*providers.Response, error) {
+			switch calls.Add(1) {
+			case 1:
+				return nil, errors.New("provider API error (500): unavailable")
+			case 2:
+				return nil, errors.New("provider API error (429): rate limited")
+			default:
+				return &providers.Response{ID: "recovered", Model: "gpt-4o"}, nil
+			}
+		},
+	})
+
+	req := providers.Request{Model: "gpt-4o", Messages: []providers.Message{{Role: "user", Content: "hi"}}}
+	if _, err := gw.Route(context.Background(), req); err == nil {
+		t.Fatal("expected first provider failure to open the circuit")
+	}
+	time.Sleep(5 * time.Millisecond)
+	if _, err := gw.Route(context.Background(), req); err == nil || !isRateLimitError(err) {
+		t.Fatalf("expected ignored 429 from half-open probe, got %v", err)
+	}
+	resp, err := gw.Route(context.Background(), req)
+	if err != nil {
+		t.Fatalf("expected released half-open slot to allow recovery probe, got %v", err)
+	}
+	if resp.ID != "recovered" {
+		t.Fatalf("response ID = %q, want recovered", resp.ID)
+	}
+}
+
+func TestRecordStreamCircuitBreakerOutcome_ReleasesHalfOpenProbeForClientCancel(t *testing.T) {
+	cb := circuitbreaker.New(1, 1, 1, 1*time.Millisecond)
+	cb.RecordFailure()
+	time.Sleep(5 * time.Millisecond)
+	_ = cb.State()
+	if !cb.Allow() {
+		t.Fatal("expected first half-open stream probe allowed")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	recordStreamCircuitBreakerOutcome(ctx, cb, mockProviderName, context.Canceled)
+
+	if cb.State() != circuitbreaker.StateHalfOpen {
+		t.Fatalf("expected ignored client cancel to keep half-open state, got %s", cb.State())
+	}
+	if !cb.Allow() {
+		t.Fatal("expected ignored stream outcome to release half-open probe slot")
+	}
+}
+
 func TestGateway_RouteStream_FallbackSkipsOpenCircuitBreakerTarget(t *testing.T) {
 	var selected atomic.Value
 	gw, err := New(Config{

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -3287,6 +3287,97 @@ func BenchmarkFindByModel(b *testing.B) {
 	}
 }
 
+// blockAfterFirstMock fails on its first Complete call (to trip the circuit
+// breaker) and blocks on the second call until release is closed — used to
+// hold a half-open probe slot while a concurrent request tests the cap.
+type blockAfterFirstMock struct {
+	mockProvider
+	callN   atomic.Int32
+	ready   chan struct{} // closed when the second call enters Complete
+	release chan struct{} // closed to let the second call return
+}
+
+func (m *blockAfterFirstMock) Complete(_ context.Context, _ providers.Request) (*providers.Response, error) {
+	if n := m.callN.Add(1); n == 1 {
+		return nil, errors.New("provider down")
+	}
+	close(m.ready)
+	<-m.release
+	return m.resp, nil
+}
+
+// TestGateway_CircuitBreaker_MaxHalfThreshold_FromConfig verifies that the
+// MaxHalfThreshold value in CircuitBreakerConfig is wired into the circuit
+// breaker: while one half-open probe is in-flight, a concurrent request must
+// be rejected with ErrCircuitOpen.
+func TestGateway_CircuitBreaker_MaxHalfThreshold_FromConfig(t *testing.T) {
+	mock := &blockAfterFirstMock{
+		mockProvider: mockProvider{
+			name:   "mock-cb",
+			models: []string{"gpt-4o"},
+			resp:   &providers.Response{ID: "ok", Model: "gpt-4o"},
+		},
+		ready:   make(chan struct{}),
+		release: make(chan struct{}),
+	}
+
+	gw, _ := New(Config{
+		Strategy: StrategyConfig{Mode: ModeSingle},
+		Targets: []Target{{
+			VirtualKey: "mock-cb",
+			CircuitBreaker: &CircuitBreakerConfig{
+				FailureThreshold: 1,
+				SuccessThreshold: 1,
+				MaxHalfThreshold: 1,
+				Timeout:          "1ms",
+			},
+		}},
+	})
+	gw.RegisterProvider(mock)
+
+	req := providers.Request{
+		Model:    "gpt-4o",
+		Messages: []providers.Message{{Role: "user", Content: "hi"}},
+	}
+
+	// Trip the circuit: first call fails → circuit opens.
+	_, _ = gw.Route(context.Background(), req)
+
+	// Wait for half-open transition.
+	time.Sleep(5 * time.Millisecond)
+
+	// Probe 1: admitted into half-open, blocks inside provider holding the slot.
+	probe1Err := make(chan error, 1)
+	go func() {
+		_, err := gw.Route(context.Background(), req)
+		probe1Err <- err
+	}()
+
+	// Wait until probe 1 is holding the in-flight slot (halfOpenProbes=1).
+	select {
+	case <-mock.ready:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for probe 1 to enter provider")
+	}
+
+	// Probe 2: cap=1 already consumed → must be rejected.
+	_, err := gw.Route(context.Background(), req)
+	if !errors.Is(err, circuitbreaker.ErrCircuitOpen) {
+		t.Errorf("expected ErrCircuitOpen for second concurrent half-open probe, got %v", err)
+	}
+
+	// Release probe 1 and verify it succeeds.
+	close(mock.release)
+	select {
+	case err := <-probe1Err:
+		if err != nil {
+			t.Errorf("probe 1 expected success, got %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for probe 1 to complete")
+	}
+}
+
 func BenchmarkPublishEvent(b *testing.B) {
 	silenceLogs(b)
 	gw, err := New(Config{})

--- a/internal/cache/memory.go
+++ b/internal/cache/memory.go
@@ -17,8 +17,8 @@ type memoryEntry struct {
 // Memory is a thread-safe in-memory LRU cache with TTL expiration.
 type Memory struct {
 	mu        sync.Mutex
-	capacity  int
-	ttl       time.Duration
+	Capacity  int
+	TTL       time.Duration
 	items     map[string]*list.Element
 	evictList *list.List
 }
@@ -26,8 +26,8 @@ type Memory struct {
 // NewMemory creates a new in-memory LRU cache.
 func NewMemory(capacity int, ttl time.Duration) *Memory {
 	return &Memory{
-		capacity:  capacity,
-		ttl:       ttl,
+		Capacity:  capacity,
+		TTL:       ttl,
 		items:     make(map[string]*list.Element),
 		evictList: list.New(),
 	}
@@ -62,18 +62,18 @@ func (m *Memory) Set(key string, resp *providers.Response) {
 		m.evictList.MoveToFront(elem)
 		entry := elem.Value.(*memoryEntry)
 		entry.response = resp
-		entry.expiresAt = time.Now().Add(m.ttl)
+		entry.expiresAt = time.Now().Add(m.TTL)
 		return
 	}
 
-	if m.evictList.Len() >= m.capacity {
+	if m.evictList.Len() >= m.Capacity {
 		m.removeOldest()
 	}
 
 	entry := &memoryEntry{
 		key:       key,
 		response:  resp,
-		expiresAt: time.Now().Add(m.ttl),
+		expiresAt: time.Now().Add(m.TTL),
 	}
 	elem := m.evictList.PushFront(entry)
 	m.items[key] = elem

--- a/internal/circuitbreaker/circuit_breaker.go
+++ b/internal/circuitbreaker/circuit_breaker.go
@@ -118,6 +118,17 @@ func (cb *CircuitBreaker) Allow() bool {
 	return true
 }
 
+// ReleaseProbe releases an admitted half-open probe without recording success
+// or failure. It is used when the gateway intentionally ignores an outcome,
+// such as rate limits or caller-side cancellation.
+func (cb *CircuitBreaker) ReleaseProbe() {
+	cb.mu.Lock()
+	defer cb.mu.Unlock()
+	if cb.state == StateHalfOpen && cb.halfOpenProbes > 0 {
+		cb.halfOpenProbes--
+	}
+}
+
 // RecordSuccess notifies the breaker that a call succeeded.
 func (cb *CircuitBreaker) RecordSuccess() {
 	cb.mu.Lock()

--- a/internal/circuitbreaker/circuit_breaker.go
+++ b/internal/circuitbreaker/circuit_breaker.go
@@ -52,6 +52,8 @@ type CircuitBreaker struct {
 	successCount     int
 	failureThreshold int
 	successThreshold int
+	maxHalfThreshold int // cap on concurrent in-flight probes while half-open
+	halfOpenProbes   int // current number of in-flight probes
 	timeout          time.Duration
 	openUntil        time.Time
 }
@@ -59,12 +61,15 @@ type CircuitBreaker struct {
 // New creates a CircuitBreaker with the given thresholds and open timeout.
 // Defaults are applied for zero/negative values: failureThreshold=5,
 // successThreshold=1, timeout=30s.
-func New(failureThreshold, successThreshold int, timeout time.Duration) *CircuitBreaker {
+func New(failureThreshold, successThreshold int, maxHalfThreshold int, timeout time.Duration) *CircuitBreaker {
 	if failureThreshold <= 0 {
 		failureThreshold = 5
 	}
 	if successThreshold <= 0 {
 		successThreshold = 1
+	}
+	if maxHalfThreshold <= 0 {
+		maxHalfThreshold = 1
 	}
 	if timeout <= 0 {
 		timeout = 30 * time.Second
@@ -73,6 +78,7 @@ func New(failureThreshold, successThreshold int, timeout time.Duration) *Circuit
 		state:            StateClosed,
 		failureThreshold: failureThreshold,
 		successThreshold: successThreshold,
+		maxHalfThreshold: maxHalfThreshold,
 		timeout:          timeout,
 	}
 }
@@ -90,6 +96,7 @@ func (cb *CircuitBreaker) resolveState() State {
 	if cb.state == StateOpen && time.Now().After(cb.openUntil) {
 		cb.state = StateHalfOpen
 		cb.successCount = 0
+		cb.halfOpenProbes = 0
 	}
 	return cb.state
 }
@@ -99,7 +106,16 @@ func (cb *CircuitBreaker) resolveState() State {
 func (cb *CircuitBreaker) Allow() bool {
 	cb.mu.Lock()
 	defer cb.mu.Unlock()
-	return cb.resolveState() != StateOpen
+	if cb.resolveState() == StateOpen {
+		return false
+	}
+	if cb.state == StateHalfOpen {
+		if cb.halfOpenProbes >= cb.maxHalfThreshold {
+			return false
+		}
+		cb.halfOpenProbes++
+	}
+	return true
 }
 
 // RecordSuccess notifies the breaker that a call succeeded.
@@ -108,11 +124,15 @@ func (cb *CircuitBreaker) RecordSuccess() {
 	defer cb.mu.Unlock()
 	switch cb.state {
 	case StateHalfOpen:
+		if cb.halfOpenProbes > 0 {
+			cb.halfOpenProbes--
+		}
 		cb.successCount++
 		if cb.successCount >= cb.successThreshold {
 			cb.state = StateClosed
 			cb.failureCount = 0
 			cb.successCount = 0
+			cb.halfOpenProbes = 0
 		}
 	case StateClosed:
 		cb.failureCount = 0
@@ -134,5 +154,6 @@ func (cb *CircuitBreaker) RecordFailure() {
 		cb.state = StateOpen
 		cb.openUntil = time.Now().Add(cb.timeout)
 		cb.successCount = 0
+		cb.halfOpenProbes = 0
 	}
 }

--- a/internal/circuitbreaker/circuit_breaker_test.go
+++ b/internal/circuitbreaker/circuit_breaker_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestInitialStateClosed(t *testing.T) {
-	cb := New(3, 1, 10*time.Second)
+	cb := New(3, 1, 1, 10*time.Second)
 	if cb.State() != StateClosed {
 		t.Fatalf("expected closed, got %s", cb.State())
 	}
@@ -16,7 +16,7 @@ func TestInitialStateClosed(t *testing.T) {
 }
 
 func TestOpensAfterThreshold(t *testing.T) {
-	cb := New(3, 1, 10*time.Second)
+	cb := New(3, 1, 1, 10*time.Second)
 	for i := 0; i < 3; i++ {
 		cb.RecordFailure()
 	}
@@ -29,7 +29,7 @@ func TestOpensAfterThreshold(t *testing.T) {
 }
 
 func TestTransitionsToHalfOpenAfterTimeout(t *testing.T) {
-	cb := New(1, 1, 1*time.Millisecond)
+	cb := New(1, 1, 1, 1*time.Millisecond)
 	cb.RecordFailure()
 	time.Sleep(5 * time.Millisecond)
 	if cb.State() != StateHalfOpen {
@@ -41,10 +41,11 @@ func TestTransitionsToHalfOpenAfterTimeout(t *testing.T) {
 }
 
 func TestClosesAfterSuccessInHalfOpen(t *testing.T) {
-	cb := New(1, 1, 1*time.Millisecond)
+	cb := New(1, 1, 1, 1*time.Millisecond)
 	cb.RecordFailure()
 	time.Sleep(5 * time.Millisecond)
 	_ = cb.State() // trigger half-open transition
+	cb.Allow()
 	cb.RecordSuccess()
 	if cb.State() != StateClosed {
 		t.Fatalf("expected closed after success in half_open, got %s", cb.State())
@@ -52,10 +53,11 @@ func TestClosesAfterSuccessInHalfOpen(t *testing.T) {
 }
 
 func TestReopensOnFailureInHalfOpen(t *testing.T) {
-	cb := New(1, 1, 1*time.Millisecond)
+	cb := New(1, 1, 1, 1*time.Millisecond)
 	cb.RecordFailure()
 	time.Sleep(5 * time.Millisecond)
 	_ = cb.State() // trigger half-open transition
+	cb.Allow()
 	cb.RecordFailure()
 	if cb.State() != StateOpen {
 		t.Fatalf("expected open after failure in half_open, got %s", cb.State())
@@ -63,7 +65,7 @@ func TestReopensOnFailureInHalfOpen(t *testing.T) {
 }
 
 func TestSuccessResetFailureCount(t *testing.T) {
-	cb := New(3, 1, 10*time.Second)
+	cb := New(3, 1, 1, 10*time.Second)
 	cb.RecordFailure()
 	cb.RecordFailure()
 	cb.RecordSuccess()
@@ -71,5 +73,216 @@ func TestSuccessResetFailureCount(t *testing.T) {
 	cb.RecordFailure()
 	if cb.State() != StateClosed {
 		t.Fatalf("expected still closed (failure count reset), got %s", cb.State())
+	}
+}
+
+func TestHalfOpenProbeCap(t *testing.T) {
+	cb := New(1, 1, 2, 1*time.Millisecond)
+	cb.RecordFailure()
+	time.Sleep(5 * time.Millisecond)
+	_ = cb.State() // trigger half-open transition
+
+	// First two probes should be allowed (cap = 2)
+	if !cb.Allow() {
+		t.Fatal("expected first probe allowed")
+	}
+	if !cb.Allow() {
+		t.Fatal("expected second probe allowed")
+	}
+	// Third probe must be rejected — cap reached
+	if cb.Allow() {
+		t.Fatal("expected third probe rejected, cap is 2")
+	}
+
+	// After one probe completes successfully, a slot opens
+	cb.RecordSuccess()
+	if !cb.Allow() {
+		t.Fatal("expected probe allowed after slot freed by RecordSuccess")
+	}
+}
+
+func TestHalfOpenProbeCapReleasedOnFailure(t *testing.T) {
+	// cap=2: fill both slots, then one probe fails; after re-entering half-open
+	// both slots must be available again, proving RecordFailure decremented before reset.
+	cb := New(1, 1, 2, 1*time.Millisecond)
+	cb.RecordFailure()
+	time.Sleep(5 * time.Millisecond)
+	_ = cb.State()
+
+	if !cb.Allow() {
+		t.Fatal("expected first probe allowed")
+	}
+	if !cb.Allow() {
+		t.Fatal("expected second probe allowed")
+	}
+	if cb.Allow() {
+		t.Fatal("expected third probe rejected, cap is 2")
+	}
+
+	cb.RecordFailure() // one probe fails → circuit reopens, halfOpenProbes decremented then zeroed
+
+	if cb.State() != StateOpen {
+		t.Fatalf("expected open after failure, got %s", cb.State())
+	}
+
+	time.Sleep(5 * time.Millisecond)
+	_ = cb.State() // re-enter half-open
+
+	// Both slots must be free — counter was cleanly reset by RecordFailure
+	if !cb.Allow() {
+		t.Fatal("expected slot 1 available after re-entering half-open")
+	}
+	if !cb.Allow() {
+		t.Fatal("expected slot 2 available after re-entering half-open")
+	}
+	if cb.Allow() {
+		t.Fatal("expected third probe rejected, cap still 2")
+	}
+}
+
+func TestHalfOpenProbesResetOnReopen(t *testing.T) {
+	cb := New(1, 2, 1, 1*time.Millisecond)
+	cb.RecordFailure()
+	time.Sleep(5 * time.Millisecond)
+	_ = cb.State() // trigger half-open transition
+
+	cb.Allow()
+	cb.RecordFailure() // probe fails → back to open
+
+	if cb.State() != StateOpen {
+		t.Fatalf("expected open, got %s", cb.State())
+	}
+	// Simulate timeout expiry and re-entry into half-open
+	time.Sleep(5 * time.Millisecond)
+	_ = cb.State() // transition to half-open again
+
+	// Probe counter should be reset — first probe must be allowed
+	if !cb.Allow() {
+		t.Fatal("expected Allow=true after re-entering half-open")
+	}
+}
+
+// TestDefaultMaxHalfThreshold verifies that passing maxHalfThreshold=0 is
+// normalized to 1, so a second concurrent probe is rejected.
+func TestDefaultMaxHalfThreshold(t *testing.T) {
+	cb := New(1, 1, 0, 1*time.Millisecond) // 0 → normalized to 1
+	cb.RecordFailure()
+	time.Sleep(5 * time.Millisecond)
+	_ = cb.State()
+
+	if !cb.Allow() {
+		t.Fatal("expected first probe allowed with default cap 1")
+	}
+	if cb.Allow() {
+		t.Fatal("expected second probe rejected: default cap is 1, not unlimited")
+	}
+}
+
+// TestHalfOpenSuccessThresholdWithSlotRecycling verifies that when
+// successThreshold > 1, each RecordSuccess frees a probe slot so that new
+// probes can be admitted before the circuit closes.
+func TestHalfOpenSuccessThresholdWithSlotRecycling(t *testing.T) {
+	// cap=2, need 2 successes to close
+	cb := New(1, 2, 2, 1*time.Millisecond)
+	cb.RecordFailure()
+	time.Sleep(5 * time.Millisecond)
+	_ = cb.State()
+
+	if !cb.Allow() {
+		t.Fatal("expected probe 1 allowed")
+	}
+	if !cb.Allow() {
+		t.Fatal("expected probe 2 allowed")
+	}
+	if cb.Allow() {
+		t.Fatal("expected probe 3 rejected: cap reached")
+	}
+
+	// Probe 1 succeeds: slot freed, successCount=1 (not yet at threshold=2)
+	cb.RecordSuccess()
+	if cb.State() != StateHalfOpen {
+		t.Fatalf("expected still half_open after first success, got %s", cb.State())
+	}
+
+	// Freed slot allows a new probe
+	if !cb.Allow() {
+		t.Fatal("expected new probe allowed after slot freed by first RecordSuccess")
+	}
+	if cb.Allow() {
+		t.Fatal("expected cap enforced again after refill")
+	}
+
+	// Second success closes the circuit
+	cb.RecordSuccess()
+	if cb.State() != StateClosed {
+		t.Fatalf("expected closed after second success, got %s", cb.State())
+	}
+}
+
+// TestRecordSuccessAfterConcurrentReopenIsNoop verifies that a late
+// RecordSuccess arriving after a concurrent probe already reopened the circuit
+// does not corrupt state.
+func TestRecordSuccessAfterConcurrentReopenIsNoop(t *testing.T) {
+	// cap=2: probe A and probe B both admitted; probe B fails first (reopens);
+	// probe A's RecordSuccess arrives after the reopen.
+	cb := New(1, 1, 2, 1*time.Millisecond)
+	cb.RecordFailure()
+	time.Sleep(5 * time.Millisecond)
+	_ = cb.State()
+
+	cb.Allow() // probe A admitted
+	cb.Allow() // probe B admitted
+
+	cb.RecordFailure() // probe B fails → circuit reopens, halfOpenProbes zeroed
+
+	if cb.State() != StateOpen {
+		t.Fatalf("expected open after probe B failure, got %s", cb.State())
+	}
+
+	// Probe A's result arrives late — circuit is already Open
+	cb.RecordSuccess() // must be a silent no-op
+
+	if cb.State() != StateOpen {
+		t.Fatalf("expected still open after stale RecordSuccess, got %s", cb.State())
+	}
+
+	// After timeout the circuit should re-enter half-open cleanly
+	time.Sleep(5 * time.Millisecond)
+	if cb.State() != StateHalfOpen {
+		t.Fatalf("expected half_open after timeout, got %s", cb.State())
+	}
+	if !cb.Allow() {
+		t.Fatal("expected probe slot available after clean re-entry into half_open")
+	}
+}
+
+// TestHalfOpenProbesZeroOnClosedToOpenTransition asserts that halfOpenProbes
+// is never left non-zero when transitioning Closed → Open, ensuring subsequent
+// half-open entry always starts with a clean counter.
+func TestHalfOpenProbesZeroOnClosedToOpenTransition(t *testing.T) {
+	cb := New(1, 1, 1, 1*time.Millisecond)
+
+	// Drive through a full cycle: closed→open→half-open→closed
+	cb.RecordFailure()
+	time.Sleep(5 * time.Millisecond)
+	_ = cb.State()    // →half-open
+	cb.Allow()        // probe admitted (halfOpenProbes=1)
+	cb.RecordSuccess() // closes (halfOpenProbes zeroed)
+
+	if cb.State() != StateClosed {
+		t.Fatalf("expected closed, got %s", cb.State())
+	}
+
+	// Now open again from closed — probe counter must still be 0
+	cb.RecordFailure()
+	if cb.State() != StateOpen {
+		t.Fatalf("expected open, got %s", cb.State())
+	}
+
+	// Re-enter half-open: both slots must be free
+	time.Sleep(5 * time.Millisecond)
+	_ = cb.State()
+	if !cb.Allow() {
+		t.Fatal("expected probe allowed: halfOpenProbes must be 0 after Closed→Open transition")
 	}
 }

--- a/internal/circuitbreaker/circuit_breaker_test.go
+++ b/internal/circuitbreaker/circuit_breaker_test.go
@@ -265,8 +265,8 @@ func TestHalfOpenProbesZeroOnClosedToOpenTransition(t *testing.T) {
 	// Drive through a full cycle: closed→open→half-open→closed
 	cb.RecordFailure()
 	time.Sleep(5 * time.Millisecond)
-	_ = cb.State()    // →half-open
-	cb.Allow()        // probe admitted (halfOpenProbes=1)
+	_ = cb.State()     // →half-open
+	cb.Allow()         // probe admitted (halfOpenProbes=1)
 	cb.RecordSuccess() // closes (halfOpenProbes zeroed)
 
 	if cb.State() != StateClosed {

--- a/internal/circuitbreaker/circuit_breaker_test.go
+++ b/internal/circuitbreaker/circuit_breaker_test.go
@@ -178,6 +178,29 @@ func TestDefaultMaxHalfThreshold(t *testing.T) {
 	}
 }
 
+func TestReleaseProbeFreesHalfOpenSlotWithoutRecordingOutcome(t *testing.T) {
+	cb := New(1, 1, 1, 1*time.Millisecond)
+	cb.RecordFailure()
+	time.Sleep(5 * time.Millisecond)
+	_ = cb.State()
+
+	if !cb.Allow() {
+		t.Fatal("expected first half-open probe allowed")
+	}
+	if cb.Allow() {
+		t.Fatal("expected second half-open probe rejected before release")
+	}
+
+	cb.ReleaseProbe()
+
+	if cb.State() != StateHalfOpen {
+		t.Fatalf("expected release to keep half-open state, got %s", cb.State())
+	}
+	if !cb.Allow() {
+		t.Fatal("expected released half-open slot to admit another probe")
+	}
+}
+
 // TestHalfOpenSuccessThresholdWithSlotRecycling verifies that when
 // successThreshold > 1, each RecordSuccess frees a probe slot so that new
 // probes can be admitted before the circuit closes.

--- a/internal/plugins/cache/cache.go
+++ b/internal/plugins/cache/cache.go
@@ -11,9 +11,10 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"hash"
-	"sync"
+	"strconv"
 	"time"
 
+	internalCache "github.com/ferro-labs/ai-gateway/internal/cache"
 	"github.com/ferro-labs/ai-gateway/plugin"
 	"github.com/ferro-labs/ai-gateway/providers"
 )
@@ -30,12 +31,10 @@ type cacheEntry struct {
 }
 
 // ResponseCache is a transform plugin that caches LLM responses using
-// exact-match hashing of the request (model + messages).
+// exact-match hashing of the request (model + messages + logprobs + toplogprobs(optional)).
+// It aliases Memory from the internal cache package.
 type ResponseCache struct {
-	mu         sync.RWMutex
-	entries    map[string]cacheEntry
-	maxAge     time.Duration
-	maxEntries int
+	*internalCache.Memory
 }
 
 // Name returns the plugin identifier.
@@ -58,21 +57,20 @@ func (c *ResponseCache) Init(config map[string]interface{}) error {
 	case float64:
 		maxAge = int(v)
 	}
-	c.maxAge = time.Duration(maxAge) * time.Second
+	ttl := time.Duration(maxAge) * time.Second
 
-	c.maxEntries = 1000
+	capacity := 1000
 	switch v := config["max_entries"].(type) {
 	case int:
-		c.maxEntries = v
+		capacity = v
 	case float64:
-		c.maxEntries = int(v)
+		capacity = int(v)
 	}
-
-	c.entries = make(map[string]cacheEntry)
+	c.Memory = internalCache.NewMemory(capacity, ttl)
 	return nil
 }
 
-// Execute checks for a cache hit (before request) or stores the response (after request).
+// Execute checks for a cache hit (before request) or stores the response (after request) and does maintenance as per LRU policy.
 func (c *ResponseCache) Execute(_ context.Context, pctx *plugin.Context) error {
 	if pctx.Request == nil {
 		return nil
@@ -82,12 +80,8 @@ func (c *ResponseCache) Execute(_ context.Context, pctx *plugin.Context) error {
 
 	if pctx.Response == nil {
 		// before_request: lookup
-		c.mu.RLock()
-		entry, ok := c.entries[key]
-		c.mu.RUnlock()
-
-		if ok && time.Now().Before(entry.expiresAt) {
-			pctx.Response = entry.response
+		if resp, ok := c.Memory.Get(key); ok {
+			pctx.Response = resp
 			pctx.Skip = true
 			pctx.Metadata["cache_hit"] = true
 		}
@@ -99,32 +93,11 @@ func (c *ResponseCache) Execute(_ context.Context, pctx *plugin.Context) error {
 		return nil
 	}
 
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	if c.maxEntries <= 0 {
+	if c.Memory.Capacity <= 0 {
 		return nil
 	}
 
-	_, exists := c.entries[key]
-	if !exists && len(c.entries) >= c.maxEntries {
-		var evictKey string
-		var evictAt time.Time
-		for existingKey, existingEntry := range c.entries {
-			if evictKey == "" || existingEntry.expiresAt.Before(evictAt) {
-				evictKey = existingKey
-				evictAt = existingEntry.expiresAt
-			}
-		}
-		if evictKey != "" {
-			delete(c.entries, evictKey)
-		}
-	}
-
-	c.entries[key] = cacheEntry{
-		response:  pctx.Response,
-		expiresAt: time.Now().Add(c.maxAge),
-	}
+	c.Memory.Set(key, pctx.Response)
 	return nil
 }
 
@@ -136,6 +109,15 @@ func cacheKey(req *providers.Request) string {
 		writeCacheKeyString(h, m.Name)
 		writeCacheKeyString(h, m.Content)
 	}
+	if req.LogProbs {
+		writeCacheKeyString(h, "true")
+		if req.TopLogProbs != nil {
+			writeCacheKeyString(h, strconv.Itoa(*req.TopLogProbs))
+		}
+	} else {
+		writeCacheKeyString(h, "false")
+	}
+
 	return hex.EncodeToString(h.Sum(nil))
 }
 

--- a/internal/plugins/cache/cache.go
+++ b/internal/plugins/cache/cache.go
@@ -10,7 +10,9 @@ import (
 	"crypto/sha256"
 	"encoding/binary"
 	"encoding/hex"
+	"encoding/json"
 	"hash"
+	"sort"
 	"strconv"
 	"time"
 
@@ -26,7 +28,7 @@ func init() {
 }
 
 // ResponseCache is a transform plugin that caches LLM responses using
-// exact-match hashing of the request (model + messages + logprobs + toplogprobs(optional)).
+// exact-match hashing of the request fields that can affect provider output.
 // It aliases Memory from the internal cache package.
 type ResponseCache struct {
 	*internalCache.Memory
@@ -98,22 +100,103 @@ func (c *ResponseCache) Execute(_ context.Context, pctx *plugin.Context) error {
 
 func cacheKey(req *providers.Request) string {
 	h := sha256.New()
+	writeCacheKeyString(h, "model")
 	writeCacheKeyString(h, req.Model)
+	writeCacheKeyString(h, "messages")
+	writeCacheKeyInt(h, len(req.Messages))
 	for _, m := range req.Messages {
 		writeCacheKeyString(h, m.Role)
 		writeCacheKeyString(h, m.Name)
 		writeCacheKeyString(h, m.Content)
 	}
-	if req.LogProbs {
-		writeCacheKeyString(h, "true")
-		if req.TopLogProbs != nil {
-			writeCacheKeyString(h, strconv.Itoa(*req.TopLogProbs))
-		}
-	} else {
-		writeCacheKeyString(h, "false")
-	}
+	writeCacheKeyOptionalFloat64(h, "temperature", req.Temperature)
+	writeCacheKeyOptionalFloat64(h, "top_p", req.TopP)
+	writeCacheKeyOptionalInt(h, "n", req.N)
+	writeCacheKeyOptionalInt64(h, "seed", req.Seed)
+	writeCacheKeyOptionalInt(h, "max_tokens", req.MaxTokens)
+	writeCacheKeyOptionalInt(h, "max_completion_tokens", req.MaxCompletionTokens)
+	writeCacheKeyOptionalFloat64(h, "presence_penalty", req.PresencePenalty)
+	writeCacheKeyOptionalFloat64(h, "frequency_penalty", req.FrequencyPenalty)
+	writeCacheKeyStringSlice(h, "stop", req.Stop)
+	writeCacheKeyJSON(h, "tools", req.Tools)
+	writeCacheKeyJSON(h, "tool_choice", req.ToolChoice)
+	writeCacheKeyJSON(h, "response_format", req.ResponseFormat)
+	writeCacheKeyBool(h, "logprobs", req.LogProbs)
+	writeCacheKeyOptionalInt(h, "top_logprobs", req.TopLogProbs)
+	writeCacheKeyBool(h, "stream", req.Stream)
+	writeCacheKeyString(h, "user")
+	writeCacheKeyString(h, req.User)
+	writeCacheKeyFloatMap(h, "logit_bias", req.LogitBias)
 
 	return hex.EncodeToString(h.Sum(nil))
+}
+
+func writeCacheKeyBool(h hash.Hash, label string, v bool) {
+	writeCacheKeyString(h, label)
+	writeCacheKeyString(h, strconv.FormatBool(v))
+}
+
+func writeCacheKeyInt(h hash.Hash, v int) {
+	writeCacheKeyString(h, strconv.Itoa(v))
+}
+
+func writeCacheKeyOptionalInt(h hash.Hash, label string, v *int) {
+	writeCacheKeyString(h, label)
+	if v == nil {
+		writeCacheKeyString(h, "<nil>")
+		return
+	}
+	writeCacheKeyString(h, strconv.Itoa(*v))
+}
+
+func writeCacheKeyOptionalInt64(h hash.Hash, label string, v *int64) {
+	writeCacheKeyString(h, label)
+	if v == nil {
+		writeCacheKeyString(h, "<nil>")
+		return
+	}
+	writeCacheKeyString(h, strconv.FormatInt(*v, 10))
+}
+
+func writeCacheKeyOptionalFloat64(h hash.Hash, label string, v *float64) {
+	writeCacheKeyString(h, label)
+	if v == nil {
+		writeCacheKeyString(h, "<nil>")
+		return
+	}
+	writeCacheKeyString(h, strconv.FormatFloat(*v, 'g', -1, 64))
+}
+
+func writeCacheKeyStringSlice(h hash.Hash, label string, values []string) {
+	writeCacheKeyString(h, label)
+	writeCacheKeyInt(h, len(values))
+	for _, value := range values {
+		writeCacheKeyString(h, value)
+	}
+}
+
+func writeCacheKeyFloatMap(h hash.Hash, label string, values map[string]float64) {
+	writeCacheKeyString(h, label)
+	writeCacheKeyInt(h, len(values))
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		writeCacheKeyString(h, key)
+		writeCacheKeyString(h, strconv.FormatFloat(values[key], 'g', -1, 64))
+	}
+}
+
+func writeCacheKeyJSON(h hash.Hash, label string, v any) {
+	writeCacheKeyString(h, label)
+	b, err := json.Marshal(v)
+	if err != nil {
+		writeCacheKeyString(h, err.Error())
+		return
+	}
+	writeCacheKeyString(h, string(b))
 }
 
 func writeCacheKeyString(h hash.Hash, s string) {

--- a/internal/plugins/cache/cache.go
+++ b/internal/plugins/cache/cache.go
@@ -25,11 +25,6 @@ func init() {
 	})
 }
 
-type cacheEntry struct {
-	response  *providers.Response
-	expiresAt time.Time
-}
-
 // ResponseCache is a transform plugin that caches LLM responses using
 // exact-match hashing of the request (model + messages + logprobs + toplogprobs(optional)).
 // It aliases Memory from the internal cache package.
@@ -80,7 +75,7 @@ func (c *ResponseCache) Execute(_ context.Context, pctx *plugin.Context) error {
 
 	if pctx.Response == nil {
 		// before_request: lookup
-		if resp, ok := c.Memory.Get(key); ok {
+		if resp, ok := c.Get(key); ok {
 			pctx.Response = resp
 			pctx.Skip = true
 			pctx.Metadata["cache_hit"] = true
@@ -93,11 +88,11 @@ func (c *ResponseCache) Execute(_ context.Context, pctx *plugin.Context) error {
 		return nil
 	}
 
-	if c.Memory.Capacity <= 0 {
+	if c.Capacity <= 0 {
 		return nil
 	}
 
-	c.Memory.Set(key, pctx.Response)
+	c.Set(key, pctx.Response)
 	return nil
 }
 

--- a/internal/plugins/cache/cache_test.go
+++ b/internal/plugins/cache/cache_test.go
@@ -398,6 +398,75 @@ func TestCacheKey_DifferentTopLogProbsProducesDistinctKey(t *testing.T) {
 	}
 }
 
+func TestCacheKey_OutputParamsProduceDistinctKeys(t *testing.T) {
+	base := func() *providers.Request {
+		temp := 0.2
+		topP := 0.9
+		seed := int64(7)
+		maxTokens := 64
+		return &providers.Request{
+			Model:       "gpt-4",
+			Messages:    []providers.Message{{Role: "user", Content: "hello"}},
+			Temperature: &temp,
+			TopP:        &topP,
+			Seed:        &seed,
+			MaxTokens:   &maxTokens,
+			Stop:        []string{"END"},
+		}
+	}
+
+	tests := []struct {
+		name   string
+		mutate func(*providers.Request)
+	}{
+		{
+			name: "temperature",
+			mutate: func(req *providers.Request) {
+				v := 0.8
+				req.Temperature = &v
+			},
+		},
+		{
+			name: "top_p",
+			mutate: func(req *providers.Request) {
+				v := 0.5
+				req.TopP = &v
+			},
+		},
+		{
+			name: "seed",
+			mutate: func(req *providers.Request) {
+				v := int64(42)
+				req.Seed = &v
+			},
+		},
+		{
+			name: "max_tokens",
+			mutate: func(req *providers.Request) {
+				v := 128
+				req.MaxTokens = &v
+			},
+		},
+		{
+			name: "stop",
+			mutate: func(req *providers.Request) {
+				req.Stop = []string{"DONE"}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reqA := base()
+			reqB := base()
+			tt.mutate(reqB)
+			if cacheKey(reqA) == cacheKey(reqB) {
+				t.Fatalf("requests with different %s must produce distinct cache keys", tt.name)
+			}
+		})
+	}
+}
+
 func TestCacheKey_LogProbsNilTopLogProbsDoesNotPanic(_ *testing.T) {
 	req := &providers.Request{
 		Model:       "gpt-4",

--- a/internal/plugins/cache/cache_test.go
+++ b/internal/plugins/cache/cache_test.go
@@ -398,7 +398,7 @@ func TestCacheKey_DifferentTopLogProbsProducesDistinctKey(t *testing.T) {
 	}
 }
 
-func TestCacheKey_LogProbsNilTopLogProbsDoesNotPanic(t *testing.T) {
+func TestCacheKey_LogProbsNilTopLogProbsDoesNotPanic(_ *testing.T) {
 	req := &providers.Request{
 		Model:       "gpt-4",
 		Messages:    []providers.Message{{Role: "user", Content: "hello"}},
@@ -476,28 +476,28 @@ func TestCachePlugin_LogProbsCacheHit(t *testing.T) {
 }
 
 func TestCachePlugin_MaxEntriesMany(t *testing.T) {
-	const cap = 5
-	c := initCache(t, map[string]interface{}{"max_entries": cap})
+	const maxEntries = 5
+	c := initCache(t, map[string]interface{}{"max_entries": maxEntries})
 	resp := testResponse()
 
-	for i := 0; i < cap; i++ {
+	for i := 0; i < maxEntries; i++ {
 		pctx := plugin.NewContext(testRequest("gpt-4", fmt.Sprintf("msg-%d", i)))
 		pctx.Response = resp
 		if err := c.Execute(context.Background(), pctx); err != nil {
 			t.Fatalf("store %d: %v", i, err)
 		}
 	}
-	if c.Len() != cap {
-		t.Fatalf("expected %d entries, got %d", cap, c.Len())
+	if c.Len() != maxEntries {
+		t.Fatalf("expected %d entries, got %d", maxEntries, c.Len())
 	}
 
-	// Adding one more must not grow beyond cap.
+	// Adding one more must not grow beyond maxEntries.
 	overflow := plugin.NewContext(testRequest("gpt-4", "overflow"))
 	overflow.Response = resp
 	if err := c.Execute(context.Background(), overflow); err != nil {
 		t.Fatalf("store overflow: %v", err)
 	}
-	if c.Len() != cap {
-		t.Fatalf("expected %d entries after overflow, got %d", cap, c.Len())
+	if c.Len() != maxEntries {
+		t.Fatalf("expected %d entries after overflow, got %d", maxEntries, c.Len())
 	}
 }

--- a/internal/plugins/cache/cache_test.go
+++ b/internal/plugins/cache/cache_test.go
@@ -43,25 +43,25 @@ func initCache(t *testing.T, config map[string]interface{}) *ResponseCache {
 func TestCachePlugin_Init(t *testing.T) {
 	t.Run("default config", func(t *testing.T) {
 		c := initCache(t, map[string]interface{}{})
-		if c.maxAge != 300*time.Second {
-			t.Errorf("expected default maxAge 300s, got %v", c.maxAge)
+		if c.TTL != 300*time.Second {
+			t.Errorf("expected default TTL 300s, got %v", c.TTL)
 		}
-		if c.maxEntries != 1000 {
-			t.Errorf("expected default maxEntries 1000, got %d", c.maxEntries)
+		if c.Capacity != 1000 {
+			t.Errorf("expected default Capacity 1000, got %d", c.Capacity)
 		}
 	})
 
 	t.Run("custom max_age", func(t *testing.T) {
 		c := initCache(t, map[string]interface{}{"max_age": 60})
-		if c.maxAge != 60*time.Second {
-			t.Errorf("expected maxAge 60s, got %v", c.maxAge)
+		if c.TTL != 60*time.Second {
+			t.Errorf("expected TTL 60s, got %v", c.TTL)
 		}
 	})
 
 	t.Run("custom max_entries", func(t *testing.T) {
 		c := initCache(t, map[string]interface{}{"max_entries": 50})
-		if c.maxEntries != 50 {
-			t.Errorf("expected maxEntries 50, got %d", c.maxEntries)
+		if c.Capacity != 50 {
+			t.Errorf("expected Capacity 50, got %d", c.Capacity)
 		}
 	})
 }
@@ -207,26 +207,23 @@ func TestCachePlugin_DelimiterCharactersDoNotCollide(t *testing.T) {
 }
 
 func TestCachePlugin_Expiration(t *testing.T) {
-	c := initCache(t, map[string]interface{}{"max_age": 300})
+	// Use a 10ms TTL so we can let it expire without a long sleep.
+	c := initCache(t, map[string]interface{}{"max_age": float64(0)})
+	// Override TTL directly since Init clamps 0 to 0s (immediate expiry isn't
+	// easily configurable via the int config; set a short but nonzero duration).
+	c.TTL = 10 * time.Millisecond
+
 	req := testRequest("gpt-4", "hello")
 	resp := testResponse()
 
-	// Store response
 	storePctx := plugin.NewContext(req)
 	storePctx.Response = resp
 	if err := c.Execute(context.Background(), storePctx); err != nil {
 		t.Fatalf("Execute (store) error: %v", err)
 	}
 
-	// Manually expire the entry
-	key := cacheKey(req)
-	c.mu.Lock()
-	entry := c.entries[key]
-	entry.expiresAt = time.Now().Add(-1 * time.Second)
-	c.entries[key] = entry
-	c.mu.Unlock()
+	time.Sleep(20 * time.Millisecond)
 
-	// Lookup should miss
 	lookupPctx := plugin.NewContext(req)
 	if err := c.Execute(context.Background(), lookupPctx); err != nil {
 		t.Fatalf("Execute (lookup) error: %v", err)
@@ -236,63 +233,53 @@ func TestCachePlugin_Expiration(t *testing.T) {
 	}
 }
 
-func TestCachePlugin_MaxEntries(t *testing.T) {
+// TestCachePlugin_LRUEviction verifies that adding a new entry beyond capacity
+// evicts the least-recently-used entry, not the earliest-expiring one.
+func TestCachePlugin_LRUEviction(t *testing.T) {
 	c := initCache(t, map[string]interface{}{"max_entries": 2})
 	resp := testResponse()
 
-	for i := 0; i < 2; i++ {
-		pctx := plugin.NewContext(testRequest("gpt-4", fmt.Sprintf("msg-%d", i)))
+	store := func(content string) {
+		pctx := plugin.NewContext(testRequest("gpt-4", content))
 		pctx.Response = resp
 		if err := c.Execute(context.Background(), pctx); err != nil {
-			t.Fatalf("Execute (store %d) error: %v", i, err)
+			t.Fatalf("Execute (store %q) error: %v", content, err)
 		}
 	}
-
-	// Make msg-0 the oldest entry to ensure deterministic eviction.
-	c.mu.Lock()
-	entry0 := c.entries[cacheKey(testRequest("gpt-4", "msg-0"))]
-	entry1 := c.entries[cacheKey(testRequest("gpt-4", "msg-1"))]
-	entry0.expiresAt = time.Now().Add(10 * time.Second)
-	entry1.expiresAt = time.Now().Add(20 * time.Second)
-	c.entries[cacheKey(testRequest("gpt-4", "msg-0"))] = entry0
-	c.entries[cacheKey(testRequest("gpt-4", "msg-1"))] = entry1
-	c.mu.Unlock()
-
-	// Third entry should evict the earliest expiring entry (msg-0).
-	pctx := plugin.NewContext(testRequest("gpt-4", "msg-overflow"))
-	pctx.Response = resp
-	if err := c.Execute(context.Background(), pctx); err != nil {
-		t.Fatalf("Execute (store overflow) error: %v", err)
+	hit := func(content string) bool {
+		pctx := plugin.NewContext(testRequest("gpt-4", content))
+		if err := c.Execute(context.Background(), pctx); err != nil {
+			t.Fatalf("Execute (lookup %q) error: %v", content, err)
+		}
+		return pctx.Skip
 	}
 
-	c.mu.RLock()
-	count := len(c.entries)
-	c.mu.RUnlock()
-	if count != 2 {
-		t.Errorf("expected 2 entries, got %d", count)
-	}
+	store("msg-0") // LRU list: [msg-0]
+	store("msg-1") // LRU list: [msg-1, msg-0]
 
-	lookupOverflow := plugin.NewContext(testRequest("gpt-4", "msg-overflow"))
-	if err := c.Execute(context.Background(), lookupOverflow); err != nil {
-		t.Fatalf("Execute (lookup overflow) error: %v", err)
+	// Access msg-0 to make it recently used; msg-1 becomes LRU.
+	if !hit("msg-0") {
+		t.Fatal("expected hit for msg-0 before eviction")
 	}
-	if !lookupOverflow.Skip {
-		t.Error("expected cache hit for newest entry after eviction")
-	}
+	// LRU list: [msg-0, msg-1]
 
-	lookupEvicted := plugin.NewContext(testRequest("gpt-4", "msg-0"))
-	if err := c.Execute(context.Background(), lookupEvicted); err != nil {
-		t.Fatalf("Execute (lookup evicted) error: %v", err)
+	store("msg-2") // capacity exceeded → evicts msg-1 (LRU back)
+
+	if hit("msg-1") {
+		t.Error("expected msg-1 to be evicted (was LRU)")
 	}
-	if lookupEvicted.Skip {
-		t.Error("expected cache miss for evicted earliest-expiring entry")
+	if !hit("msg-0") {
+		t.Error("expected msg-0 to be present (recently accessed)")
+	}
+	if !hit("msg-2") {
+		t.Error("expected msg-2 to be present (just inserted)")
 	}
 }
 
 func TestCachePlugin_MaxEntriesUpdateDoesNotEvict(t *testing.T) {
 	c := initCache(t, map[string]interface{}{"max_entries": 2})
 
-	store := func(content, id string, expiresIn time.Duration) {
+	store := func(content, id string) {
 		resp := testResponse()
 		resp.ID = id
 		pctx := plugin.NewContext(testRequest("gpt-4", content))
@@ -300,17 +287,11 @@ func TestCachePlugin_MaxEntriesUpdateDoesNotEvict(t *testing.T) {
 		if err := c.Execute(context.Background(), pctx); err != nil {
 			t.Fatalf("Execute (store %s) error: %v", content, err)
 		}
-		key := cacheKey(testRequest("gpt-4", content))
-		c.mu.Lock()
-		entry := c.entries[key]
-		entry.expiresAt = time.Now().Add(expiresIn)
-		c.entries[key] = entry
-		c.mu.Unlock()
 	}
 
-	store("msg-0", "resp-0", 10*time.Second)
-	store("msg-1", "resp-1", 20*time.Second)
-	store("msg-1", "resp-1-updated", 30*time.Second)
+	store("msg-0", "resp-0")
+	store("msg-1", "resp-1")
+	store("msg-1", "resp-1-updated") // update existing key — must not evict msg-0
 
 	lookup0 := plugin.NewContext(testRequest("gpt-4", "msg-0"))
 	if err := c.Execute(context.Background(), lookup0); err != nil {
@@ -347,11 +328,8 @@ func TestCachePlugin_MaxEntriesZeroDisablesStore(t *testing.T) {
 	if lookup.Skip {
 		t.Fatal("expected cache miss when max_entries=0")
 	}
-
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-	if len(c.entries) != 0 {
-		t.Fatalf("expected no cached entries when max_entries=0, got %d", len(c.entries))
+	if c.Len() != 0 {
+		t.Fatalf("expected no cached entries when max_entries=0, got %d", c.Len())
 	}
 }
 
@@ -376,5 +354,150 @@ func TestCachePlugin_CacheHitMetadata(t *testing.T) {
 	hit, ok := lookupPctx.Metadata["cache_hit"].(bool)
 	if !ok || !hit {
 		t.Errorf("expected cache_hit=true in metadata, got %v", lookupPctx.Metadata["cache_hit"])
+	}
+}
+
+// --- logprobs cache-key coverage (issue #152) ---
+
+func TestCacheKey_LogProbsProducesDistinctKey(t *testing.T) {
+	top := 5
+	withLogprobs := &providers.Request{
+		Model:       "gpt-4",
+		Messages:    []providers.Message{{Role: "user", Content: "hello"}},
+		LogProbs:    true,
+		TopLogProbs: &top,
+	}
+	withoutLogprobs := &providers.Request{
+		Model:    "gpt-4",
+		Messages: []providers.Message{{Role: "user", Content: "hello"}},
+		LogProbs: false,
+	}
+
+	if cacheKey(withLogprobs) == cacheKey(withoutLogprobs) {
+		t.Fatal("logprobs=true and logprobs=false must produce distinct cache keys")
+	}
+}
+
+func TestCacheKey_DifferentTopLogProbsProducesDistinctKey(t *testing.T) {
+	top3, top5 := 3, 5
+	req3 := &providers.Request{
+		Model:       "gpt-4",
+		Messages:    []providers.Message{{Role: "user", Content: "hello"}},
+		LogProbs:    true,
+		TopLogProbs: &top3,
+	}
+	req5 := &providers.Request{
+		Model:       "gpt-4",
+		Messages:    []providers.Message{{Role: "user", Content: "hello"}},
+		LogProbs:    true,
+		TopLogProbs: &top5,
+	}
+
+	if cacheKey(req3) == cacheKey(req5) {
+		t.Fatal("requests with different top_logprobs must produce distinct cache keys")
+	}
+}
+
+func TestCacheKey_LogProbsNilTopLogProbsDoesNotPanic(t *testing.T) {
+	req := &providers.Request{
+		Model:       "gpt-4",
+		Messages:    []providers.Message{{Role: "user", Content: "hello"}},
+		LogProbs:    true,
+		TopLogProbs: nil,
+	}
+	// Must not panic.
+	_ = cacheKey(req)
+}
+
+// TestCachePlugin_LogProbsCacheMissWithoutLogprobs verifies that a cached
+// response from a logprobs=true request is not served to a logprobs=false
+// request for the same model/messages.
+func TestCachePlugin_LogProbsCacheMissWithoutLogprobs(t *testing.T) {
+	c := initCache(t, map[string]interface{}{})
+	top := 5
+
+	withLogprobs := &providers.Request{
+		Model:       "gpt-4",
+		Messages:    []providers.Message{{Role: "user", Content: "what is 2+2"}},
+		LogProbs:    true,
+		TopLogProbs: &top,
+	}
+	withoutLogprobs := &providers.Request{
+		Model:    "gpt-4",
+		Messages: []providers.Message{{Role: "user", Content: "what is 2+2"}},
+		LogProbs: false,
+	}
+
+	// Store a response for the logprobs=true request.
+	storePctx := plugin.NewContext(withLogprobs)
+	storePctx.Response = testResponse()
+	if err := c.Execute(context.Background(), storePctx); err != nil {
+		t.Fatalf("Execute (store) error: %v", err)
+	}
+
+	// A logprobs=false request must not receive the logprobs=true cached entry.
+	lookupPctx := plugin.NewContext(withoutLogprobs)
+	if err := c.Execute(context.Background(), lookupPctx); err != nil {
+		t.Fatalf("Execute (lookup) error: %v", err)
+	}
+	if lookupPctx.Skip {
+		t.Error("logprobs=false request must not hit a logprobs=true cache entry")
+	}
+}
+
+// TestCachePlugin_LogProbsCacheHit verifies that a cached response from a
+// logprobs=true request is served to an identical logprobs=true request.
+func TestCachePlugin_LogProbsCacheHit(t *testing.T) {
+	c := initCache(t, map[string]interface{}{})
+	top := 5
+
+	withLogprobs := func() *providers.Request {
+		return &providers.Request{
+			Model:       "gpt-4",
+			Messages:    []providers.Message{{Role: "user", Content: "what is 2+2"}},
+			LogProbs:    true,
+			TopLogProbs: &top,
+		}
+	}
+
+	storePctx := plugin.NewContext(withLogprobs())
+	storePctx.Response = testResponse()
+	if err := c.Execute(context.Background(), storePctx); err != nil {
+		t.Fatalf("Execute (store) error: %v", err)
+	}
+
+	lookupPctx := plugin.NewContext(withLogprobs())
+	if err := c.Execute(context.Background(), lookupPctx); err != nil {
+		t.Fatalf("Execute (lookup) error: %v", err)
+	}
+	if !lookupPctx.Skip {
+		t.Error("expected cache hit for identical logprobs=true request")
+	}
+}
+
+func TestCachePlugin_MaxEntriesMany(t *testing.T) {
+	const cap = 5
+	c := initCache(t, map[string]interface{}{"max_entries": cap})
+	resp := testResponse()
+
+	for i := 0; i < cap; i++ {
+		pctx := plugin.NewContext(testRequest("gpt-4", fmt.Sprintf("msg-%d", i)))
+		pctx.Response = resp
+		if err := c.Execute(context.Background(), pctx); err != nil {
+			t.Fatalf("store %d: %v", i, err)
+		}
+	}
+	if c.Len() != cap {
+		t.Fatalf("expected %d entries, got %d", cap, c.Len())
+	}
+
+	// Adding one more must not grow beyond cap.
+	overflow := plugin.NewContext(testRequest("gpt-4", "overflow"))
+	overflow.Response = resp
+	if err := c.Execute(context.Background(), overflow); err != nil {
+		t.Fatalf("store overflow: %v", err)
+	}
+	if c.Len() != cap {
+		t.Fatalf("expected %d entries after overflow, got %d", cap, c.Len())
 	}
 }


### PR DESCRIPTION
## Summary

Fixes 3 correctness bugs:
1. Cache key ommited `logprobs` and `top_logprobs`.
2. LRU instead of earliest-TTL as eviction policy for cache plugin.
3. Capping requests to avoid thundering herd problem with `half-open` state of the circuit breaker.

## Type of change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] New provider
- [ ] New plugin
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Performance improvement
- [ ] Refactor / code quality
- [ ] Documentation / comments only
- [ ] CI / tooling

## Related issues

Fixes #152 

## Changes
- A request with `logprobs=true` could previously receive a cached response that contained no logprob data. `cacheKey()` now hashes both fields, so requests that differ only by logprobs settings are keyed separately. A nil guard is also added to prevent a panic when `LogProbs=true` but `TopLogProbs` is nil.

- `ResponseCache` previously maintained its own `map[string]cacheEntry` and evicted the entry with the earliest `expiresAt` on overflow, cold entries with long TTLs survived while hot entries with short TTLs were evicted first. The plugin now embeds `internal/cache.Memory`, which uses a doubly-linked list for O(1) LRU eviction. `Memory.Capacity` and `Memory.TTL` are exported to allow `Init()` to configure them after construction.

- The circuit breaker previously allowed unlimited concurrent probes during recovery, creating a thundering-herd risk. A `maxHalfThreshold` field (default 1) is added to `CircuitBreaker`. `Allow()` rejects probes beyond the cap; `RecordSuccess()` decrements the in-flight counter to free a slot; `RecordFailure()` and state transitions zero the counter. The new field is exposed as `max_half_threshold` in `CircuitBreakerConfig` and wired through `gateway.go`.

## Testing

- `internal/plugins/cache/cache_test.go`: rewrote to compile against the refactored struct; replaced earliest-expiry eviction test with LRU access-order test; added logprobs key-differentiation tests (logprobs=true vs false, different top_logprobs values, nil `TopLogProbs` no-panic, end-to-end cache miss/hit with logprobs).
- `internal/circuitbreaker/circuit_breaker_test.go` : added `TestDefaultMaxHalfThreshold`, `TestHalfOpenSuccessThresholdWithSlotRecycling`, `TestRecordSuccessAfterConcurrentReopenIsNoop`, `TestHalfOpenProbesZeroOnClosedToOpenTransition`.
- `config_load_test.go` — added JSON and YAML round-trip tests for `max_half_threshold` to catch tag/naming regressions.
- `gateway_test.go` — added `TestGateway_CircuitBreaker_MaxHalfThreshold_FromConfig`, an end-to-end test that trips the circuit, holds a half-open probe in-flight with a blocking mock, and verifies the second concurrent probe is rejected with `ErrCircuitOpen`.

- [x] Existing tests pass (`go test ./...`)
- [x] New unit tests added (if applicable)

## Breaking change notes
- `circuitbreaker.New` now takes a `maxHalfThreshold` int as its third argument (before timeout): `New(failureThreshold, successThreshold, maxHalfThreshold, timeout)`

