### PR TITLE
Fix/issue127: Panic: send on closed hook-dispatch channel during shutdown

### DIFF
--- a/gateway_test.go
+++ b/gateway_test.go
@@ -333,6 +333,471 @@ func TestGatewayClose_IsIdempotent(t *testing.T) {
 	}
 }
 
+// gateMockProvider blocks in Complete until release is closed, so tests can
+// overlap provider execution with Gateway.Close().
+type gateMockProvider struct {
+	mockProvider
+	release     chan struct{}
+	active      atomic.Int32
+	releaseOnce sync.Once
+}
+
+func newGateMockProvider(resp *providers.Response, err error) *gateMockProvider {
+	return &gateMockProvider{
+		mockProvider: mockProvider{
+			name:   "gate",
+			models: []string{"gpt-4o"},
+			resp:   resp,
+			err:    err,
+		},
+		release: make(chan struct{}),
+	}
+}
+
+func (p *gateMockProvider) Complete(_ context.Context, _ providers.Request) (*providers.Response, error) {
+	p.active.Add(1)
+	<-p.release
+	if p.err != nil {
+		return nil, p.err
+	}
+	if p.resp == nil {
+		return nil, nil
+	}
+	resp := *p.resp
+	return &resp, nil
+}
+
+func (p *gateMockProvider) releaseAll() {
+	p.releaseOnce.Do(func() { close(p.release) })
+}
+
+func (p *gateMockProvider) waitActive(t *testing.T, want int32) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for p.active.Load() < want {
+		if time.Now().After(deadline) {
+			t.Fatalf("active routes = %d, want %d", p.active.Load(), want)
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
+// gateStreamProvider blocks before emitting stream chunks until release closes.
+type gateStreamProvider struct {
+	mockStreamProvider
+	enterOnce sync.Once
+	enter     chan struct{}
+	release   chan struct{}
+}
+
+func newGateStreamProvider() *gateStreamProvider {
+	return &gateStreamProvider{
+		mockStreamProvider: mockStreamProvider{
+			mockProvider: mockProvider{
+				name:   "gate-stream",
+				models: []string{"gpt-4o"},
+			},
+		},
+		enter:   make(chan struct{}),
+		release: make(chan struct{}),
+	}
+}
+
+func (p *gateStreamProvider) CompleteStream(_ context.Context, _ providers.Request) (<-chan providers.StreamChunk, error) {
+	ch := make(chan providers.StreamChunk, 1)
+	go func() {
+		p.enterOnce.Do(func() { close(p.enter) })
+		<-p.release
+		ch <- providers.StreamChunk{
+			ID:     "stream-1",
+			Object: "chat.completion.chunk",
+			Model:  "gpt-4o",
+			Choices: []providers.StreamChoice{{
+				Index: 0,
+				Delta: providers.MessageDelta{Role: "assistant", Content: "hi"},
+			}},
+		}
+		close(ch)
+	}()
+	return ch, nil
+}
+
+func completedHookEvent(traceID string) events.HookEvent {
+	return events.CompletedRequest(
+		traceID,
+		"mock",
+		"gpt-4o",
+		time.Millisecond,
+		false,
+		1,
+		1,
+		models.CostResult{},
+		true,
+	)
+}
+
+func runWithPanicCapture(t *testing.T, fn func()) any {
+	t.Helper()
+	done := make(chan any, 1)
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				done <- r
+				return
+			}
+			done <- nil
+		}()
+		fn()
+	}()
+
+	select {
+	case r := <-done:
+		return r
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for goroutine")
+		return nil
+	}
+}
+
+func newHookedGateway(t *testing.T, provider providers.Provider) (*Gateway, *gateMockProvider) {
+	t.Helper()
+	gw, err := New(Config{
+		Strategy: StrategyConfig{Mode: ModeSingle},
+		Targets:  []Target{{VirtualKey: provider.Name()}},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	gate, ok := provider.(*gateMockProvider)
+	if !ok {
+		t.Fatalf("provider must be *gateMockProvider, got %T", provider)
+	}
+	gw.RegisterProvider(gate)
+	gw.AddHook(func(context.Context, string, map[string]interface{}) {})
+	return gw, gate
+}
+
+func TestGateway_Close_DuringInFlightRouteDoesNotPanic(t *testing.T) {
+	provider := newGateMockProvider(&providers.Response{ID: "ok", Model: "gpt-4o"}, nil)
+	gw, gate := newHookedGateway(t, provider)
+
+	routeDone := make(chan error, 1)
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				routeDone <- fmt.Errorf("panic: %v", r)
+			}
+		}()
+		_, err := gw.Route(context.Background(), providers.Request{
+			Model:    "gpt-4o",
+			Messages: []providers.Message{{Role: "user", Content: "hi"}},
+		})
+		routeDone <- err
+	}()
+
+	gate.waitActive(t, 1)
+	if err := gw.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	gate.releaseAll()
+
+	select {
+	case err := <-routeDone:
+		if err != nil {
+			t.Fatalf("Route failed during shutdown: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for in-flight route")
+	}
+}
+
+func TestGateway_Close_DuringInFlightRouteStreamDoesNotPanic(t *testing.T) {
+	gw, err := New(Config{
+		Strategy: StrategyConfig{Mode: ModeSingle},
+		Targets:  []Target{{VirtualKey: "gate-stream"}},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	streamProvider := newGateStreamProvider()
+	gw.RegisterProvider(streamProvider)
+	gw.AddHook(func(context.Context, string, map[string]interface{}) {})
+
+	routeDone := make(chan any, 1)
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				routeDone <- r
+				return
+			}
+			routeDone <- nil
+		}()
+		ch, err := gw.RouteStream(context.Background(), providers.Request{
+			Model:    "gpt-4o",
+			Messages: []providers.Message{{Role: "user", Content: "hi"}},
+			Stream:   true,
+		})
+		if err != nil {
+			routeDone <- err
+			return
+		}
+		// Drain the stream.
+		//nolint:revive // intentionally draining the stream channel to completion
+		for range ch {
+		}
+		routeDone <- nil
+	}()
+
+	select {
+	case <-streamProvider.enter:
+	case <-time.After(time.Second):
+		t.Fatal("stream provider never started")
+	}
+
+	if err := gw.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	close(streamProvider.release)
+
+	select {
+	case result := <-routeDone:
+		if result != nil {
+			t.Fatalf("RouteStream failed or panicked: %v", result)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for stream route to finish")
+	}
+}
+
+func TestGateway_Close_DuringFailedRouteDoesNotPanic(t *testing.T) {
+	provider := newGateMockProvider(nil, fmt.Errorf("provider down"))
+	gw, gate := newHookedGateway(t, provider)
+
+	routeDone := make(chan error, 1)
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				routeDone <- fmt.Errorf("panic: %v", r)
+			}
+		}()
+		_, err := gw.Route(context.Background(), providers.Request{
+			Model:    "gpt-4o",
+			Messages: []providers.Message{{Role: "user", Content: "hi"}},
+		})
+		routeDone <- err
+	}()
+
+	gate.waitActive(t, 1)
+	if err := gw.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	gate.releaseAll()
+
+	select {
+	case err := <-routeDone:
+		if err == nil {
+			t.Fatal("expected route error, got nil")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for failed route")
+	}
+}
+
+func TestGateway_PublishEvent_AfterCloseDoesNotPanic(t *testing.T) {
+	gw, err := New(Config{})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	gw.AddHook(func(context.Context, string, map[string]interface{}) {})
+
+	if err := gw.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	if p := runWithPanicCapture(t, func() {
+		gw.publishEvent(context.Background(), completedHookEvent("trace-after-close"))
+	}); p != nil {
+		t.Fatalf("publishEvent panicked after Close: %v", p)
+	}
+}
+
+func TestGateway_PublishEvent_AfterShutdownWithFullQueueDoesNotPanic(t *testing.T) {
+	gw := &Gateway{
+		hookDispatchQ: make(chan hookDispatch, 1),
+	}
+	gw.shutdownCtx, gw.shutdownCancel = context.WithCancel(context.Background())
+	gw.hookSnapshot.Store([]EventHookFunc{
+		func(context.Context, string, map[string]interface{}) {},
+		func(context.Context, string, map[string]interface{}) {},
+	})
+	gw.startHookWorkers()
+	t.Cleanup(func() { gw.shutdownCancel() })
+
+	// Fill the queue so the next publishEvent hits the default branch.
+	gw.publishEvent(context.Background(), completedHookEvent("trace-fill"))
+
+	gw.shutdownCancel()
+
+	if p := runWithPanicCapture(t, func() {
+		gw.publishEvent(context.Background(), completedHookEvent("trace-shutdown-full"))
+	}); p != nil {
+		t.Fatalf("publishEvent panicked after shutdown with full queue: %v", p)
+	}
+}
+
+func TestGateway_Close_ConcurrentPublishEventStress(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping concurrent hook shutdown stress in -short")
+	}
+
+	gw, err := New(Config{})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	gw.AddHook(func(context.Context, string, map[string]interface{}) {
+		time.Sleep(2 * time.Millisecond)
+	})
+
+	const publishers = 32
+	panicCh := make(chan any, publishers)
+	var wg sync.WaitGroup
+	for range publishers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			defer func() {
+				if r := recover(); r != nil {
+					panicCh <- r
+				}
+			}()
+			for range 50 {
+				gw.publishEvent(context.Background(), completedHookEvent("trace-stress"))
+			}
+		}()
+	}
+
+	time.Sleep(5 * time.Millisecond)
+	if err := gw.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	wg.Wait()
+	close(panicCh)
+	for p := range panicCh {
+		t.Fatalf("concurrent publishEvent panicked during Close: %v", p)
+	}
+}
+
+func TestGateway_Close_DuringConcurrentRoutesDoesNotPanic(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping concurrent route shutdown stress in -short")
+	}
+
+	gw, err := New(Config{
+		Strategy: StrategyConfig{Mode: ModeSingle},
+		Targets:  []Target{{VirtualKey: "gate"}},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	provider := newGateMockProvider(&providers.Response{ID: "ok", Model: "gpt-4o"}, nil)
+	gw.RegisterProvider(provider)
+	gw.AddHook(func(context.Context, string, map[string]interface{}) {
+		time.Sleep(time.Millisecond)
+	})
+
+	const routes = 16
+	panicCh := make(chan any, routes)
+	var wg sync.WaitGroup
+
+	for range routes {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			defer func() {
+				if r := recover(); r != nil {
+					panicCh <- r
+				}
+			}()
+			_, err := gw.Route(context.Background(), providers.Request{
+				Model:    "gpt-4o",
+				Messages: []providers.Message{{Role: "user", Content: "hi"}},
+			})
+			if err != nil {
+				panicCh <- err
+			}
+		}()
+	}
+
+	provider.waitActive(t, int32(routes))
+
+	if err := gw.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	provider.releaseAll()
+
+	wg.Wait()
+	close(panicCh)
+	for p := range panicCh {
+		t.Fatalf("concurrent Route panicked during Close: %v", p)
+	}
+}
+
+func TestGateway_Close_MultipleHooksDuringRouteDoesNotPanic(t *testing.T) {
+	provider := newGateMockProvider(&providers.Response{ID: "ok", Model: "gpt-4o"}, nil)
+	gw, err := New(Config{
+		Strategy: StrategyConfig{Mode: ModeSingle},
+		Targets:  []Target{{VirtualKey: "gate"}},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	gw.RegisterProvider(provider)
+	for range 3 {
+		gw.AddHook(func(context.Context, string, map[string]interface{}) {})
+	}
+
+	routeDone := make(chan error, 1)
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				routeDone <- fmt.Errorf("panic: %v", r)
+			}
+		}()
+		_, err := gw.Route(context.Background(), providers.Request{
+			Model:    "gpt-4o",
+			Messages: []providers.Message{{Role: "user", Content: "hi"}},
+		})
+		routeDone <- err
+	}()
+
+	provider.waitActive(t, 1)
+	if err := gw.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	provider.releaseAll()
+
+	select {
+	case err := <-routeDone:
+		if err != nil {
+			t.Fatalf("Route failed or panicked with multiple hooks: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for route with multiple hooks")
+	}
+}
+
+func TestGateway_PublishEvent_NoHooks(_ *testing.T) {
+	gw := &Gateway{
+		hookDispatchQ: make(chan hookDispatch, 1),
+	}
+	gw.hookSnapshot.Store([]EventHookFunc{})
+
+	gw.publishEvent(context.Background(), completedHookEvent("no-hooks"))
+}
+
 func TestGateway_Route_ProviderNotFound(t *testing.T) {
 	gw, _ := New(Config{
 		Strategy: StrategyConfig{Mode: ModeSingle},


### PR DESCRIPTION
Fixes #127 — test-only follow-up after rebase onto upstream main.

The production fix for the hook-dispatch shutdown panic already landed upstream in #158 (v1.1.1): `Close()` cancels a `shutdownCtx` instead of closing `hookDispatchQ`, so `publishEvent` drops events safely during shutdown rather than panicking on a closed channel.

This PR adds unit-level regression coverage for that behavior, complementing the existing stress test in `gateway_stress_test.go` (`TestStress_ShutdownUnderLoad_NoPanic`).

- Added tests (`gateway_test.go`):
- No production code changes — only test helpers (`gateMockProvider`, `gateStreamProvider,` etc.) and the tests above.