### PR TITLE
Index catalog model ID lookups

### DIFF
--- a/models/calculator.go
+++ b/models/calculator.go
@@ -45,7 +45,7 @@ func perM(price *float64, n int) float64 {
 
 // Calculate computes the full cost for a completed request.
 // modelKey should be "provider/model-id"; a bare model ID is also accepted
-// but triggers a linear scan of the catalog.
+// using the catalog's model_id index.
 func Calculate(catalog Catalog, modelKey string, usage Usage) CostResult {
 	model, ok := catalog.Get(modelKey)
 	if !ok {

--- a/models/catalog.go
+++ b/models/catalog.go
@@ -15,6 +15,8 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"reflect"
+	"sync"
 	"time"
 )
 
@@ -29,6 +31,15 @@ const defaultCatalogURL = "https://raw.githubusercontent.com/ferro-labs/ai-gatew
 
 // Catalog is a flat map of "provider/model-id" → Model.
 type Catalog map[string]Model
+
+type catalogModelIndex struct {
+	size      int
+	byModelID map[string]string
+}
+
+// Catalog stays a map for callers, so the bare-model lookup index lives next
+// to each map value and is preloaded when catalog JSON is parsed.
+var catalogModelIndexes sync.Map // map[uintptr]catalogModelIndex
 
 // Model holds all metadata for a single model.
 type Model struct {
@@ -140,22 +151,59 @@ func parse(data []byte) (Catalog, error) {
 	if err := json.Unmarshal(data, &c); err != nil {
 		return nil, fmt.Errorf("catalog parse: %w", err)
 	}
+	storeCatalogModelIndex(c)
 	return c, nil
 }
 
 // Get looks up a model by "provider/model-id".
-// If not found, scans for a bare model ID match as fallback.
+// If not found, it falls back to the catalog's model_id index.
 func (c Catalog) Get(key string) (Model, bool) {
 	if m, ok := c[key]; ok {
 		return m, true
 	}
-	// Bare model ID: return the first matching entry.
-	for _, v := range c {
-		if v.ModelID == key {
-			return v, true
+	if catalogKey, ok := c.modelIDIndex()[key]; ok {
+		if m, ok := c[catalogKey]; ok && m.ModelID == key {
+			return m, true
 		}
 	}
 	return Model{}, false
+}
+
+func (c Catalog) modelIDIndex() map[string]string {
+	if len(c) == 0 {
+		return nil
+	}
+	cacheKey := c.cacheKey()
+	if cached, ok := catalogModelIndexes.Load(cacheKey); ok {
+		index := cached.(catalogModelIndex)
+		if index.size == len(c) {
+			return index.byModelID
+		}
+	}
+	return storeCatalogModelIndex(c).byModelID
+}
+
+func storeCatalogModelIndex(c Catalog) catalogModelIndex {
+	index := catalogModelIndex{
+		size:      len(c),
+		byModelID: make(map[string]string, len(c)),
+	}
+	for key, model := range c {
+		if model.ModelID == "" {
+			continue
+		}
+		if _, exists := index.byModelID[model.ModelID]; !exists {
+			index.byModelID[model.ModelID] = key
+		}
+	}
+	if len(c) > 0 {
+		catalogModelIndexes.Store(c.cacheKey(), index)
+	}
+	return index
+}
+
+func (c Catalog) cacheKey() uintptr {
+	return reflect.ValueOf(c).Pointer()
 }
 
 // IsDeprecated returns true when the model's lifecycle status is deprecated or legacy.

--- a/models/catalog_test.go
+++ b/models/catalog_test.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"fmt"
 	"testing"
 )
 
@@ -107,11 +108,100 @@ func TestCatalogGet(t *testing.T) {
 		t.Error("Get with provider prefix should succeed")
 	}
 	if _, ok := c.Get("gpt-4o"); !ok {
-		t.Error("Get with bare model ID should succeed via fallback scan")
+		t.Error("Get with bare model ID should succeed via fallback index")
 	}
 	if _, ok := c.Get("nonexistent-model"); ok {
 		t.Error("Get with unknown model should return false")
 	}
+}
+
+func TestCatalogParseBuildsModelIDIndex(t *testing.T) {
+	c, err := parse([]byte(`{
+		"openai/gpt-4o": {"provider": "openai", "model_id": "gpt-4o", "mode": "chat"}
+	}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := catalogModelIndexes.Load(c.cacheKey()); !ok {
+		t.Fatal("expected parse to preload model_id index")
+	}
+	if _, ok := c.Get("gpt-4o"); !ok {
+		t.Fatal("Get with bare model ID should use preloaded index")
+	}
+}
+
+func TestCatalogGetRebuildsStaleIndexAfterGrowth(t *testing.T) {
+	c := Catalog{
+		"openai/gpt-4o": {
+			Provider: "openai",
+			ModelID:  "gpt-4o",
+			Mode:     ModeChat,
+		},
+	}
+	if _, ok := c.Get("claude-3-haiku"); ok {
+		t.Fatal("unexpected lookup hit before catalog update")
+	}
+
+	c["anthropic/claude-3-haiku"] = Model{
+		Provider: "anthropic",
+		ModelID:  "claude-3-haiku",
+		Mode:     ModeChat,
+	}
+	if got, ok := c.Get("claude-3-haiku"); !ok || got.Provider != "anthropic" {
+		t.Fatalf("Get after catalog growth = (%q, %v), want anthropic hit", got.Provider, ok)
+	}
+}
+
+func BenchmarkCatalogGetBareModelID(b *testing.B) {
+	for _, size := range []int{100, 10_000} {
+		b.Run(fmt.Sprintf("size_%d", size), func(b *testing.B) {
+			c := benchmarkCatalog(size)
+			target := fmt.Sprintf("model-%d", size-1)
+			if _, ok := c.Get(target); !ok {
+				b.Fatal("warmup lookup failed")
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if _, ok := c.Get(target); !ok {
+					b.Fatal("lookup failed")
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkCatalogGetMiss(b *testing.B) {
+	for _, size := range []int{100, 10_000} {
+		b.Run(fmt.Sprintf("size_%d", size), func(b *testing.B) {
+			c := benchmarkCatalog(size)
+			if _, ok := c.Get("missing-provider/missing-model"); ok {
+				b.Fatal("warmup lookup should miss")
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if _, ok := c.Get("missing-provider/missing-model"); ok {
+					b.Fatal("lookup should miss")
+				}
+			}
+		})
+	}
+}
+
+func benchmarkCatalog(size int) Catalog {
+	c := make(Catalog, size)
+	for i := 0; i < size; i++ {
+		modelID := fmt.Sprintf("model-%d", i)
+		c["provider/"+modelID] = Model{
+			Provider: "provider",
+			ModelID:  modelID,
+			Mode:     ModeChat,
+		}
+	}
+	return c
 }
 
 // TestIsDeprecated checks that both "deprecated" and "legacy" statuses are


### PR DESCRIPTION
Fixes #134.

`Catalog.Get` now uses a sidecar `model_id` index after the exact key lookup. The index is built when catalog JSON is parsed and is also rebuilt lazily for custom/test catalogs if their size changes.

Benchmarks on my machine stayed flat between 100 and 10,000 entries:

```
BenchmarkCatalogGetBareModelID/size_100-4      785.9 ns/op   0 B/op   0 allocs/op
BenchmarkCatalogGetBareModelID/size_10000-4    489.4 ns/op   0 B/op   0 allocs/op
BenchmarkCatalogGetMiss/size_100-4             355.4 ns/op   0 B/op   0 allocs/op
BenchmarkCatalogGetMiss/size_10000-4           341.8 ns/op   0 B/op   0 allocs/op
```

Tests:
- `go test ./models -count=1`
- `go test . -count=1`
- `go test ./models -run '^$' -bench 'BenchmarkCatalogGet(BareModelID|Miss)' -benchtime=100ms`