### PR TITLE
Respect latency and cost order for streams

### DIFF
--- a/config.go
+++ b/config.go
@@ -143,6 +143,12 @@ const (
 	ModeABTest        StrategyMode = "ab-test"
 )
 
+const (
+	unpricedStrategyFallback = "fallback"
+	unpricedStrategySkip     = "skip"
+	unpricedStrategyAllow    = "allow"
+)
+
 // Condition represents a condition for conditional routing.
 type Condition struct {
 	Key       string `json:"key" yaml:"key"`

--- a/config_load.go
+++ b/config_load.go
@@ -69,7 +69,7 @@ func ValidateConfig(cfg Config) error {
 
 	if mode == ModeCostOptimized {
 		switch cfg.Strategy.UnpricedStrategy {
-		case "", "fallback", "skip", "allow":
+		case "", unpricedStrategyFallback, unpricedStrategySkip, unpricedStrategyAllow:
 		default:
 			return fmt.Errorf("cost-optimized unpriced_strategy must be one of fallback, skip, allow")
 		}

--- a/config_load_test.go
+++ b/config_load_test.go
@@ -41,8 +41,8 @@ func TestLoadConfig_CostOptimizedUnpricedStrategy(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if cfg.Strategy.UnpricedStrategy != "skip" {
-		t.Errorf("expected unpriced_strategy %q, got %q", "skip", cfg.Strategy.UnpricedStrategy)
+	if cfg.Strategy.UnpricedStrategy != unpricedStrategySkip {
+		t.Errorf("expected unpriced_strategy %q, got %q", unpricedStrategySkip, cfg.Strategy.UnpricedStrategy)
 	}
 }
 
@@ -132,8 +132,8 @@ func TestValidateConfig_CostOptimizedUnpricedStrategy(t *testing.T) {
 	}{
 		{name: "default"},
 		{name: "fallback", unpricedStrategy: "fallback"},
-		{name: "skip", unpricedStrategy: "skip"},
-		{name: "allow", unpricedStrategy: "allow"},
+		{name: "skip", unpricedStrategy: unpricedStrategySkip},
+		{name: "allow", unpricedStrategy: unpricedStrategyAllow},
 		{name: "invalid", unpricedStrategy: "free", wantValidationErr: true},
 	}
 

--- a/gateway.go
+++ b/gateway.go
@@ -20,6 +20,7 @@ import (
 	"regexp"
 	"runtime"
 	"runtime/trace"
+	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -1447,6 +1448,10 @@ func (g *Gateway) streamingTargetOrderLocked(req providers.Request) []string {
 			keys = append(keys, targets[(startIdx+i)%len(targets)].VirtualKey)
 		}
 		return keys
+	case ModeLatency:
+		return g.streamingLatencyOrderLocked(targets, req)
+	case ModeCostOptimized:
+		return g.streamingCostOrderLocked(targets, req)
 	default:
 		keys := make([]string, 0, len(targets))
 		for _, t := range targets {
@@ -1454,6 +1459,154 @@ func (g *Gateway) streamingTargetOrderLocked(req providers.Request) []string {
 		}
 		return keys
 	}
+}
+
+type streamingLatencyCandidate struct {
+	key        string
+	p50        time.Duration
+	hasSamples bool
+}
+
+func (g *Gateway) streamingLatencyOrderLocked(targets []Target, req providers.Request) []string {
+	var unseen []streamingLatencyCandidate
+	var sampled []streamingLatencyCandidate
+	for _, t := range targets {
+		if !g.isStreamingTargetCandidateLocked(t, req.Model) {
+			continue
+		}
+		candidate := streamingLatencyCandidate{
+			key:        t.VirtualKey,
+			p50:        g.latencyTracker.P50(t.VirtualKey),
+			hasSamples: g.latencyTracker.HasSamples(t.VirtualKey),
+		}
+		if candidate.hasSamples {
+			sampled = append(sampled, candidate)
+		} else {
+			unseen = append(unseen, candidate)
+		}
+	}
+
+	if len(unseen) == 0 && len(sampled) == 0 {
+		return targetKeys(targets)
+	}
+
+	if len(unseen) > 1 {
+		rand.Shuffle(len(unseen), func(i, j int) {
+			unseen[i], unseen[j] = unseen[j], unseen[i]
+		}) //nolint:gosec
+	}
+	sort.SliceStable(sampled, func(i, j int) bool {
+		return sampled[i].p50 < sampled[j].p50
+	})
+
+	keys := make([]string, 0, len(targets))
+	for _, candidate := range unseen {
+		keys = appendUniqueKey(keys, candidate.key)
+	}
+	for _, candidate := range sampled {
+		keys = appendUniqueKey(keys, candidate.key)
+	}
+	return appendRemainingTargetKeys(keys, targets)
+}
+
+type streamingCostCandidate struct {
+	key        string
+	costUSD    float64
+	hasPrice   bool
+	modelFound bool
+}
+
+func (g *Gateway) streamingCostOrderLocked(targets []Target, req providers.Request) []string {
+	estimatedPromptTokens := estimatePromptTokens(req)
+	candidates := make([]streamingCostCandidate, 0, len(targets))
+	for _, t := range targets {
+		if !g.isStreamingTargetCandidateLocked(t, req.Model) {
+			continue
+		}
+		result := models.Calculate(g.catalog, t.VirtualKey+"/"+req.Model, models.Usage{
+			PromptTokens: estimatedPromptTokens,
+		})
+		candidates = append(candidates, streamingCostCandidate{
+			key:        t.VirtualKey,
+			costUSD:    result.InputUSD,
+			hasPrice:   result.Priced,
+			modelFound: result.ModelFound,
+		})
+	}
+	if len(candidates) == 0 {
+		return targetKeys(targets)
+	}
+
+	ranked := make([]streamingCostCandidate, 0, len(candidates))
+	switch g.config.Strategy.UnpricedStrategy {
+	case unpricedStrategyAllow:
+		for _, candidate := range candidates {
+			if candidate.modelFound {
+				ranked = append(ranked, candidate)
+			}
+		}
+	case unpricedStrategySkip:
+		for _, candidate := range candidates {
+			if candidate.modelFound && candidate.hasPrice {
+				ranked = append(ranked, candidate)
+			}
+		}
+	default:
+		for _, candidate := range candidates {
+			if candidate.modelFound && candidate.hasPrice {
+				ranked = append(ranked, candidate)
+			}
+		}
+	}
+
+	if len(ranked) == 0 {
+		return targetKeys(targets)
+	}
+
+	sort.SliceStable(ranked, func(i, j int) bool {
+		return ranked[i].costUSD < ranked[j].costUSD
+	})
+
+	keys := make([]string, 0, len(targets))
+	for _, candidate := range ranked {
+		keys = appendUniqueKey(keys, candidate.key)
+	}
+	for _, candidate := range candidates {
+		keys = appendUniqueKey(keys, candidate.key)
+	}
+	return appendRemainingTargetKeys(keys, targets)
+}
+
+func (g *Gateway) isStreamingTargetCandidateLocked(t Target, model string) bool {
+	p, ok := g.providers[t.VirtualKey]
+	if !ok || !p.SupportsModel(model) {
+		return false
+	}
+	_, ok = p.(providers.StreamProvider)
+	return ok
+}
+
+func estimatePromptTokens(req providers.Request) int {
+	promptChars := 0
+	for _, msg := range req.Messages {
+		promptChars += len(msg.Content)
+	}
+	return promptChars/4 + 1
+}
+
+func targetKeys(targets []Target) []string {
+	keys := make([]string, 0, len(targets))
+	for _, t := range targets {
+		keys = append(keys, t.VirtualKey)
+	}
+	return keys
+}
+
+func appendRemainingTargetKeys(keys []string, targets []Target) []string {
+	for _, t := range targets {
+		keys = appendUniqueKey(keys, t.VirtualKey)
+	}
+	return keys
 }
 
 func (g *Gateway) rebuildModelIndexesLocked() {

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -656,6 +656,64 @@ func TestGateway_StreamingLatencyOrderFallsBackWithoutStreamingCandidates(t *tes
 	requireKeys(t, got, "plain", "unsupported", "missing")
 }
 
+func TestGateway_StreamingLatencyOrderTriesUnseenBeforeSampled(t *testing.T) {
+	gw, err := New(Config{
+		Strategy: StrategyConfig{Mode: ModeLatency},
+		Targets: []Target{
+			{VirtualKey: "unseen-a"},
+			{VirtualKey: "sampled"},
+			{VirtualKey: "unseen-b"},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	gw.RegisterProvider(&mockStreamProvider{
+		mockProvider: mockProvider{name: "unseen-a", models: []string{"gpt-4o"}},
+	})
+	gw.RegisterProvider(&mockStreamProvider{
+		mockProvider: mockProvider{name: "sampled", models: []string{"gpt-4o"}},
+	})
+	gw.RegisterProvider(&mockStreamProvider{
+		mockProvider: mockProvider{name: "unseen-b", models: []string{"gpt-4o"}},
+	})
+	gw.latencyTracker.Record("sampled", 10*time.Millisecond)
+
+	got := gw.streamingLatencyOrderLocked(gw.config.Targets, providers.Request{Model: "gpt-4o"})
+	if got[2] != "sampled" {
+		t.Fatalf("got keys %v, want sampled provider after unseen providers", got)
+	}
+	firstTwoUnseen := (got[0] == "unseen-a" && got[1] == "unseen-b") ||
+		(got[0] == "unseen-b" && got[1] == "unseen-a")
+	if !firstTwoUnseen {
+		t.Fatalf("got keys %v, want unseen providers first", got)
+	}
+}
+
+func TestGateway_StreamingCostOrderFallsBackWithoutStreamingCandidates(t *testing.T) {
+	gw, err := New(Config{
+		Strategy: StrategyConfig{Mode: ModeCostOptimized},
+		Targets: []Target{
+			{VirtualKey: "plain"},
+			{VirtualKey: "unsupported"},
+			{VirtualKey: "missing"},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	gw.RegisterProvider(&mockProvider{
+		name:   "plain",
+		models: []string{"gpt-4o"},
+	})
+	gw.RegisterProvider(&mockStreamProvider{
+		mockProvider: mockProvider{name: "unsupported", models: []string{"other-model"}},
+	})
+
+	got := gw.streamingCostOrderLocked(gw.config.Targets, providers.Request{Model: "gpt-4o"})
+	requireKeys(t, got, "plain", "unsupported", "missing")
+}
+
 func TestGateway_RouteStream_ImmediateFailure_IncrementsProviderErrors(t *testing.T) {
 	gw, _ := New(Config{
 		Strategy: StrategyConfig{Mode: ModeSingle},

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -88,6 +88,15 @@ func counterValue(t *testing.T, c prometheus.Counter) float64 {
 
 func ptrFloat64(v float64) *float64 { return &v }
 
+func drainStream(t *testing.T, ch <-chan providers.StreamChunk) {
+	t.Helper()
+	for chunk := range ch {
+		if chunk.Error != nil {
+			t.Fatalf("stream chunk error: %v", chunk.Error)
+		}
+	}
+}
+
 func TestGateway_Route_Single(t *testing.T) {
 	gw, _ := New(Config{
 		Strategy: StrategyConfig{Mode: ModeSingle},
@@ -150,12 +159,12 @@ func TestGateway_Route_CostOptimizedPassesUnpricedStrategy(t *testing.T) {
 	}{
 		{
 			name:             "skip routes to priced provider",
-			unpricedStrategy: "skip",
+			unpricedStrategy: unpricedStrategySkip,
 			wantProvider:     "priced",
 		},
 		{
 			name:             "allow routes to unpriced provider",
-			unpricedStrategy: "allow",
+			unpricedStrategy: unpricedStrategyAllow,
 			wantProvider:     "unpriced",
 		},
 	}
@@ -427,6 +436,84 @@ func TestStreamingContentConditionMatchesPromptRegexRequiresCompiledRegex(t *tes
 	}, req) {
 		t.Fatal("unknown streaming content condition should not match")
 	}
+}
+
+func TestGateway_RouteStream_LeastLatencyUsesObservedP50(t *testing.T) {
+	gw, err := New(Config{
+		Strategy: StrategyConfig{Mode: ModeLatency},
+		Targets: []Target{
+			{VirtualKey: "slow"},
+			{VirtualKey: "fast"},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	gw.RegisterProvider(&mockStreamProvider{
+		mockProvider: mockProvider{name: "slow", models: []string{"gpt-4o"}},
+		streamErr:    errors.New("slow provider selected"),
+	})
+	gw.RegisterProvider(&mockStreamProvider{
+		mockProvider: mockProvider{name: "fast", models: []string{"gpt-4o"}},
+	})
+	gw.latencyTracker.Record("slow", 120*time.Millisecond)
+	gw.latencyTracker.Record("fast", 10*time.Millisecond)
+
+	ch, err := gw.RouteStream(context.Background(), providers.Request{
+		Model:    "gpt-4o",
+		Messages: []providers.Message{{Role: "user", Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("RouteStream error = %v, want fast provider", err)
+	}
+	drainStream(t, ch)
+}
+
+func TestGateway_RouteStream_CostOptimizedUsesCatalogCost(t *testing.T) {
+	gw, err := New(Config{
+		Strategy: StrategyConfig{Mode: ModeCostOptimized},
+		Targets: []Target{
+			{VirtualKey: "expensive"},
+			{VirtualKey: "cheap"},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	gw.catalog = models.Catalog{
+		"expensive/gpt-4o": {
+			Provider: "expensive",
+			ModelID:  "gpt-4o",
+			Mode:     models.ModeChat,
+			Pricing: models.Pricing{
+				InputPerMTokens: ptrFloat64(10),
+			},
+		},
+		"cheap/gpt-4o": {
+			Provider: "cheap",
+			ModelID:  "gpt-4o",
+			Mode:     models.ModeChat,
+			Pricing: models.Pricing{
+				InputPerMTokens: ptrFloat64(1),
+			},
+		},
+	}
+	gw.RegisterProvider(&mockStreamProvider{
+		mockProvider: mockProvider{name: "expensive", models: []string{"gpt-4o"}},
+		streamErr:    errors.New("expensive provider selected"),
+	})
+	gw.RegisterProvider(&mockStreamProvider{
+		mockProvider: mockProvider{name: "cheap", models: []string{"gpt-4o"}},
+	})
+
+	ch, err := gw.RouteStream(context.Background(), providers.Request{
+		Model:    "gpt-4o",
+		Messages: []providers.Message{{Role: "user", Content: "hello world"}},
+	})
+	if err != nil {
+		t.Fatalf("RouteStream error = %v, want cheap provider", err)
+	}
+	drainStream(t, ch)
 }
 
 func TestGateway_RouteStream_ImmediateFailure_IncrementsProviderErrors(t *testing.T) {

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -97,6 +97,18 @@ func drainStream(t *testing.T, ch <-chan providers.StreamChunk) {
 	}
 }
 
+func requireKeys(t *testing.T, got []string, want ...string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("got keys %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("got keys %v, want %v", got, want)
+		}
+	}
+}
+
 func TestGateway_Route_Single(t *testing.T) {
 	gw, _ := New(Config{
 		Strategy: StrategyConfig{Mode: ModeSingle},
@@ -514,6 +526,134 @@ func TestGateway_RouteStream_CostOptimizedUsesCatalogCost(t *testing.T) {
 		t.Fatalf("RouteStream error = %v, want cheap provider", err)
 	}
 	drainStream(t, ch)
+}
+
+func TestGateway_StreamingCostOrderHandlesUnpricedStrategies(t *testing.T) {
+	tests := []struct {
+		name             string
+		unpricedStrategy string
+		catalog          models.Catalog
+		want             []string
+	}{
+		{
+			name:             "skip puts priced providers first",
+			unpricedStrategy: unpricedStrategySkip,
+			catalog: models.Catalog{
+				"unpriced/gpt-4o": {
+					Provider: "unpriced",
+					ModelID:  "gpt-4o",
+					Mode:     models.ModeChat,
+					Pricing:  models.Pricing{},
+				},
+				"priced/gpt-4o": {
+					Provider: "priced",
+					ModelID:  "gpt-4o",
+					Mode:     models.ModeChat,
+					Pricing: models.Pricing{
+						InputPerMTokens: ptrFloat64(1),
+					},
+				},
+			},
+			want: []string{"priced", "unpriced", "missing", "plain"},
+		},
+		{
+			name:             "allow keeps model-found unpriced providers eligible",
+			unpricedStrategy: unpricedStrategyAllow,
+			catalog: models.Catalog{
+				"unpriced/gpt-4o": {
+					Provider: "unpriced",
+					ModelID:  "gpt-4o",
+					Mode:     models.ModeChat,
+					Pricing:  models.Pricing{},
+				},
+				"priced/gpt-4o": {
+					Provider: "priced",
+					ModelID:  "gpt-4o",
+					Mode:     models.ModeChat,
+					Pricing: models.Pricing{
+						InputPerMTokens: ptrFloat64(1),
+					},
+				},
+			},
+			want: []string{"unpriced", "priced", "missing", "plain"},
+		},
+		{
+			name: "fallback returns target order when nothing is priced",
+			catalog: models.Catalog{
+				"unpriced/gpt-4o": {
+					Provider: "unpriced",
+					ModelID:  "gpt-4o",
+					Mode:     models.ModeChat,
+					Pricing:  models.Pricing{},
+				},
+			},
+			want: []string{"unpriced", "priced", "missing", "plain"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gw, err := New(Config{
+				Strategy: StrategyConfig{
+					Mode:             ModeCostOptimized,
+					UnpricedStrategy: tt.unpricedStrategy,
+				},
+				Targets: []Target{
+					{VirtualKey: "unpriced"},
+					{VirtualKey: "priced"},
+					{VirtualKey: "missing"},
+					{VirtualKey: "plain"},
+				},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			gw.catalog = tt.catalog
+			gw.RegisterProvider(&mockStreamProvider{
+				mockProvider: mockProvider{name: "unpriced", models: []string{"gpt-4o"}},
+			})
+			gw.RegisterProvider(&mockStreamProvider{
+				mockProvider: mockProvider{name: "priced", models: []string{"gpt-4o"}},
+			})
+			gw.RegisterProvider(&mockStreamProvider{
+				mockProvider: mockProvider{name: "missing", models: []string{"gpt-4o"}},
+			})
+			gw.RegisterProvider(&mockProvider{
+				name:   "plain",
+				models: []string{"gpt-4o"},
+			})
+
+			got := gw.streamingCostOrderLocked(gw.config.Targets, providers.Request{
+				Model:    "gpt-4o",
+				Messages: []providers.Message{{Role: "user", Content: "hello world"}},
+			})
+			requireKeys(t, got, tt.want...)
+		})
+	}
+}
+
+func TestGateway_StreamingLatencyOrderFallsBackWithoutStreamingCandidates(t *testing.T) {
+	gw, err := New(Config{
+		Strategy: StrategyConfig{Mode: ModeLatency},
+		Targets: []Target{
+			{VirtualKey: "plain"},
+			{VirtualKey: "unsupported"},
+			{VirtualKey: "missing"},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	gw.RegisterProvider(&mockProvider{
+		name:   "plain",
+		models: []string{"gpt-4o"},
+	})
+	gw.RegisterProvider(&mockStreamProvider{
+		mockProvider: mockProvider{name: "unsupported", models: []string{"other-model"}},
+	})
+
+	got := gw.streamingLatencyOrderLocked(gw.config.Targets, providers.Request{Model: "gpt-4o"})
+	requireKeys(t, got, "plain", "unsupported", "missing")
 }
 
 func TestGateway_RouteStream_ImmediateFailure_IncrementsProviderErrors(t *testing.T) {


### PR DESCRIPTION
Fixes #138.

Streams were still using declaration order for `least-latency` and `cost-optimized`. This adds strategy-specific ordering for stream-capable targets that support the requested model, then keeps the existing configured-order fallback.

Tests:
- `go test . -run "Test(LoadConfig_CostOptimizedUnpricedStrategy|ValidateConfig_CostOptimizedUnpricedStrategy|Gateway_Route_CostOptimizedPassesUnpricedStrategy|Gateway_RouteStream_(LeastLatencyUsesObservedP50|CostOptimizedUsesCatalogCost))" -count=1 -v`
- `go test . -count=1`