### PR TITLE
fix: mcpregistry and mcpexecutors race conditions

### DIFF
--- a/gateway.go
+++ b/gateway.go
@@ -325,6 +325,8 @@ func (g *Gateway) Route(ctx context.Context, req providers.Request) (*providers.
 	strategyMode := string(g.config.Strategy.Mode)
 	obs := g.obs
 	obsEventsActive := g.obsEventsActive
+	mcpRegistrySnapshot := g.mcpRegistry
+	mcpExecutorSnapshot := g.mcpExecutor
 	g.mu.RUnlock()
 	ctx, span := obs.StartRequestSpan(ctx, observability.RequestAttrs{
 		Operation:       "chat",
@@ -365,8 +367,8 @@ func (g *Gateway) Route(ctx context.Context, req providers.Request) (*providers.
 
 	// Inject MCP tool definitions into the request when servers are ready.
 	var mcpTools []mcp.Tool
-	if g.mcpRegistry != nil {
-		mcpTools = g.mcpRegistry.AllTools()
+	if mcpRegistrySnapshot != nil {
+		mcpTools = mcpRegistrySnapshot.AllTools()
 	}
 	if len(mcpTools) > 0 {
 		// Build a set of tool names already present in the request so we do not
@@ -460,15 +462,15 @@ func (g *Gateway) Route(ctx context.Context, req providers.Request) (*providers.
 	// Agentic MCP tool-call loop. Runs only when MCP is active and the LLM
 	// returned tool_calls. Each iteration executes the tools and re-contacts
 	// the LLM until no more tool_calls are present or the depth limit is hit.
-	if g.mcpExecutor != nil && len(mcpTools) > 0 {
+	if mcpExecutorSnapshot != nil && len(mcpTools) > 0 {
 		depth := 0
 		trace.WithRegion(ctx, "gateway.route.mcp.loop", func() {
-			for g.mcpExecutor.ShouldContinueLoop(resp, depth) {
+			for mcpExecutorSnapshot.ShouldContinueLoop(resp, depth) {
 				depth++
 
 				// ResolvePendingToolCalls returns the assistant message (with tool_calls)
 				// plus one tool-result message per call — append all at once.
-				toolMsgs, toolErr := g.mcpExecutor.ResolvePendingToolCalls(ctx, resp)
+				toolMsgs, toolErr := mcpExecutorSnapshot.ResolvePendingToolCalls(ctx, resp)
 				if toolErr != nil {
 					err = fmt.Errorf("mcp tool execution at depth %d: %w", depth, toolErr)
 					return
@@ -989,6 +991,7 @@ func (g *Gateway) RouteStream(ctx context.Context, req providers.Request) (<-cha
 	strategyMode := string(g.config.Strategy.Mode)
 	obs := g.obs
 	obsEventsActive := g.obsEventsActive
+	mcpRegistrySnapshot := g.mcpRegistry
 	g.mu.RUnlock()
 	ctx, span := obs.StartRequestSpan(ctx, observability.RequestAttrs{
 		Operation:       "chat",
@@ -1012,9 +1015,7 @@ func (g *Gateway) RouteStream(ctx context.Context, req providers.Request) (<-cha
 	// MCP redirect: when tool servers are registered, the agentic loop must
 	// run to completion before any response is sent. Route() handles this
 	// entirely; we wrap its non-streaming result into a channel here.
-	g.mu.RLock()
-	hasMCP := g.mcpRegistry != nil && g.mcpRegistry.HasServers()
-	g.mu.RUnlock()
+	hasMCP := mcpRegistrySnapshot != nil && mcpRegistrySnapshot.HasServers()
 	if hasMCP {
 		// Do not force req.Stream = false here: let Route() capture the
 		// original stream flag via its own originalStream variable so that

--- a/gateway_race_test.go
+++ b/gateway_race_test.go
@@ -1,0 +1,205 @@
+package aigateway
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	internalmcp "github.com/ferro-labs/ai-gateway/internal/mcp"
+	"github.com/ferro-labs/ai-gateway/providers"
+)
+
+// freshMockProvider returns a new *providers.Response on every call, avoiding
+// the shared-pointer data race that would occur if multiple goroutines mutate
+// a single response returned by the default mockProvider.
+type freshMockProvider struct {
+	name   string
+	models []string
+}
+
+func (p *freshMockProvider) Name() string                  { return p.name }
+func (p *freshMockProvider) SupportedModels() []string     { return p.models }
+func (p *freshMockProvider) Models() []providers.ModelInfo { return nil }
+func (p *freshMockProvider) SupportsModel(model string) bool {
+	for _, m := range p.models {
+		if m == model {
+			return true
+		}
+	}
+	return false
+}
+func (p *freshMockProvider) Complete(_ context.Context, _ providers.Request) (*providers.Response, error) {
+	return &providers.Response{
+		ID:      "r1",
+		Choices: []providers.Choice{{Message: providers.Message{Role: "assistant", Content: "ok"}}},
+	}, nil
+}
+
+// TestRoute_MCPSnapshotIsolation verifies that Route uses the mcpRegistry /
+// mcpExecutor values captured at request entry, not whatever the live fields
+// contain later. Concretely: if the registry is nil when the snapshot is taken,
+// no MCP tool injection occurs even if a registry is installed after the lock
+// is released.
+func TestRoute_MCPSnapshotIsolation(t *testing.T) {
+	gw, err := New(Config{
+		Strategy: StrategyConfig{Mode: ModeSingle},
+		Targets:  []Target{{VirtualKey: "mock"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	gw.RegisterProvider(&freshMockProvider{
+		name:   "mock",
+		models: []string{"gpt-4o"},
+	})
+
+	// mcpRegistry is nil at this point — snapshot taken inside Route will be nil.
+	resp, err := gw.Route(context.Background(), providers.Request{
+		Model:    "gpt-4o",
+		Messages: []providers.Message{{Role: "user", Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("Route() error: %v", err)
+	}
+	if len(resp.Choices) == 0 {
+		t.Fatal("expected at least one choice")
+	}
+	// No MCP tools should have been injected (registry was nil at snapshot time).
+	if len(resp.Choices[0].Message.ToolCalls) != 0 {
+		t.Errorf("unexpected tool calls: %v", resp.Choices[0].Message.ToolCalls)
+	}
+}
+
+// TestRoute_MCPFieldsSnapshotRace verifies that concurrent writes to
+// g.mcpRegistry / g.mcpExecutor (under g.mu.Lock) do not race with Route's
+// reads of those fields.
+//
+// Before the fix, Route read g.mcpRegistry and g.mcpExecutor after releasing
+// g.mu, so a concurrent writer could replace the pointers mid-flight.  The
+// fix snapshots both fields inside the initial g.mu.RLock block.
+//
+// Run with: go test -race -run TestRoute_MCPFieldsSnapshotRace .
+func TestRoute_MCPFieldsSnapshotRace(t *testing.T) {
+	gw, err := New(Config{
+		Strategy: StrategyConfig{Mode: ModeSingle},
+		Targets:  []Target{{VirtualKey: "mock"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	gw.RegisterProvider(&freshMockProvider{
+		name:   "mock",
+		models: []string{"gpt-4o"},
+	})
+
+	req := providers.Request{
+		Model:    "gpt-4o",
+		Messages: []providers.Message{{Role: "user", Content: "hi"}},
+	}
+
+	var wg sync.WaitGroup
+	const iters = 300
+
+	// Writer: toggles mcpRegistry/mcpExecutor under the gateway lock, exactly
+	// as ReloadConfig does (but without touching any other field, so we isolate
+	// only the MCP snapshot race).
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iters; i++ {
+			gw.mu.Lock()
+			reg := internalmcp.NewRegistry()
+			gw.mcpRegistry = reg
+			gw.mcpExecutor = internalmcp.NewExecutor(reg, 5, nil)
+			gw.mu.Unlock()
+
+			gw.mu.Lock()
+			gw.mcpRegistry = nil
+			gw.mcpExecutor = nil
+			gw.mu.Unlock()
+		}
+	}()
+
+	// Readers: call Route concurrently with the writer.
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iters; j++ {
+				_, _ = gw.Route(context.Background(), req)
+			}
+		}()
+	}
+
+	wg.Wait()
+}
+
+// TestRouteStream_MCPRegistrySnapshotRace verifies that RouteStream's
+// mcpRegistry snapshot (taken inside the initial g.mu.RLock block) does not
+// race with concurrent writes to g.mcpRegistry.
+//
+// The old code acquired a *second* g.mu.RLock just for the hasMCP check; the
+// fix collapses it into the first lock block so the field is read exactly once,
+// under the same lock that protects all other request-entry snapshots.
+func TestRouteStream_MCPRegistrySnapshotRace(t *testing.T) {
+	ch := make(chan providers.StreamChunk)
+	close(ch)
+
+	gw, err := New(Config{
+		Strategy: StrategyConfig{Mode: ModeSingle},
+		Targets:  []Target{{VirtualKey: "mock-stream"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	gw.RegisterProvider(&mockStreamProvider{
+		mockProvider: mockProvider{
+			name:   "mock-stream",
+			models: []string{"gpt-4o"},
+		},
+		streamCh: ch,
+	})
+
+	req := providers.Request{
+		Model:    "gpt-4o",
+		Stream:   true,
+		Messages: []providers.Message{{Role: "user", Content: "hi"}},
+	}
+
+	var wg sync.WaitGroup
+	const iters = 300
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iters; i++ {
+			gw.mu.Lock()
+			reg := internalmcp.NewRegistry()
+			gw.mcpRegistry = reg
+			gw.mcpExecutor = internalmcp.NewExecutor(reg, 5, nil)
+			gw.mu.Unlock()
+
+			gw.mu.Lock()
+			gw.mcpRegistry = nil
+			gw.mcpExecutor = nil
+			gw.mu.Unlock()
+		}
+	}()
+
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iters; j++ {
+				out, err := gw.RouteStream(context.Background(), req)
+				if err != nil {
+					continue
+				}
+				for range out { //nolint:revive
+				}
+			}
+		}()
+	}
+
+	wg.Wait()
+}

--- a/plugin/manager.go
+++ b/plugin/manager.go
@@ -3,6 +3,7 @@ package plugin
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	"github.com/ferro-labs/ai-gateway/internal/logging"
 	"github.com/ferro-labs/ai-gateway/observability"
@@ -38,6 +39,7 @@ type Manager struct {
 	before []Plugin
 	after  []Plugin
 	onErr  []Plugin
+	mu     sync.RWMutex
 }
 
 // NewManager creates a new plugin manager.
@@ -47,6 +49,9 @@ func NewManager() *Manager {
 
 // Register registers a plugin at the given stage.
 func (m *Manager) Register(stage Stage, p Plugin) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	switch stage {
 	case StageBeforeRequest:
 		m.before = append(m.before, p)
@@ -64,7 +69,10 @@ func (m *Manager) Register(stage Stage, p Plugin) error {
 // RunBefore executes all before-request plugins. Returns an error if a plugin
 // rejects the request.
 func (m *Manager) RunBefore(ctx context.Context, pctx *Context) error {
-	for _, p := range m.before {
+	m.mu.RLock()
+	plugins := m.before
+	m.mu.RUnlock()
+	for _, p := range plugins {
 		err := m.executePlugin(ctx, p, pctx, string(StageBeforeRequest))
 		if err != nil {
 			if pctx.Reject {
@@ -92,7 +100,10 @@ func (m *Manager) RunBefore(ctx context.Context, pctx *Context) error {
 
 // RunAfter executes all after-request plugins.
 func (m *Manager) RunAfter(ctx context.Context, pctx *Context) error {
-	for _, p := range m.after {
+	m.mu.RLock()
+	plugins := m.after
+	m.mu.RUnlock()
+	for _, p := range plugins {
 		err := m.executePlugin(ctx, p, pctx, string(StageAfterRequest))
 		if pctx.Reject {
 			reason := pctx.Reason
@@ -117,7 +128,10 @@ func (m *Manager) RunAfter(ctx context.Context, pctx *Context) error {
 
 // RunOnError executes all on-error plugins.
 func (m *Manager) RunOnError(ctx context.Context, pctx *Context) {
-	for _, p := range m.onErr {
+	m.mu.RLock()
+	plugins := m.onErr
+	m.mu.RUnlock()
+	for _, p := range plugins {
 		if err := m.executePlugin(ctx, p, pctx, string(StageOnError)); err != nil {
 			logging.Logger.Warn("on-error plugin error", "plugin", p.Name(), "error", err)
 		}
@@ -154,5 +168,7 @@ func (m *Manager) executePlugin(ctx context.Context, p Plugin, pctx *Context, st
 
 // HasPlugins returns true if any plugins are registered.
 func (m *Manager) HasPlugins() bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
 	return len(m.before)+len(m.after)+len(m.onErr) > 0
 }

--- a/plugin/manager_race_test.go
+++ b/plugin/manager_race_test.go
@@ -84,7 +84,7 @@ func TestManager_ConcurrentRegisterAndRunOnError(_ *testing.T) {
 // TestManager_ConcurrentRegisterAndHasPlugins checks that HasPlugins does not
 // race with concurrent Register calls (it reads all three slice lengths without
 // a lock).
-func TestManager_ConcurrentRegisterAndHasPlugins( _ *testing.T) {
+func TestManager_ConcurrentRegisterAndHasPlugins(_ *testing.T) {
 	m := NewManager()
 
 	var wg sync.WaitGroup
@@ -108,7 +108,7 @@ func TestManager_ConcurrentRegisterAndHasPlugins( _ *testing.T) {
 // RunOnError, and HasPlugins simultaneously against concurrent Register calls.
 // This catches any reader–reader or reader–writer races that the individual
 // pairwise tests might miss under a specific schedule.
-func TestManager_ConcurrentAllReadersAndRegister( _ *testing.T) {
+func TestManager_ConcurrentAllReadersAndRegister(_ *testing.T) {
 	m := NewManager()
 	pctxBefore := NewContext(&providers.Request{Model: "gpt-4o"})
 	pctxAfter := NewContext(&providers.Request{Model: "gpt-4o"})

--- a/plugin/manager_race_test.go
+++ b/plugin/manager_race_test.go
@@ -84,7 +84,7 @@ func TestManager_ConcurrentRegisterAndRunOnError(_ *testing.T) {
 // TestManager_ConcurrentRegisterAndHasPlugins checks that HasPlugins does not
 // race with concurrent Register calls (it reads all three slice lengths without
 // a lock).
-func TestManager_ConcurrentRegisterAndHasPlugins(t *testing.T) {
+func TestManager_ConcurrentRegisterAndHasPlugins( _ *testing.T) {
 	m := NewManager()
 
 	var wg sync.WaitGroup
@@ -108,7 +108,7 @@ func TestManager_ConcurrentRegisterAndHasPlugins(t *testing.T) {
 // RunOnError, and HasPlugins simultaneously against concurrent Register calls.
 // This catches any reader–reader or reader–writer races that the individual
 // pairwise tests might miss under a specific schedule.
-func TestManager_ConcurrentAllReadersAndRegister(t *testing.T) {
+func TestManager_ConcurrentAllReadersAndRegister( _ *testing.T) {
 	m := NewManager()
 	pctxBefore := NewContext(&providers.Request{Model: "gpt-4o"})
 	pctxAfter := NewContext(&providers.Request{Model: "gpt-4o"})

--- a/plugin/manager_race_test.go
+++ b/plugin/manager_race_test.go
@@ -1,0 +1,145 @@
+package plugin
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/ferro-labs/ai-gateway/providers"
+)
+
+// TestManager_ConcurrentRegisterAndRunBefore verifies that concurrent calls to
+// Register and RunBefore do not race. Requires -race to detect the defect: the
+// fix adds a lock to Register but RunBefore ranges over m.before without
+// holding m.mu.RLock(), so the goroutine scheduler can interleave a slice
+// grow (in Register) with the range read (in RunBefore).
+func TestManager_ConcurrentRegisterAndRunBefore(t *testing.T) {
+	m := NewManager()
+	pctx := NewContext(&providers.Request{Model: "gpt-4o"})
+
+	var wg sync.WaitGroup
+	const n = 200
+
+	for i := 0; i < n; i++ {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			_ = m.Register(StageBeforeRequest, &mockPlugin{name: "p", typ: TypeGuardrail})
+		}()
+		go func() {
+			defer wg.Done()
+			_ = m.RunBefore(context.Background(), pctx)
+		}()
+	}
+	wg.Wait()
+}
+
+// TestManager_ConcurrentRegisterAndRunAfter is the same race check for
+// RunAfter / m.after.
+func TestManager_ConcurrentRegisterAndRunAfter(t *testing.T) {
+	m := NewManager()
+	pctx := NewContext(&providers.Request{Model: "gpt-4o"})
+	pctx.Response = &providers.Response{ID: "r1"}
+
+	var wg sync.WaitGroup
+	const n = 200
+
+	for i := 0; i < n; i++ {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			_ = m.Register(StageAfterRequest, &mockPlugin{name: "p", typ: TypeLogging})
+		}()
+		go func() {
+			defer wg.Done()
+			_ = m.RunAfter(context.Background(), pctx)
+		}()
+	}
+	wg.Wait()
+}
+
+// TestManager_ConcurrentRegisterAndRunOnError is the same race check for
+// RunOnError / m.onErr.
+func TestManager_ConcurrentRegisterAndRunOnError(t *testing.T) {
+	m := NewManager()
+	pctx := NewContext(&providers.Request{Model: "gpt-4o"})
+
+	var wg sync.WaitGroup
+	const n = 200
+
+	for i := 0; i < n; i++ {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			_ = m.Register(StageOnError, &mockPlugin{name: "p", typ: TypeLogging})
+		}()
+		go func() {
+			defer wg.Done()
+			m.RunOnError(context.Background(), pctx)
+		}()
+	}
+	wg.Wait()
+}
+
+// TestManager_ConcurrentRegisterAndHasPlugins checks that HasPlugins does not
+// race with concurrent Register calls (it reads all three slice lengths without
+// a lock).
+func TestManager_ConcurrentRegisterAndHasPlugins(t *testing.T) {
+	m := NewManager()
+
+	var wg sync.WaitGroup
+	const n = 200
+
+	for i := 0; i < n; i++ {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			_ = m.Register(StageBeforeRequest, &mockPlugin{name: "p", typ: TypeGuardrail})
+		}()
+		go func() {
+			defer wg.Done()
+			_ = m.HasPlugins()
+		}()
+	}
+	wg.Wait()
+}
+
+// TestManager_ConcurrentAllReadersAndRegister fires RunBefore, RunAfter,
+// RunOnError, and HasPlugins simultaneously against concurrent Register calls.
+// This catches any reader–reader or reader–writer races that the individual
+// pairwise tests might miss under a specific schedule.
+func TestManager_ConcurrentAllReadersAndRegister(t *testing.T) {
+	m := NewManager()
+	pctxBefore := NewContext(&providers.Request{Model: "gpt-4o"})
+	pctxAfter := NewContext(&providers.Request{Model: "gpt-4o"})
+	pctxAfter.Response = &providers.Response{ID: "r1"}
+	pctxErr := NewContext(&providers.Request{Model: "gpt-4o"})
+
+	var wg sync.WaitGroup
+	const n = 100
+
+	for i := 0; i < n; i++ {
+		wg.Add(5)
+		go func() {
+			defer wg.Done()
+			_ = m.Register(StageBeforeRequest, &mockPlugin{name: "p", typ: TypeGuardrail})
+		}()
+		go func() {
+			defer wg.Done()
+			_ = m.RunBefore(context.Background(), pctxBefore)
+		}()
+		go func() {
+			defer wg.Done()
+			_ = m.RunAfter(context.Background(), pctxAfter)
+		}()
+		go func() {
+			defer wg.Done()
+			m.RunOnError(context.Background(), pctxErr)
+		}()
+		go func() {
+			defer wg.Done()
+			_ = m.HasPlugins()
+		}()
+	}
+	wg.Wait()
+}

--- a/plugin/manager_race_test.go
+++ b/plugin/manager_race_test.go
@@ -13,7 +13,7 @@ import (
 // fix adds a lock to Register but RunBefore ranges over m.before without
 // holding m.mu.RLock(), so the goroutine scheduler can interleave a slice
 // grow (in Register) with the range read (in RunBefore).
-func TestManager_ConcurrentRegisterAndRunBefore(t *testing.T) {
+func TestManager_ConcurrentRegisterAndRunBefore(_ *testing.T) {
 	m := NewManager()
 	pctx := NewContext(&providers.Request{Model: "gpt-4o"})
 
@@ -36,7 +36,7 @@ func TestManager_ConcurrentRegisterAndRunBefore(t *testing.T) {
 
 // TestManager_ConcurrentRegisterAndRunAfter is the same race check for
 // RunAfter / m.after.
-func TestManager_ConcurrentRegisterAndRunAfter(t *testing.T) {
+func TestManager_ConcurrentRegisterAndRunAfter(_ *testing.T) {
 	m := NewManager()
 	pctx := NewContext(&providers.Request{Model: "gpt-4o"})
 	pctx.Response = &providers.Response{ID: "r1"}
@@ -60,7 +60,7 @@ func TestManager_ConcurrentRegisterAndRunAfter(t *testing.T) {
 
 // TestManager_ConcurrentRegisterAndRunOnError is the same race check for
 // RunOnError / m.onErr.
-func TestManager_ConcurrentRegisterAndRunOnError(t *testing.T) {
+func TestManager_ConcurrentRegisterAndRunOnError(_ *testing.T) {
 	m := NewManager()
 	pctx := NewContext(&providers.Request{Model: "gpt-4o"})
 

--- a/plugin/plugin_test.go
+++ b/plugin/plugin_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 	"testing"
 
 	"github.com/ferro-labs/ai-gateway/providers"
@@ -236,5 +237,82 @@ func TestManager_NoPlugins(t *testing.T) {
 	pctx := NewContext(&providers.Request{})
 	if err := m.RunBefore(context.Background(), pctx); err != nil {
 		t.Fatal(err)
+	}
+}
+
+// TestManager_Register_AllStages verifies that HasPlugins reports true once a
+// plugin is registered at any stage and that each stage is independent.
+func TestManager_Register_AllStages(t *testing.T) {
+	for _, stage := range []Stage{StageBeforeRequest, StageAfterRequest, StageOnError} {
+		m := NewManager()
+		if m.HasPlugins() {
+			t.Fatalf("stage %s: expected HasPlugins=false before register", stage)
+		}
+		if err := m.Register(stage, &mockPlugin{name: "p", typ: TypeGuardrail}); err != nil {
+			t.Fatalf("stage %s: Register() error: %v", stage, err)
+		}
+		if !m.HasPlugins() {
+			t.Errorf("stage %s: expected HasPlugins=true after register", stage)
+		}
+	}
+}
+
+// TestManager_RunBefore_SnapshotIsolation verifies that a plugin registered
+// after RunBefore takes its slice snapshot is not included in that run.
+// This checks the snapshot semantics introduced by the RLock fix.
+func TestManager_RunBefore_SnapshotIsolation(t *testing.T) {
+	m := NewManager()
+
+	// firstStarted is closed by the first plugin's Execute, proving that
+	// RunBefore has already taken the slice snapshot and entered the loop.
+	firstStarted := make(chan struct{})
+	gate := make(chan struct{})
+	secondCalled := false
+
+	var firstOnce sync.Once
+	_ = m.Register(StageBeforeRequest, &mockPlugin{
+		name: "first",
+		typ:  TypeGuardrail,
+		execFn: func(_ context.Context, _ *Context) error {
+			// Only coordinate on the first call; subsequent runs just pass through.
+			firstOnce.Do(func() {
+				close(firstStarted) // snapshot was taken; we are inside the loop
+				<-gate              // block until the test has registered the second plugin
+			})
+			return nil
+		},
+	})
+
+	done := make(chan error, 1)
+	go func() {
+		done <- m.RunBefore(context.Background(), NewContext(&providers.Request{Model: "gpt-4o"}))
+	}()
+
+	// Wait until the first plugin is executing — the snapshot is now fixed.
+	<-firstStarted
+
+	// Register a second plugin. Because the snapshot was already taken, this
+	// registration must not affect the current RunBefore call.
+	_ = m.Register(StageBeforeRequest, &mockPlugin{
+		name: "second",
+		typ:  TypeGuardrail,
+		execFn: func(_ context.Context, _ *Context) error {
+			secondCalled = true
+			return nil
+		},
+	})
+
+	close(gate) // let the first plugin finish
+	if err := <-done; err != nil {
+		t.Fatalf("RunBefore() error: %v", err)
+	}
+	if secondCalled {
+		t.Error("second plugin (registered after snapshot) must not be called in this run")
+	}
+
+	// A subsequent RunBefore takes a fresh snapshot that includes "second".
+	_ = m.RunBefore(context.Background(), NewContext(&providers.Request{Model: "gpt-4o"}))
+	if !secondCalled {
+		t.Error("subsequent RunBefore must execute the newly registered second plugin")
 	}
 }


### PR DESCRIPTION
## Summary

Fix two data races in the hot request path: `Route` read `g.mcpRegistry` and `g.mcpExecutor` after releasing `g.mu`, racing with `ReloadConfig`; and `plugin.Manager` exposed its `before`/`after`/`onErr` slices to concurrent readers with no lock at all. Both are now safe under `sync.RWMutex`.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] New provider
- [ ] New plugin
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Performance improvement
- [ ] Refactor / code quality
- [ ] Documentation / comments only
- [ ] CI / tooling

## Related issues

Fixes #131

## Changes

- `gateway.go` — `Route`: snapshot `g.mcpRegistry` and `g.mcpExecutor` inside the existing `g.mu.RLock` block at request entry; all downstream reads use the snapshots instead of the live fields
- `gateway.go` — `RouteStream`: snapshot `g.mcpRegistry` in the same initial `RLock` block; remove the now-redundant second `RLock/RUnlock` that was taken solely to read that field
- `plugin/manager.go` — add `sync.RWMutex` to `Manager`; `Register` takes a write lock; `RunBefore`, `RunAfter`, `RunOnError`, and `HasPlugins` take a read lock and snapshot the relevant slice before iterating, so plugin execution never holds the lock

## Testing

- [x] Existing tests pass (`go test ./...`)
- [x] New unit tests added (if applicable)

**New race tests** (`go test -race`):
- `TestRoute_MCPFieldsSnapshotRace` — concurrent writes to `mcpRegistry`/`mcpExecutor` vs `Route`
- `TestRouteStream_MCPRegistrySnapshotRace` — concurrent writes to `mcpRegistry` vs `RouteStream`
- `TestManager_ConcurrentRegisterAndRunBefore/After/OnError/HasPlugins` — pairwise: each reader vs concurrent `Register`
- `TestManager_ConcurrentAllReadersAndRegister` — all readers + `Register` simultaneously

**New unit tests:**
- `TestManager_Register_AllStages` — `HasPlugins` reflects registration across all three stages
- `TestManager_RunBefore_SnapshotIsolation` — a plugin registered after the snapshot is taken is excluded from the in-flight run but included in the next one
- `TestRoute_MCPSnapshotIsolation` — nil registry at snapshot time means no MCP tool injection, regardless of later field writes