### PR TITLE
fix: support new provider model prefixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to Ferro Labs AI Gateway are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.4] — 2026-06-19
+
+Provider-translation correctness release. Tool/function calling, sampling parameters, completion-token limits, finish-reason normalization, multimodal input, and streaming fidelity are now correctly translated across native and OpenAI-compatible providers. Bundles an 11-bump dependency sweep and an internal shared-helper refactor (~1,800 lines of duplication removed) with no public API breaks. Fixes every issue labelled [`release-1.1.4`](https://github.com/ferro-labs/ai-gateway/issues?q=label%3Arelease-1.1.4): [#139](https://github.com/ferro-labs/ai-gateway/issues/139), [#140](https://github.com/ferro-labs/ai-gateway/issues/140), [#141](https://github.com/ferro-labs/ai-gateway/issues/141), [#142](https://github.com/ferro-labs/ai-gateway/issues/142), [#143](https://github.com/ferro-labs/ai-gateway/issues/143), [#144](https://github.com/ferro-labs/ai-gateway/issues/144), and [#145](https://github.com/ferro-labs/ai-gateway/issues/145).
+
+### Fixed
+
+- **Tool / function calling dropped on native non-OpenAI providers** (issue [#139](https://github.com/ferro-labs/ai-gateway/issues/139), PR [#214](https://github.com/ferro-labs/ai-gateway/pull/214)): Anthropic, Gemini, Bedrock (Claude), and Cohere now forward `tools` / `tool_choice` in each provider's native shape, parse `tool_use` / `tool_calls` responses (JSON-object arguments → JSON string), assemble streaming tool-call deltas with index remapping, and handle multi-turn tool round-trips. OpenAI-compatible providers preserve streamed `tool_calls` deltas via a shared decoder.
+- **Sampling / output params silently dropped** (issue [#140](https://github.com/ferro-labs/ai-gateway/issues/140)): a shared `internal/openaicompat` request builder forwards the full OpenAI-shaped body (`top_p`, `stop`, `seed`, penalties, `response_format`, `n`, …); native providers translate to upstream field names and warn-and-drop only what an API cannot express.
+- **`max_completion_tokens` ignored by non-OpenAI providers** (issue [#141](https://github.com/ferro-labs/ai-gateway/issues/141), PR [#213](https://github.com/ferro-labs/ai-gateway/pull/213)): the limit is normalized at the gateway seam so every provider honors it, and OpenAI / Azure o-series reasoning models receive `max_completion_tokens` instead of the rejected `max_tokens`.
+- **`finish_reason` not normalized to OpenAI values** (issue [#142](https://github.com/ferro-labs/ai-gateway/issues/142)): Anthropic / Bedrock / Cohere native stop reasons now map to `stop | length | tool_calls | content_filter`, so clients can detect truncation and tool use.
+- **Anthropic multimodal images dropped and tool-role messages malformed** (issue [#143](https://github.com/ferro-labs/ai-gateway/issues/143)): image content maps to Anthropic content blocks (vision no longer degrades to text-only) and tool results emit `tool_result` blocks inside a user turn instead of a bare `{"role":"tool"}` object the API rejects.
+- **Gemini system prompt prepended to the user message** (issue [#144](https://github.com/ferro-labs/ai-gateway/issues/144)): routed through the dedicated top-level `systemInstruction` field (Gemini 1.5+) instead of being smuggled into the first user turn, and no longer lost when a system message has no following user turn.
+- **Streaming and per-provider translation fidelity** (issue [#145](https://github.com/ferro-labs/ai-gateway/issues/145)): Anthropic streaming usage is parsed (non-zero token / cost metrics); DeepSeek `reasoning_content` and prompt-cache tokens are surfaced; Cohere embeddings `input_type` is configurable (defaults to `search_document`).
+
+### Changed
+
+- **Dependency sweep (11 bumps):** aws-sdk-go-v2 (config / credentials / bedrockruntime), OpenTelemetry (otel + otlptracegrpc), go-chi/chi v5, modernc.org/sqlite, lib/pq, codecov-action, and upload-artifact, plus SA1019 deprecation fixes surfaced by the bumps.
+- **Internal shared-helper refactor:** `openaicompat.StreamSSE` / `PostChat` / `PostStream` collapse ~23 OpenAI-compatible providers' duplicated request and stream plumbing; new `core.NormalizeToolChoice` / `NormalizeFinishReason` / `Ptr` helpers and a shared `anthropicwire` tool mapper; `interface{}` → `any` modernization. ~1,800 net lines removed with no behavior change beyond unifying SSE decode-error handling.
+
+---
+
 ## [1.1.3] — 2026-06-15
 
 Streaming-correctness release. Brings the streaming routing path (`RouteStream`) to parity with non-streaming `Route`: the post-request plugin pipeline, the per-provider circuit breaker, and least-latency / cost-optimized ordering now all apply to `stream: true` traffic. Also tightens fallback retry semantics and async-context propagation. No public API breaks. Fixes every issue labelled [`release-1.1.3`](https://github.com/ferro-labs/ai-gateway/issues?q=label%3Arelease-1.1.3): [#135](https://github.com/ferro-labs/ai-gateway/issues/135), [#136](https://github.com/ferro-labs/ai-gateway/issues/136), [#137](https://github.com/ferro-labs/ai-gateway/issues/137), and [#138](https://github.com/ferro-labs/ai-gateway/issues/138), plus enhancement [#181](https://github.com/ferro-labs/ai-gateway/issues/181).

--- a/providers/bedrock/bedrock.go
+++ b/providers/bedrock/bedrock.go
@@ -141,6 +141,10 @@ func (p *Provider) SupportedModels() []string {
 		"amazon.titan-text-express-v1",
 		"amazon.titan-text-lite-v1",
 		"amazon.titan-text-premier-v1:0",
+		"amazon.nova-micro-v1:0",
+		"amazon.nova-lite-v1:0",
+		"amazon.nova-pro-v1:0",
+		"amazon.nova-premier-v1:0",
 		"meta.llama3-1-405b-instruct-v1:0",
 		"meta.llama3-1-70b-instruct-v1:0",
 		"meta.llama3-1-8b-instruct-v1:0",
@@ -166,10 +170,14 @@ func (p *Provider) SupportsModel(model string) bool {
 	for _, prefix := range []string{
 		"anthropic.claude-",
 		"amazon.titan-text-",
+		"amazon.nova-",
 		"amazon.titan-embed-text-",
 		"cohere.embed-",
 		"meta.llama",
 	} {
+		if strings.HasPrefix(model, "amazon.nova-") && !isBedrockNovaTextModel(model) {
+			continue
+		}
 		if strings.HasPrefix(model, prefix) {
 			return true
 		}
@@ -248,6 +256,48 @@ type bedrockTitanResponse struct {
 		OutputText       string `json:"outputText"`
 		CompletionReason string `json:"completionReason"`
 	} `json:"results"`
+}
+
+// ── Amazon Nova ──────────────────────────────────────────────────────────────
+
+type bedrockNovaRequest struct {
+	SchemaVersion   string                      `json:"schemaVersion"`
+	Messages        []bedrockNovaMessage        `json:"messages"`
+	System          []bedrockNovaTextBlock      `json:"system,omitempty"`
+	InferenceConfig *bedrockNovaInferenceConfig `json:"inferenceConfig,omitempty"`
+}
+
+type bedrockNovaMessage struct {
+	Role    string                 `json:"role"`
+	Content []bedrockNovaTextBlock `json:"content"`
+}
+
+type bedrockNovaTextBlock struct {
+	Text string `json:"text"`
+}
+
+type bedrockNovaInferenceConfig struct {
+	MaxTokens     int      `json:"maxTokens,omitempty"`
+	Temperature   *float64 `json:"temperature,omitempty"`
+	TopP          *float64 `json:"topP,omitempty"`
+	StopSequences []string `json:"stopSequences,omitempty"`
+}
+
+type bedrockNovaResponse struct {
+	Output struct {
+		Message struct {
+			Role    string `json:"role"`
+			Content []struct {
+				Text string `json:"text"`
+			} `json:"content"`
+		} `json:"message"`
+	} `json:"output"`
+	StopReason string `json:"stopReason"`
+	Usage      struct {
+		InputTokens  int `json:"inputTokens"`
+		OutputTokens int `json:"outputTokens"`
+		TotalTokens  int `json:"totalTokens"`
+	} `json:"usage"`
 }
 
 // ── Meta Llama ────────────────────────────────────────────────────────────────
@@ -468,7 +518,7 @@ func bedrockModelRoutingID(model string) string {
 	if idx := strings.LastIndex(model, "/"); idx >= 0 && idx < len(model)-1 {
 		model = model[idx+1:]
 	}
-	for _, prefix := range []string{"us.", "eu.", "apac."} {
+	for _, prefix := range []string{"us.", "eu.", "apac.", "global."} {
 		if strings.HasPrefix(model, prefix) {
 			return strings.TrimPrefix(model, prefix)
 		}
@@ -482,6 +532,22 @@ func isBedrockTitanTextEmbeddingModel(model string) bool {
 
 func isBedrockCohereEmbeddingModel(model string) bool {
 	return strings.HasPrefix(model, "cohere.embed-")
+}
+
+func isBedrockNovaTextModel(model string) bool {
+	for _, prefix := range []string{
+		"amazon.nova-micro-",
+		"amazon.nova-lite-",
+		"amazon.nova-pro-",
+		"amazon.nova-premier-",
+		"amazon.nova-2-lite-",
+		"amazon.nova-2-pro-",
+	} {
+		if strings.HasPrefix(model, prefix) {
+			return true
+		}
+	}
+	return false
 }
 
 // Complete sends a request to AWS Bedrock and returns the response.
@@ -574,10 +640,13 @@ func bedrockAnthropicToolChoice(choice any, tools []core.Tool) any {
 // Complete sends a non-streaming chat completion request to Bedrock, dispatching
 // to the model family (Anthropic, Titan, Llama) that matches the model prefix.
 func (p *Provider) Complete(ctx context.Context, req core.Request) (*core.Response, error) {
-	modelID := req.Model
+	modelID := bedrockModelRoutingID(req.Model)
 	core.WarnUnsupportedParams(ctx, p.Name(), modelID, req, bedrockSupportedParams(modelID)...)
 	if strings.HasPrefix(modelID, "anthropic.") {
 		return p.completeAnthropic(ctx, req)
+	}
+	if isBedrockNovaTextModel(modelID) {
+		return p.completeNova(ctx, req)
 	}
 	if strings.HasPrefix(modelID, "amazon.titan") {
 		return p.completeTitan(ctx, req)
@@ -665,6 +734,81 @@ func (p *Provider) completeAnthropic(ctx context.Context, req core.Request) (*co
 			TotalTokens:      anthropicResp.Usage.InputTokens + anthropicResp.Usage.OutputTokens,
 		},
 	}, nil
+}
+
+func (p *Provider) completeNova(ctx context.Context, req core.Request) (*core.Response, error) {
+	novaReq := bedrockNovaRequest{
+		SchemaVersion: "messages-v1",
+	}
+	for _, msg := range req.Messages {
+		content := bedrockNovaMessageTextContent(msg)
+		if msg.Role == core.RoleSystem {
+			novaReq.System = append(novaReq.System, content...)
+			continue
+		}
+		novaReq.Messages = append(novaReq.Messages, bedrockNovaMessage{
+			Role:    msg.Role,
+			Content: content,
+		})
+	}
+
+	if req.MaxTokens != nil || req.Temperature != nil || req.TopP != nil || len(req.Stop) > 0 {
+		novaReq.InferenceConfig = &bedrockNovaInferenceConfig{
+			Temperature:   req.Temperature,
+			TopP:          req.TopP,
+			StopSequences: req.Stop,
+		}
+		if req.MaxTokens != nil {
+			novaReq.InferenceConfig.MaxTokens = *req.MaxTokens
+		}
+	}
+
+	var novaResp bedrockNovaResponse
+	if err := p.invokeModelJSON(ctx, req.Model, novaReq, &novaResp); err != nil {
+		return nil, err
+	}
+
+	var text strings.Builder
+	for _, c := range novaResp.Output.Message.Content {
+		text.WriteString(c.Text)
+	}
+
+	totalTokens := novaResp.Usage.TotalTokens
+	if totalTokens == 0 {
+		totalTokens = novaResp.Usage.InputTokens + novaResp.Usage.OutputTokens
+	}
+
+	return &core.Response{
+		Model:    req.Model,
+		Provider: p.name,
+		Choices: []core.Choice{{
+			Index:        0,
+			Message:      core.Message{Role: core.RoleAssistant, Content: text.String()},
+			FinishReason: novaResp.StopReason,
+		}},
+		Usage: core.Usage{
+			PromptTokens:     novaResp.Usage.InputTokens,
+			CompletionTokens: novaResp.Usage.OutputTokens,
+			TotalTokens:      totalTokens,
+		},
+	}, nil
+}
+
+func bedrockNovaMessageTextContent(msg core.Message) []bedrockNovaTextBlock {
+	if len(msg.ContentParts) == 0 {
+		return []bedrockNovaTextBlock{{Text: msg.Content}}
+	}
+
+	content := make([]bedrockNovaTextBlock, 0, len(msg.ContentParts))
+	for _, part := range msg.ContentParts {
+		if part.Type == core.ContentTypeText {
+			content = append(content, bedrockNovaTextBlock{Text: part.Text})
+		}
+	}
+	if len(content) == 0 && msg.Content != "" {
+		content = append(content, bedrockNovaTextBlock{Text: msg.Content})
+	}
+	return content
 }
 
 func (p *Provider) completeTitan(ctx context.Context, req core.Request) (*core.Response, error) {
@@ -783,10 +927,10 @@ func (p *Provider) completeLlama(ctx context.Context, req core.Request) (*core.R
 // CompleteStream sends a streaming request to AWS Bedrock via InvokeModelWithResponseStream.
 // Currently only Anthropic Claude streaming is implemented.
 func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan core.StreamChunk, error) {
-	if !strings.HasPrefix(req.Model, "anthropic.") {
+	if !strings.HasPrefix(bedrockModelRoutingID(req.Model), "anthropic.") {
 		return nil, fmt.Errorf("streaming on Bedrock is currently only supported for anthropic.claude-* models")
 	}
-	core.WarnUnsupportedParams(ctx, p.Name(), req.Model, req, bedrockSupportedParams(req.Model)...)
+	core.WarnUnsupportedParams(ctx, p.Name(), req.Model, req, bedrockSupportedParams(bedrockModelRoutingID(req.Model))...)
 
 	maxTokens := 1024
 	if req.MaxTokens != nil {

--- a/providers/bedrock/bedrock_test.go
+++ b/providers/bedrock/bedrock_test.go
@@ -85,6 +85,7 @@ func TestBedrockProvider_SupportedEmbeddingModels(t *testing.T) {
 
 	for _, wantSupported := range []string{
 		"us.amazon.titan-embed-text-v2:0",
+		"global.amazon.titan-embed-text-v2:0",
 		"us-gov-east-1/amazon.titan-embed-text-v1",
 		"cohere.embed-future:0",
 	} {
@@ -101,6 +102,173 @@ func TestBedrockProvider_SupportedEmbeddingModels(t *testing.T) {
 		if p.SupportsModel(wantRejected) {
 			t.Errorf("SupportsModel(%q) = true, want false", wantRejected)
 		}
+	}
+}
+
+func TestBedrockProvider_SupportsModel_CrossRegionInferenceProfiles(t *testing.T) {
+	p := &Provider{name: Name}
+
+	for _, model := range []string{
+		"us.anthropic.claude-3-5-sonnet-20241022-v2:0",
+		"eu.amazon.titan-text-express-v1",
+		"apac.meta.llama3-1-70b-instruct-v1:0",
+		"global.anthropic.claude-sonnet-4-20250514-v1:0",
+		"us.amazon.nova-lite-v1:0",
+		"global.amazon.nova-pro-v1:0",
+		"global.amazon.nova-2-lite-v1:0",
+		"us-gov-west-1/amazon.nova-pro-v1:0",
+		"us-gov-west-1/amazon.titan-text-premier-v1:0",
+	} {
+		t.Run(model, func(t *testing.T) {
+			if !p.SupportsModel(model) {
+				t.Errorf("SupportsModel(%q) = false, want true", model)
+			}
+		})
+	}
+}
+
+func TestBedrockProvider_SupportsModel_NovaTextModels(t *testing.T) {
+	p := &Provider{name: Name}
+
+	for _, model := range []string{
+		"amazon.nova-micro-v1:0",
+		"amazon.nova-lite-v1:0",
+		"amazon.nova-pro-v1:0",
+		"amazon.nova-premier-v1:0",
+		"amazon.nova-2-lite-v1:0",
+		"amazon.nova-2-pro-preview-20251202-v1:0",
+		"us.amazon.nova-lite-v1:0",
+		"eu.amazon.nova-micro-v1:0",
+		"apac.amazon.nova-pro-v1:0",
+		"global.amazon.nova-2-lite-v1:0",
+		"us-gov-west-1/amazon.nova-pro-v1:0",
+	} {
+		t.Run(model, func(t *testing.T) {
+			if !p.SupportsModel(model) {
+				t.Errorf("SupportsModel(%q) = false, want true", model)
+			}
+		})
+	}
+
+	for _, model := range []string{
+		"amazon.nova-canvas-v1:0",
+		"amazon.nova-reel-v1:0",
+		"amazon.nova-2-multimodal-embeddings-v1:0",
+	} {
+		t.Run(model, func(t *testing.T) {
+			if p.SupportsModel(model) {
+				t.Errorf("SupportsModel(%q) = true, want false", model)
+			}
+		})
+	}
+}
+
+func TestBedrockProvider_Complete_CrossRegionInferenceProfileDispatchesWithOriginalModelID(t *testing.T) {
+	fake := &fakeBedrockRuntimeClient{
+		responses: [][]byte{
+			[]byte(`{"id":"msg-1","type":"message","role":"assistant","content":[{"type":"text","text":"hello"}],"stop_reason":"end_turn","usage":{"input_tokens":2,"output_tokens":1}}`),
+		},
+	}
+	p := &Provider{name: Name, client: fake}
+
+	resp, err := p.Complete(context.Background(), core.Request{
+		Model: "global.anthropic.claude-sonnet-4-20250514-v1:0",
+		Messages: []core.Message{
+			{Role: core.RoleUser, Content: "hello"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Complete() error: %v", err)
+	}
+	if len(fake.invokeCalls) != 1 {
+		t.Fatalf("InvokeModel calls = %d, want 1", len(fake.invokeCalls))
+	}
+	if got := aws.ToString(fake.invokeCalls[0].ModelId); got != "global.anthropic.claude-sonnet-4-20250514-v1:0" {
+		t.Errorf("ModelId = %q, want original inference profile ID", got)
+	}
+	if resp.Model != "global.anthropic.claude-sonnet-4-20250514-v1:0" {
+		t.Errorf("response Model = %q, want original inference profile ID", resp.Model)
+	}
+}
+
+func TestBedrockProvider_Complete_NovaDispatchesWithOriginalModelID(t *testing.T) {
+	fake := &fakeBedrockRuntimeClient{
+		responses: [][]byte{
+			[]byte(`{"output":{"message":{"role":"assistant","content":[{"text":"hello"},{"text":" world"}]}},"stopReason":"end_turn","usage":{"inputTokens":3,"outputTokens":2,"totalTokens":5}}`),
+		},
+	}
+	p := &Provider{name: Name, client: fake}
+	maxTokens := 64
+	temperature := 0.3
+	topP := 0.9
+
+	resp, err := p.Complete(context.Background(), core.Request{
+		Model:       "global.amazon.nova-pro-v1:0",
+		MaxTokens:   &maxTokens,
+		Temperature: &temperature,
+		TopP:        &topP,
+		Stop:        []string{"STOP"},
+		Messages: []core.Message{
+			{Role: core.RoleSystem, Content: "be concise"},
+			{Role: core.RoleUser, Content: "hello"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Complete() error: %v", err)
+	}
+	if len(fake.invokeCalls) != 1 {
+		t.Fatalf("InvokeModel calls = %d, want 1", len(fake.invokeCalls))
+	}
+	if got := aws.ToString(fake.invokeCalls[0].ModelId); got != "global.amazon.nova-pro-v1:0" {
+		t.Errorf("ModelId = %q, want original inference profile ID", got)
+	}
+	var body bedrockNovaRequest
+	mustUnmarshalBody(t, fake.invokeCalls[0].Body, &body)
+	if body.SchemaVersion != "messages-v1" {
+		t.Errorf("schemaVersion = %q, want messages-v1", body.SchemaVersion)
+	}
+	if len(body.System) != 1 || body.System[0].Text != "be concise" {
+		t.Errorf("system = %#v, want system prompt", body.System)
+	}
+	if len(body.Messages) != 1 || body.Messages[0].Role != "user" || len(body.Messages[0].Content) != 1 || body.Messages[0].Content[0].Text != "hello" {
+		t.Errorf("messages = %#v, want user text message", body.Messages)
+	}
+	if body.InferenceConfig == nil {
+		t.Fatal("inferenceConfig = nil, want configured sampling params")
+	}
+	if body.InferenceConfig.MaxTokens != maxTokens || body.InferenceConfig.Temperature == nil || *body.InferenceConfig.Temperature != temperature || body.InferenceConfig.TopP == nil || *body.InferenceConfig.TopP != topP {
+		t.Errorf("inferenceConfig = %+v, want configured sampling params", body.InferenceConfig)
+	}
+	if len(body.InferenceConfig.StopSequences) != 1 || body.InferenceConfig.StopSequences[0] != "STOP" {
+		t.Errorf("stopSequences = %#v, want STOP", body.InferenceConfig.StopSequences)
+	}
+	if resp.Model != "global.amazon.nova-pro-v1:0" || resp.Choices[0].Message.Content != "hello world" || resp.Choices[0].FinishReason != "end_turn" {
+		t.Errorf("response = %+v, want mapped Nova response", resp)
+	}
+	if resp.Usage.PromptTokens != 3 || resp.Usage.CompletionTokens != 2 || resp.Usage.TotalTokens != 5 {
+		t.Errorf("usage = %+v, want Nova usage", resp.Usage)
+	}
+}
+
+func TestBedrockProvider_Complete_NovaUsageFallsBackToInputPlusOutputTokens(t *testing.T) {
+	fake := &fakeBedrockRuntimeClient{
+		responses: [][]byte{
+			[]byte(`{"output":{"message":{"role":"assistant","content":[{"text":"ok"}]}},"stopReason":"end_turn","usage":{"inputTokens":1,"outputTokens":2}}`),
+		},
+	}
+	p := &Provider{name: Name, client: fake}
+
+	resp, err := p.Complete(context.Background(), core.Request{
+		Model: "amazon.nova-micro-v1:0",
+		Messages: []core.Message{
+			{Role: core.RoleUser, Content: "hello"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Complete() error: %v", err)
+	}
+	if resp.Usage.TotalTokens != 3 {
+		t.Errorf("TotalTokens = %d, want input+output fallback 3", resp.Usage.TotalTokens)
 	}
 }
 

--- a/providers/openai/openai.go
+++ b/providers/openai/openai.go
@@ -114,7 +114,7 @@ func (p *Provider) SupportedModels() []string {
 
 // SupportsModel returns true if the model matches known OpenAI prefixes.
 func (p *Provider) SupportsModel(model string) bool {
-	for _, prefix := range []string{"gpt-", "chatgpt-", "dall-e-", "whisper-", "tts-", "text-embedding-", "ft:", "babbage-", "davinci-"} {
+	for _, prefix := range []string{"gpt-", "chatgpt-", "codex-", "sora-", "dall-e-", "whisper-", "tts-", "text-embedding-", "ft:", "babbage-", "davinci-"} {
 		if strings.HasPrefix(model, prefix) {
 			return true
 		}

--- a/providers/openai/openai_test.go
+++ b/providers/openai/openai_test.go
@@ -65,6 +65,8 @@ func TestOpenAIProvider_SupportsModel(t *testing.T) {
 		{"gpt-4-turbo supported", "gpt-4-turbo", true},
 		{"gpt-3.5-turbo supported", "gpt-3.5-turbo", true},
 		{"unknown model passthrough", "gpt-99", true},
+		{"codex family supported", "codex-mini-latest", true},
+		{"sora family supported", "sora-2-pro", true},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

Closes #147.

This updates model-family routing for the gaps called out in the issue:

- Adds OpenAI `codex-` and `sora-` prefixes to `SupportsModel`.
- Allows Bedrock cross-region inference profile IDs such as `us.*`, `eu.*`, `apac.*`, and `global.*` to match the underlying provider family while still passing the original profile ID to AWS.
- Adds Amazon Nova text model support for the Bedrock `InvokeModel` path using the Nova `messages-v1` request/response shape.

I kept Nova support limited to text/chat-capable Nova model families so image/video/embedding Nova IDs do not route through an incompatible codec.

## Verification

- `go test ./providers/openai ./providers/bedrock`
- `go test ./providers ./providers/openai ./providers/bedrock ./internal/strategies ./internal/proxy`
- `go vet ./providers/bedrock ./providers/openai`
- `gofmt -l providers/bedrock providers/openai`
- `git diff --check`
