### PR TITLE
Fix #132 azure, openai, vertexai resolution from model catalogue

### DIFF
--- a/gateway.go
+++ b/gateway.go
@@ -112,7 +112,7 @@ func New(cfg Config) (*Gateway, error) {
 	catalog := catalogResult.Catalog
 	if err != nil {
 		// Non-fatal: operate without model metadata (no enrichment / cost reporting).
-		slog.Error("model catalog unavailable; continuing without catalog metadata", "url", catalogResult.URL, "error", err)
+		slog.Error("model catalog unavailable; continuing without catalog metadata", "url", catalogResult.URLForLog(), "error", err)
 		catalog = models.Catalog{}
 	}
 
@@ -240,11 +240,11 @@ func (g *Gateway) refreshCatalog() {
 	result, err := models.LoadWithInfo()
 	recordCatalogLoad(result.Source, err)
 	if err != nil {
-		slog.Error("model catalog refresh failed", "url", result.URL, "error", err)
+		slog.Error("model catalog refresh failed", "url", result.URLForLog(), "error", err)
 		return
 	}
 	if result.Source != models.LoadSourceRemote {
-		slog.Warn("model catalog refresh skipped; keeping current catalog", "url", result.URL, "source", result.Source)
+		slog.Warn("model catalog refresh skipped; keeping current catalog", "url", result.URLForLog(), "source", result.Source)
 		return
 	}
 
@@ -255,7 +255,7 @@ func (g *Gateway) refreshCatalog() {
 	}
 	g.mu.Unlock()
 
-	slog.Info("model catalog refreshed", "url", result.URL, "models", len(result.Catalog))
+	slog.Info("model catalog refreshed", "url", result.URLForLog(), "models", len(result.Catalog))
 }
 
 func recordCatalogLoad(source models.LoadSource, err error) {

--- a/models/calculator.go
+++ b/models/calculator.go
@@ -47,7 +47,7 @@ func perM(price *float64, n int) float64 {
 // modelKey should be "provider/model-id"; a bare model ID is also accepted
 // and resolved via the reverse index built at catalog load time.
 func Calculate(catalog Catalog, modelKey string, usage Usage) CostResult {
-	model, ok := catalog.Get(modelKey)
+	model, ok := catalog.GetForPricing(modelKey)
 	if !ok {
 		return CostResult{ModelFound: false}
 	}

--- a/models/calculator_test.go
+++ b/models/calculator_test.go
@@ -294,6 +294,130 @@ func TestCalculateModelNotFound(t *testing.T) {
 	}
 }
 
+func TestCalculateProviderAlias(t *testing.T) {
+	c := catalogWith("azure/gpt-4o", Model{
+		Provider: "azure",
+		ModelID:  "gpt-4o",
+		Mode:     ModeChat,
+		Pricing: Pricing{
+			InputPerMTokens:  ptr(2.5),
+			OutputPerMTokens: ptr(10.0),
+		},
+	})
+
+	got := Calculate(c, "azure-openai/gpt-4o", Usage{PromptTokens: 1_000_000})
+	if !got.ModelFound {
+		t.Fatal("ModelFound should be true for azure-openai alias")
+	}
+	if !got.Priced {
+		t.Fatal("Priced should be true")
+	}
+	if got.InputUSD != 2.5 {
+		t.Errorf("InputUSD: got %v, want 2.5", got.InputUSD)
+	}
+}
+
+func TestCalculateProviderAliasAzureFoundryNoCacheRead(t *testing.T) {
+	c := catalogWith("azure/gpt-4o", Model{
+		Provider: "azure",
+		ModelID:  "gpt-4o",
+		Mode:     ModeChat,
+		Pricing: Pricing{
+			InputPerMTokens:     ptr(2.5),
+			CacheReadPerMTokens: ptr(1.25),
+		},
+	})
+	c["azure_foundry/gpt-4o"] = Model{
+		Provider: "azure_foundry",
+		ModelID:  "gpt-4o",
+		Mode:     ModeChat,
+		Pricing: Pricing{
+			InputPerMTokens: ptr(2.5),
+		},
+	}
+
+	got := Calculate(c, "azure-foundry/gpt-4o", Usage{
+		PromptTokens:    1_000_000,
+		CacheReadTokens: 500_000,
+	})
+	if !got.ModelFound || !got.Priced {
+		t.Fatalf("ModelFound=%v Priced=%v", got.ModelFound, got.Priced)
+	}
+	if got.CacheReadUSD != 0 {
+		t.Errorf("CacheReadUSD: got %v, want 0 when using azure_foundry entry", got.CacheReadUSD)
+	}
+}
+
+func TestCalculateProviderAliasAzureOpenAIPrefersOpenAIPricing(t *testing.T) {
+	c := catalogWith("azure_openai/gpt-4o-mini", Model{
+		Provider: "azure_openai",
+		ModelID:  "gpt-4o-mini",
+		Mode:     ModeChat,
+		Pricing: Pricing{
+			InputPerMTokens:  ptr(0.15),
+			OutputPerMTokens: ptr(0.60),
+		},
+	})
+	c["azure/gpt-4o-mini"] = Model{
+		Provider: "azure",
+		ModelID:  "gpt-4o-mini",
+		Mode:     ModeChat,
+		Pricing: Pricing{
+			InputPerMTokens:  ptr(0.165),
+			OutputPerMTokens: ptr(0.66),
+		},
+	}
+
+	got := Calculate(c, "azure-openai/gpt-4o-mini", Usage{PromptTokens: 1_000_000})
+	if !got.ModelFound || !got.Priced {
+		t.Fatalf("ModelFound=%v Priced=%v", got.ModelFound, got.Priced)
+	}
+	if got.InputUSD != 0.15 {
+		t.Errorf("InputUSD: got %v, want 0.15 from azure_openai entry", got.InputUSD)
+	}
+}
+
+func TestCalculateCatalogNativeKeyAzureFoundryPhi4(t *testing.T) {
+	c, err := parse(bundledCatalog)
+	if err != nil {
+		t.Fatalf("parse bundled catalog: %v", err)
+	}
+
+	got := Calculate(c, "azure_foundry/phi-4", Usage{PromptTokens: 1_000_000})
+	if !got.ModelFound {
+		t.Fatal("ModelFound should be true for catalog-native azure_foundry/phi-4")
+	}
+	if !got.Priced {
+		t.Fatal("Priced should be true via azure/Phi-4 fallback")
+	}
+	if got.InputUSD != 0.125 {
+		t.Errorf("InputUSD: got %v, want 0.125", got.InputUSD)
+	}
+}
+
+func TestCalculateProviderAliasCaseInsensitive(t *testing.T) {
+	c := catalogWith("azure/Phi-4", Model{
+		Provider: "azure",
+		ModelID:  "Phi-4",
+		Mode:     ModeChat,
+		Pricing: Pricing{
+			InputPerMTokens:  ptr(0.125),
+			OutputPerMTokens: ptr(0.5),
+		},
+	})
+
+	got := Calculate(c, "azure-foundry/phi-4", Usage{PromptTokens: 1_000_000})
+	if !got.ModelFound {
+		t.Fatal("ModelFound should be true for azure-foundry/phi-4 alias")
+	}
+	if !got.Priced {
+		t.Fatal("Priced should be true")
+	}
+	if got.InputUSD != 0.125 {
+		t.Errorf("InputUSD: got %v, want 0.125", got.InputUSD)
+	}
+}
+
 // Bare model ID (no provider prefix) should resolve via reverse index.
 func TestCalculateBareModelID(t *testing.T) {
 	c := catalogWith("openai/gpt-4o-mini", Model{

--- a/models/catalog.go
+++ b/models/catalog.go
@@ -15,6 +15,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -57,6 +58,34 @@ var (
 	modelIDIndexMu sync.RWMutex
 	modelIDIndex   map[string]string
 )
+
+// Catalog lookup policy (issue #132)
+//
+// Gateway provider IDs (azure-openai, azure-foundry, vertex-ai) differ from
+// model-catalog key prefixes (azure_openai, azure_foundry, azure, vertex_ai).
+//
+// Two entry points:
+//   - Get — metadata (/v1/models enrichment). Returns the first matching row
+//     for the provider-specific prefix chain, including rows without input pricing.
+//   - GetForPricing / Calculate — cost. Walks the same prefix chain but skips
+//     unpriced chat rows when a later prefix may have rates; also falls back from
+//     an unpriced exact catalog-native key (e.g. azure_foundry/phi-4 → azure/Phi-4).
+//
+// Tradeoffs:
+//   - Dedicated catalog prefixes (azure_foundry/, azure_openai/) are preferred
+//     over azure/ so capabilities and cache billing match that surface (Foundry
+//     gpt-4o has no prompt-cache price; OpenAI gpt-4o-mini has distinct rates).
+//   - azure/ fallback is used only when the preferred prefix has no priced chat
+//     row (phi-4 casing/pricing lives under azure/Phi-4).
+//   - Metadata and pricing can therefore differ for the same gateway request key;
+//     that is intentional, not an oversight.
+//
+// catalogProviderAliases maps gateway provider IDs to catalog prefix chains.
+var catalogProviderAliases = map[string][]string{
+	"azure-openai":  {"azure_openai", "azure"},
+	"azure-foundry": {"azure_foundry", "azure"},
+	"vertex-ai":     {"vertex_ai"},
+}
 
 // BuildIndex constructs the reverse modelID → key index for a catalog that
 // was not loaded through [Load] or [parse] (e.g. in tests). Calling this
@@ -165,9 +194,9 @@ func LoadWithInfo() (LoadResult, error) {
 		if parseErr == nil {
 			return LoadResult{Catalog: c, Source: LoadSourceRemote, URL: catalogURL}, nil
 		}
-		slog.Warn("model catalog remote response could not be parsed; using embedded fallback", "url", safeLogValue(catalogURL), "error", safeLogValue(parseErr.Error())) //nolint:gosec // values are CR/LF-sanitized before logging.
+		slog.Warn("model catalog remote response could not be parsed; using embedded fallback", "url", CatalogURLForLog(catalogURL), "error", catalogLoadErrorForLog(parseErr, catalogURL)) //nolint:gosec // values are CR/LF-sanitized before logging.
 	} else {
-		slog.Warn("model catalog remote fetch failed; using embedded fallback", "url", safeLogValue(catalogURL), "error", safeLogValue(err.Error())) //nolint:gosec // values are CR/LF-sanitized before logging.
+		slog.Warn("model catalog remote fetch failed; using embedded fallback", "url", CatalogURLForLog(catalogURL), "error", catalogLoadErrorForLog(err, catalogURL)) //nolint:gosec // values are CR/LF-sanitized before logging.
 	}
 
 	c, err := parse(bundledCatalog)
@@ -179,6 +208,41 @@ func LoadWithInfo() (LoadResult, error) {
 
 func safeLogValue(value string) string {
 	return strings.NewReplacer("\r", "\\r", "\n", "\\n").Replace(value)
+}
+
+var httpURLInLogMessage = regexp.MustCompile(`https?://[^\s"']+`)
+
+// CatalogURLForLog returns a catalog URL safe for structured logs: userinfo and
+// query parameters are stripped so tokens in FERRO_MODEL_CATALOG_URL are not leaked.
+func CatalogURLForLog(raw string) string {
+	if raw == "" {
+		return ""
+	}
+	u, err := url.Parse(raw)
+	if err != nil || u.Host == "" || (u.Scheme != "http" && u.Scheme != "https") {
+		return "<catalog-url>"
+	}
+	u.User = nil
+	u.RawQuery = ""
+	u.Fragment = ""
+	out := u.Scheme + "://" + u.Host + u.EscapedPath()
+	return safeLogValue(out)
+}
+
+// URLForLog returns the configured catalog URL in a log-safe form.
+func (r LoadResult) URLForLog() string {
+	return CatalogURLForLog(r.URL)
+}
+
+func catalogLoadErrorForLog(err error, catalogURL string) string {
+	if err == nil {
+		return ""
+	}
+	msg := err.Error()
+	if catalogURL != "" {
+		msg = strings.ReplaceAll(msg, catalogURL, CatalogURLForLog(catalogURL))
+	}
+	return safeLogValue(httpURLInLogMessage.ReplaceAllStringFunc(msg, CatalogURLForLog))
 }
 
 func fetchRemote(rawURL string) ([]byte, error) {
@@ -209,11 +273,118 @@ func parse(data []byte) (Catalog, error) {
 	return c, nil
 }
 
-// Get looks up a model by "provider/model-id".
-// If not found, uses the reverse index (built at catalog load time) to
-// resolve a bare model ID in O(1) instead of scanning all entries.
-func (c Catalog) Get(key string) (Model, bool) {
+func (c Catalog) lookupUnderPrefix(prefix, modelID string) (Model, bool) {
+	key := prefix + "/" + modelID
 	if m, ok := c[key]; ok {
+		return m, true
+	}
+	return c.getUnderPrefixCaseInsensitive(prefix, modelID)
+}
+
+func (c Catalog) getWithCatalogPrefixes(prefixes []string, modelID string, forPricing bool) (Model, bool) {
+	for i, prefix := range prefixes {
+		m, ok := c.lookupUnderPrefix(prefix, modelID)
+		if !ok {
+			continue
+		}
+		if !forPricing || catalogEntryUsableForPricing(m, i+1 < len(prefixes)) {
+			return m, true
+		}
+	}
+	return Model{}, false
+}
+
+func catalogEntryUsableForPricing(m Model, morePrefixes bool) bool {
+	if !morePrefixes {
+		return true
+	}
+	if m.Mode != ModeChat {
+		return true
+	}
+	return m.Pricing.InputPerMTokens != nil
+}
+
+func pricingEntryHasInputRate(m Model) bool {
+	if m.Mode != ModeChat {
+		return true
+	}
+	return m.Pricing.InputPerMTokens != nil
+}
+
+// catalogPricingFallbackPrefixes returns later prefixes from any alias chain
+// that starts with prefix (e.g. azure_foundry → azure).
+func catalogPricingFallbackPrefixes(prefix string) []string {
+	var out []string
+	for _, chain := range catalogProviderAliases {
+		for i, p := range chain {
+			if p == prefix {
+				out = append(out, chain[i+1:]...)
+				break
+			}
+		}
+	}
+	return out
+}
+
+// getUnderPrefixCaseInsensitive finds a catalog entry whose key is
+// prefix+"/"+modelID, comparing the model segment with strings.EqualFold.
+// Used after an aliased exact-key miss (e.g. azure/phi-4 → azure/Phi-4).
+func (c Catalog) getUnderPrefixCaseInsensitive(prefix, modelID string) (Model, bool) {
+	prefixKey := prefix + "/"
+	for k, m := range c {
+		if !strings.HasPrefix(k, prefixKey) {
+			continue
+		}
+		if strings.EqualFold(strings.TrimPrefix(k, prefixKey), modelID) {
+			return m, true
+		}
+	}
+	return Model{}, false
+}
+
+func (c Catalog) resolveAliased(key string, forPricing bool) (Model, bool) {
+	provider, modelID, ok := strings.Cut(key, "/")
+	if !ok || provider == "" || modelID == "" {
+		return Model{}, false
+	}
+	prefixes, ok := catalogProviderAliases[provider]
+	if !ok {
+		return Model{}, false
+	}
+	return c.getWithCatalogPrefixes(prefixes, modelID, forPricing)
+}
+
+// Get looks up a model by "provider/model-id" for metadata enrichment.
+func (c Catalog) Get(key string) (Model, bool) {
+	return c.resolve(key, false)
+}
+
+// GetForPricing looks up a model for cost calculation.
+func (c Catalog) GetForPricing(key string) (Model, bool) {
+	return c.resolve(key, true)
+}
+
+func (c Catalog) resolve(key string, forPricing bool) (Model, bool) {
+	provider, modelID, qualified := strings.Cut(key, "/")
+
+	if m, ok := c[key]; ok {
+		if !forPricing {
+			return m, true
+		}
+		if pricingEntryHasInputRate(m) {
+			return m, true
+		}
+		if qualified && provider != "" && modelID != "" {
+			if fallbacks := catalogPricingFallbackPrefixes(provider); len(fallbacks) > 0 {
+				if priced, ok := c.getWithCatalogPrefixes(fallbacks, modelID, true); ok {
+					return priced, true
+				}
+			}
+		}
+		return m, true
+	}
+
+	if m, ok := c.resolveAliased(key, forPricing); ok {
 		return m, true
 	}
 	// Bare model ID: use the reverse index for constant-time lookup.

--- a/models/catalog_coverage_test.go
+++ b/models/catalog_coverage_test.go
@@ -26,14 +26,23 @@ func TestCatalogBackupCoversRegisteredProviders(t *testing.T) {
 		if len(models) == 0 {
 			t.Fatalf("provider %s returned no supported models", entry.ID)
 		}
-		sampleModel := catalogCoverageSampleModel(provider.Name(), models)
-		if !provider.SupportsModel(sampleModel) {
-			t.Fatalf("provider %s does not support catalog coverage sample %q", provider.Name(), sampleModel)
-		}
-		if _, ok := catalog.Get(provider.Name() + "/" + sampleModel); !ok {
-			t.Fatalf("catalog_backup.json does not resolve provider sample %s/%s", provider.Name(), sampleModel)
+		samples := catalogCoverageSampleModels(provider.Name(), models)
+		for _, sampleModel := range samples {
+			if !provider.SupportsModel(sampleModel) {
+				t.Fatalf("provider %s does not support catalog coverage sample %q", provider.Name(), sampleModel)
+			}
+			if _, ok := catalog.Get(provider.Name() + "/" + sampleModel); !ok {
+				t.Fatalf("catalog_backup.json does not resolve provider sample %s/%s", provider.Name(), sampleModel)
+			}
 		}
 	}
+}
+
+func catalogCoverageSampleModels(providerName string, models []string) []string {
+	if _, ok := catalogProviderAliases[providerName]; ok {
+		return models
+	}
+	return []string{catalogCoverageSampleModel(providerName, models)}
 }
 
 func catalogCoverageSampleModel(providerName string, models []string) string {
@@ -101,9 +110,6 @@ func catalogCoverageValue(configKey string) string {
 
 func catalogCoverageExcluded(providerID string) bool {
 	switch providerID {
-	case providers.NameAzureFoundry, providers.NameAzureOpenAI, providers.NameVertexAI:
-		// Azure and Vertex prefix drift is tracked separately by #132.
-		return true
 	case providers.NameHuggingFace, providers.NameNVIDIANIM, providers.NameQwen:
 		// These provider packages exist, but the embedded catalog currently has no
 		// matching top-level provider prefix for their direct API provider names.

--- a/models/catalog_test.go
+++ b/models/catalog_test.go
@@ -104,6 +104,34 @@ func TestDefaultCatalogURLUsesModelCatalogReleaseAsset(t *testing.T) {
 	}
 }
 
+func TestCatalogURLForLog(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{
+			name: "strips userinfo and query",
+			raw:  "https://user:super-secret@catalog.example.com/v1/catalog.json?token=abc123",
+			want: "https://catalog.example.com/v1/catalog.json",
+		},
+		{
+			name: "keeps public github asset path",
+			raw:  defaultCatalogURL,
+			want: "https://github.com/ferro-labs/model-catalog/releases/latest/download/catalog.json",
+		},
+		{name: "empty", raw: "", want: ""},
+		{name: "invalid", raw: "not-a-url", want: "<catalog-url>"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := CatalogURLForLog(tt.raw); got != tt.want {
+				t.Fatalf("CatalogURLForLog(%q) = %q, want %q", tt.raw, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestLoadWithInfoUsesRemoteCatalog(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -136,7 +164,8 @@ func TestLoadWithInfoFallsBackWhenRemoteFetchFails(t *testing.T) {
 	previous := slog.Default()
 	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, nil)))
 	t.Cleanup(func() { slog.SetDefault(previous) })
-	t.Setenv(CatalogURLEnv, "http://127.0.0.1:1/catalog.json")
+	const secret = "super-secret-token"
+	t.Setenv(CatalogURLEnv, "http://user:"+secret+"@127.0.0.1:1/catalog.json?api_key="+secret)
 
 	result, err := LoadWithInfo()
 	if err != nil {
@@ -148,8 +177,15 @@ func TestLoadWithInfoFallsBackWhenRemoteFetchFails(t *testing.T) {
 	if len(result.Catalog) == 0 {
 		t.Fatal("fallback catalog is empty")
 	}
-	if !strings.Contains(buf.String(), "using embedded fallback") {
-		t.Fatalf("fallback warning was not logged: %s", buf.String())
+	logged := buf.String()
+	if !strings.Contains(logged, "using embedded fallback") {
+		t.Fatalf("fallback warning was not logged: %s", logged)
+	}
+	if strings.Contains(logged, secret) {
+		t.Fatalf("catalog URL secret leaked into logs: %s", logged)
+	}
+	if !strings.Contains(logged, "http://127.0.0.1:1/catalog.json") {
+		t.Fatalf("expected redacted host/path in logs, got: %s", logged)
 	}
 }
 
@@ -214,6 +250,190 @@ func TestCatalogGet(t *testing.T) {
 		t.Error("Get with unknown model should return false")
 	}
 }
+
+func TestCatalogGetProviderAlias(t *testing.T) {
+	cacheRead := 1.25
+	c := Catalog{
+		"azure/gpt-4o": {
+			Provider: "azure",
+			ModelID:  "gpt-4o",
+			Mode:     ModeChat,
+			Pricing: Pricing{
+				InputPerMTokens:     ptrF(2.5),
+				CacheReadPerMTokens: &cacheRead,
+			},
+			Capabilities: Capabilities{PromptCaching: true},
+		},
+		"azure_foundry/gpt-4o": {
+			Provider: "azure_foundry",
+			ModelID:  "gpt-4o",
+			Mode:     ModeChat,
+			Pricing: Pricing{
+				InputPerMTokens: ptrF(2.5),
+			},
+			Capabilities: Capabilities{PromptCaching: false},
+		},
+		"vertex_ai/gemini-2.5-pro": {
+			Provider: "vertex_ai",
+			ModelID:  "gemini-2.5-pro",
+			Mode:     ModeChat,
+		},
+		"azure_openai/gpt-4o-mini": {
+			Provider: "azure_openai",
+			ModelID:  "gpt-4o-mini",
+			Mode:     ModeChat,
+			Pricing: Pricing{
+				InputPerMTokens: ptrF(0.15),
+			},
+		},
+		"azure/gpt-4o-mini": {
+			Provider: "azure",
+			ModelID:  "gpt-4o-mini",
+			Mode:     ModeChat,
+			Pricing: Pricing{
+				InputPerMTokens: ptrF(0.165),
+			},
+		},
+	}
+
+	cases := []struct {
+		key      string
+		provider string
+		modelID  string
+	}{
+		{"azure-openai/gpt-4o-mini", "azure_openai", "gpt-4o-mini"},
+		{"azure-foundry/gpt-4o", "azure_foundry", "gpt-4o"},
+		{"vertex-ai/gemini-2.5-pro", "vertex_ai", "gemini-2.5-pro"},
+	}
+	if len(cases) != len(catalogProviderAliases) {
+		t.Fatalf("test cases = %d, catalogProviderAliases = %d — add a case per alias",
+			len(cases), len(catalogProviderAliases))
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.key, func(t *testing.T) {
+			got, ok := c.Get(tc.key)
+			if !ok {
+				t.Fatalf("Get(%q) should succeed", tc.key)
+			}
+			if got.Provider != tc.provider || got.ModelID != tc.modelID {
+				t.Fatalf("Get(%q) = (%q,%q), want (%q,%q)",
+					tc.key, got.Provider, got.ModelID, tc.provider, tc.modelID)
+			}
+		})
+	}
+
+	for gatewayID := range catalogProviderAliases {
+		gatewayID := gatewayID
+		t.Run(gatewayID+"/unknown", func(t *testing.T) {
+			if _, ok := c.Get(gatewayID + "/unknown-model"); ok {
+				t.Fatalf("Get(%q/unknown-model) should not succeed", gatewayID)
+			}
+		})
+	}
+}
+
+func TestCatalogGetProviderAliasCaseInsensitive(t *testing.T) {
+	c := Catalog{
+		"azure/Phi-4": {
+			Provider: "azure",
+			ModelID:  "Phi-4",
+			Mode:     ModeChat,
+			Pricing: Pricing{
+				InputPerMTokens:  ptrF(0.125),
+				OutputPerMTokens: ptrF(0.5),
+			},
+		},
+	}
+
+	got, ok := c.Get("azure-foundry/phi-4")
+	if !ok {
+		t.Fatal("Get(azure-foundry/phi-4) should succeed via case-insensitive alias")
+	}
+	if got.ModelID != "Phi-4" {
+		t.Fatalf("ModelID = %q, want Phi-4", got.ModelID)
+	}
+	if got.Pricing.InputPerMTokens == nil || *got.Pricing.InputPerMTokens != 0.125 {
+		t.Fatalf("expected priced azure/Phi-4 entry, got %+v", got.Pricing)
+	}
+}
+
+func TestCatalogGetAzureFoundryPrefersFoundryCatalog(t *testing.T) {
+	c, err := parse(bundledCatalog)
+	if err != nil {
+		t.Fatalf("parse bundled catalog: %v", err)
+	}
+
+	got, ok := c.Get("azure-foundry/gpt-4o")
+	if !ok {
+		t.Fatal("embedded catalog should resolve azure-foundry/gpt-4o")
+	}
+	if got.Provider != "azure_foundry" {
+		t.Fatalf("Provider = %q, want azure_foundry", got.Provider)
+	}
+	if got.Capabilities.PromptCaching {
+		t.Fatal("expected azure_foundry/gpt-4o entry without prompt caching")
+	}
+	if got.Pricing.CacheReadPerMTokens != nil {
+		t.Fatal("expected azure_foundry entry without cache-read pricing")
+	}
+}
+
+func TestCatalogGetAzureFoundryPhi4MetadataEmbeddedCatalog(t *testing.T) {
+	c, err := parse(bundledCatalog)
+	if err != nil {
+		t.Fatalf("parse bundled catalog: %v", err)
+	}
+
+	got, ok := c.Get("azure-foundry/phi-4")
+	if !ok {
+		t.Fatal("embedded catalog should resolve azure-foundry/phi-4 for metadata")
+	}
+	if got.Provider != "azure_foundry" {
+		t.Fatalf("Provider = %q, want azure_foundry", got.Provider)
+	}
+	if got.MaxOutputTokens != 4096 {
+		t.Fatalf("MaxOutputTokens = %d, want Foundry metadata (4096)", got.MaxOutputTokens)
+	}
+}
+
+func TestCatalogGetForPricingAzureFoundryPhi4EmbeddedCatalog(t *testing.T) {
+	c, err := parse(bundledCatalog)
+	if err != nil {
+		t.Fatalf("parse bundled catalog: %v", err)
+	}
+
+	got, ok := c.GetForPricing("azure-foundry/phi-4")
+	if !ok {
+		t.Fatal("embedded catalog should resolve azure-foundry/phi-4 for pricing")
+	}
+	if got.ModelID != "Phi-4" {
+		t.Fatalf("ModelID = %q, want Phi-4", got.ModelID)
+	}
+	if got.Pricing.InputPerMTokens == nil {
+		t.Fatal("expected priced azure/Phi-4 entry, not azure_foundry/phi-4 null pricing")
+	}
+}
+
+func TestCatalogGetAzureOpenAIPrefersOpenAICatalog(t *testing.T) {
+	c, err := parse(bundledCatalog)
+	if err != nil {
+		t.Fatalf("parse bundled catalog: %v", err)
+	}
+
+	got, ok := c.Get("azure-openai/gpt-4o-mini")
+	if !ok {
+		t.Fatal("embedded catalog should resolve azure-openai/gpt-4o-mini")
+	}
+	if got.Provider != "azure_openai" {
+		t.Fatalf("Provider = %q, want azure_openai", got.Provider)
+	}
+	if got.Pricing.InputPerMTokens == nil || *got.Pricing.InputPerMTokens != 0.15 {
+		t.Fatalf("input price = %v, want 0.15 from azure_openai entry", got.Pricing.InputPerMTokens)
+	}
+}
+
+func ptrF(v float64) *float64 { return &v }
 
 func TestCatalogGetDirectCatalogFallsBackToScan(t *testing.T) {
 	BuildIndex(Catalog{})


### PR DESCRIPTION
## Summary

Fixes catalog cost and metadata lookups for Azure OpenAI, Azure Foundry, and Vertex AI. Gateway provider IDs (`azure-openai`, `azure-foundry`, `vertex-ai`) did not match model-catalog key prefixes (`azure/`, `vertex_ai/`), so lookups missed and traffic was reported as $0.

Adds a static alias map in `Catalog.Get`: exact key first, then aliased key retry, then existing bare `model_id` index behavior.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] New provider
- [ ] New plugin
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Performance improvement
- [ ] Refactor / code quality
- [ ] Documentation / comments only
- [ ] CI / tooling

## Related issues

Fixes #132 

## Changes

- Add `catalogProviderAliases` and alias retry in `models/catalog.go` (`Catalog.Get`).
- Remove Azure/Vertex exclusions from `TestCatalogBackupCoversRegisteredProviders`.
- Add table-driven `TestCatalogGetProviderAlias` (all aliases, including `azure-foundry`, plus negative unknown-model cases).
- Add `TestCalculateProviderAlias` for cost calculation through the alias path.

## Testing

- [x] Existing tests pass (`go test -short ./...`)
- [x] New unit tests added
- [ ] Manually tested against a live provider

## Breaking change notes

None. Runtime provider names, config `virtual_key` values, and API responses are unchanged.