### PR TITLE
Support new OpenAI and Bedrock model IDs

### DIFF
--- a/providers/bedrock/bedrock.go
+++ b/providers/bedrock/bedrock.go
@@ -117,6 +117,9 @@ func (p *Provider) SupportedModels() []string {
 		"amazon.titan-text-express-v1",
 		"amazon.titan-text-lite-v1",
 		"amazon.titan-text-premier-v1:0",
+		"amazon.nova-micro-v1:0",
+		"amazon.nova-lite-v1:0",
+		"amazon.nova-pro-v1:0",
 		"meta.llama3-1-405b-instruct-v1:0",
 		"meta.llama3-1-70b-instruct-v1:0",
 		"meta.llama3-1-8b-instruct-v1:0",
@@ -139,14 +142,17 @@ func (p *Provider) SupportsModel(model string) bool {
 			return true
 		}
 	}
-	for _, prefix := range []string{
+	if isBedrockNovaTextModel(model) {
+		return true
+	}
+	for _, supportedPrefix := range []string{
 		"anthropic.claude-",
 		"amazon.titan-text-",
 		"amazon.titan-embed-text-",
 		"cohere.embed-",
 		"meta.llama",
 	} {
-		if strings.HasPrefix(model, prefix) {
+		if strings.HasPrefix(model, supportedPrefix) {
 			return true
 		}
 	}
@@ -220,6 +226,43 @@ type bedrockLlamaResponse struct {
 	PromptTokenCount     int    `json:"prompt_token_count"`
 	GenerationTokenCount int    `json:"generation_token_count"`
 	StopReason           string `json:"stop_reason"`
+}
+
+// ── Amazon Nova ──────────────────────────────────────────────────────────────
+
+type bedrockNovaRequest struct {
+	SchemaVersion   string                    `json:"schemaVersion"`
+	System          []bedrockNovaContentBlock `json:"system,omitempty"`
+	Messages        []bedrockNovaMessage      `json:"messages"`
+	InferenceConfig *bedrockNovaInference     `json:"inferenceConfig,omitempty"`
+}
+
+type bedrockNovaMessage struct {
+	Role    string                    `json:"role"`
+	Content []bedrockNovaContentBlock `json:"content"`
+}
+
+type bedrockNovaContentBlock struct {
+	Text string `json:"text"`
+}
+
+type bedrockNovaInference struct {
+	MaxTokens     *int     `json:"maxTokens,omitempty"`
+	Temperature   *float64 `json:"temperature,omitempty"`
+	TopP          *float64 `json:"topP,omitempty"`
+	StopSequences []string `json:"stopSequences,omitempty"`
+}
+
+type bedrockNovaResponse struct {
+	Output struct {
+		Message bedrockNovaMessage `json:"message"`
+	} `json:"output"`
+	StopReason string `json:"stopReason"`
+	Usage      struct {
+		InputTokens  int `json:"inputTokens"`
+		OutputTokens int `json:"outputTokens"`
+		TotalTokens  int `json:"totalTokens"`
+	} `json:"usage"`
 }
 
 // ── Embeddings ───────────────────────────────────────────────────────────────
@@ -424,7 +467,7 @@ func bedrockModelRoutingID(model string) string {
 	if idx := strings.LastIndex(model, "/"); idx >= 0 && idx < len(model)-1 {
 		model = model[idx+1:]
 	}
-	for _, prefix := range []string{"us.", "eu.", "apac."} {
+	for _, prefix := range []string{"us.", "eu.", "apac.", "global."} {
 		if strings.HasPrefix(model, prefix) {
 			return strings.TrimPrefix(model, prefix)
 		}
@@ -440,11 +483,32 @@ func isBedrockCohereEmbeddingModel(model string) bool {
 	return strings.HasPrefix(model, "cohere.embed-")
 }
 
+func isBedrockNovaTextModel(model string) bool {
+	for _, supportedPrefix := range []string{
+		"amazon.nova-micro-",
+		"amazon.nova-lite-",
+		"amazon.nova-pro-",
+		"amazon.nova-premier-",
+		"amazon.nova-2-micro-",
+		"amazon.nova-2-lite-",
+		"amazon.nova-2-pro-",
+		"amazon.nova-2-premier-",
+	} {
+		if strings.HasPrefix(model, supportedPrefix) {
+			return true
+		}
+	}
+	return false
+}
+
 // Complete sends a request to AWS Bedrock and returns the response.
 func (p *Provider) Complete(ctx context.Context, req core.Request) (*core.Response, error) {
-	modelID := req.Model
+	modelID := bedrockModelRoutingID(req.Model)
 	if strings.HasPrefix(modelID, "anthropic.") {
 		return p.completeAnthropic(ctx, req)
+	}
+	if isBedrockNovaTextModel(modelID) {
+		return p.completeNova(ctx, req)
 	}
 	if strings.HasPrefix(modelID, "amazon.titan") {
 		return p.completeTitan(ctx, req)
@@ -637,10 +701,69 @@ func (p *Provider) completeLlama(ctx context.Context, req core.Request) (*core.R
 	}, nil
 }
 
+func (p *Provider) completeNova(ctx context.Context, req core.Request) (*core.Response, error) {
+	novaReq := bedrockNovaRequest{
+		SchemaVersion: "messages-v1",
+	}
+	for _, msg := range req.Messages {
+		if msg.Role == core.RoleSystem {
+			novaReq.System = append(novaReq.System, bedrockNovaContentBlock{Text: msg.Content})
+			continue
+		}
+		novaReq.Messages = append(novaReq.Messages, bedrockNovaMessage{
+			Role: msg.Role,
+			Content: []bedrockNovaContentBlock{
+				{Text: msg.Content},
+			},
+		})
+	}
+	if len(novaReq.Messages) == 0 {
+		return nil, fmt.Errorf("nova request requires at least one non-system message")
+	}
+
+	inference := &bedrockNovaInference{
+		MaxTokens:     req.MaxTokens,
+		Temperature:   req.Temperature,
+		TopP:          req.TopP,
+		StopSequences: req.Stop,
+	}
+	if inference.MaxTokens == nil {
+		inference.MaxTokens = req.MaxCompletionTokens
+	}
+	if inference.MaxTokens != nil || inference.Temperature != nil || inference.TopP != nil || len(inference.StopSequences) > 0 {
+		novaReq.InferenceConfig = inference
+	}
+
+	var novaResp bedrockNovaResponse
+	if err := p.invokeModelJSON(ctx, req.Model, novaReq, &novaResp); err != nil {
+		return nil, err
+	}
+
+	text := ""
+	for _, block := range novaResp.Output.Message.Content {
+		text += block.Text
+	}
+
+	return &core.Response{
+		Model:    req.Model,
+		Provider: p.name,
+		Choices: []core.Choice{{
+			Index:        0,
+			Message:      core.Message{Role: core.RoleAssistant, Content: text},
+			FinishReason: novaResp.StopReason,
+		}},
+		Usage: core.Usage{
+			PromptTokens:     novaResp.Usage.InputTokens,
+			CompletionTokens: novaResp.Usage.OutputTokens,
+			TotalTokens:      novaResp.Usage.TotalTokens,
+		},
+	}, nil
+}
+
 // CompleteStream sends a streaming request to AWS Bedrock via InvokeModelWithResponseStream.
 // Currently only Anthropic Claude streaming is implemented.
 func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan core.StreamChunk, error) {
-	if !strings.HasPrefix(req.Model, "anthropic.") {
+	if !strings.HasPrefix(bedrockModelRoutingID(req.Model), "anthropic.") {
 		return nil, fmt.Errorf("streaming on Bedrock is currently only supported for anthropic.claude-* models")
 	}
 

--- a/providers/bedrock/bedrock_test.go
+++ b/providers/bedrock/bedrock_test.go
@@ -103,6 +103,118 @@ func TestBedrockProvider_SupportedEmbeddingModels(t *testing.T) {
 	}
 }
 
+func TestBedrockProvider_SupportsModelProfilesAndNova(t *testing.T) {
+	p := &Provider{name: Name}
+
+	for _, model := range []string{
+		"us.anthropic.claude-3-5-sonnet-20241022-v2:0",
+		"eu.anthropic.claude-3-5-sonnet-20241022-v2:0",
+		"global.anthropic.claude-sonnet-4-5-20250929-v1:0",
+		"amazon.nova-lite-v1:0",
+		"us.amazon.nova-pro-v1:0",
+		"us-gov-east-1/amazon.nova-micro-v1:0",
+		"us.amazon.nova-2-lite-v1:0",
+	} {
+		if !p.SupportsModel(model) {
+			t.Errorf("SupportsModel(%q) = false, want true", model)
+		}
+	}
+
+	for _, model := range []string{
+		"openai/gpt-4o",
+		"amazon.titan-image-generator-v1",
+		"global.unknown.model",
+	} {
+		if p.SupportsModel(model) {
+			t.Errorf("SupportsModel(%q) = true, want false", model)
+		}
+	}
+}
+
+func TestBedrockProvider_Complete_AnthropicProfileKeepsOriginalModelID(t *testing.T) {
+	fake := &fakeBedrockRuntimeClient{
+		responses: [][]byte{
+			[]byte(`{"id":"msg-1","type":"message","role":"assistant","content":[{"type":"text","text":"ok"}],"stop_reason":"end_turn","usage":{"input_tokens":2,"output_tokens":3}}`),
+		},
+	}
+	p := &Provider{name: Name, client: fake}
+
+	model := "global.anthropic.claude-sonnet-4-5-20250929-v1:0"
+	resp, err := p.Complete(context.Background(), core.Request{
+		Model:    model,
+		Messages: []core.Message{{Role: core.RoleUser, Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("Complete() error: %v", err)
+	}
+	if len(fake.invokeCalls) != 1 {
+		t.Fatalf("InvokeModel calls = %d, want 1", len(fake.invokeCalls))
+	}
+	if got := aws.ToString(fake.invokeCalls[0].ModelId); got != model {
+		t.Fatalf("ModelId = %q, want %q", got, model)
+	}
+	if resp.Model != model || resp.Choices[0].Message.Content != "ok" {
+		t.Fatalf("response = %+v, want model preserved and text returned", resp)
+	}
+	if resp.Usage.TotalTokens != 5 {
+		t.Fatalf("total tokens = %d, want 5", resp.Usage.TotalTokens)
+	}
+}
+
+func TestBedrockProvider_Complete_NovaMapsRequestAndResponse(t *testing.T) {
+	fake := &fakeBedrockRuntimeClient{
+		responses: [][]byte{
+			[]byte(`{"output":{"message":{"role":"assistant","content":[{"text":"hello"},{"text":" world"}]}},"stopReason":"end_turn","usage":{"inputTokens":4,"outputTokens":5,"totalTokens":9}}`),
+		},
+	}
+	p := &Provider{name: Name, client: fake}
+
+	model := "us.amazon.nova-lite-v1:0"
+	resp, err := p.Complete(context.Background(), core.Request{
+		Model: model,
+		Messages: []core.Message{
+			{Role: core.RoleSystem, Content: "be brief"},
+			{Role: core.RoleUser, Content: "hi"},
+		},
+		MaxCompletionTokens: intPtr(64),
+		Stop:                []string{"done"},
+	})
+	if err != nil {
+		t.Fatalf("Complete() error: %v", err)
+	}
+	if len(fake.invokeCalls) != 1 {
+		t.Fatalf("InvokeModel calls = %d, want 1", len(fake.invokeCalls))
+	}
+	if got := aws.ToString(fake.invokeCalls[0].ModelId); got != model {
+		t.Fatalf("ModelId = %q, want %q", got, model)
+	}
+
+	var body bedrockNovaRequest
+	mustUnmarshalBody(t, fake.invokeCalls[0].Body, &body)
+	if body.SchemaVersion != "messages-v1" {
+		t.Fatalf("schemaVersion = %q, want messages-v1", body.SchemaVersion)
+	}
+	if len(body.System) != 1 || body.System[0].Text != "be brief" {
+		t.Fatalf("system = %#v, want one text block", body.System)
+	}
+	if len(body.Messages) != 1 || body.Messages[0].Role != core.RoleUser || body.Messages[0].Content[0].Text != "hi" {
+		t.Fatalf("messages = %#v, want one user text message", body.Messages)
+	}
+	if body.InferenceConfig == nil || body.InferenceConfig.MaxTokens == nil || *body.InferenceConfig.MaxTokens != 64 {
+		t.Fatalf("inferenceConfig = %#v, want maxTokens 64", body.InferenceConfig)
+	}
+	if len(body.InferenceConfig.StopSequences) != 1 || body.InferenceConfig.StopSequences[0] != "done" {
+		t.Fatalf("stopSequences = %#v, want [done]", body.InferenceConfig.StopSequences)
+	}
+
+	if resp.Choices[0].Message.Content != "hello world" {
+		t.Fatalf("content = %q, want hello world", resp.Choices[0].Message.Content)
+	}
+	if resp.Usage.PromptTokens != 4 || resp.Usage.CompletionTokens != 5 || resp.Usage.TotalTokens != 9 {
+		t.Fatalf("usage = %+v, want 4/5/9", resp.Usage)
+	}
+}
+
 func TestBedrockProvider_Embed_TitanTextLoopsAndMapsResponse(t *testing.T) {
 	fake := &fakeBedrockRuntimeClient{
 		responses: [][]byte{

--- a/providers/openai/openai.go
+++ b/providers/openai/openai.go
@@ -114,7 +114,7 @@ func (p *Provider) SupportedModels() []string {
 
 // SupportsModel returns true if the model matches known OpenAI prefixes.
 func (p *Provider) SupportsModel(model string) bool {
-	for _, prefix := range []string{"gpt-", "chatgpt-", "dall-e-", "whisper-", "tts-", "text-embedding-", "ft:", "babbage-", "davinci-"} {
+	for _, prefix := range []string{"gpt-", "chatgpt-", "codex-", "sora-", "dall-e-", "whisper-", "tts-", "text-embedding-", "ft:", "babbage-", "davinci-"} {
 		if strings.HasPrefix(model, prefix) {
 			return true
 		}

--- a/providers/openai/openai_test.go
+++ b/providers/openai/openai_test.go
@@ -52,7 +52,6 @@ func TestOpenAIProvider_SupportedModels(t *testing.T) {
 }
 
 // TestOpenAIProvider_SupportsModel tests the SupportsModel method.
-// With passthrough enabled, all model strings are accepted.
 func TestOpenAIProvider_SupportsModel(t *testing.T) {
 	provider, _ := New("sk-test-key", "")
 
@@ -64,6 +63,9 @@ func TestOpenAIProvider_SupportsModel(t *testing.T) {
 		{"gpt-4o supported", "gpt-4o", true},
 		{"gpt-4-turbo supported", "gpt-4-turbo", true},
 		{"gpt-3.5-turbo supported", "gpt-3.5-turbo", true},
+		{"codex model supported", "codex-mini-latest", true},
+		{"sora model supported", "sora-2", true},
+		{"reasoning model supported", "o3-mini", true},
 		{"unknown model passthrough", "gpt-99", true},
 	}
 


### PR DESCRIPTION
Fixes #147.

This fills the model IDs called out in the issue without widening Bedrock too far.

Changes:
- OpenAI accepts additional model ID prefixes for newer model families.
- Bedrock strips `global.` inference-profile prefixes for routing, like the existing `us.`/`eu.`/`apac.` handling.
- Bedrock routes Nova text models through the Invoke `messages-v1` payload while keeping the original model ID for AWS.

Tests:
- `go test ./providers/openai ./providers/bedrock`
- `git diff --check`

Note: I also ran `go test -short ./...` locally. The changed provider packages passed, but the full run fails on Windows in existing SQLite temp-dir cleanup tests under `cmd/ferrogw` and `internal/bootstrap` because the temp DB files are still open during cleanup.
