### PR TITLE
Return copied API keys from memory store

### DIFF
--- a/internal/admin/keys.go
+++ b/internal/admin/keys.go
@@ -80,7 +80,10 @@ func (s *KeyStore) Get(id string) (*APIKey, bool) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	k, ok := s.byID[id]
-	return k, ok
+	if !ok {
+		return nil, false
+	}
+	return cloneAPIKey(k), true
 }
 
 // List returns all keys with the Key field masked.
@@ -208,5 +211,26 @@ func (s *KeyStore) ValidateKey(key string) (*APIKey, bool) {
 	lastUsedAt := now
 	k.LastUsedAt = &lastUsedAt
 	k.UsageCount++
-	return k, true
+	return cloneAPIKey(k), true
+}
+
+func cloneAPIKey(k *APIKey) *APIKey {
+	if k == nil {
+		return nil
+	}
+	cp := *k
+	cp.Scopes = append([]string(nil), k.Scopes...)
+	cp.RevokedAt = cloneTime(k.RevokedAt)
+	cp.ExpiresAt = cloneTime(k.ExpiresAt)
+	cp.RotatedAt = cloneTime(k.RotatedAt)
+	cp.LastUsedAt = cloneTime(k.LastUsedAt)
+	return &cp
+}
+
+func cloneTime(t *time.Time) *time.Time {
+	if t == nil {
+		return nil
+	}
+	cp := *t
+	return &cp
 }

--- a/internal/admin/keys_test.go
+++ b/internal/admin/keys_test.go
@@ -39,6 +39,38 @@ func TestGet_Existing(t *testing.T) {
 	}
 }
 
+func TestGet_ReturnsCopy(t *testing.T) {
+	store := NewKeyStore()
+	created, _ := store.Create("copy-key", []string{ScopeAdmin}, nil)
+
+	got, ok := store.Get(created.ID)
+	if !ok {
+		t.Fatal("expected to find key")
+	}
+	got.Name = "changed"
+	got.Scopes[0] = ScopeReadOnly
+	got.UsageCount = 99
+	now := time.Now()
+	got.LastUsedAt = &now
+
+	stored, ok := store.Get(created.ID)
+	if !ok {
+		t.Fatal("expected key to still exist")
+	}
+	if stored.Name != "copy-key" {
+		t.Fatalf("stored name = %q, want copy-key", stored.Name)
+	}
+	if stored.Scopes[0] != ScopeAdmin {
+		t.Fatalf("stored scope = %q, want %q", stored.Scopes[0], ScopeAdmin)
+	}
+	if stored.UsageCount != 0 {
+		t.Fatalf("stored usage_count = %d, want 0", stored.UsageCount)
+	}
+	if stored.LastUsedAt != nil {
+		t.Fatalf("stored last_used_at = %v, want nil", stored.LastUsedAt)
+	}
+}
+
 func TestGet_NonExisting(t *testing.T) {
 	store := NewKeyStore()
 	_, ok := store.Get("does-not-exist")
@@ -147,6 +179,33 @@ func TestValidateKey_IncrementsUsage(t *testing.T) {
 	}
 	if second.UsageCount != 2 {
 		t.Fatalf("expected usage_count 2, got %d", second.UsageCount)
+	}
+}
+
+func TestValidateKey_ReturnsCopy(t *testing.T) {
+	store := NewKeyStore()
+	created, _ := store.Create("validate-copy", []string{ScopeAdmin}, nil)
+
+	validated, ok := store.ValidateKey(created.Key)
+	if !ok {
+		t.Fatal("expected key to validate")
+	}
+	validated.Scopes[0] = ScopeReadOnly
+	validated.UsageCount = 100
+	validated.LastUsedAt = nil
+
+	stored, ok := store.Get(created.ID)
+	if !ok {
+		t.Fatal("expected key to still exist")
+	}
+	if stored.Scopes[0] != ScopeAdmin {
+		t.Fatalf("stored scope = %q, want %q", stored.Scopes[0], ScopeAdmin)
+	}
+	if stored.UsageCount != 1 {
+		t.Fatalf("stored usage_count = %d, want 1", stored.UsageCount)
+	}
+	if stored.LastUsedAt == nil {
+		t.Fatal("stored last_used_at = nil, want validation timestamp")
 	}
 }
 


### PR DESCRIPTION
Fixes #183.

The memory-backed key store was returning the map entry directly from `Get`, and `ValidateKey` returned the same entry after updating usage metadata. Callers could then read or mutate that struct outside the store lock.

This returns a cloned `APIKey` from both paths, including the time pointer fields and scopes slice.

Tested on Windows:
```sh
go test ./internal/admin -run "Test(Get_ReturnsCopy|ValidateKey_ReturnsCopy)$" -count=1 -v
go test ./internal/admin -count=1
```

I also tried `go test ./...`; this local Windows run fails in existing SQLite temp cleanup tests under `cmd/ferrogw` and `internal/bootstrap` because the db file is still locked during `TempDir` cleanup. `go test -race` could not build here because cgo needs `gcc`, which is not installed.