### PR TITLE
snapshot the providers and circuitbreakers under write lock

### DIFF
--- a/gateway.go
+++ b/gateway.go
@@ -812,23 +812,25 @@ func (g *Gateway) getStrategy() (strategies.Strategy, error) {
 		g.circuitBreakers[t.VirtualKey] = cb
 	}
 
+	// Snapshot both maps under the write lock already held. The lookup closure
+	// runs inside Strategy.Execute with no lock held, so capturing local copies
+	// here is the only safe access pattern.
+	// maps.Clone is a shallow copy — safe because map values (Provider, *CB) are
+	// themselves immutable references; we never mutate through them in the closure.
+	providerSnap := maps.Clone(g.providers)
+	cbSnap := maps.Clone(g.circuitBreakers)
+
 	// Provider lookup with transparent circuit-breaker wrapping.
 	//
 	// The closure is captured into the strategy and invoked later from the
-	// request hot path, AFTER Route/RouteStream have released g.mu. It
-	// therefore needs its own RLock to coordinate with RegisterProvider and
-	// ReloadConfig (which reassigns circuitBreakers wholesale, line 707).
-	// Safe under sync.RWMutex because the calling paths drop the lock before
-	// strategy execution — see gateway.go:330 (Route) and
-	// gateway.go:1108 (RouteStream).
+	// request hot path, AFTER Route/RouteStream have released g.mu. It reads
+	// from the snapshots captured above, so no lock is needed in the closure.
 	lookup := func(name string) (providers.Provider, bool) {
-		g.mu.RLock()
-		defer g.mu.RUnlock()
-		p, ok := g.providers[name]
+		p, ok := providerSnap[name]
 		if !ok {
 			return nil, false
 		}
-		if cb, hasCB := g.circuitBreakers[name]; hasCB {
+		if cb, hasCB := cbSnap[name]; hasCB {
 			return &cbProvider{Provider: p, cb: cb, name: name}, true
 		}
 		return p, ok

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -1398,8 +1398,8 @@ type freshProvider struct {
 	models []string
 }
 
-func (f *freshProvider) Name() string              { return f.name }
-func (f *freshProvider) SupportedModels() []string { return f.models }
+func (f *freshProvider) Name() string                  { return f.name }
+func (f *freshProvider) SupportedModels() []string     { return f.models }
 func (f *freshProvider) Models() []providers.ModelInfo { return nil }
 func (f *freshProvider) SupportsModel(model string) bool {
 	for _, m := range f.models {

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -1390,3 +1390,89 @@ func BenchmarkPublishEvent(b *testing.B) {
 		b.Fatalf("timed out waiting for hook dispatch: completed=%d want=%d", calls.Load(), b.N)
 	}
 }
+
+// freshProvider returns a new *providers.Response on every Complete call so
+// concurrent goroutines never share a response pointer. Used by race tests.
+type freshProvider struct {
+	name   string
+	models []string
+}
+
+func (f *freshProvider) Name() string              { return f.name }
+func (f *freshProvider) SupportedModels() []string { return f.models }
+func (f *freshProvider) Models() []providers.ModelInfo { return nil }
+func (f *freshProvider) SupportsModel(model string) bool {
+	for _, m := range f.models {
+		if m == model {
+			return true
+		}
+	}
+	return false
+}
+func (f *freshProvider) Complete(_ context.Context, req providers.Request) (*providers.Response, error) {
+	return &providers.Response{ID: "r", Model: req.Model, Provider: f.name}, nil
+}
+
+// TestRoute_ProviderLookup_NoDataRace is the acceptance test for issue #128.
+//
+// The lookup closure built inside getStrategy runs inside Strategy.Execute with
+// no lock held. If it reads g.providers / g.circuitBreakers directly instead of
+// from a snapshot taken under lock, a concurrent RegisterProvider (or
+// runDiscovery) that writes those maps will cause a fatal data race.
+//
+// Run with -race to verify: go test -race -run TestRoute_ProviderLookup_NoDataRace
+func TestRoute_ProviderLookup_NoDataRace(t *testing.T) {
+	gw, err := New(Config{
+		Strategy: StrategyConfig{Mode: ModeFallback},
+		Targets: []Target{
+			{VirtualKey: "p1"},
+			{VirtualKey: "p2"},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	gw.RegisterProvider(&freshProvider{name: "p1", models: []string{"test-model"}})
+	gw.RegisterProvider(&freshProvider{name: "p2", models: []string{"test-model"}})
+
+	const routerGoroutines = 20
+	const writerGoroutines = 10
+	const iters = 40
+
+	ctx := context.Background()
+	req := providers.Request{
+		Model:    "test-model",
+		Messages: []providers.Message{{Role: roleUser, Content: "hello"}},
+	}
+
+	var wg sync.WaitGroup
+
+	// Goroutines calling Route concurrently — these will execute the lookup
+	// closure while the writers below mutate g.providers under lock.
+	for i := 0; i < routerGoroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iters; j++ {
+				_, _ = gw.Route(ctx, req)
+			}
+		}()
+	}
+
+	// Goroutines calling RegisterProvider concurrently — mirrors runtime
+	// model discovery writing g.providers under lock (issue #128 trigger).
+	for i := 0; i < writerGoroutines; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			for j := 0; j < iters/2; j++ {
+				gw.RegisterProvider(&freshProvider{
+					name:   fmt.Sprintf("dynamic-%d-%d", id, j),
+					models: []string{"other-model"},
+				})
+			}
+		}(i)
+	}
+
+	wg.Wait()
+}


### PR DESCRIPTION
## Summary

Fixes a data race where the provider lookup closure in `getStrategy` read `g.providers` and `g.circuitBreakers` after the gateway lock was released (the closure runs inside `Strategy.Execute` with no lock held). Concurrent writes from `RegisterProvider` or `runDiscovery` would trip `fatal error: concurrent map read and map write` and crash the gateway.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] New provider
- [ ] New plugin
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Performance improvement
- [ ] Refactor / code quality
- [ ] Documentation / comments only
- [ ] CI / tooling

## Related issues

Fixes #128

## Changes

- `gateway.go`: In `getStrategy`, snapshot `g.providers` and `g.circuitBreakers` via `maps.Clone` under the already-held write lock, and have the `lookup` closure capture those local snapshots instead of the shared gateway maps. The values (`Provider`, `*CircuitBreaker`) are reference-stable and never mutated through the closure, so a shallow clone is sufficient.
- `gateway_test.go`: Add `TestRoute_ProviderLookup_NoDataRace`, the acceptance test for #128. It runs 20 goroutines calling `Route` against a fallback strategy while 10 goroutines concurrently call `RegisterProvider`, mirroring the runtime discovery write pattern. Verifies under `-race` that the lookup closure no longer touches shared maps.
- Adds a `freshProvider` test helper that returns a new `*providers.Response` per call so concurrent routers don't share response pointers.

## Testing

- [x] Existing tests pass (`go test ./...`)
- [x] New unit tests added (if applicable)
- [ ] Manually tested against a live provider (if provider change)