### PR TITLE
Precompile streaming content regexes

### DIFF
--- a/gateway.go
+++ b/gateway.go
@@ -54,6 +54,7 @@ type Gateway struct {
 	providers          map[string]providers.Provider
 	providerNames      []string
 	strategy           strategies.Strategy
+	streamingContent   []streamingContentCondition
 	plugins            *plugin.Manager
 	closeOnce          sync.Once
 	hooks              []EventHookFunc
@@ -94,6 +95,11 @@ type modelLookupIndex struct {
 	exactImageProviders  map[string][]string
 }
 
+type streamingContentCondition struct {
+	ContentCondition
+	re *regexp.Regexp
+}
+
 type hookDispatch struct {
 	ctx   context.Context
 	event events.HookEvent
@@ -116,10 +122,16 @@ func New(cfg Config) (*Gateway, error) {
 		catalog = models.Catalog{}
 	}
 
+	streamingContent, err := compileStreamingContentConditions(cfg.Strategy.Mode, cfg.Strategy.ContentConditions)
+	if err != nil {
+		return nil, err
+	}
+
 	gw := &Gateway{
 		config:           cfg,
 		catalog:          catalog,
 		providers:        make(map[string]providers.Provider),
+		streamingContent: streamingContent,
 		plugins:          plugin.NewManager(),
 		circuitBreakers:  make(map[string]*circuitbreaker.CircuitBreaker),
 		discoveredModels: make(map[string][]providers.ModelInfo),
@@ -799,9 +811,14 @@ func (g *Gateway) ReloadConfig(cfg Config) error {
 	if err := ValidateConfig(cfg); err != nil {
 		return fmt.Errorf("invalid config: %w", err)
 	}
+	streamingContent, err := compileStreamingContentConditions(cfg.Strategy.Mode, cfg.Strategy.ContentConditions)
+	if err != nil {
+		return fmt.Errorf("invalid config: %w", err)
+	}
 	g.mu.Lock()
 	defer g.mu.Unlock()
 	g.config = cfg
+	g.streamingContent = streamingContent
 	g.strategy = nil // force rebuild on next request
 	g.circuitBreakers = make(map[string]*circuitbreaker.CircuitBreaker)
 
@@ -1366,7 +1383,7 @@ func (g *Gateway) streamingTargetOrderLocked(req providers.Request) []string {
 		return keys
 	case ModeContentBased:
 		// Evaluate content rules in order; first match wins, fallback is targets[0].
-		for _, cond := range g.config.Strategy.ContentConditions {
+		for _, cond := range g.streamingContent {
 			if streamingContentConditionMatches(cond, req) {
 				// Matched target first, then remaining targets as fallback.
 				keys := []string{cond.TargetKey}
@@ -1564,9 +1581,28 @@ func conditionMatches(cond Condition, model string) bool {
 	}
 }
 
+func compileStreamingContentConditions(mode StrategyMode, conditions []ContentCondition) ([]streamingContentCondition, error) {
+	if mode != ModeContentBased {
+		return nil, nil
+	}
+	compiled := make([]streamingContentCondition, len(conditions))
+	for i, cond := range conditions {
+		compiled[i].ContentCondition = cond
+		if cond.Type != "prompt_regex" {
+			continue
+		}
+		re, err := regexp.Compile(cond.Value)
+		if err != nil {
+			return nil, fmt.Errorf("streaming content-based routing: invalid regex %q in rule %d: %w", cond.Value, i, err)
+		}
+		compiled[i].re = re
+	}
+	return compiled, nil
+}
+
 // streamingContentConditionMatches evaluates a single ContentCondition against
 // a request, mirroring the logic in internal/strategies/contentbased.go.
-func streamingContentConditionMatches(cond ContentCondition, req providers.Request) bool {
+func streamingContentConditionMatches(cond streamingContentCondition, req providers.Request) bool {
 	switch cond.Type {
 	case "prompt_contains":
 		lower := strings.ToLower(cond.Value)
@@ -1585,12 +1621,11 @@ func streamingContentConditionMatches(cond ContentCondition, req providers.Reque
 		}
 		return true
 	case "prompt_regex":
-		re, err := regexp.Compile(cond.Value)
-		if err != nil {
+		if cond.re == nil {
 			return false
 		}
 		for _, msg := range req.Messages {
-			if msg.Role == roleUser && re.MatchString(msg.Content) {
+			if msg.Role == roleUser && cond.re.MatchString(msg.Content) {
 				return true
 			}
 		}

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -296,6 +297,65 @@ func TestGateway_RouteStream_ContentBasedPromptRegex(t *testing.T) {
 		}
 	default:
 		t.Fatal("stream provider was not selected")
+	}
+}
+
+func TestGateway_NewRejectsInvalidStreamingPromptRegex(t *testing.T) {
+	_, err := New(Config{
+		Strategy: StrategyConfig{
+			Mode: ModeContentBased,
+			ContentConditions: []ContentCondition{{
+				Type:      "prompt_regex",
+				Value:     `[invalid`,
+				TargetKey: "code-stream",
+			}},
+		},
+		Targets: []Target{{VirtualKey: "code-stream"}},
+	})
+	if err == nil {
+		t.Fatal("expected invalid regex error")
+	}
+	if !strings.Contains(err.Error(), "invalid regex") {
+		t.Fatalf("error = %v, want invalid regex", err)
+	}
+}
+
+func TestGateway_ReloadConfigRebuildsStreamingContentRegex(t *testing.T) {
+	gw, err := New(Config{
+		Strategy: StrategyConfig{Mode: ModeSingle},
+		Targets:  []Target{{VirtualKey: "general-stream"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(gw.streamingContent) != 0 {
+		t.Fatalf("single strategy streaming content = %d, want 0", len(gw.streamingContent))
+	}
+
+	err = gw.ReloadConfig(Config{
+		Strategy: StrategyConfig{
+			Mode: ModeContentBased,
+			ContentConditions: []ContentCondition{
+				{Type: "prompt_contains", Value: "docs", TargetKey: "general-stream"},
+				{Type: "prompt_regex", Value: `(?i)\b(code|function)\b`, TargetKey: "code-stream"},
+			},
+		},
+		Targets: []Target{
+			{VirtualKey: "general-stream"},
+			{VirtualKey: "code-stream"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("ReloadConfig: %v", err)
+	}
+	if len(gw.streamingContent) != 2 {
+		t.Fatalf("streaming content = %d, want 2", len(gw.streamingContent))
+	}
+	if gw.streamingContent[0].re != nil {
+		t.Fatal("prompt_contains rule should not have a compiled regex")
+	}
+	if gw.streamingContent[1].re == nil {
+		t.Fatal("prompt_regex rule should have a compiled regex")
 	}
 }
 

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -57,11 +57,15 @@ type mockStreamProvider struct {
 	mockProvider
 	streamErr error
 	streamCh  <-chan providers.StreamChunk
+	streamFn  func(context.Context, providers.Request) (<-chan providers.StreamChunk, error)
 }
 
-func (m *mockStreamProvider) CompleteStream(_ context.Context, _ providers.Request) (<-chan providers.StreamChunk, error) {
+func (m *mockStreamProvider) CompleteStream(ctx context.Context, req providers.Request) (<-chan providers.StreamChunk, error) {
 	if m.streamErr != nil {
 		return nil, m.streamErr
+	}
+	if m.streamFn != nil {
+		return m.streamFn(ctx, req)
 	}
 	if m.streamCh != nil {
 		return m.streamCh, nil
@@ -225,6 +229,73 @@ func TestGateway_Route_NoTargets(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("expected error for no targets")
+	}
+}
+
+func TestGateway_RouteStream_ContentBasedPromptRegex(t *testing.T) {
+	gw, err := New(Config{
+		Strategy: StrategyConfig{
+			Mode: ModeContentBased,
+			ContentConditions: []ContentCondition{{
+				Type:      "prompt_regex",
+				Value:     `(?i)\b(code|function)\b`,
+				TargetKey: "code-stream",
+			}},
+		},
+		Targets: []Target{
+			{VirtualKey: "general-stream"},
+			{VirtualKey: "code-stream"},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(gw.streamingContent) != 1 || gw.streamingContent[0].re == nil {
+		t.Fatal("expected compiled streaming content regex")
+	}
+
+	selected := make(chan string, 2)
+	recordStream := func(name string) func(context.Context, providers.Request) (<-chan providers.StreamChunk, error) {
+		return func(context.Context, providers.Request) (<-chan providers.StreamChunk, error) {
+			selected <- name
+			ch := make(chan providers.StreamChunk)
+			close(ch)
+			return ch, nil
+		}
+	}
+	gw.RegisterProvider(&mockStreamProvider{
+		mockProvider: mockProvider{
+			name:   "general-stream",
+			models: []string{"gpt-4o"},
+		},
+		streamFn: recordStream("general-stream"),
+	})
+	gw.RegisterProvider(&mockStreamProvider{
+		mockProvider: mockProvider{
+			name:   "code-stream",
+			models: []string{"gpt-4o"},
+		},
+		streamFn: recordStream("code-stream"),
+	})
+
+	out, err := gw.RouteStream(context.Background(), providers.Request{
+		Model:    "gpt-4o",
+		Stream:   true,
+		Messages: []providers.Message{{Role: "user", Content: "write a Go function"}},
+	})
+	if err != nil {
+		t.Fatalf("RouteStream: %v", err)
+	}
+	for range out { //nolint:revive
+	}
+
+	select {
+	case got := <-selected:
+		if got != "code-stream" {
+			t.Fatalf("selected provider = %q, want code-stream", got)
+		}
+	default:
+		t.Fatal("stream provider was not selected")
 	}
 }
 

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -320,6 +320,47 @@ func TestGateway_NewRejectsInvalidStreamingPromptRegex(t *testing.T) {
 	}
 }
 
+func TestGateway_ReloadConfigRejectsInvalidStreamingPromptRegex(t *testing.T) {
+	gw, err := New(Config{
+		Strategy: StrategyConfig{
+			Mode: ModeContentBased,
+			ContentConditions: []ContentCondition{{
+				Type:      "prompt_regex",
+				Value:     `docs`,
+				TargetKey: "general-stream",
+			}},
+		},
+		Targets: []Target{{VirtualKey: "general-stream"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = gw.ReloadConfig(Config{
+		Strategy: StrategyConfig{
+			Mode: ModeContentBased,
+			ContentConditions: []ContentCondition{{
+				Type:      "prompt_regex",
+				Value:     `[invalid`,
+				TargetKey: "general-stream",
+			}},
+		},
+		Targets: []Target{{VirtualKey: "general-stream"}},
+	})
+	if err == nil {
+		t.Fatal("expected invalid regex error")
+	}
+	if !strings.Contains(err.Error(), "invalid regex") {
+		t.Fatalf("error = %v, want invalid regex", err)
+	}
+	if len(gw.streamingContent) != 1 {
+		t.Fatalf("streaming content = %d, want previous config to remain", len(gw.streamingContent))
+	}
+	if gw.streamingContent[0].Value != "docs" || gw.streamingContent[0].re == nil {
+		t.Fatalf("streaming content was replaced after invalid reload: %#v", gw.streamingContent[0])
+	}
+}
+
 func TestGateway_ReloadConfigRebuildsStreamingContentRegex(t *testing.T) {
 	gw, err := New(Config{
 		Strategy: StrategyConfig{Mode: ModeSingle},
@@ -356,6 +397,35 @@ func TestGateway_ReloadConfigRebuildsStreamingContentRegex(t *testing.T) {
 	}
 	if gw.streamingContent[1].re == nil {
 		t.Fatal("prompt_regex rule should have a compiled regex")
+	}
+}
+
+func TestStreamingContentConditionMatchesPromptRegexRequiresCompiledRegex(t *testing.T) {
+	req := providers.Request{
+		Messages: []providers.Message{{Role: "user", Content: "write docs"}},
+	}
+
+	if streamingContentConditionMatches(streamingContentCondition{
+		ContentCondition: ContentCondition{Type: "prompt_regex", Value: "docs"},
+	}, req) {
+		t.Fatal("uncompiled prompt_regex should not match")
+	}
+
+	compiled, err := compileStreamingContentConditions(ModeContentBased, []ContentCondition{{
+		Type:      "prompt_regex",
+		Value:     "docs",
+		TargetKey: "general-stream",
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !streamingContentConditionMatches(compiled[0], req) {
+		t.Fatal("compiled prompt_regex should match")
+	}
+	if streamingContentConditionMatches(streamingContentCondition{
+		ContentCondition: ContentCondition{Type: "unknown", Value: "docs"},
+	}, req) {
+		t.Fatal("unknown streaming content condition should not match")
 	}
 }
 


### PR DESCRIPTION
Fixes #45.

`RouteStream` was still compiling `prompt_regex` rules while choosing the streaming target order. This keeps a compiled copy on the gateway and refreshes it on config reload, matching the non-streaming content strategy.

Tests:
- `go test . -run TestGateway_RouteStream_ContentBasedPromptRegex -count=1 -v`
- `go test . -run "TestGateway_RouteStream|TestGateway_ReloadConfig|TestGateway_Route_NoTargets" -count=1`
- `go test ./internal/strategies -count=1`
- `go test . -count=1`