### PR TITLE
Return copied memory API keys

### DIFF
--- a/internal/admin/keys.go
+++ b/internal/admin/keys.go
@@ -38,6 +38,28 @@ func NewKeyStore() *KeyStore {
 	}
 }
 
+func cloneAPIKey(k *APIKey) *APIKey {
+	if k == nil {
+		return nil
+	}
+
+	cp := *k
+	cp.Scopes = append([]string(nil), k.Scopes...)
+	cp.RevokedAt = cloneTime(k.RevokedAt)
+	cp.ExpiresAt = cloneTime(k.ExpiresAt)
+	cp.RotatedAt = cloneTime(k.RotatedAt)
+	cp.LastUsedAt = cloneTime(k.LastUsedAt)
+	return &cp
+}
+
+func cloneTime(t *time.Time) *time.Time {
+	if t == nil {
+		return nil
+	}
+	cp := *t
+	return &cp
+}
+
 // Create generates a new API key with the given name, scopes, and optional expiration.
 func (s *KeyStore) Create(name string, scopes []string, expiresAt *time.Time) (*APIKey, error) {
 	keyBytes := make([]byte, 32)
@@ -61,9 +83,9 @@ func (s *KeyStore) Create(name string, scopes []string, expiresAt *time.Time) (*
 		ID:         id,
 		Key:        key,
 		Name:       name,
-		Scopes:     scopes,
+		Scopes:     append([]string(nil), scopes...),
 		CreatedAt:  time.Now(),
-		ExpiresAt:  expiresAt,
+		ExpiresAt:  cloneTime(expiresAt),
 		UsageCount: 0,
 		Active:     true,
 	}
@@ -72,7 +94,7 @@ func (s *KeyStore) Create(name string, scopes []string, expiresAt *time.Time) (*
 	defer s.mu.Unlock()
 	s.byID[id] = apiKey
 	s.byKey[key] = id
-	return apiKey, nil
+	return cloneAPIKey(apiKey), nil
 }
 
 // Get retrieves an API key by ID.
@@ -80,7 +102,10 @@ func (s *KeyStore) Get(id string) (*APIKey, bool) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	k, ok := s.byID[id]
-	return k, ok
+	if !ok {
+		return nil, false
+	}
+	return cloneAPIKey(k), true
 }
 
 // List returns all keys with the Key field masked.
@@ -89,11 +114,11 @@ func (s *KeyStore) List() []*APIKey {
 	defer s.mu.RUnlock()
 	keys := make([]*APIKey, 0, len(s.byID))
 	for _, k := range s.byID {
-		masked := *k
+		masked := cloneAPIKey(k)
 		if len(masked.Key) > 8 {
 			masked.Key = masked.Key[:8] + "..."
 		}
-		keys = append(keys, &masked)
+		keys = append(keys, masked)
 	}
 	return keys
 }
@@ -124,13 +149,13 @@ func (s *KeyStore) Update(id string, name string, scopes []string) (*APIKey, err
 		k.Name = name
 	}
 	if len(scopes) > 0 {
-		k.Scopes = scopes
+		k.Scopes = append([]string(nil), scopes...)
 	}
-	masked := *k
+	masked := cloneAPIKey(k)
 	if len(masked.Key) > 8 {
 		masked.Key = masked.Key[:8] + "..."
 	}
-	return &masked, nil
+	return masked, nil
 }
 
 // SetExpiration updates the expiration time for an API key.
@@ -186,7 +211,7 @@ func (s *KeyStore) RotateKey(id string) (*APIKey, error) {
 	now := time.Now()
 	k.RotatedAt = &now
 
-	return k, nil
+	return cloneAPIKey(k), nil
 }
 
 // ValidateKey looks up a key by its full string and returns it if active.
@@ -208,5 +233,5 @@ func (s *KeyStore) ValidateKey(key string) (*APIKey, bool) {
 	lastUsedAt := now
 	k.LastUsedAt = &lastUsedAt
 	k.UsageCount++
-	return k, true
+	return cloneAPIKey(k), true
 }

--- a/internal/admin/keys_test.go
+++ b/internal/admin/keys_test.go
@@ -226,3 +226,58 @@ func TestSetExpiration_StoresUTCCopyWithoutAliasing(t *testing.T) {
 		t.Fatalf("expected stored expiration %v, got %v", expectedUTC, *stored.ExpiresAt)
 	}
 }
+
+func TestGet_ReturnsDefensiveCopy(t *testing.T) {
+	store := NewKeyStore()
+	expiresAt := time.Now().Add(time.Hour)
+	created, _ := store.Create("copy-me", []string{ScopeReadOnly}, &expiresAt)
+
+	got, ok := store.Get(created.ID)
+	if !ok {
+		t.Fatal("expected key to exist")
+	}
+	got.Name = "mutated"
+	got.Scopes[0] = ScopeAdmin
+	*got.ExpiresAt = got.ExpiresAt.Add(time.Hour)
+
+	again, ok := store.Get(created.ID)
+	if !ok {
+		t.Fatal("expected key to exist")
+	}
+	if again.Name != "copy-me" {
+		t.Fatalf("stored name = %q, want copy-me", again.Name)
+	}
+	if again.Scopes[0] != ScopeReadOnly {
+		t.Fatalf("stored scope = %q, want %q", again.Scopes[0], ScopeReadOnly)
+	}
+	if !again.ExpiresAt.Equal(expiresAt.UTC()) {
+		t.Fatalf("stored expiration = %v, want %v", *again.ExpiresAt, expiresAt.UTC())
+	}
+}
+
+func TestValidateKey_ReturnsDefensiveCopy(t *testing.T) {
+	store := NewKeyStore()
+	created, _ := store.Create("validate-copy", []string{ScopeReadOnly}, nil)
+
+	validated, ok := store.ValidateKey(created.Key)
+	if !ok {
+		t.Fatal("expected key to validate")
+	}
+	validated.UsageCount = 100
+	validated.LastUsedAt = nil
+	validated.Scopes[0] = ScopeAdmin
+
+	stored, ok := store.Get(created.ID)
+	if !ok {
+		t.Fatal("expected key to exist")
+	}
+	if stored.UsageCount != 1 {
+		t.Fatalf("stored usage count = %d, want 1", stored.UsageCount)
+	}
+	if stored.LastUsedAt == nil {
+		t.Fatal("stored last-used timestamp was cleared through returned key")
+	}
+	if stored.Scopes[0] != ScopeReadOnly {
+		t.Fatalf("stored scope = %q, want %q", stored.Scopes[0], ScopeReadOnly)
+	}
+}


### PR DESCRIPTION
Fixes #183.

Summary:
- return copied API key values from the in-memory store
- copy scopes and time pointer fields so returned keys cannot mutate store state
- add regression coverage for Get and ValidateKey defensive copies

Checks:
- go test ./internal/admin -count=1
- go test ./internal/admin ./internal/middleware -count=1
- git diff --check

Notes:
- go test -race requires cgo/gcc locally; gcc is not installed in this environment.