### PR TITLE
v1.1.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to Ferro Labs AI Gateway are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.3] — 2026-06-15
+
+Streaming-correctness release. Brings the streaming routing path (`RouteStream`) to parity with non-streaming `Route`: the post-request plugin pipeline, the per-provider circuit breaker, and least-latency / cost-optimized ordering now all apply to `stream: true` traffic. Also tightens fallback retry semantics and async-context propagation. No public API breaks. Fixes every issue labelled [`release-1.1.3`](https://github.com/ferro-labs/ai-gateway/issues?q=label%3Arelease-1.1.3): [#135](https://github.com/ferro-labs/ai-gateway/issues/135), [#136](https://github.com/ferro-labs/ai-gateway/issues/136), [#137](https://github.com/ferro-labs/ai-gateway/issues/137), and [#138](https://github.com/ferro-labs/ai-gateway/issues/138), plus enhancement [#181](https://github.com/ferro-labs/ai-gateway/issues/181).
+
+### Fixed
+
+- **Streaming requests skipped the post-request plugin pipeline** (issue [#135](https://github.com/ferro-labs/ai-gateway/issues/135), PR [#201](https://github.com/ferro-labs/ai-gateway/pull/201)): `RouteStream` ran only `before_request` plugins, so `after_request` (response-cache store, request-logger) and `on_error` plugins never fired for streaming traffic and a cache `Skip` hit was discarded with the provider called anyway. The full plugin lifecycle now runs for streams: `RunAfter` fires once the stream drains — with the response reconstructed from streamed chunks so the response-cache can store it — `RunOnError` fires on resolution / provider / stream / after-plugin failures, and a cache hit short-circuits the provider into a single streamed chunk.
+- **Circuit breaker was a no-op for streaming-first traffic** (issue [#136](https://github.com/ferro-labs/ai-gateway/issues/136), PR [#199](https://github.com/ferro-labs/ai-gateway/pull/199)): the streaming path never recorded breaker outcomes, so mid-stream provider failures did not count and the breaker never opened. Stream success is now recorded at stream completion and failures (both at startup and mid-stream) count toward the breaker; open-circuit streaming targets are skipped during resolution so fallback advances instead of returning circuit-open.
+- **Fallback strategy retried cancellations and open circuits** (issue [#137](https://github.com/ferro-labs/ai-gateway/issues/137), PR [#198](https://github.com/ferro-labs/ai-gateway/pull/198)): `shouldRetry` returned true for any error without a parseable HTTP status code, so `context.Canceled` / `context.DeadlineExceeded` and `circuitbreaker.ErrCircuitOpen` re-attempted already-cancelled requests and burned the whole retry budget against an open circuit. These sentinels are now non-retryable, and the retry loop checks `ctx.Err()` before each attempt.
+- **Streaming ignored least-latency / cost-optimized ordering** (issue [#138](https://github.com/ferro-labs/ai-gateway/issues/138), PR [#198](https://github.com/ferro-labs/ai-gateway/pull/198)): `streamingTargetOrderLocked` had no case for these modes and silently fell through to declaration order. Streaming now orders targets by observed p50 latency (exploring unsampled targets first) and by catalog model cost, mirroring the non-streaming path, and records successful stream latency samples so least-latency converges for streaming-only traffic.
+
+### Changed
+
+- **Circuit-breaker failure accounting** (issue [#136](https://github.com/ferro-labs/ai-gateway/issues/136), PR [#199](https://github.com/ferro-labs/ai-gateway/pull/199)): caller-side cancellation and client deadlines no longer trip the breaker, while provider-side timeouts that surface as `context.DeadlineExceeded` while the request context is still live are counted as failures. Applies to both `Route` and `RouteStream`.
+- **Detached background goroutines preserve trace context** (issue [#181](https://github.com/ferro-labs/ai-gateway/issues/181), PR [#202](https://github.com/ferro-labs/ai-gateway/pull/202)): async event hooks and the streaming observability completion event now run under `context.WithoutCancel(ctx)` instead of the already-cancelled request context / `context.Background()`, so fire-and-forget work (DB writes, outbound calls) is no longer dead-on-arrival and recorded events stay linked to the originating trace. MCP background initialization parents its 60s timeout on the gateway shutdown context so `Close()` cancels in-flight handshakes instead of letting them linger.
+
+### Notes
+
+- Under `cost-optimized` routing with `unpriced_strategy: skip`, the streaming path keeps unpriced providers as a last-resort fallback (and errors only when *no* candidate is priced), whereas the non-streaming path never selects an unpriced provider. This is intentional for the streaming fallback chain.
+- All public `release-1.1.3` issues — [#135](https://github.com/ferro-labs/ai-gateway/issues/135), [#136](https://github.com/ferro-labs/ai-gateway/issues/136), [#137](https://github.com/ferro-labs/ai-gateway/issues/137), [#138](https://github.com/ferro-labs/ai-gateway/issues/138) — and enhancement [#181](https://github.com/ferro-labs/ai-gateway/issues/181) are closed by this release.
+
+---
+
 ## [1.1.2] — 2026-06-06
 
 Release hardening patch for the external model catalog cutover, catalog pricing correctness, and response-body lifecycle fixes. No public API breaks. Fixes every issue labelled [`release-1.1.2`](https://github.com/ferro-labs/ai-gateway/issues?q=label%3Arelease-1.1.2): [#132](https://github.com/ferro-labs/ai-gateway/issues/132), [#133](https://github.com/ferro-labs/ai-gateway/issues/133), [#134](https://github.com/ferro-labs/ai-gateway/issues/134), and [#185](https://github.com/ferro-labs/ai-gateway/issues/185).
@@ -261,13 +284,13 @@ Patch release focused on security maintenance, cache correctness, and refreshed 
 - **`ferrogw init`**: First-run setup command — generates a `fgw_`+32-hex master key with 128-bit entropy, writes a minimal `config.yaml`. Never writes secrets to disk.
 - **Dashboard login page** (`/dashboard/login`): Validates key via `/admin/health`, stores in `localStorage`, shows Admin / Read Only badge, and hides write actions for read-only sessions.
 - **`/admin/health` returns scopes**: The health endpoint now includes the authenticated key's scopes so clients can determine permission level without a separate request.
-- **`.env.example`**: Full reference file documenting `MASTER_KEY`, all 29 provider API keys, storage backends, rate limiting, and CORS origins. Bootstrap env vars marked deprecated.
+- **`.env.example`**: Full reference file documenting `MASTER_KEY`, all 29 provider API keys, storage backends, rate limiting, and CORS origins. Bootstrap env vars marked deprecated. <!-- drift-ok: historical v1.0.3 count -->
 
 ### Changed
 
 - **Single binary**: `ferrogw-cli` has been merged into `ferrogw` as Cobra subcommands (`doctor`, `status`, `admin`, `validate`, `plugins`, `version`). Running `ferrogw` with no subcommand still starts the server (backward compatible).
 - **`proxyAuth`**: `/v1/*` routes now enforce `AuthMiddleware` by default and are only open when `ALLOW_UNAUTHENTICATED_PROXY=true` is set for local development. Operational endpoints such as `/metrics`, `/debug/vars`, and `/debug/pprof/*` continue to require auth.
-- **Enhanced startup banner**: Shows top-5 provider status, masked master key, key store / config store backends, and a warning when deprecated bootstrap keys are in use.
+- **Enhanced startup banner**: Shows top-5 provider status, masked master key, key store / config store backends, and a warning when deprecated bootstrap keys are in use. <!-- drift-ok: "top-5" is a display limit, not a provider count -->
 - **Bootstrap keys deprecated**: `ADMIN_BOOTSTRAP_KEY` and `ADMIN_BOOTSTRAP_READ_ONLY_KEY` still work but are superseded by `MASTER_KEY`. They only activate when the key store is empty.
 
 ### Removed
@@ -287,8 +310,8 @@ Patch release focused on security maintenance, cache correctness, and refreshed 
 
 ### Changed
 
-- **Config examples**: Added all 29 providers as targets, conditional routing examples, retry/circuit-breaker config, and previously undocumented plugin fields (`max_input_length`, `burst`, `max_keys`).
-- **`docker-compose.yml`**: Refactored to shared base config with commented env var stubs for all 29 providers.
+- **Config examples**: Added all 29 providers as targets, conditional routing examples, retry/circuit-breaker config, and previously undocumented plugin fields (`max_input_length`, `burst`, `max_keys`). <!-- drift-ok: historical v1.0.2 count -->
+- **`docker-compose.yml`**: Refactored to shared base config with commented env var stubs for all 29 providers. <!-- drift-ok: historical v1.0.2 count -->
 - **AGENTS.md / CONTRIBUTING.md**: Updated "Adding a New Provider" checklist with config example and docker-compose steps; removed duplicate sections.
 
 ---
@@ -372,7 +395,7 @@ No breaking changes from `1.0.0-rc.3`. Updated README and CONTRIBUTING docs for 
   `ResponseHeaderTimeout` for SSE. Known provider presets for OpenAI,
   Anthropic, Gemini, Bedrock, Vertex AI, Groq, Ollama, and Azure OpenAI.
   Prometheus metrics for connection pool observability.
-- **Per-provider HTTP clients**: All 28 providers now use
+- **Per-provider HTTP clients**: All 28 providers now use <!-- drift-ok: historical rc.3 count -->
   `httpclient.ForProvider(Name)` for isolated connection pools instead of a
   single shared client. Legacy completions handler switched from
   `http.DefaultClient`.
@@ -381,7 +404,7 @@ No breaking changes from `1.0.0-rc.3`. Updated README and CONTRIBUTING docs for 
   pooled. All fields explicitly reset before pool return for multi-tenant
   safety.
 - **Pooled JSON marshaling buffers**: Added `core.MarshalJSON` and
-  `core.JSONBodyReader` backed by `sync.Pool`. All 28 provider subpackages
+  `core.JSONBodyReader` backed by `sync.Pool`. All 28 provider subpackages <!-- drift-ok: historical rc.3 count -->
   updated to use pooled buffers for request body serialization.
 - **getStrategy() lock contention fix**: Changed from exclusive `Mutex.Lock`
   to double-checked locking with `RLock` fast path. Eliminates write-lock

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -40,11 +40,11 @@ Status: **Shipped** (2026-05-04)
 
 ## v1.1.0 — OpenTelemetry Core
 
-Status: **In progress** — branch `release/v1.1.0-observability`. Tracking issue: [#49](https://github.com/ferro-labs/ai-gateway/issues/49).
+Status: **Shipped** (2026-05-24). Tracking issue: [#49](https://github.com/ferro-labs/ai-gateway/issues/49).
 
 This release is intentionally **scoped to a pure OpenTelemetry core**. Vendor-specific bridges (LangSmith, Langfuse, Phoenix, Datadog, New Relic, Sentry, Helicone, Honeycomb, Grafana, …) are deliberately deferred to the v1.2.0 plugin SDK so they live once, in Go, in a dedicated repo — instead of being duplicated across the gateway core, the Python SDK, and the TypeScript SDK.
 
-### In this release
+### What shipped
 
 - **Public `observability` package** — semver-stable `Provider` / `Span` / `Exporter` / `Event` contract with `gen_ai.*` (OTel GenAI semantic conventions) plus `ferro.*` extension attributes for cost, routing, cache, MCP, and stream timings.
 - **OTLP tracing pipeline** — gRPC and HTTP/protobuf exporters via `internal/otel`, global W3C `TraceContext` + `Baggage` propagation, head sampling.
@@ -56,12 +56,18 @@ This release is intentionally **scoped to a pure OpenTelemetry core**. Vendor-sp
 - **SDK observability** in [ferrolabs-python-sdk](https://github.com/ferro-labs/ferrolabs-python-sdk) and [ferrolabs-typescript-sdk](https://github.com/ferro-labs/ferrolabs-typescript-sdk) — runtime OTel detection (no hard dependency), `traceparent` injection, `trace_id` / `traceId` surfaced from gateway response headers.
 
 
-### Backlog (still landing under v1.1.x patch releases)
+## v1.1.x — Stability Fixes
+
+Status: **Shipped** through v1.1.2.
+
+Patch releases stayed limited to stability and release-hardening work: shutdown/race/leak fixes, safer streaming, catalog pricing and fallback correctness, OpenAI response-body lifecycle cleanup, and catalog load guardrails. No public API breaks.
+
+### Carried into v1.1.x / v1.2.x backlog
 
 - Plugin-stage child spans inside `plugin/Manager.Run{Before,After,OnError}`.
 - Span hand-off from `RouteStream` into `streamwrap.Meter` so token / cost / stream-timing attributes land on the same span.
 - MCP tool-call child spans.
-- Semantic caching, Redis-backed auth cache, additional provider expansion — moved out of v1.1.0 to keep this release focused; tracked under v1.1.x / v1.2.x.
+- Semantic caching, Redis-backed auth cache, additional provider expansion.
 
 ## v1.2.0 — Plugin SDK & Vendor Bridges
 

--- a/config.go
+++ b/config.go
@@ -143,6 +143,12 @@ const (
 	ModeABTest        StrategyMode = "ab-test"
 )
 
+const (
+	unpricedStrategyFallback = "fallback"
+	unpricedStrategySkip     = "skip"
+	unpricedStrategyAllow    = "allow"
+)
+
 // Condition represents a condition for conditional routing.
 type Condition struct {
 	Key       string `json:"key" yaml:"key"`

--- a/config_load.go
+++ b/config_load.go
@@ -69,7 +69,7 @@ func ValidateConfig(cfg Config) error {
 
 	if mode == ModeCostOptimized {
 		switch cfg.Strategy.UnpricedStrategy {
-		case "", "fallback", "skip", "allow":
+		case "", unpricedStrategyFallback, unpricedStrategySkip, unpricedStrategyAllow:
 		default:
 			return fmt.Errorf("cost-optimized unpriced_strategy must be one of fallback, skip, allow")
 		}

--- a/config_load_test.go
+++ b/config_load_test.go
@@ -41,8 +41,8 @@ func TestLoadConfig_CostOptimizedUnpricedStrategy(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if cfg.Strategy.UnpricedStrategy != "skip" {
-		t.Errorf("expected unpriced_strategy %q, got %q", "skip", cfg.Strategy.UnpricedStrategy)
+	if cfg.Strategy.UnpricedStrategy != unpricedStrategySkip {
+		t.Errorf("expected unpriced_strategy %q, got %q", unpricedStrategySkip, cfg.Strategy.UnpricedStrategy)
 	}
 }
 
@@ -132,8 +132,8 @@ func TestValidateConfig_CostOptimizedUnpricedStrategy(t *testing.T) {
 	}{
 		{name: "default"},
 		{name: "fallback", unpricedStrategy: "fallback"},
-		{name: "skip", unpricedStrategy: "skip"},
-		{name: "allow", unpricedStrategy: "allow"},
+		{name: "skip", unpricedStrategy: unpricedStrategySkip},
+		{name: "allow", unpricedStrategy: unpricedStrategyAllow},
 		{name: "invalid", unpricedStrategy: "free", wantValidationErr: true},
 	}
 

--- a/gateway.go
+++ b/gateway.go
@@ -20,6 +20,7 @@ import (
 	"regexp"
 	"runtime"
 	"runtime/trace"
+	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -1447,6 +1448,10 @@ func (g *Gateway) streamingTargetOrderLocked(req providers.Request) []string {
 			keys = append(keys, targets[(startIdx+i)%len(targets)].VirtualKey)
 		}
 		return keys
+	case ModeLatency:
+		return g.streamingLatencyOrderLocked(targets, req)
+	case ModeCostOptimized:
+		return g.streamingCostOrderLocked(targets, req)
 	default:
 		keys := make([]string, 0, len(targets))
 		for _, t := range targets {
@@ -1454,6 +1459,154 @@ func (g *Gateway) streamingTargetOrderLocked(req providers.Request) []string {
 		}
 		return keys
 	}
+}
+
+type streamingLatencyCandidate struct {
+	key        string
+	p50        time.Duration
+	hasSamples bool
+}
+
+func (g *Gateway) streamingLatencyOrderLocked(targets []Target, req providers.Request) []string {
+	var unseen []streamingLatencyCandidate
+	var sampled []streamingLatencyCandidate
+	for _, t := range targets {
+		if !g.isStreamingTargetCandidateLocked(t, req.Model) {
+			continue
+		}
+		candidate := streamingLatencyCandidate{
+			key:        t.VirtualKey,
+			p50:        g.latencyTracker.P50(t.VirtualKey),
+			hasSamples: g.latencyTracker.HasSamples(t.VirtualKey),
+		}
+		if candidate.hasSamples {
+			sampled = append(sampled, candidate)
+		} else {
+			unseen = append(unseen, candidate)
+		}
+	}
+
+	if len(unseen) == 0 && len(sampled) == 0 {
+		return targetKeys(targets)
+	}
+
+	if len(unseen) > 1 {
+		rand.Shuffle(len(unseen), func(i, j int) {
+			unseen[i], unseen[j] = unseen[j], unseen[i]
+		}) //nolint:gosec
+	}
+	sort.SliceStable(sampled, func(i, j int) bool {
+		return sampled[i].p50 < sampled[j].p50
+	})
+
+	keys := make([]string, 0, len(targets))
+	for _, candidate := range unseen {
+		keys = appendUniqueKey(keys, candidate.key)
+	}
+	for _, candidate := range sampled {
+		keys = appendUniqueKey(keys, candidate.key)
+	}
+	return appendRemainingTargetKeys(keys, targets)
+}
+
+type streamingCostCandidate struct {
+	key        string
+	costUSD    float64
+	hasPrice   bool
+	modelFound bool
+}
+
+func (g *Gateway) streamingCostOrderLocked(targets []Target, req providers.Request) []string {
+	estimatedPromptTokens := estimatePromptTokens(req)
+	candidates := make([]streamingCostCandidate, 0, len(targets))
+	for _, t := range targets {
+		if !g.isStreamingTargetCandidateLocked(t, req.Model) {
+			continue
+		}
+		result := models.Calculate(g.catalog, t.VirtualKey+"/"+req.Model, models.Usage{
+			PromptTokens: estimatedPromptTokens,
+		})
+		candidates = append(candidates, streamingCostCandidate{
+			key:        t.VirtualKey,
+			costUSD:    result.InputUSD,
+			hasPrice:   result.Priced,
+			modelFound: result.ModelFound,
+		})
+	}
+	if len(candidates) == 0 {
+		return targetKeys(targets)
+	}
+
+	ranked := make([]streamingCostCandidate, 0, len(candidates))
+	switch g.config.Strategy.UnpricedStrategy {
+	case unpricedStrategyAllow:
+		for _, candidate := range candidates {
+			if candidate.modelFound {
+				ranked = append(ranked, candidate)
+			}
+		}
+	case unpricedStrategySkip:
+		for _, candidate := range candidates {
+			if candidate.modelFound && candidate.hasPrice {
+				ranked = append(ranked, candidate)
+			}
+		}
+	default:
+		for _, candidate := range candidates {
+			if candidate.modelFound && candidate.hasPrice {
+				ranked = append(ranked, candidate)
+			}
+		}
+	}
+
+	if len(ranked) == 0 {
+		return targetKeys(targets)
+	}
+
+	sort.SliceStable(ranked, func(i, j int) bool {
+		return ranked[i].costUSD < ranked[j].costUSD
+	})
+
+	keys := make([]string, 0, len(targets))
+	for _, candidate := range ranked {
+		keys = appendUniqueKey(keys, candidate.key)
+	}
+	for _, candidate := range candidates {
+		keys = appendUniqueKey(keys, candidate.key)
+	}
+	return appendRemainingTargetKeys(keys, targets)
+}
+
+func (g *Gateway) isStreamingTargetCandidateLocked(t Target, model string) bool {
+	p, ok := g.providers[t.VirtualKey]
+	if !ok || !p.SupportsModel(model) {
+		return false
+	}
+	_, ok = p.(providers.StreamProvider)
+	return ok
+}
+
+func estimatePromptTokens(req providers.Request) int {
+	promptChars := 0
+	for _, msg := range req.Messages {
+		promptChars += len(msg.Content)
+	}
+	return promptChars/4 + 1
+}
+
+func targetKeys(targets []Target) []string {
+	keys := make([]string, 0, len(targets))
+	for _, t := range targets {
+		keys = append(keys, t.VirtualKey)
+	}
+	return keys
+}
+
+func appendRemainingTargetKeys(keys []string, targets []Target) []string {
+	for _, t := range targets {
+		keys = appendUniqueKey(keys, t.VirtualKey)
+	}
+	return keys
 }
 
 func (g *Gateway) rebuildModelIndexesLocked() {

--- a/gateway.go
+++ b/gateway.go
@@ -1293,10 +1293,11 @@ func (g *Gateway) RouteStream(ctx context.Context, req providers.Request) (<-cha
 	g.mu.RUnlock()
 
 	meta := streamwrap.MeterMeta{
-		Provider: providerName,
-		Model:    req.Model,
-		Catalog:  catalog,
-		TraceID:  logging.TraceIDFromContext(ctx),
+		Provider:        providerName,
+		Model:           req.Model,
+		Catalog:         catalog,
+		TraceID:         logging.TraceIDFromContext(ctx),
+		LatencyRecorder: g.latencyTracker.Record,
 	}
 	if hooksEnabled {
 		meta.PublishFn = g.publishEvent

--- a/gateway.go
+++ b/gateway.go
@@ -1195,57 +1195,29 @@ func (g *Gateway) RouteStream(ctx context.Context, req providers.Request) (<-cha
 		if err != nil {
 			return nil, err
 		}
-		// Convert the completed Response into a buffered single-chunk channel.
-		// Preserve all choices so n>1 requests are handled correctly, and use
-		// the real FinishReason from each choice rather than hardcoding "stop".
-		ch := make(chan providers.StreamChunk, 1)
-		streamChoices := make([]providers.StreamChoice, len(resp.Choices))
-		for i, c := range resp.Choices {
-			streamChoices[i] = providers.StreamChoice{
-				Index: c.Index,
-				Delta: providers.MessageDelta{
-					Role:      c.Message.Role,
-					Content:   c.Message.Content,
-					ToolCalls: c.Message.ToolCalls,
-				},
-				FinishReason: c.FinishReason,
-			}
-		}
-		ch <- providers.StreamChunk{
-			ID:      resp.ID,
-			Object:  "chat.completion.chunk",
-			Created: resp.Created,
-			Model:   resp.Model,
-			Choices: streamChoices,
-			Usage:   &resp.Usage,
-		}
-		close(ch)
 		_ = start // latency already recorded inside Route()
-		return ch, nil
+		return responseStream(resp), nil
 	}
 
 	// Run before-request plugins (word-filter, max-token, rate-limit, etc.).
+	var pctx *plugin.Context
 	if g.plugins.HasPlugins() {
-		pctx := plugin.NewContext(&req)
+		pctx = plugin.NewContext(&req)
+		var early *providers.Response
 		trace.WithRegion(ctx, "gateway.route_stream.plugins.before", func() {
-			err = g.plugins.RunBefore(ctx, pctx)
+			early, err = g.runBeforePlugins(ctx, pctx, &req)
 		})
 		if err != nil {
 			plugin.PutContext(pctx)
+			pctx = nil
 			metrics.ForRequest("", req.Model).Rejected.Inc()
 			return nil, err
 		}
-		if pctx.Reject {
-			reason := pctx.Reason
+		if early != nil {
 			plugin.PutContext(pctx)
-			metrics.ForRequest("", req.Model).Rejected.Inc()
-			return nil, fmt.Errorf("request rejected by plugin: %s", reason)
+			pctx = nil
+			return responseStream(early), nil
 		}
-		// Propagate any modifications made by plugins (e.g., capped max_tokens).
-		if pctx.Request != nil {
-			req = *pctx.Request
-		}
-		plugin.PutContext(pctx)
 	}
 
 	// Resolve provider according to strategy mode.
@@ -1259,12 +1231,22 @@ func (g *Gateway) RouteStream(ctx context.Context, req providers.Request) (<-cha
 	if orderErr != nil {
 		err = orderErr
 		span.SetError(err)
+		if pctx != nil {
+			pctx.Error = err
+			g.plugins.RunOnError(ctx, pctx)
+			plugin.PutContext(pctx)
+		}
 		return nil, err
 	}
 
 	if sp == nil {
 		err = fmt.Errorf("no streaming-capable provider found for model: %s", req.Model)
 		span.SetError(err)
+		if pctx != nil {
+			pctx.Error = err
+			g.plugins.RunOnError(ctx, pctx)
+			plugin.PutContext(pctx)
+		}
 		return nil, err
 	}
 
@@ -1286,6 +1268,11 @@ func (g *Gateway) RouteStream(ctx context.Context, req providers.Request) (<-cha
 		errType := "provider_error"
 		if errors.Is(err, circuitbreaker.ErrCircuitOpen) {
 			errType = "circuit_open"
+		}
+		if pctx != nil {
+			pctx.Error = err
+			g.plugins.RunOnError(ctx, pctx)
+			plugin.PutContext(pctx)
 		}
 		metrics.ForRequest(providerName, req.Model).Error.Inc()
 		metrics.ForProviderError(providerName, errType).Inc()
@@ -1325,6 +1312,31 @@ func (g *Gateway) RouteStream(ctx context.Context, req providers.Request) (<-cha
 		cbName := wrapped.name
 		meta.CircuitBreakerOutcome = func(err error) {
 			recordStreamCircuitBreakerOutcome(ctx, cb, cbName, err)
+		}
+	}
+	if pctx != nil {
+		meta.CompletionFn = func(ctx context.Context, resp *providers.Response) error {
+			pctx.Response = resp
+			err := g.plugins.RunAfter(ctx, pctx)
+			if pctx.Response != nil {
+				*resp = *pctx.Response
+			}
+			if err != nil {
+				pctx.Error = err
+				g.plugins.RunOnError(ctx, pctx)
+			}
+			plugin.PutContext(pctx)
+			pctx = nil
+			return err
+		}
+		meta.ErrorFn = func(ctx context.Context, err error) {
+			if pctx == nil {
+				return
+			}
+			pctx.Error = err
+			g.plugins.RunOnError(ctx, pctx)
+			plugin.PutContext(pctx)
+			pctx = nil
 		}
 	}
 
@@ -1387,6 +1399,32 @@ func (g *Gateway) RouteStream(ctx context.Context, req providers.Request) (<-cha
 		}
 	})
 	return streamwrap.Meter(ctx, rawCh, start, meta), nil
+}
+
+func responseStream(resp *providers.Response) <-chan providers.StreamChunk {
+	ch := make(chan providers.StreamChunk, 1)
+	streamChoices := make([]providers.StreamChoice, len(resp.Choices))
+	for i, c := range resp.Choices {
+		streamChoices[i] = providers.StreamChoice{
+			Index: c.Index,
+			Delta: providers.MessageDelta{
+				Role:      c.Message.Role,
+				Content:   c.Message.Content,
+				ToolCalls: c.Message.ToolCalls,
+			},
+			FinishReason: c.FinishReason,
+		}
+	}
+	ch <- providers.StreamChunk{
+		ID:      resp.ID,
+		Object:  "chat.completion.chunk",
+		Created: resp.Created,
+		Model:   resp.Model,
+		Choices: streamChoices,
+		Usage:   &resp.Usage,
+	}
+	close(ch)
+	return ch
 }
 
 func (g *Gateway) resolveStreamingProviderLocked(req providers.Request) (providers.StreamProvider, error) {

--- a/gateway.go
+++ b/gateway.go
@@ -188,6 +188,10 @@ func New(cfg Config) (*Gateway, error) {
 		}()
 	}
 
+	gw.mu.Lock()
+	gw.ensureCircuitBreakersLocked()
+	gw.mu.Unlock()
+
 	return gw, nil
 }
 
@@ -822,6 +826,7 @@ func (g *Gateway) ReloadConfig(cfg Config) error {
 	g.streamingContent = streamingContent
 	g.strategy = nil // force rebuild on next request
 	g.circuitBreakers = make(map[string]*circuitbreaker.CircuitBreaker)
+	g.ensureCircuitBreakersLocked()
 
 	// Re-register MCP servers from the new config.
 	if len(cfg.MCPServers) > 0 {
@@ -875,18 +880,7 @@ func (g *Gateway) getStrategy() (strategies.Strategy, error) {
 		return g.strategy, nil
 	}
 
-	// Build circuit breakers for targets that have them configured.
-	for _, t := range g.config.Targets {
-		if t.CircuitBreaker == nil {
-			continue
-		}
-		if _, exists := g.circuitBreakers[t.VirtualKey]; exists {
-			continue
-		}
-		timeout, _ := time.ParseDuration(t.CircuitBreaker.Timeout)
-		cb := circuitbreaker.New(t.CircuitBreaker.FailureThreshold, t.CircuitBreaker.SuccessThreshold, timeout)
-		g.circuitBreakers[t.VirtualKey] = cb
-	}
+	g.ensureCircuitBreakersLocked()
 
 	// Snapshot both maps under the write lock already held. The lookup closure
 	// runs inside Strategy.Execute with no lock held, so capturing local copies
@@ -1033,7 +1027,7 @@ func (p *cbProvider) Complete(ctx context.Context, req providers.Request) (*prov
 	}
 	resp, err := p.Provider.Complete(ctx, req)
 	if err != nil {
-		if !isRateLimitError(err) {
+		if shouldRecordCircuitBreakerFailure(ctx, err) {
 			p.cb.RecordFailure()
 			metrics.CircuitBreakerState.WithLabelValues(p.name).Set(float64(p.cb.State()))
 		}
@@ -1055,15 +1049,63 @@ func (p *cbProvider) CompleteStream(ctx context.Context, req providers.Request) 
 	}
 	ch, err := sp.CompleteStream(ctx, req)
 	if err != nil {
-		if !isRateLimitError(err) {
+		if shouldRecordCircuitBreakerFailure(ctx, err) {
 			p.cb.RecordFailure()
 			metrics.CircuitBreakerState.WithLabelValues(p.name).Set(float64(p.cb.State()))
 		}
 		return nil, err
 	}
-	p.cb.RecordSuccess()
-	metrics.CircuitBreakerState.WithLabelValues(p.name).Set(0)
 	return ch, nil
+}
+
+// shouldRecordCircuitBreakerFailure reports whether an error should count toward
+// opening the circuit. Caller-side cancellation/deadlines and rate limits are
+// excluded so transient client behavior does not block healthy traffic.
+// Provider-side timeouts that surface as context.DeadlineExceeded while the
+// request context is still active are counted as failures.
+func shouldRecordCircuitBreakerFailure(ctx context.Context, err error) bool {
+	if err == nil {
+		return false
+	}
+	if ctx.Err() != nil && (errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)) {
+		return false
+	}
+	return !isRateLimitError(err)
+}
+
+// recordStreamCircuitBreakerOutcome updates breaker state when a stream
+// finishes. Startup failures are recorded in cbProvider.CompleteStream;
+// this handles stream completion only.
+func recordStreamCircuitBreakerOutcome(ctx context.Context, cb *circuitbreaker.CircuitBreaker, name string, err error) {
+	if err != nil {
+		if !shouldRecordCircuitBreakerFailure(ctx, err) {
+			return
+		}
+		cb.RecordFailure()
+		metrics.CircuitBreakerState.WithLabelValues(name).Set(float64(cb.State()))
+		return
+	}
+	cb.RecordSuccess()
+	metrics.CircuitBreakerState.WithLabelValues(name).Set(0)
+}
+
+// ensureCircuitBreakersLocked creates circuit breakers for configured targets.
+// Caller must hold g.mu.
+func (g *Gateway) ensureCircuitBreakersLocked() {
+	for _, t := range g.config.Targets {
+		if t.CircuitBreaker == nil {
+			continue
+		}
+		if _, exists := g.circuitBreakers[t.VirtualKey]; exists {
+			continue
+		}
+		timeout, _ := time.ParseDuration(t.CircuitBreaker.Timeout)
+		g.circuitBreakers[t.VirtualKey] = circuitbreaker.New(
+			t.CircuitBreaker.FailureThreshold,
+			t.CircuitBreaker.SuccessThreshold,
+			timeout,
+		)
+	}
 }
 
 // isRateLimitError checks if the error is a 429 rate limit response.
@@ -1207,6 +1249,9 @@ func (g *Gateway) RouteStream(ctx context.Context, req providers.Request) (<-cha
 	}
 
 	// Resolve provider according to strategy mode.
+	g.mu.Lock()
+	g.ensureCircuitBreakersLocked()
+	g.mu.Unlock()
 	g.mu.RLock()
 	sp, orderErr := g.resolveStreamingProviderLocked(req)
 	g.mu.RUnlock()
@@ -1275,6 +1320,13 @@ func (g *Gateway) RouteStream(ctx context.Context, req providers.Request) (<-cha
 	if hooksEnabled {
 		meta.PublishFn = g.publishEvent
 	}
+	if wrapped, ok := sp.(*cbProvider); ok {
+		cb := wrapped.cb
+		cbName := wrapped.name
+		meta.CircuitBreakerOutcome = func(err error) {
+			recordStreamCircuitBreakerOutcome(ctx, cb, cbName, err)
+		}
+	}
 
 	// Hand the root span off to streamwrap so token, cost, and timing
 	// attributes are stamped after the channel drains. The finisher
@@ -1342,10 +1394,20 @@ func (g *Gateway) resolveStreamingProviderLocked(req providers.Request) (provide
 	if err != nil {
 		return nil, err
 	}
+	var openCircuitTarget providers.StreamProvider
 	for _, key := range orderedKeys {
-		if sp, ok := g.streamingProviderForTargetLocked(key, req.Model); ok {
-			return sp, nil
+		sp, ok := g.streamingProviderForTargetLocked(key, req.Model)
+		if !ok {
+			continue
 		}
+		if wrapped, isCB := sp.(*cbProvider); isCB && !wrapped.cb.Allow() {
+			openCircuitTarget = sp
+			continue
+		}
+		return sp, nil
+	}
+	if openCircuitTarget != nil {
+		return openCircuitTarget, nil
 	}
 
 	// Fallback: any registered provider that supports this model and streaming.
@@ -1365,13 +1427,16 @@ func (g *Gateway) streamingProviderForTargetLocked(key, model string) (providers
 		return nil, false
 	}
 
-	// Apply circuit breaker if configured.
-	candidate := p
-	if cb, hasCB := g.circuitBreakers[key]; hasCB {
-		candidate = &cbProvider{Provider: p, cb: cb, name: key}
+	sp, ok := p.(providers.StreamProvider)
+	if !ok {
+		return nil, false
 	}
-	sp, ok := candidate.(providers.StreamProvider)
-	return sp, ok
+
+	// Apply circuit breaker if configured.
+	if cb, hasCB := g.circuitBreakers[key]; hasCB {
+		return &cbProvider{Provider: p, cb: cb, name: key}, true
+	}
+	return sp, true
 }
 
 func (g *Gateway) streamingTargetOrderLocked(req providers.Request) ([]string, error) {

--- a/gateway.go
+++ b/gateway.go
@@ -1208,34 +1208,7 @@ func (g *Gateway) RouteStream(ctx context.Context, req providers.Request) (<-cha
 
 	// Resolve provider according to strategy mode.
 	g.mu.RLock()
-	orderedKeys, orderErr := g.streamingTargetOrderLocked(req)
-	var sp providers.StreamProvider
-	if orderErr == nil {
-		for _, key := range orderedKeys {
-			p, ok := g.providers[key]
-			if !ok || !p.SupportsModel(req.Model) {
-				continue
-			}
-			// Apply circuit breaker if configured.
-			candidate := p
-			if cb, hasCB := g.circuitBreakers[key]; hasCB {
-				candidate = &cbProvider{Provider: p, cb: cb, name: key}
-			}
-			if casted, ok := candidate.(providers.StreamProvider); ok {
-				sp = casted
-				break
-			}
-		}
-		// Fallback: any registered provider that supports this model and streaming.
-		if sp == nil {
-			if name, fallback, ok := g.findStreamingProviderMatchByModelLocked(req.Model); ok {
-				sp = fallback
-				if cb, hasCB := g.circuitBreakers[name]; hasCB {
-					sp = &cbProvider{Provider: g.providers[name], cb: cb, name: name}
-				}
-			}
-		}
-	}
+	sp, orderErr := g.resolveStreamingProviderLocked(req)
 	g.mu.RUnlock()
 
 	if orderErr != nil {
@@ -1362,6 +1335,43 @@ func (g *Gateway) RouteStream(ctx context.Context, req providers.Request) (<-cha
 		}
 	})
 	return streamwrap.Meter(ctx, rawCh, start, meta), nil
+}
+
+func (g *Gateway) resolveStreamingProviderLocked(req providers.Request) (providers.StreamProvider, error) {
+	orderedKeys, err := g.streamingTargetOrderLocked(req)
+	if err != nil {
+		return nil, err
+	}
+	for _, key := range orderedKeys {
+		if sp, ok := g.streamingProviderForTargetLocked(key, req.Model); ok {
+			return sp, nil
+		}
+	}
+
+	// Fallback: any registered provider that supports this model and streaming.
+	name, fallback, ok := g.findStreamingProviderMatchByModelLocked(req.Model)
+	if !ok {
+		return nil, nil
+	}
+	if cb, hasCB := g.circuitBreakers[name]; hasCB {
+		return &cbProvider{Provider: g.providers[name], cb: cb, name: name}, nil
+	}
+	return fallback, nil
+}
+
+func (g *Gateway) streamingProviderForTargetLocked(key, model string) (providers.StreamProvider, bool) {
+	p, ok := g.providers[key]
+	if !ok || !p.SupportsModel(model) {
+		return nil, false
+	}
+
+	// Apply circuit breaker if configured.
+	candidate := p
+	if cb, hasCB := g.circuitBreakers[key]; hasCB {
+		candidate = &cbProvider{Provider: p, cb: cb, name: key}
+	}
+	sp, ok := candidate.(providers.StreamProvider)
+	return sp, ok
 }
 
 func (g *Gateway) streamingTargetOrderLocked(req providers.Request) ([]string, error) {

--- a/gateway.go
+++ b/gateway.go
@@ -177,7 +177,10 @@ func New(cfg Config) (*Gateway, error) {
 		gw.mcpInitDone = done
 		go func() {
 			defer close(done)
-			ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+			// Parent the init timeout on the gateway shutdown context so a slow
+			// MCP handshake is cancelled by Close() instead of lingering up to
+			// the full timeout after shutdown.
+			ctx, cancel := context.WithTimeout(gw.shutdownCtx, 60*time.Second)
 			defer cancel()
 			reg.InitializeAll(ctx, func(name string, initErr error) {
 				slog.Error("mcp: server initialization failed",
@@ -685,9 +688,17 @@ func (g *Gateway) publishEvent(ctx context.Context, event events.HookEvent) {
 		return
 	}
 
+	// Detach from the request lifecycle: hooks are dispatched asynchronously
+	// and usually run after the HTTP handler has returned and ctx is already
+	// cancelled. WithoutCancel drops cancellation (so ctx-aware hook work like
+	// DB writes / outbound calls is not dead-on-arrival) while preserving the
+	// request's trace context and values. Worker shutdown is governed by
+	// g.shutdownCtx, not this context.
+	detachedCtx := context.WithoutCancel(ctx)
+
 	for _, hook := range hooks {
 		dispatch := hookDispatch{
-			ctx:   ctx,
+			ctx:   detachedCtx,
 			event: event,
 			hook:  hook,
 		}
@@ -846,7 +857,10 @@ func (g *Gateway) ReloadConfig(cfg Config) error {
 		g.mcpInitDone = done
 		go func() {
 			defer close(done)
-			ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+			// Parent the init timeout on the gateway shutdown context so a slow
+			// MCP handshake is cancelled by Close() instead of lingering up to
+			// the full timeout after shutdown.
+			ctx, cancel := context.WithTimeout(g.shutdownCtx, 60*time.Second)
 			defer cancel()
 			reg.InitializeAll(ctx, func(name string, initErr error) {
 				slog.Error("mcp: server initialization failed after reload",
@@ -1392,10 +1406,12 @@ func (g *Gateway) RouteStream(ctx context.Context, req providers.Request) (<-cha
 					false,
 				)
 			}
-			// Use a detached context: this closure runs in the streamwrap
-			// goroutine after the HTTP handler has returned and the
-			// request ctx is already cancelled.
-			obsProvider.RecordEvent(context.Background(), obsEventFromHook(he))
+			// Detach from the request lifecycle: this closure runs in the
+			// streamwrap goroutine after the HTTP handler has returned and the
+			// request ctx is already cancelled. WithoutCancel drops cancellation
+			// while preserving the request's trace context, so the recorded
+			// event stays linked to the originating trace.
+			obsProvider.RecordEvent(context.WithoutCancel(ctx), obsEventFromHook(he))
 		}
 	})
 	return streamwrap.Meter(ctx, rawCh, start, meta), nil

--- a/gateway.go
+++ b/gateway.go
@@ -1208,33 +1208,41 @@ func (g *Gateway) RouteStream(ctx context.Context, req providers.Request) (<-cha
 
 	// Resolve provider according to strategy mode.
 	g.mu.RLock()
-	orderedKeys := g.streamingTargetOrderLocked(req)
+	orderedKeys, orderErr := g.streamingTargetOrderLocked(req)
 	var sp providers.StreamProvider
-	for _, key := range orderedKeys {
-		p, ok := g.providers[key]
-		if !ok || !p.SupportsModel(req.Model) {
-			continue
+	if orderErr == nil {
+		for _, key := range orderedKeys {
+			p, ok := g.providers[key]
+			if !ok || !p.SupportsModel(req.Model) {
+				continue
+			}
+			// Apply circuit breaker if configured.
+			candidate := p
+			if cb, hasCB := g.circuitBreakers[key]; hasCB {
+				candidate = &cbProvider{Provider: p, cb: cb, name: key}
+			}
+			if casted, ok := candidate.(providers.StreamProvider); ok {
+				sp = casted
+				break
+			}
 		}
-		// Apply circuit breaker if configured.
-		candidate := p
-		if cb, hasCB := g.circuitBreakers[key]; hasCB {
-			candidate = &cbProvider{Provider: p, cb: cb, name: key}
-		}
-		if casted, ok := candidate.(providers.StreamProvider); ok {
-			sp = casted
-			break
-		}
-	}
-	// Fallback: any registered provider that supports this model and streaming.
-	if sp == nil {
-		if name, fallback, ok := g.findStreamingProviderMatchByModelLocked(req.Model); ok {
-			sp = fallback
-			if cb, hasCB := g.circuitBreakers[name]; hasCB {
-				sp = &cbProvider{Provider: g.providers[name], cb: cb, name: name}
+		// Fallback: any registered provider that supports this model and streaming.
+		if sp == nil {
+			if name, fallback, ok := g.findStreamingProviderMatchByModelLocked(req.Model); ok {
+				sp = fallback
+				if cb, hasCB := g.circuitBreakers[name]; hasCB {
+					sp = &cbProvider{Provider: g.providers[name], cb: cb, name: name}
+				}
 			}
 		}
 	}
 	g.mu.RUnlock()
+
+	if orderErr != nil {
+		err = orderErr
+		span.SetError(err)
+		return nil, err
+	}
 
 	if sp == nil {
 		err = fmt.Errorf("no streaming-capable provider found for model: %s", req.Model)
@@ -1355,21 +1363,21 @@ func (g *Gateway) RouteStream(ctx context.Context, req providers.Request) (<-cha
 	return streamwrap.Meter(ctx, rawCh, start, meta), nil
 }
 
-func (g *Gateway) streamingTargetOrderLocked(req providers.Request) []string {
+func (g *Gateway) streamingTargetOrderLocked(req providers.Request) ([]string, error) {
 	targets := g.config.Targets
 	if len(targets) == 0 {
-		return nil
+		return nil, nil
 	}
 
 	switch g.config.Strategy.Mode {
 	case ModeSingle, "":
-		return []string{targets[0].VirtualKey}
+		return []string{targets[0].VirtualKey}, nil
 	case ModeFallback:
 		keys := make([]string, 0, len(targets))
 		for _, t := range targets {
 			keys = append(keys, t.VirtualKey)
 		}
-		return keys
+		return keys, nil
 	case ModeConditional:
 		keys := make([]string, 0, len(targets))
 		for _, cond := range g.config.Strategy.Conditions {
@@ -1381,7 +1389,7 @@ func (g *Gateway) streamingTargetOrderLocked(req providers.Request) []string {
 		for _, t := range targets {
 			keys = appendUniqueKey(keys, t.VirtualKey)
 		}
-		return keys
+		return keys, nil
 	case ModeContentBased:
 		// Evaluate content rules in order; first match wins, fallback is targets[0].
 		for _, cond := range g.streamingContent {
@@ -1391,7 +1399,7 @@ func (g *Gateway) streamingTargetOrderLocked(req providers.Request) []string {
 				for _, t := range targets {
 					keys = appendUniqueKey(keys, t.VirtualKey)
 				}
-				return keys
+				return keys, nil
 			}
 		}
 		// No rule matched — use declared target order (targets[0] is the fallback).
@@ -1399,7 +1407,7 @@ func (g *Gateway) streamingTargetOrderLocked(req providers.Request) []string {
 		for _, t := range targets {
 			keys = append(keys, t.VirtualKey)
 		}
-		return keys
+		return keys, nil
 	case ModeABTest:
 		// Weighted random variant selection mirrors ABTest.selectVariant.
 		total := 0.0
@@ -1424,7 +1432,7 @@ func (g *Gateway) streamingTargetOrderLocked(req providers.Request) []string {
 					for _, t := range targets {
 						keys = appendUniqueKey(keys, t.VirtualKey)
 					}
-					return keys
+					return keys, nil
 				}
 			}
 			// Floating-point safety net — use last variant.
@@ -1433,23 +1441,23 @@ func (g *Gateway) streamingTargetOrderLocked(req providers.Request) []string {
 			for _, t := range targets {
 				keys = appendUniqueKey(keys, t.VirtualKey)
 			}
-			return keys
+			return keys, nil
 		}
 		// No variants configured — fall through to raw order.
 		keys := make([]string, 0, len(targets))
 		for _, t := range targets {
 			keys = append(keys, t.VirtualKey)
 		}
-		return keys
+		return keys, nil
 	case ModeLoadBalance:
 		startIdx := weightedStartIndex(targets)
 		keys := make([]string, 0, len(targets))
 		for i := 0; i < len(targets); i++ {
 			keys = append(keys, targets[(startIdx+i)%len(targets)].VirtualKey)
 		}
-		return keys
+		return keys, nil
 	case ModeLatency:
-		return g.streamingLatencyOrderLocked(targets, req)
+		return g.streamingLatencyOrderLocked(targets, req), nil
 	case ModeCostOptimized:
 		return g.streamingCostOrderLocked(targets, req)
 	default:
@@ -1457,7 +1465,7 @@ func (g *Gateway) streamingTargetOrderLocked(req providers.Request) []string {
 		for _, t := range targets {
 			keys = append(keys, t.VirtualKey)
 		}
-		return keys
+		return keys, nil
 	}
 }
 
@@ -1516,7 +1524,7 @@ type streamingCostCandidate struct {
 	modelFound bool
 }
 
-func (g *Gateway) streamingCostOrderLocked(targets []Target, req providers.Request) []string {
+func (g *Gateway) streamingCostOrderLocked(targets []Target, req providers.Request) ([]string, error) {
 	estimatedPromptTokens := estimatePromptTokens(req)
 	candidates := make([]streamingCostCandidate, 0, len(targets))
 	for _, t := range targets {
@@ -1534,7 +1542,7 @@ func (g *Gateway) streamingCostOrderLocked(targets []Target, req providers.Reque
 		})
 	}
 	if len(candidates) == 0 {
-		return targetKeys(targets)
+		return targetKeys(targets), nil
 	}
 
 	ranked := make([]streamingCostCandidate, 0, len(candidates))
@@ -1560,7 +1568,10 @@ func (g *Gateway) streamingCostOrderLocked(targets []Target, req providers.Reque
 	}
 
 	if len(ranked) == 0 {
-		return targetKeys(targets)
+		if g.config.Strategy.UnpricedStrategy == unpricedStrategySkip {
+			return nil, fmt.Errorf("no priced provider supports model %s", req.Model)
+		}
+		return targetKeys(targets), nil
 	}
 
 	sort.SliceStable(ranked, func(i, j int) bool {
@@ -1574,7 +1585,7 @@ func (g *Gateway) streamingCostOrderLocked(targets []Target, req providers.Reque
 	for _, candidate := range candidates {
 		keys = appendUniqueKey(keys, candidate.key)
 	}
-	return appendRemainingTargetKeys(keys, targets)
+	return appendRemainingTargetKeys(keys, targets), nil
 }
 
 func (g *Gateway) isStreamingTargetCandidateLocked(t Target, model string) bool {

--- a/gateway_observability_test.go
+++ b/gateway_observability_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/ferro-labs/ai-gateway/observability"
 	"github.com/ferro-labs/ai-gateway/providers"
@@ -19,13 +20,24 @@ type eventCapturingProvider struct {
 	fakeProvider
 	mu              sync.Mutex
 	events          []observability.Event
+	eventCtxs       []context.Context
 	recordingActive bool
 }
 
-func (p *eventCapturingProvider) RecordEvent(_ context.Context, evt observability.Event) {
+func (p *eventCapturingProvider) RecordEvent(ctx context.Context, evt observability.Event) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.events = append(p.events, evt)
+	p.eventCtxs = append(p.eventCtxs, ctx)
+}
+
+func (p *eventCapturingProvider) lastEventCtx() context.Context {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if len(p.eventCtxs) == 0 {
+		return nil
+	}
+	return p.eventCtxs[len(p.eventCtxs)-1]
 }
 
 func (p *eventCapturingProvider) RecordingEnabled() bool {
@@ -280,6 +292,60 @@ func TestGateway_RouteStream_StampsRoutingAttrs(t *testing.T) {
 	}
 	if s, ok := got.(string); !ok || s == "" {
 		t.Errorf("ferro.routing.target_key must be a non-empty string, got %T(%v)", got, got)
+	}
+}
+
+// TestGateway_RouteStream_EventContextDetachedButTraced covers issue #181: the
+// observability event recorded from the streamwrap goroutine must be detached
+// from request cancellation (so it is not dead-on-arrival once the HTTP handler
+// returns) while still carrying the request's trace context / values via
+// context.WithoutCancel.
+func TestGateway_RouteStream_EventContextDetachedButTraced(t *testing.T) {
+	gw, _ := New(Config{
+		Strategy: StrategyConfig{Mode: ModeSingle},
+		Targets:  []Target{{VirtualKey: "mock"}},
+	})
+	ep := &eventCapturingProvider{recordingActive: true}
+	gw.SetObservability(ep)
+
+	gw.RegisterProvider(&mockStreamProvider{
+		mockProvider: mockProvider{name: "mock", models: []string{testModel}},
+	})
+
+	type ctxKey string
+	const marker ctxKey = "trace-marker"
+	reqCtx, cancel := context.WithCancel(context.WithValue(context.Background(), marker, "trace-xyz"))
+
+	ch, err := gw.RouteStream(reqCtx, providers.Request{
+		Model:    testModel,
+		Stream:   true,
+		Messages: []providers.Message{{Role: "user", Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("RouteStream: %v", err)
+	}
+	// Simulate the HTTP handler returning before the streamwrap goroutine
+	// records its completion event.
+	cancel()
+	//nolint:revive // intentionally draining the stream channel to completion
+	for range ch {
+	}
+
+	var evtCtx context.Context
+	for range 200 {
+		if evtCtx = ep.lastEventCtx(); evtCtx != nil {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if evtCtx == nil {
+		t.Fatal("no observability event was recorded")
+	}
+	if err := evtCtx.Err(); err != nil {
+		t.Fatalf("event ctx should be detached from cancellation, got %v", err)
+	}
+	if v, _ := evtCtx.Value(marker).(string); v != "trace-xyz" {
+		t.Fatalf("event ctx lost request trace value: got %q, want trace-xyz", v)
 	}
 }
 

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -481,6 +481,32 @@ func TestGateway_RouteStream_LeastLatencyUsesObservedP50(t *testing.T) {
 	drainStream(t, ch)
 }
 
+func TestGateway_RouteStream_LeastLatencyRecordsStreamLatency(t *testing.T) {
+	gw, err := New(Config{
+		Strategy: StrategyConfig{Mode: ModeLatency},
+		Targets:  []Target{{VirtualKey: "stream"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	gw.RegisterProvider(&mockStreamProvider{
+		mockProvider: mockProvider{name: "stream", models: []string{"gpt-4o"}},
+	})
+
+	ch, err := gw.RouteStream(context.Background(), providers.Request{
+		Model:    "gpt-4o",
+		Messages: []providers.Message{{Role: "user", Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("RouteStream error = %v", err)
+	}
+	drainStream(t, ch)
+
+	if !gw.latencyTracker.HasSamples("stream") {
+		t.Fatal("expected RouteStream to record a latency sample")
+	}
+}
+
 func TestGateway_RouteStream_CostOptimizedUsesCatalogCost(t *testing.T) {
 	gw, err := New(Config{
 		Strategy: StrategyConfig{Mode: ModeCostOptimized},

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -88,6 +88,27 @@ func counterValue(t *testing.T, c prometheus.Counter) float64 {
 
 func ptrFloat64(v float64) *float64 { return &v }
 
+func drainStream(t *testing.T, ch <-chan providers.StreamChunk) {
+	t.Helper()
+	for chunk := range ch {
+		if chunk.Error != nil {
+			t.Fatalf("stream chunk error: %v", chunk.Error)
+		}
+	}
+}
+
+func requireKeys(t *testing.T, got []string, want ...string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("got keys %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("got keys %v, want %v", got, want)
+		}
+	}
+}
+
 func TestGateway_Route_Single(t *testing.T) {
 	gw, _ := New(Config{
 		Strategy: StrategyConfig{Mode: ModeSingle},
@@ -150,12 +171,12 @@ func TestGateway_Route_CostOptimizedPassesUnpricedStrategy(t *testing.T) {
 	}{
 		{
 			name:             "skip routes to priced provider",
-			unpricedStrategy: "skip",
+			unpricedStrategy: unpricedStrategySkip,
 			wantProvider:     "priced",
 		},
 		{
 			name:             "allow routes to unpriced provider",
-			unpricedStrategy: "allow",
+			unpricedStrategy: unpricedStrategyAllow,
 			wantProvider:     "unpriced",
 		},
 	}
@@ -427,6 +448,270 @@ func TestStreamingContentConditionMatchesPromptRegexRequiresCompiledRegex(t *tes
 	}, req) {
 		t.Fatal("unknown streaming content condition should not match")
 	}
+}
+
+func TestGateway_RouteStream_LeastLatencyUsesObservedP50(t *testing.T) {
+	gw, err := New(Config{
+		Strategy: StrategyConfig{Mode: ModeLatency},
+		Targets: []Target{
+			{VirtualKey: "slow"},
+			{VirtualKey: "fast"},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	gw.RegisterProvider(&mockStreamProvider{
+		mockProvider: mockProvider{name: "slow", models: []string{"gpt-4o"}},
+		streamErr:    errors.New("slow provider selected"),
+	})
+	gw.RegisterProvider(&mockStreamProvider{
+		mockProvider: mockProvider{name: "fast", models: []string{"gpt-4o"}},
+	})
+	gw.latencyTracker.Record("slow", 120*time.Millisecond)
+	gw.latencyTracker.Record("fast", 10*time.Millisecond)
+
+	ch, err := gw.RouteStream(context.Background(), providers.Request{
+		Model:    "gpt-4o",
+		Messages: []providers.Message{{Role: "user", Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("RouteStream error = %v, want fast provider", err)
+	}
+	drainStream(t, ch)
+}
+
+func TestGateway_RouteStream_CostOptimizedUsesCatalogCost(t *testing.T) {
+	gw, err := New(Config{
+		Strategy: StrategyConfig{Mode: ModeCostOptimized},
+		Targets: []Target{
+			{VirtualKey: "expensive"},
+			{VirtualKey: "cheap"},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	gw.catalog = models.Catalog{
+		"expensive/gpt-4o": {
+			Provider: "expensive",
+			ModelID:  "gpt-4o",
+			Mode:     models.ModeChat,
+			Pricing: models.Pricing{
+				InputPerMTokens: ptrFloat64(10),
+			},
+		},
+		"cheap/gpt-4o": {
+			Provider: "cheap",
+			ModelID:  "gpt-4o",
+			Mode:     models.ModeChat,
+			Pricing: models.Pricing{
+				InputPerMTokens: ptrFloat64(1),
+			},
+		},
+	}
+	gw.RegisterProvider(&mockStreamProvider{
+		mockProvider: mockProvider{name: "expensive", models: []string{"gpt-4o"}},
+		streamErr:    errors.New("expensive provider selected"),
+	})
+	gw.RegisterProvider(&mockStreamProvider{
+		mockProvider: mockProvider{name: "cheap", models: []string{"gpt-4o"}},
+	})
+
+	ch, err := gw.RouteStream(context.Background(), providers.Request{
+		Model:    "gpt-4o",
+		Messages: []providers.Message{{Role: "user", Content: "hello world"}},
+	})
+	if err != nil {
+		t.Fatalf("RouteStream error = %v, want cheap provider", err)
+	}
+	drainStream(t, ch)
+}
+
+func TestGateway_StreamingCostOrderHandlesUnpricedStrategies(t *testing.T) {
+	tests := []struct {
+		name             string
+		unpricedStrategy string
+		catalog          models.Catalog
+		want             []string
+	}{
+		{
+			name:             "skip puts priced providers first",
+			unpricedStrategy: unpricedStrategySkip,
+			catalog: models.Catalog{
+				"unpriced/gpt-4o": {
+					Provider: "unpriced",
+					ModelID:  "gpt-4o",
+					Mode:     models.ModeChat,
+					Pricing:  models.Pricing{},
+				},
+				"priced/gpt-4o": {
+					Provider: "priced",
+					ModelID:  "gpt-4o",
+					Mode:     models.ModeChat,
+					Pricing: models.Pricing{
+						InputPerMTokens: ptrFloat64(1),
+					},
+				},
+			},
+			want: []string{"priced", "unpriced", "missing", "plain"},
+		},
+		{
+			name:             "allow keeps model-found unpriced providers eligible",
+			unpricedStrategy: unpricedStrategyAllow,
+			catalog: models.Catalog{
+				"unpriced/gpt-4o": {
+					Provider: "unpriced",
+					ModelID:  "gpt-4o",
+					Mode:     models.ModeChat,
+					Pricing:  models.Pricing{},
+				},
+				"priced/gpt-4o": {
+					Provider: "priced",
+					ModelID:  "gpt-4o",
+					Mode:     models.ModeChat,
+					Pricing: models.Pricing{
+						InputPerMTokens: ptrFloat64(1),
+					},
+				},
+			},
+			want: []string{"unpriced", "priced", "missing", "plain"},
+		},
+		{
+			name: "fallback returns target order when nothing is priced",
+			catalog: models.Catalog{
+				"unpriced/gpt-4o": {
+					Provider: "unpriced",
+					ModelID:  "gpt-4o",
+					Mode:     models.ModeChat,
+					Pricing:  models.Pricing{},
+				},
+			},
+			want: []string{"unpriced", "priced", "missing", "plain"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gw, err := New(Config{
+				Strategy: StrategyConfig{
+					Mode:             ModeCostOptimized,
+					UnpricedStrategy: tt.unpricedStrategy,
+				},
+				Targets: []Target{
+					{VirtualKey: "unpriced"},
+					{VirtualKey: "priced"},
+					{VirtualKey: "missing"},
+					{VirtualKey: "plain"},
+				},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			gw.catalog = tt.catalog
+			gw.RegisterProvider(&mockStreamProvider{
+				mockProvider: mockProvider{name: "unpriced", models: []string{"gpt-4o"}},
+			})
+			gw.RegisterProvider(&mockStreamProvider{
+				mockProvider: mockProvider{name: "priced", models: []string{"gpt-4o"}},
+			})
+			gw.RegisterProvider(&mockStreamProvider{
+				mockProvider: mockProvider{name: "missing", models: []string{"gpt-4o"}},
+			})
+			gw.RegisterProvider(&mockProvider{
+				name:   "plain",
+				models: []string{"gpt-4o"},
+			})
+
+			got := gw.streamingCostOrderLocked(gw.config.Targets, providers.Request{
+				Model:    "gpt-4o",
+				Messages: []providers.Message{{Role: "user", Content: "hello world"}},
+			})
+			requireKeys(t, got, tt.want...)
+		})
+	}
+}
+
+func TestGateway_StreamingLatencyOrderFallsBackWithoutStreamingCandidates(t *testing.T) {
+	gw, err := New(Config{
+		Strategy: StrategyConfig{Mode: ModeLatency},
+		Targets: []Target{
+			{VirtualKey: "plain"},
+			{VirtualKey: "unsupported"},
+			{VirtualKey: "missing"},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	gw.RegisterProvider(&mockProvider{
+		name:   "plain",
+		models: []string{"gpt-4o"},
+	})
+	gw.RegisterProvider(&mockStreamProvider{
+		mockProvider: mockProvider{name: "unsupported", models: []string{"other-model"}},
+	})
+
+	got := gw.streamingLatencyOrderLocked(gw.config.Targets, providers.Request{Model: "gpt-4o"})
+	requireKeys(t, got, "plain", "unsupported", "missing")
+}
+
+func TestGateway_StreamingLatencyOrderTriesUnseenBeforeSampled(t *testing.T) {
+	gw, err := New(Config{
+		Strategy: StrategyConfig{Mode: ModeLatency},
+		Targets: []Target{
+			{VirtualKey: "unseen-a"},
+			{VirtualKey: "sampled"},
+			{VirtualKey: "unseen-b"},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	gw.RegisterProvider(&mockStreamProvider{
+		mockProvider: mockProvider{name: "unseen-a", models: []string{"gpt-4o"}},
+	})
+	gw.RegisterProvider(&mockStreamProvider{
+		mockProvider: mockProvider{name: "sampled", models: []string{"gpt-4o"}},
+	})
+	gw.RegisterProvider(&mockStreamProvider{
+		mockProvider: mockProvider{name: "unseen-b", models: []string{"gpt-4o"}},
+	})
+	gw.latencyTracker.Record("sampled", 10*time.Millisecond)
+
+	got := gw.streamingLatencyOrderLocked(gw.config.Targets, providers.Request{Model: "gpt-4o"})
+	if got[2] != "sampled" {
+		t.Fatalf("got keys %v, want sampled provider after unseen providers", got)
+	}
+	firstTwoUnseen := (got[0] == "unseen-a" && got[1] == "unseen-b") ||
+		(got[0] == "unseen-b" && got[1] == "unseen-a")
+	if !firstTwoUnseen {
+		t.Fatalf("got keys %v, want unseen providers first", got)
+	}
+}
+
+func TestGateway_StreamingCostOrderFallsBackWithoutStreamingCandidates(t *testing.T) {
+	gw, err := New(Config{
+		Strategy: StrategyConfig{Mode: ModeCostOptimized},
+		Targets: []Target{
+			{VirtualKey: "plain"},
+			{VirtualKey: "unsupported"},
+			{VirtualKey: "missing"},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	gw.RegisterProvider(&mockProvider{
+		name:   "plain",
+		models: []string{"gpt-4o"},
+	})
+	gw.RegisterProvider(&mockStreamProvider{
+		mockProvider: mockProvider{name: "unsupported", models: []string{"other-model"}},
+	})
+
+	got := gw.streamingCostOrderLocked(gw.config.Targets, providers.Request{Model: "gpt-4o"})
+	requireKeys(t, got, "plain", "unsupported", "missing")
 }
 
 func TestGateway_RouteStream_ImmediateFailure_IncrementsProviderErrors(t *testing.T) {

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/ferro-labs/ai-gateway/internal/events"
 	"github.com/ferro-labs/ai-gateway/internal/logging"
 	"github.com/ferro-labs/ai-gateway/internal/metrics"
+	cacheplugin "github.com/ferro-labs/ai-gateway/internal/plugins/cache"
 	"github.com/ferro-labs/ai-gateway/mcp"
 	"github.com/ferro-labs/ai-gateway/models"
 	"github.com/ferro-labs/ai-gateway/plugin"
@@ -1388,6 +1389,294 @@ func TestGateway_RouteStream_BeforePluginCanSetNilRequest(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("expected error for missing streaming provider")
+	}
+}
+
+func TestGateway_RouteStream_RunAfterReceivesStreamResponse(t *testing.T) {
+	gw, _ := New(Config{
+		Strategy: StrategyConfig{Mode: ModeSingle},
+		Targets:  []Target{{VirtualKey: "mock"}},
+	})
+	gw.RegisterProvider(&mockStreamProvider{
+		mockProvider: mockProvider{name: "mock", models: []string{"gpt-4o"}},
+		streamFn: func(context.Context, providers.Request) (<-chan providers.StreamChunk, error) {
+			ch := make(chan providers.StreamChunk, 3)
+			ch <- providers.StreamChunk{
+				ID:      "chatcmpl-stream",
+				Object:  "chat.completion.chunk",
+				Created: 123,
+				Model:   "gpt-4o",
+				Choices: []providers.StreamChoice{{
+					Index: 0,
+					Delta: providers.MessageDelta{Role: "assistant", Content: "hello "},
+				}},
+			}
+			ch <- providers.StreamChunk{
+				ID:      "chatcmpl-stream",
+				Object:  "chat.completion.chunk",
+				Created: 123,
+				Model:   "gpt-4o",
+				Choices: []providers.StreamChoice{{
+					Index:        0,
+					Delta:        providers.MessageDelta{Content: "world"},
+					FinishReason: "stop",
+				}},
+			}
+			ch <- providers.StreamChunk{
+				ID:      "chatcmpl-stream",
+				Object:  "chat.completion.chunk",
+				Created: 123,
+				Model:   "gpt-4o",
+				Usage:   &providers.Usage{PromptTokens: 2, CompletionTokens: 3, TotalTokens: 5},
+			}
+			close(ch)
+			return ch, nil
+		},
+	})
+
+	var afterCalls int
+	_ = gw.RegisterPlugin(plugin.StageAfterRequest, &testPlugin{
+		name: "after",
+		typ:  plugin.TypeLogging,
+		execFn: func(_ context.Context, pctx *plugin.Context) error {
+			afterCalls++
+			if pctx.Request == nil {
+				t.Fatal("after plugin request is nil")
+			}
+			if pctx.Response == nil {
+				t.Fatal("after plugin response is nil")
+			}
+			if pctx.Response.Provider != "mock" {
+				t.Fatalf("after plugin provider = %q, want mock", pctx.Response.Provider)
+			}
+			if pctx.Response.Model != "gpt-4o" {
+				t.Fatalf("after plugin model = %q, want gpt-4o", pctx.Response.Model)
+			}
+			if pctx.Response.Usage.TotalTokens != 5 {
+				t.Fatalf("after plugin total tokens = %d, want 5", pctx.Response.Usage.TotalTokens)
+			}
+			if got := pctx.Response.Choices[0].Message.Content; got != "hello world" {
+				t.Fatalf("after plugin content = %q, want hello world", got)
+			}
+			return nil
+		},
+	})
+
+	ch, err := gw.RouteStream(context.Background(), providers.Request{
+		Model:    "gpt-4o",
+		Messages: []providers.Message{{Role: "user", Content: "hi"}},
+		Stream:   true,
+	})
+	if err != nil {
+		t.Fatalf("RouteStream: %v", err)
+	}
+	drainStream(t, ch)
+
+	if afterCalls != 1 {
+		t.Fatalf("after plugin calls = %d, want 1", afterCalls)
+	}
+}
+
+func TestGateway_RouteStream_RunOnErrorReceivesStreamError(t *testing.T) {
+	streamErr := errors.New("stream failed")
+	gw, _ := New(Config{
+		Strategy: StrategyConfig{Mode: ModeSingle},
+		Targets:  []Target{{VirtualKey: "mock"}},
+	})
+	gw.RegisterProvider(&mockStreamProvider{
+		mockProvider: mockProvider{name: "mock", models: []string{"gpt-4o"}},
+		streamFn: func(context.Context, providers.Request) (<-chan providers.StreamChunk, error) {
+			ch := make(chan providers.StreamChunk, 1)
+			ch <- providers.StreamChunk{Error: streamErr}
+			close(ch)
+			return ch, nil
+		},
+	})
+
+	var onErrorCalls int
+	_ = gw.RegisterPlugin(plugin.StageOnError, &testPlugin{
+		name: "on-error",
+		typ:  plugin.TypeLogging,
+		execFn: func(_ context.Context, pctx *plugin.Context) error {
+			onErrorCalls++
+			if !errors.Is(pctx.Error, streamErr) {
+				t.Fatalf("on-error plugin error = %v, want %v", pctx.Error, streamErr)
+			}
+			if pctx.Response != nil {
+				t.Fatalf("on-error plugin response = %#v, want nil", pctx.Response)
+			}
+			return nil
+		},
+	})
+
+	ch, err := gw.RouteStream(context.Background(), providers.Request{
+		Model:    "gpt-4o",
+		Messages: []providers.Message{{Role: "user", Content: "hi"}},
+		Stream:   true,
+	})
+	if err != nil {
+		t.Fatalf("RouteStream: %v", err)
+	}
+	for chunk := range ch {
+		if !errors.Is(chunk.Error, streamErr) {
+			t.Fatalf("stream chunk error = %v, want %v", chunk.Error, streamErr)
+		}
+	}
+
+	if onErrorCalls != 1 {
+		t.Fatalf("on-error plugin calls = %d, want 1", onErrorCalls)
+	}
+}
+
+func TestGateway_RouteStream_AfterPluginRejectRunsOnError(t *testing.T) {
+	gw, _ := New(Config{
+		Strategy: StrategyConfig{Mode: ModeSingle},
+		Targets:  []Target{{VirtualKey: "mock"}},
+	})
+	gw.RegisterProvider(&mockStreamProvider{
+		mockProvider: mockProvider{name: "mock", models: []string{"gpt-4o"}},
+		streamFn: func(context.Context, providers.Request) (<-chan providers.StreamChunk, error) {
+			ch := make(chan providers.StreamChunk, 2)
+			ch <- providers.StreamChunk{
+				Model: "gpt-4o",
+				Choices: []providers.StreamChoice{{
+					Index:        0,
+					Delta:        providers.MessageDelta{Role: "assistant", Content: "ok"},
+					FinishReason: "stop",
+				}},
+			}
+			ch <- providers.StreamChunk{
+				Usage: &providers.Usage{PromptTokens: 1, CompletionTokens: 1, TotalTokens: 2},
+			}
+			close(ch)
+			return ch, nil
+		},
+	})
+
+	var onErrorCalls int
+	_ = gw.RegisterPlugin(plugin.StageAfterRequest, &testPlugin{
+		name: "after",
+		typ:  plugin.TypeLogging,
+		execFn: func(_ context.Context, pctx *plugin.Context) error {
+			pctx.Reject = true
+			pctx.Reason = "after plugin rejected"
+			return nil
+		},
+	})
+	_ = gw.RegisterPlugin(plugin.StageOnError, &testPlugin{
+		name: "on-error",
+		typ:  plugin.TypeLogging,
+		execFn: func(_ context.Context, pctx *plugin.Context) error {
+			onErrorCalls++
+			var rejection *plugin.RejectionError
+			if !errors.As(pctx.Error, &rejection) {
+				t.Fatalf("on-error plugin error = %T(%v), want *plugin.RejectionError", pctx.Error, pctx.Error)
+			}
+			return nil
+		},
+	})
+
+	ch, err := gw.RouteStream(context.Background(), providers.Request{
+		Model:    "gpt-4o",
+		Messages: []providers.Message{{Role: "user", Content: "hi"}},
+		Stream:   true,
+	})
+	if err != nil {
+		t.Fatalf("RouteStream: %v", err)
+	}
+	var sawPluginErr bool
+	for chunk := range ch {
+		if chunk.Error != nil {
+			sawPluginErr = true
+		}
+	}
+	if !sawPluginErr {
+		t.Fatal("expected stream chunk carrying after plugin rejection error")
+	}
+	if onErrorCalls != 1 {
+		t.Fatalf("on-error plugin calls = %d, want 1", onErrorCalls)
+	}
+}
+
+func TestGateway_RouteStream_ResponseCacheHitSkipsProvider(t *testing.T) {
+	gw, _ := New(Config{
+		Strategy: StrategyConfig{Mode: ModeSingle},
+		Targets:  []Target{{VirtualKey: "mock"}},
+	})
+	var streamCalls atomic.Int32
+	gw.RegisterProvider(&mockStreamProvider{
+		mockProvider: mockProvider{name: "mock", models: []string{"gpt-4o"}},
+		streamFn: func(context.Context, providers.Request) (<-chan providers.StreamChunk, error) {
+			streamCalls.Add(1)
+			ch := make(chan providers.StreamChunk, 2)
+			ch <- providers.StreamChunk{
+				ID:      "chatcmpl-cacheable",
+				Object:  "chat.completion.chunk",
+				Created: 123,
+				Model:   "gpt-4o",
+				Choices: []providers.StreamChoice{{
+					Index:        0,
+					Delta:        providers.MessageDelta{Role: "assistant", Content: "cached"},
+					FinishReason: "stop",
+				}},
+			}
+			ch <- providers.StreamChunk{
+				ID:      "chatcmpl-cacheable",
+				Object:  "chat.completion.chunk",
+				Created: 123,
+				Model:   "gpt-4o",
+				Usage:   &providers.Usage{PromptTokens: 1, CompletionTokens: 1, TotalTokens: 2},
+			}
+			close(ch)
+			return ch, nil
+		},
+	})
+	cache := &cacheplugin.ResponseCache{}
+	if err := cache.Init(map[string]interface{}{"max_age": 60}); err != nil {
+		t.Fatalf("cache init: %v", err)
+	}
+	_ = gw.RegisterPlugin(plugin.StageBeforeRequest, cache)
+	_ = gw.RegisterPlugin(plugin.StageAfterRequest, cache)
+
+	req := providers.Request{
+		Model:    "gpt-4o",
+		Messages: []providers.Message{{Role: "user", Content: "hi"}},
+		Stream:   true,
+	}
+	first, err := gw.RouteStream(context.Background(), req)
+	if err != nil {
+		t.Fatalf("first RouteStream: %v", err)
+	}
+	drainStream(t, first)
+	if got := streamCalls.Load(); got != 1 {
+		t.Fatalf("stream calls after first request = %d, want 1", got)
+	}
+
+	second, err := gw.RouteStream(context.Background(), req)
+	if err != nil {
+		t.Fatalf("second RouteStream: %v", err)
+	}
+	var content string
+	var usage *providers.Usage
+	for chunk := range second {
+		if chunk.Error != nil {
+			t.Fatalf("cached stream chunk error: %v", chunk.Error)
+		}
+		for _, choice := range chunk.Choices {
+			content += choice.Delta.Content
+		}
+		if chunk.Usage != nil {
+			usage = chunk.Usage
+		}
+	}
+	if got := streamCalls.Load(); got != 1 {
+		t.Fatalf("stream calls after cache hit = %d, want 1", got)
+	}
+	if content != "cached" {
+		t.Fatalf("cached stream content = %q, want cached", content)
+	}
+	if usage == nil || usage.TotalTokens != 2 {
+		t.Fatalf("cached stream usage = %#v, want total tokens 2", usage)
 	}
 }
 

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -863,6 +863,510 @@ func TestGateway_RouteStream_ImmediateCircuitOpen_IncrementsCircuitOpenProviderE
 	}
 }
 
+func streamTestRequest() providers.Request {
+	return providers.Request{
+		Model:    "gpt-4o",
+		Messages: []providers.Message{{Role: "user", Content: "hi"}},
+	}
+}
+
+func drainMeteredStream(t *testing.T, ch <-chan providers.StreamChunk) {
+	t.Helper()
+	for range ch { //nolint:revive
+	}
+}
+
+func TestGateway_RouteStream_StartupFailureTripsCircuitWithoutRoute(t *testing.T) {
+	gw, err := New(Config{
+		Strategy: StrategyConfig{Mode: ModeSingle},
+		Targets: []Target{{
+			VirtualKey: "flaky-stream",
+			CircuitBreaker: &CircuitBreakerConfig{
+				FailureThreshold: 2,
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	gw.RegisterProvider(&mockStreamProvider{
+		mockProvider: mockProvider{
+			name:   "flaky-stream",
+			models: []string{"gpt-4o"},
+		},
+		streamErr: errors.New("stream startup failed"),
+	})
+
+	req := streamTestRequest()
+	for i := 0; i < 2; i++ {
+		_, err := gw.RouteStream(context.Background(), req)
+		if err == nil {
+			t.Fatalf("attempt %d: expected startup error", i+1)
+		}
+	}
+
+	_, err = gw.RouteStream(context.Background(), req)
+	if !errors.Is(err, circuitbreaker.ErrCircuitOpen) {
+		t.Fatalf("expected circuit open, got %v", err)
+	}
+}
+
+func TestGateway_RouteStream_FallbackSkipsNonStreamingTargetWithCircuitBreaker(t *testing.T) {
+	var selected atomic.Value
+	gw, err := New(Config{
+		Strategy: StrategyConfig{Mode: ModeFallback},
+		Targets: []Target{
+			{
+				VirtualKey: "plain",
+				CircuitBreaker: &CircuitBreakerConfig{
+					FailureThreshold: 2,
+				},
+			},
+			{VirtualKey: "stream"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	gw.RegisterProvider(&mockProvider{
+		name:   "plain",
+		models: []string{"gpt-4o"},
+	})
+	gw.RegisterProvider(&mockStreamProvider{
+		mockProvider: mockProvider{
+			name:   "stream",
+			models: []string{"gpt-4o"},
+		},
+		streamFn: func(_ context.Context, _ providers.Request) (<-chan providers.StreamChunk, error) {
+			selected.Store("stream")
+			ch := make(chan providers.StreamChunk, 1)
+			ch <- providers.StreamChunk{
+				ID: "stream-ok",
+				Choices: []providers.StreamChoice{{
+					Delta: providers.MessageDelta{Content: "ok"},
+				}},
+			}
+			close(ch)
+			return ch, nil
+		},
+	})
+
+	ch, err := gw.RouteStream(context.Background(), streamTestRequest())
+	if err != nil {
+		t.Fatalf("RouteStream error = %v, want streaming fallback target", err)
+	}
+	drainMeteredStream(t, ch)
+	if got := selected.Load(); got != "stream" {
+		t.Fatalf("selected provider = %v, want stream", got)
+	}
+}
+
+func TestGateway_RouteStream_StartupCancellationDoesNotTripCircuit(t *testing.T) {
+	gw, err := New(Config{
+		Strategy: StrategyConfig{Mode: ModeSingle},
+		Targets: []Target{{
+			VirtualKey: "flaky-stream",
+			CircuitBreaker: &CircuitBreakerConfig{
+				FailureThreshold: 2,
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	gw.RegisterProvider(&mockStreamProvider{
+		mockProvider: mockProvider{
+			name:   "flaky-stream",
+			models: []string{"gpt-4o"},
+		},
+		streamErr: context.Canceled,
+	})
+
+	req := streamTestRequest()
+	for i := 0; i < 3; i++ {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		_, err := gw.RouteStream(ctx, req)
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("attempt %d: error = %v, want context.Canceled", i+1, err)
+		}
+	}
+
+	gw.mu.RLock()
+	cb := gw.circuitBreakers["flaky-stream"]
+	gw.mu.RUnlock()
+	if cb == nil {
+		t.Fatal("expected circuit breaker for flaky-stream")
+	}
+	if cb.State() != circuitbreaker.StateClosed {
+		t.Fatalf("circuit state = %v, want closed after startup cancellations", cb.State())
+	}
+}
+
+func TestGateway_Route_ProviderTimeoutTripsCircuit(t *testing.T) {
+	gw, err := New(Config{
+		Strategy: StrategyConfig{Mode: ModeSingle},
+		Targets: []Target{{
+			VirtualKey: "slow",
+			CircuitBreaker: &CircuitBreakerConfig{
+				FailureThreshold: 2,
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	gw.RegisterProvider(&mockProvider{
+		name:   "slow",
+		models: []string{"gpt-4o"},
+		err:    context.DeadlineExceeded,
+	})
+
+	req := providers.Request{
+		Model:    "gpt-4o",
+		Messages: []providers.Message{{Role: "user", Content: "hi"}},
+	}
+	for i := 0; i < 2; i++ {
+		_, routeErr := gw.Route(context.Background(), req)
+		if !errors.Is(routeErr, context.DeadlineExceeded) {
+			t.Fatalf("attempt %d: error = %v, want context.DeadlineExceeded", i+1, routeErr)
+		}
+	}
+
+	_, routeErr := gw.Route(context.Background(), req)
+	if !errors.Is(routeErr, circuitbreaker.ErrCircuitOpen) {
+		t.Fatalf("expected circuit open after provider timeouts, got %v", routeErr)
+	}
+}
+
+func TestGateway_RouteStream_ProviderTimeoutTripsCircuit(t *testing.T) {
+	gw, err := New(Config{
+		Strategy: StrategyConfig{Mode: ModeSingle},
+		Targets: []Target{{
+			VirtualKey: "flaky-stream",
+			CircuitBreaker: &CircuitBreakerConfig{
+				FailureThreshold: 2,
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	gw.RegisterProvider(&mockStreamProvider{
+		mockProvider: mockProvider{
+			name:   "flaky-stream",
+			models: []string{"gpt-4o"},
+		},
+		streamErr: context.DeadlineExceeded,
+	})
+
+	req := streamTestRequest()
+	for i := 0; i < 2; i++ {
+		_, err := gw.RouteStream(context.Background(), req)
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("attempt %d: error = %v, want context.DeadlineExceeded", i+1, err)
+		}
+	}
+
+	_, err = gw.RouteStream(context.Background(), req)
+	if !errors.Is(err, circuitbreaker.ErrCircuitOpen) {
+		t.Fatalf("expected circuit open after provider timeouts, got %v", err)
+	}
+}
+
+func TestShouldRecordCircuitBreakerFailure(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		ctx  context.Context
+		err  error
+		want bool
+	}{
+		{
+			name: "nil error",
+			ctx:  context.Background(),
+			err:  nil,
+			want: false,
+		},
+		{
+			name: "provider timeout with live request context",
+			ctx:  context.Background(),
+			err:  context.DeadlineExceeded,
+			want: true,
+		},
+		{
+			name: "client deadline with canceled request context",
+			ctx: func() context.Context {
+				ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+				cancel()
+				return ctx
+			}(),
+			err:  context.DeadlineExceeded,
+			want: false,
+		},
+		{
+			name: "client cancel with canceled request context",
+			ctx: func() context.Context {
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel()
+				return ctx
+			}(),
+			err:  context.Canceled,
+			want: false,
+		},
+		{
+			name: "provider error with live request context",
+			ctx:  context.Background(),
+			err:  errors.New("upstream unavailable"),
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := shouldRecordCircuitBreakerFailure(tt.ctx, tt.err); got != tt.want {
+				t.Fatalf("shouldRecordCircuitBreakerFailure() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGateway_RouteStream_FallbackSkipsOpenCircuitBreakerTarget(t *testing.T) {
+	var selected atomic.Value
+	gw, err := New(Config{
+		Strategy: StrategyConfig{Mode: ModeFallback},
+		Targets: []Target{
+			{
+				VirtualKey: "flaky-stream",
+				CircuitBreaker: &CircuitBreakerConfig{
+					FailureThreshold: 2,
+				},
+			},
+			{VirtualKey: "healthy-stream"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	gw.RegisterProvider(&mockStreamProvider{
+		mockProvider: mockProvider{
+			name:   "flaky-stream",
+			models: []string{"gpt-4o"},
+		},
+		streamErr: errors.New("stream startup failed"),
+	})
+	gw.RegisterProvider(&mockStreamProvider{
+		mockProvider: mockProvider{
+			name:   "healthy-stream",
+			models: []string{"gpt-4o"},
+		},
+		streamFn: func(_ context.Context, _ providers.Request) (<-chan providers.StreamChunk, error) {
+			selected.Store("healthy-stream")
+			ch := make(chan providers.StreamChunk, 1)
+			ch <- providers.StreamChunk{
+				ID: "healthy-ok",
+				Choices: []providers.StreamChoice{{
+					Delta: providers.MessageDelta{Content: "ok"},
+				}},
+			}
+			close(ch)
+			return ch, nil
+		},
+	})
+
+	req := streamTestRequest()
+	for i := 0; i < 2; i++ {
+		_, err := gw.RouteStream(context.Background(), req)
+		if err == nil {
+			t.Fatalf("attempt %d: expected startup error to trip breaker", i+1)
+		}
+	}
+
+	ch, err := gw.RouteStream(context.Background(), req)
+	if err != nil {
+		t.Fatalf("RouteStream error = %v, want healthy-stream fallback", err)
+	}
+	drainMeteredStream(t, ch)
+	if got := selected.Load(); got != "healthy-stream" {
+		t.Fatalf("selected provider = %v, want healthy-stream", got)
+	}
+}
+
+type slowCompleteProvider struct {
+	mockProvider
+}
+
+func (p *slowCompleteProvider) Complete(ctx context.Context, _ providers.Request) (*providers.Response, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-time.After(500 * time.Millisecond):
+		return &providers.Response{ID: "ok"}, nil
+	}
+}
+
+func TestGateway_Route_ClientDeadlineDoesNotTripCircuit(t *testing.T) {
+	gw, err := New(Config{
+		Strategy: StrategyConfig{Mode: ModeSingle},
+		Targets: []Target{{
+			VirtualKey: "slow",
+			CircuitBreaker: &CircuitBreakerConfig{
+				FailureThreshold: 2,
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	gw.RegisterProvider(&slowCompleteProvider{
+		mockProvider: mockProvider{
+			name:   "slow",
+			models: []string{"gpt-4o"},
+		},
+	})
+
+	req := providers.Request{
+		Model:    "gpt-4o",
+		Messages: []providers.Message{{Role: "user", Content: "hi"}},
+	}
+	for i := 0; i < 2; i++ {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+		_, routeErr := gw.Route(ctx, req)
+		cancel()
+		if !errors.Is(routeErr, context.DeadlineExceeded) {
+			t.Fatalf("attempt %d: error = %v, want context.DeadlineExceeded", i+1, routeErr)
+		}
+	}
+
+	gw.mu.RLock()
+	cb := gw.circuitBreakers["slow"]
+	gw.mu.RUnlock()
+	if cb == nil {
+		t.Fatal("expected circuit breaker for slow")
+	}
+	if cb.State() != circuitbreaker.StateClosed {
+		t.Fatalf("circuit state = %v, want closed after client deadlines", cb.State())
+	}
+}
+
+func TestGateway_RouteStream_ClientDeadlineDoesNotTripCircuit(t *testing.T) {
+	gw, err := New(Config{
+		Strategy: StrategyConfig{Mode: ModeSingle},
+		Targets: []Target{{
+			VirtualKey: "slow-stream",
+			CircuitBreaker: &CircuitBreakerConfig{
+				FailureThreshold: 2,
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	gw.RegisterProvider(&mockStreamProvider{
+		mockProvider: mockProvider{
+			name:   "slow-stream",
+			models: []string{"gpt-4o"},
+		},
+		streamFn: func(ctx context.Context, _ providers.Request) (<-chan providers.StreamChunk, error) {
+			ch := make(chan providers.StreamChunk)
+			go func() {
+				defer close(ch)
+				ticker := time.NewTicker(20 * time.Millisecond)
+				defer ticker.Stop()
+				for {
+					select {
+					case <-ctx.Done():
+						return
+					case <-ticker.C:
+						select {
+						case ch <- providers.StreamChunk{
+							Choices: []providers.StreamChoice{{
+								Delta: providers.MessageDelta{Content: "x"},
+							}},
+						}:
+						case <-ctx.Done():
+							return
+						}
+					}
+				}
+			}()
+			return ch, nil
+		},
+	})
+
+	req := streamTestRequest()
+	for i := 0; i < 2; i++ {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+		ch, streamErr := gw.RouteStream(ctx, req)
+		if streamErr != nil {
+			cancel()
+			t.Fatalf("attempt %d: RouteStream error = %v", i+1, streamErr)
+		}
+		for range ch { //nolint:revive
+		}
+		cancel()
+	}
+
+	gw.mu.RLock()
+	cb := gw.circuitBreakers["slow-stream"]
+	gw.mu.RUnlock()
+	if cb == nil {
+		t.Fatal("expected circuit breaker for slow-stream")
+	}
+	if cb.State() != circuitbreaker.StateClosed {
+		t.Fatalf("circuit state = %v, want closed after client deadlines", cb.State())
+	}
+}
+
+func TestGateway_RouteStream_MidStreamFailureTripsCircuit(t *testing.T) {
+	streamErr := errors.New("mid-stream provider failure")
+	gw, err := New(Config{
+		Strategy: StrategyConfig{Mode: ModeSingle},
+		Targets: []Target{{
+			VirtualKey: "flaky-stream",
+			CircuitBreaker: &CircuitBreakerConfig{
+				FailureThreshold: 2,
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	gw.RegisterProvider(&mockStreamProvider{
+		mockProvider: mockProvider{
+			name:   "flaky-stream",
+			models: []string{"gpt-4o"},
+		},
+		streamFn: func(_ context.Context, _ providers.Request) (<-chan providers.StreamChunk, error) {
+			ch := make(chan providers.StreamChunk, 2)
+			ch <- providers.StreamChunk{
+				Choices: []providers.StreamChoice{{
+					Delta: providers.MessageDelta{Content: "partial"},
+				}},
+			}
+			ch <- providers.StreamChunk{Error: streamErr}
+			close(ch)
+			return ch, nil
+		},
+	})
+
+	req := streamTestRequest()
+	for i := 0; i < 2; i++ {
+		ch, err := gw.RouteStream(context.Background(), req)
+		if err != nil {
+			t.Fatalf("attempt %d: RouteStream error = %v", i+1, err)
+		}
+		drainMeteredStream(t, ch)
+	}
+
+	_, err = gw.RouteStream(context.Background(), req)
+	if !errors.Is(err, circuitbreaker.ErrCircuitOpen) {
+		t.Fatalf("expected circuit open after mid-stream failures, got %v", err)
+	}
+}
+
 func TestGateway_RouteStream_BeforePluginCanSetNilRequest(t *testing.T) {
 	gw, _ := New(Config{
 		Strategy: StrategyConfig{Mode: ModeSingle},

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -528,6 +528,55 @@ func TestGateway_RouteStream_CostOptimizedUsesCatalogCost(t *testing.T) {
 	drainStream(t, ch)
 }
 
+func TestGateway_RouteStream_CostOptimizedSkipErrorsWhenAllStreamCandidatesUnpriced(t *testing.T) {
+	gw, err := New(Config{
+		Strategy: StrategyConfig{
+			Mode:             ModeCostOptimized,
+			UnpricedStrategy: unpricedStrategySkip,
+		},
+		Targets: []Target{
+			{VirtualKey: "first"},
+			{VirtualKey: "second"},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	gw.catalog = models.Catalog{
+		"first/gpt-4o": {
+			Provider: "first",
+			ModelID:  "gpt-4o",
+			Mode:     models.ModeChat,
+			Pricing:  models.Pricing{},
+		},
+		"second/gpt-4o": {
+			Provider: "second",
+			ModelID:  "gpt-4o",
+			Mode:     models.ModeChat,
+			Pricing:  models.Pricing{},
+		},
+	}
+	gw.RegisterProvider(&mockStreamProvider{
+		mockProvider: mockProvider{name: "first", models: []string{"gpt-4o"}},
+		streamErr:    errors.New("first provider selected"),
+	})
+	gw.RegisterProvider(&mockStreamProvider{
+		mockProvider: mockProvider{name: "second", models: []string{"gpt-4o"}},
+		streamErr:    errors.New("second provider selected"),
+	})
+
+	_, err = gw.RouteStream(context.Background(), providers.Request{
+		Model:    "gpt-4o",
+		Messages: []providers.Message{{Role: "user", Content: "hello"}},
+	})
+	if err == nil {
+		t.Fatal("expected RouteStream to reject unpriced providers in skip mode")
+	}
+	if !strings.Contains(err.Error(), "no priced provider supports model gpt-4o") {
+		t.Fatalf("RouteStream error = %v, want no priced provider error", err)
+	}
+}
+
 func TestGateway_StreamingCostOrderHandlesUnpricedStrategies(t *testing.T) {
 	tests := []struct {
 		name             string
@@ -623,10 +672,13 @@ func TestGateway_StreamingCostOrderHandlesUnpricedStrategies(t *testing.T) {
 				models: []string{"gpt-4o"},
 			})
 
-			got := gw.streamingCostOrderLocked(gw.config.Targets, providers.Request{
+			got, err := gw.streamingCostOrderLocked(gw.config.Targets, providers.Request{
 				Model:    "gpt-4o",
 				Messages: []providers.Message{{Role: "user", Content: "hello world"}},
 			})
+			if err != nil {
+				t.Fatal(err)
+			}
 			requireKeys(t, got, tt.want...)
 		})
 	}
@@ -710,7 +762,10 @@ func TestGateway_StreamingCostOrderFallsBackWithoutStreamingCandidates(t *testin
 		mockProvider: mockProvider{name: "unsupported", models: []string{"other-model"}},
 	})
 
-	got := gw.streamingCostOrderLocked(gw.config.Targets, providers.Request{Model: "gpt-4o"})
+	got, err := gw.streamingCostOrderLocked(gw.config.Targets, providers.Request{Model: "gpt-4o"})
+	if err != nil {
+		t.Fatal(err)
+	}
 	requireKeys(t, got, "plain", "unsupported", "missing")
 }
 

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -1799,6 +1799,44 @@ func completedHookEvent(traceID string) events.HookEvent {
 	)
 }
 
+// TestGateway_PublishEvent_DetachesCancellationButPreservesValues covers
+// issue #181: async event hooks must run with a context that has shed the
+// request's cancellation (they fire after the HTTP handler returns) yet still
+// carry the request's trace context / values via context.WithoutCancel.
+func TestGateway_PublishEvent_DetachesCancellationButPreservesValues(t *testing.T) {
+	gw, err := New(Config{})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { _ = gw.Close() })
+
+	type ctxKey string
+	const marker ctxKey = "trace-marker"
+
+	got := make(chan context.Context, 1)
+	gw.AddHook(func(ctx context.Context, _ string, _ map[string]any) {
+		got <- ctx
+	})
+
+	// The request context is already cancelled by the time the hook runs.
+	reqCtx, cancel := context.WithCancel(context.WithValue(context.Background(), marker, "trace-xyz"))
+	cancel()
+
+	gw.publishEvent(reqCtx, completedHookEvent("trace-1"))
+
+	select {
+	case hookCtx := <-got:
+		if err := hookCtx.Err(); err != nil {
+			t.Fatalf("hook ctx should be detached from cancellation, got %v", err)
+		}
+		if v, _ := hookCtx.Value(marker).(string); v != "trace-xyz" {
+			t.Fatalf("hook ctx lost request trace value: got %q, want trace-xyz", v)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("hook was not dispatched")
+	}
+}
+
 func runWithPanicCapture(t *testing.T, fn func()) any {
 	t.Helper()
 	done := make(chan any, 1)

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -32,6 +32,9 @@ import (
 	_ "github.com/ferro-labs/ai-gateway/internal/plugins/wordfilter"
 )
 
+// mockProviderName is the canonical provider name used by test mock providers.
+const mockProviderName = "mock"
+
 // mockProvider is a test double for providers.Provider.
 type mockProvider struct {
 	name   string
@@ -113,10 +116,10 @@ func requireKeys(t *testing.T, got []string, want ...string) {
 func TestGateway_Route_Single(t *testing.T) {
 	gw, _ := New(Config{
 		Strategy: StrategyConfig{Mode: ModeSingle},
-		Targets:  []Target{{VirtualKey: "mock"}},
+		Targets:  []Target{{VirtualKey: mockProviderName}},
 	})
 	gw.RegisterProvider(&mockProvider{
-		name:   "mock",
+		name:   mockProviderName,
 		models: []string{"gpt-4o"},
 		resp:   &providers.Response{ID: "r1", Model: "gpt-4o"},
 	})
@@ -1395,10 +1398,10 @@ func TestGateway_RouteStream_BeforePluginCanSetNilRequest(t *testing.T) {
 func TestGateway_RouteStream_RunAfterReceivesStreamResponse(t *testing.T) {
 	gw, _ := New(Config{
 		Strategy: StrategyConfig{Mode: ModeSingle},
-		Targets:  []Target{{VirtualKey: "mock"}},
+		Targets:  []Target{{VirtualKey: mockProviderName}},
 	})
 	gw.RegisterProvider(&mockStreamProvider{
-		mockProvider: mockProvider{name: "mock", models: []string{"gpt-4o"}},
+		mockProvider: mockProvider{name: mockProviderName, models: []string{"gpt-4o"}},
 		streamFn: func(context.Context, providers.Request) (<-chan providers.StreamChunk, error) {
 			ch := make(chan providers.StreamChunk, 3)
 			ch <- providers.StreamChunk{
@@ -1446,7 +1449,7 @@ func TestGateway_RouteStream_RunAfterReceivesStreamResponse(t *testing.T) {
 			if pctx.Response == nil {
 				t.Fatal("after plugin response is nil")
 			}
-			if pctx.Response.Provider != "mock" {
+			if pctx.Response.Provider != mockProviderName {
 				t.Fatalf("after plugin provider = %q, want mock", pctx.Response.Provider)
 			}
 			if pctx.Response.Model != "gpt-4o" {
@@ -1481,10 +1484,10 @@ func TestGateway_RouteStream_RunOnErrorReceivesStreamError(t *testing.T) {
 	streamErr := errors.New("stream failed")
 	gw, _ := New(Config{
 		Strategy: StrategyConfig{Mode: ModeSingle},
-		Targets:  []Target{{VirtualKey: "mock"}},
+		Targets:  []Target{{VirtualKey: mockProviderName}},
 	})
 	gw.RegisterProvider(&mockStreamProvider{
-		mockProvider: mockProvider{name: "mock", models: []string{"gpt-4o"}},
+		mockProvider: mockProvider{name: mockProviderName, models: []string{"gpt-4o"}},
 		streamFn: func(context.Context, providers.Request) (<-chan providers.StreamChunk, error) {
 			ch := make(chan providers.StreamChunk, 1)
 			ch <- providers.StreamChunk{Error: streamErr}
@@ -1531,10 +1534,10 @@ func TestGateway_RouteStream_RunOnErrorReceivesStreamError(t *testing.T) {
 func TestGateway_RouteStream_AfterPluginRejectRunsOnError(t *testing.T) {
 	gw, _ := New(Config{
 		Strategy: StrategyConfig{Mode: ModeSingle},
-		Targets:  []Target{{VirtualKey: "mock"}},
+		Targets:  []Target{{VirtualKey: mockProviderName}},
 	})
 	gw.RegisterProvider(&mockStreamProvider{
-		mockProvider: mockProvider{name: "mock", models: []string{"gpt-4o"}},
+		mockProvider: mockProvider{name: mockProviderName, models: []string{"gpt-4o"}},
 		streamFn: func(context.Context, providers.Request) (<-chan providers.StreamChunk, error) {
 			ch := make(chan providers.StreamChunk, 2)
 			ch <- providers.StreamChunk{
@@ -1601,11 +1604,11 @@ func TestGateway_RouteStream_AfterPluginRejectRunsOnError(t *testing.T) {
 func TestGateway_RouteStream_ResponseCacheHitSkipsProvider(t *testing.T) {
 	gw, _ := New(Config{
 		Strategy: StrategyConfig{Mode: ModeSingle},
-		Targets:  []Target{{VirtualKey: "mock"}},
+		Targets:  []Target{{VirtualKey: mockProviderName}},
 	})
 	var streamCalls atomic.Int32
 	gw.RegisterProvider(&mockStreamProvider{
-		mockProvider: mockProvider{name: "mock", models: []string{"gpt-4o"}},
+		mockProvider: mockProvider{name: mockProviderName, models: []string{"gpt-4o"}},
 		streamFn: func(context.Context, providers.Request) (<-chan providers.StreamChunk, error) {
 			streamCalls.Add(1)
 			ch := make(chan providers.StreamChunk, 2)
@@ -1785,7 +1788,7 @@ func (p *gateStreamProvider) CompleteStream(_ context.Context, _ providers.Reque
 func completedHookEvent(traceID string) events.HookEvent {
 	return events.CompletedRequest(
 		traceID,
-		"mock",
+		mockProviderName,
 		"gpt-4o",
 		time.Millisecond,
 		false,
@@ -2178,10 +2181,10 @@ func TestGateway_Route_ProviderNotFound(t *testing.T) {
 func TestGateway_Route_HookPanicIsRecovered(t *testing.T) {
 	gw, _ := New(Config{
 		Strategy: StrategyConfig{Mode: ModeSingle},
-		Targets:  []Target{{VirtualKey: "mock"}},
+		Targets:  []Target{{VirtualKey: mockProviderName}},
 	})
 	gw.RegisterProvider(&mockProvider{
-		name:   "mock",
+		name:   mockProviderName,
 		models: []string{"gpt-4o"},
 		resp:   &providers.Response{ID: "ok", Model: "gpt-4o"},
 	})
@@ -2220,7 +2223,7 @@ func TestGateway_PublishEvent_CallsAllHooks(t *testing.T) {
 
 	gw.publishEvent(context.Background(), events.CompletedRequest(
 		"trace-123",
-		"mock",
+		mockProviderName,
 		"gpt-4o",
 		time.Millisecond,
 		false,
@@ -2254,7 +2257,7 @@ func TestGateway_PublishEvent_EnqueuesEachHookIndividually(t *testing.T) {
 
 	gw.publishEvent(context.Background(), events.CompletedRequest(
 		"trace-123",
-		"mock",
+		mockProviderName,
 		"gpt-4o",
 		time.Millisecond,
 		false,
@@ -2272,7 +2275,7 @@ func TestGateway_PublishEvent_EnqueuesEachHookIndividually(t *testing.T) {
 func TestRunHookDispatch_CreatesFreshPayloadMapPerHook(t *testing.T) {
 	event := events.CompletedRequest(
 		"trace-123",
-		"mock",
+		mockProviderName,
 		"gpt-4o",
 		time.Millisecond,
 		false,
@@ -2304,7 +2307,7 @@ func TestRunHookDispatch_CreatesFreshPayloadMapPerHook(t *testing.T) {
 	if got := firstData["provider"]; got != "mutated" {
 		t.Fatalf("first hook provider = %v, want mutated", got)
 	}
-	if secondProvider != "mock" {
+	if secondProvider != mockProviderName {
 		t.Fatalf("second hook provider = %q, want mock", secondProvider)
 	}
 }
@@ -2322,11 +2325,11 @@ func TestGateway_PublishEvent_IncrementsDropMetricWhenQueueFull(t *testing.T) {
 
 	// Fill the queue.
 	gw.publishEvent(context.Background(), events.CompletedRequest(
-		"trace-fill", "mock", "gpt-4o", time.Millisecond, false, 1, 1, models.CostResult{}, true,
+		"trace-fill", mockProviderName, "gpt-4o", time.Millisecond, false, 1, 1, models.CostResult{}, true,
 	))
 	// This one should be dropped.
 	gw.publishEvent(context.Background(), events.CompletedRequest(
-		"trace-drop", "mock", "gpt-4o", time.Millisecond, false, 1, 1, models.CostResult{}, true,
+		"trace-drop", mockProviderName, "gpt-4o", time.Millisecond, false, 1, 1, models.CostResult{}, true,
 	))
 
 	after := counterValue(t, counter)
@@ -2355,10 +2358,10 @@ func (p *testPlugin) Execute(ctx context.Context, pctx *plugin.Context) error {
 func TestGateway_Route_WithBeforePlugin(t *testing.T) {
 	gw, _ := New(Config{
 		Strategy: StrategyConfig{Mode: ModeSingle},
-		Targets:  []Target{{VirtualKey: "mock"}},
+		Targets:  []Target{{VirtualKey: mockProviderName}},
 	})
 	gw.RegisterProvider(&mockProvider{
-		name:   "mock",
+		name:   mockProviderName,
 		models: []string{"gpt-4o"},
 		resp:   &providers.Response{ID: "ok"},
 	})
@@ -2388,10 +2391,10 @@ func TestGateway_Route_WithBeforePlugin(t *testing.T) {
 func TestGateway_Route_PluginRejectsRequest(t *testing.T) {
 	gw, _ := New(Config{
 		Strategy: StrategyConfig{Mode: ModeSingle},
-		Targets:  []Target{{VirtualKey: "mock"}},
+		Targets:  []Target{{VirtualKey: mockProviderName}},
 	})
 	gw.RegisterProvider(&mockProvider{
-		name:   "mock",
+		name:   mockProviderName,
 		models: []string{"gpt-4o"},
 		resp:   &providers.Response{ID: "should-not-reach"},
 	})
@@ -2424,7 +2427,7 @@ func init() {
 func TestGateway_LoadPlugins(t *testing.T) {
 	gw, _ := New(Config{
 		Strategy: StrategyConfig{Mode: ModeSingle},
-		Targets:  []Target{{VirtualKey: "mock"}},
+		Targets:  []Target{{VirtualKey: mockProviderName}},
 		Plugins: []PluginConfig{
 			{
 				Name:    "test-plugin",
@@ -2436,7 +2439,7 @@ func TestGateway_LoadPlugins(t *testing.T) {
 		},
 	})
 	gw.RegisterProvider(&mockProvider{
-		name:   "mock",
+		name:   mockProviderName,
 		models: []string{"gpt-4o"},
 		resp:   &providers.Response{ID: "ok"},
 	})
@@ -2452,7 +2455,7 @@ func TestGateway_LoadPlugins(t *testing.T) {
 func TestGateway_LoadPlugins_UnknownPlugin(t *testing.T) {
 	gw, _ := New(Config{
 		Strategy: StrategyConfig{Mode: ModeSingle},
-		Targets:  []Target{{VirtualKey: "mock"}},
+		Targets:  []Target{{VirtualKey: mockProviderName}},
 		Plugins: []PluginConfig{
 			{
 				Name:    "does-not-exist",
@@ -2502,13 +2505,13 @@ func (m *mockImageProvider) GenerateImage(_ context.Context, req providers.Image
 func TestGateway_Embed_ResolvesAlias(t *testing.T) {
 	ep := &mockEmbeddingProvider{
 		mockProvider: mockProvider{
-			name:   "mock",
+			name:   mockProviderName,
 			models: []string{"text-embedding-3-small"},
 		},
 	}
 	gw, _ := New(Config{
 		Strategy: StrategyConfig{Mode: ModeSingle},
-		Targets:  []Target{{VirtualKey: "mock"}},
+		Targets:  []Target{{VirtualKey: mockProviderName}},
 		Aliases:  map[string]string{"my-embed": "text-embedding-3-small"},
 	})
 	gw.RegisterProvider(ep)
@@ -2528,13 +2531,13 @@ func TestGateway_Embed_ResolvesAlias(t *testing.T) {
 func TestGateway_Embed_NoAliasPassthrough(t *testing.T) {
 	ep := &mockEmbeddingProvider{
 		mockProvider: mockProvider{
-			name:   "mock",
+			name:   mockProviderName,
 			models: []string{"text-embedding-3-small"},
 		},
 	}
 	gw, _ := New(Config{
 		Strategy: StrategyConfig{Mode: ModeSingle},
-		Targets:  []Target{{VirtualKey: "mock"}},
+		Targets:  []Target{{VirtualKey: mockProviderName}},
 	})
 	gw.RegisterProvider(ep)
 
@@ -2553,13 +2556,13 @@ func TestGateway_Embed_NoAliasPassthrough(t *testing.T) {
 func TestGateway_GenerateImage_ResolvesAlias(t *testing.T) {
 	ip := &mockImageProvider{
 		mockProvider: mockProvider{
-			name:   "mock",
+			name:   mockProviderName,
 			models: []string{"dall-e-3"},
 		},
 	}
 	gw, _ := New(Config{
 		Strategy: StrategyConfig{Mode: ModeSingle},
-		Targets:  []Target{{VirtualKey: "mock"}},
+		Targets:  []Target{{VirtualKey: mockProviderName}},
 		Aliases:  map[string]string{"my-image-model": "dall-e-3"},
 	})
 	gw.RegisterProvider(ip)

--- a/internal/strategies/fallback.go
+++ b/internal/strategies/fallback.go
@@ -2,10 +2,12 @@ package strategies
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"time"
 
+	"github.com/ferro-labs/ai-gateway/internal/circuitbreaker"
 	"github.com/ferro-labs/ai-gateway/internal/logging"
 	"github.com/ferro-labs/ai-gateway/providers"
 )
@@ -77,10 +79,16 @@ func (f *Fallback) resolveRetry(virtualKey string) targetRetry {
 }
 
 // shouldRetry returns true if the error is eligible for another attempt given
-// the configured onStatusCodes list. When onStatusCodes is empty every error
-// is retryable. When it is non-empty, only errors whose embedded HTTP status
-// code appears in the list are retried.
+// the configured onStatusCodes list. Cancellation and open-circuit sentinel
+// errors are never retryable. When onStatusCodes is empty, other errors are
+// retryable. When it is non-empty, only errors whose embedded HTTP status code
+// appears in the list are retried.
 func shouldRetry(err error, onStatusCodes []int) bool {
+	if errors.Is(err, context.Canceled) ||
+		errors.Is(err, context.DeadlineExceeded) ||
+		errors.Is(err, circuitbreaker.ErrCircuitOpen) {
+		return false
+	}
 	if len(onStatusCodes) == 0 {
 		return true
 	}
@@ -123,6 +131,9 @@ func (f *Fallback) Execute(ctx context.Context, req providers.Request) (*provide
 		retry := f.resolveRetry(target.VirtualKey)
 
 		for attempt := 0; attempt < retry.attempts; attempt++ {
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
 			if attempt > 0 {
 				backoff := time.Duration(math.Pow(2, float64(attempt-1))) *
 					time.Duration(retry.initialBackoffMs) * time.Millisecond

--- a/internal/strategies/fallback_test.go
+++ b/internal/strategies/fallback_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/ferro-labs/ai-gateway/internal/circuitbreaker"
 	"github.com/ferro-labs/ai-gateway/providers"
 )
 
@@ -16,6 +17,7 @@ type errProvider struct {
 	name   string
 	models []string
 	errMsg string
+	err    error
 	calls  int
 }
 
@@ -32,6 +34,9 @@ func (e *errProvider) SupportsModel(m string) bool {
 }
 func (e *errProvider) Complete(_ context.Context, _ providers.Request) (*providers.Response, error) {
 	e.calls++
+	if e.err != nil {
+		return nil, e.err
+	}
 	return nil, fmt.Errorf("%s", e.errMsg)
 }
 
@@ -103,6 +108,34 @@ func TestFallback_FallsThrough_ToNextTarget(t *testing.T) {
 	}
 }
 
+func TestFallback_CircuitOpenMovesToNextTargetWithoutRetry(t *testing.T) {
+	open := &errProvider{
+		name:   "open",
+		models: []string{"gpt-4o"},
+		err:    circuitbreaker.ErrCircuitOpen,
+	}
+	good := &mockProvider{name: "good", models: []string{"gpt-4o"}, resp: &providers.Response{ID: "ok"}}
+
+	fb := NewFallback(
+		[]Target{{VirtualKey: "open"}, {VirtualKey: "good"}},
+		newLookup(open, good),
+	).WithTargetRetry("open", 3, nil, 0)
+
+	resp, err := fb.Execute(context.Background(), providers.Request{Model: "gpt-4o"})
+	if err != nil {
+		t.Fatalf("expected success from fallback target, got error: %v", err)
+	}
+	if resp.ID != "ok" {
+		t.Fatalf("got response ID %q, want ok", resp.ID)
+	}
+	if open.calls != 1 {
+		t.Fatalf("open circuit target calls = %d, want 1", open.calls)
+	}
+	if good.calls != 1 {
+		t.Fatalf("fallback target calls = %d, want 1", good.calls)
+	}
+}
+
 func TestFallback_NoTargets_RetryPolicy(t *testing.T) {
 	fb := NewFallback(nil, newLookup())
 	_, err := fb.Execute(context.Background(), providers.Request{Model: "gpt-4o"})
@@ -154,4 +187,14 @@ func TestShouldRetry(t *testing.T) {
 			}
 		})
 	}
+	nonRetryable := []error{context.Canceled, context.DeadlineExceeded, circuitbreaker.ErrCircuitOpen}
+	for _, err := range nonRetryable {
+		if shouldRetry(err, nil) {
+			t.Fatalf("shouldRetry(%v, nil) = true, want false", err)
+		}
+		if shouldRetry(err, []int{429}) {
+			t.Fatalf("shouldRetry(%v, [429]) = true, want false", err)
+		}
+	}
+
 }

--- a/internal/strategies/strategy_test.go
+++ b/internal/strategies/strategy_test.go
@@ -2,6 +2,7 @@ package strategies
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -248,8 +249,11 @@ func TestFallback_ContextCancelled(t *testing.T) {
 	cancel() // cancel immediately
 
 	_, err := f.Execute(ctx, providers.Request{Model: "gpt-4o", Messages: []providers.Message{{Role: "user", Content: "hi"}}})
-	if err == nil {
-		t.Fatal("expected error on cancelled context")
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+	if bad.calls != 0 {
+		t.Fatalf("cancelled context should not call provider, got %d calls", bad.calls)
 	}
 }
 

--- a/internal/streamwrap/wrap.go
+++ b/internal/streamwrap/wrap.go
@@ -34,6 +34,8 @@ type MeterMeta struct {
 	PublishFn func(ctx context.Context, event events.HookEvent)
 	// TraceID is the per-request trace identifier, forwarded into events.
 	TraceID string
+	// LatencyRecorder, if non-nil, records successful stream latency for routing.
+	LatencyRecorder func(provider string, latency time.Duration)
 	// SpanFinisher, if non-nil, is invoked exactly once when the stream
 	// completes (with final usage + cost + timings) or fails. The
 	// gateway uses this to stamp the observability root span with the
@@ -186,6 +188,10 @@ func Meter(ctx context.Context, src <-chan providers.StreamChunk, start time.Tim
 				})
 			}
 			return
+		}
+
+		if meta.LatencyRecorder != nil && meta.Provider != "" {
+			meta.LatencyRecorder(meta.Provider, latency)
 		}
 
 		// Success path: emit the same metrics as Gateway.Route().

--- a/internal/streamwrap/wrap.go
+++ b/internal/streamwrap/wrap.go
@@ -43,6 +43,12 @@ type MeterMeta struct {
 	// type is intentionally a minimal local interface so streamwrap
 	// stays decoupled from the public observability package.
 	SpanFinisher SpanFinisher
+	// CompletionFn, if non-nil, is invoked once after the upstream stream closes
+	// successfully and before success metrics/events are emitted.
+	CompletionFn func(ctx context.Context, resp *providers.Response) error
+	// ErrorFn, if non-nil, is invoked once when the upstream stream fails or
+	// the downstream client cancels before the stream completes.
+	ErrorFn func(ctx context.Context, err error)
 	// CircuitBreakerOutcome, if non-nil, is invoked once when the stream
 	// finishes. err is nil on success; non-nil on provider/stream failure.
 	CircuitBreakerOutcome func(err error)
@@ -93,6 +99,11 @@ func Meter(ctx context.Context, src <-chan providers.StreamChunk, start time.Tim
 		var firstChunkAt time.Time
 		var lastChunkAt time.Time
 		clientCanceled := false
+		resp := providers.Response{
+			Object:   "chat.completion",
+			Provider: meta.Provider,
+			Model:    meta.Model,
+		}
 
 	loop:
 		for {
@@ -130,6 +141,7 @@ func Meter(ctx context.Context, src <-chan providers.StreamChunk, start time.Tim
 				if chunk.Usage != nil && (chunk.Usage.TotalTokens > 0 || chunk.Usage.PromptTokens > 0) {
 					usage = *chunk.Usage
 				}
+				applyChunkToResponse(&resp, chunk)
 				if chunk.Error != nil {
 					streamErr = chunk.Error
 				}
@@ -191,6 +203,9 @@ func Meter(ctx context.Context, src <-chan providers.StreamChunk, start time.Tim
 					true,
 				))
 			}
+			if meta.ErrorFn != nil {
+				meta.ErrorFn(ctx, streamErr)
+			}
 			if meta.SpanFinisher != nil {
 				meta.SpanFinisher.Finish(StreamOutcome{
 					TokensIn:  usage.PromptTokens,
@@ -208,6 +223,36 @@ func Meter(ctx context.Context, src <-chan providers.StreamChunk, start time.Tim
 
 		if meta.LatencyRecorder != nil && meta.Provider != "" {
 			meta.LatencyRecorder(meta.Provider, latency)
+		}
+
+		resp.Usage = usage
+		if resp.Usage.TotalTokens == 0 {
+			resp.Usage.TotalTokens = resp.Usage.PromptTokens + resp.Usage.CompletionTokens
+		}
+		if meta.CompletionFn != nil {
+			if err := meta.CompletionFn(ctx, &resp); err != nil {
+				requestMetrics := metrics.ForRequest(meta.Provider, meta.Model)
+				requestMetrics.Error.Inc()
+				metrics.ForProviderError(meta.Provider, "plugin_error").Inc()
+				select {
+				case out <- providers.StreamChunk{Error: err}:
+				case <-ctx.Done():
+				}
+				if meta.SpanFinisher != nil {
+					meta.SpanFinisher.Finish(StreamOutcome{
+						TokensIn:  usage.PromptTokens,
+						TokensOut: usage.CompletionTokens,
+						TTFTMs:    ttftMs,
+						TTLTMs:    ttltMs,
+						ErrorMsg:  err.Error(),
+					})
+				}
+				// Provider stream completed; plugin failure must not block CB recovery.
+				if meta.CircuitBreakerOutcome != nil {
+					meta.CircuitBreakerOutcome(nil)
+				}
+				return
+			}
 		}
 
 		// Success path: emit the same metrics as Gateway.Route().
@@ -263,4 +308,41 @@ func Meter(ctx context.Context, src <-chan providers.StreamChunk, start time.Tim
 	}()
 
 	return out
+}
+
+func applyChunkToResponse(resp *providers.Response, chunk providers.StreamChunk) {
+	if chunk.ID != "" && resp.ID == "" {
+		resp.ID = chunk.ID
+	}
+	if chunk.Created != 0 && resp.Created == 0 {
+		resp.Created = chunk.Created
+	}
+	if chunk.Model != "" {
+		resp.Model = chunk.Model
+	}
+	for _, streamChoice := range chunk.Choices {
+		idx := streamChoice.Index
+		if idx < 0 {
+			continue
+		}
+		for len(resp.Choices) <= idx {
+			resp.Choices = append(resp.Choices, providers.Choice{
+				Index: len(resp.Choices),
+				Message: providers.Message{
+					Role: "assistant",
+				},
+			})
+		}
+		choice := &resp.Choices[idx]
+		if streamChoice.Delta.Role != "" {
+			choice.Message.Role = streamChoice.Delta.Role
+		}
+		choice.Message.Content += streamChoice.Delta.Content
+		if len(streamChoice.Delta.ToolCalls) > 0 {
+			choice.Message.ToolCalls = append(choice.Message.ToolCalls, streamChoice.Delta.ToolCalls...)
+		}
+		if streamChoice.FinishReason != "" {
+			choice.FinishReason = streamChoice.FinishReason
+		}
+	}
 }

--- a/internal/streamwrap/wrap.go
+++ b/internal/streamwrap/wrap.go
@@ -43,6 +43,9 @@ type MeterMeta struct {
 	// type is intentionally a minimal local interface so streamwrap
 	// stays decoupled from the public observability package.
 	SpanFinisher SpanFinisher
+	// CircuitBreakerOutcome, if non-nil, is invoked once when the stream
+	// finishes. err is nil on success; non-nil on provider/stream failure.
+	CircuitBreakerOutcome func(err error)
 }
 
 // StreamOutcome bundles the values stamped onto the observability span
@@ -102,8 +105,13 @@ func Meter(ctx context.Context, src <-chan providers.StreamChunk, start time.Tim
 				// MUST close src eventually for this to terminate; that is
 				// the existing contract for every CompleteStream impl.
 				clientCanceled = true
-				streamErr = ctx.Err()
-				for range src { //nolint:revive
+				if streamErr == nil {
+					streamErr = ctx.Err()
+				}
+				for chunk := range src {
+					if chunk.Error != nil {
+						streamErr = chunk.Error
+					}
 				}
 				break loop
 			case chunk, ok := <-src:
@@ -132,8 +140,13 @@ func Meter(ctx context.Context, src <-chan providers.StreamChunk, start time.Tim
 				case out <- chunk:
 				case <-ctx.Done():
 					clientCanceled = true
-					streamErr = ctx.Err()
-					for range src { //nolint:revive
+					if streamErr == nil {
+						streamErr = ctx.Err()
+					}
+					for chunk := range src {
+						if chunk.Error != nil {
+							streamErr = chunk.Error
+						}
 					}
 					break loop
 				}
@@ -186,6 +199,9 @@ func Meter(ctx context.Context, src <-chan providers.StreamChunk, start time.Tim
 					TTLTMs:    ttltMs,
 					ErrorMsg:  streamErr.Error(),
 				})
+			}
+			if meta.CircuitBreakerOutcome != nil {
+				meta.CircuitBreakerOutcome(streamErr)
 			}
 			return
 		}
@@ -240,6 +256,9 @@ func Meter(ctx context.Context, src <-chan providers.StreamChunk, start time.Tim
 				TTFTMs:      ttftMs,
 				TTLTMs:      ttltMs,
 			})
+		}
+		if meta.CircuitBreakerOutcome != nil {
+			meta.CircuitBreakerOutcome(nil)
 		}
 	}()
 

--- a/internal/streamwrap/wrap.go
+++ b/internal/streamwrap/wrap.go
@@ -183,41 +183,7 @@ func Meter(ctx context.Context, src <-chan providers.StreamChunk, start time.Tim
 		}
 
 		if streamErr != nil {
-			errType := "provider_error"
-			switch {
-			case clientCanceled:
-				errType = "client_canceled"
-			case errors.Is(streamErr, circuitbreaker.ErrCircuitOpen):
-				errType = "circuit_open"
-			}
-			requestMetrics := metrics.ForRequest(meta.Provider, meta.Model)
-			requestMetrics.Error.Inc()
-			metrics.ForProviderError(meta.Provider, errType).Inc()
-			if meta.PublishFn != nil {
-				meta.PublishFn(ctx, events.FailedRequest(
-					meta.TraceID,
-					meta.Provider,
-					meta.Model,
-					streamErr.Error(),
-					latency,
-					true,
-				))
-			}
-			if meta.ErrorFn != nil {
-				meta.ErrorFn(ctx, streamErr)
-			}
-			if meta.SpanFinisher != nil {
-				meta.SpanFinisher.Finish(StreamOutcome{
-					TokensIn:  usage.PromptTokens,
-					TokensOut: usage.CompletionTokens,
-					TTFTMs:    ttftMs,
-					TTLTMs:    ttltMs,
-					ErrorMsg:  streamErr.Error(),
-				})
-			}
-			if meta.CircuitBreakerOutcome != nil {
-				meta.CircuitBreakerOutcome(streamErr)
-			}
+			finishStreamOnError(ctx, meta, usage, ttftMs, ttltMs, clientCanceled, streamErr, latency)
 			return
 		}
 
@@ -229,85 +195,169 @@ func Meter(ctx context.Context, src <-chan providers.StreamChunk, start time.Tim
 		if resp.Usage.TotalTokens == 0 {
 			resp.Usage.TotalTokens = resp.Usage.PromptTokens + resp.Usage.CompletionTokens
 		}
-		if meta.CompletionFn != nil {
-			if err := meta.CompletionFn(ctx, &resp); err != nil {
-				requestMetrics := metrics.ForRequest(meta.Provider, meta.Model)
-				requestMetrics.Error.Inc()
-				metrics.ForProviderError(meta.Provider, "plugin_error").Inc()
-				select {
-				case out <- providers.StreamChunk{Error: err}:
-				case <-ctx.Done():
-				}
-				if meta.SpanFinisher != nil {
-					meta.SpanFinisher.Finish(StreamOutcome{
-						TokensIn:  usage.PromptTokens,
-						TokensOut: usage.CompletionTokens,
-						TTFTMs:    ttftMs,
-						TTLTMs:    ttltMs,
-						ErrorMsg:  err.Error(),
-					})
-				}
-				// Provider stream completed; plugin failure must not block CB recovery.
-				if meta.CircuitBreakerOutcome != nil {
-					meta.CircuitBreakerOutcome(nil)
-				}
-				return
-			}
+		if handleCompletionFn(ctx, meta, usage, ttftMs, ttltMs, &resp, out) {
+			return
 		}
 
 		// Success path: emit the same metrics as Gateway.Route().
-		requestMetrics := metrics.ForRequest(meta.Provider, meta.Model)
-		requestMetrics.Duration.Observe(latency.Seconds())
-		requestMetrics.Success.Inc()
-
-		if usage.PromptTokens > 0 {
-			requestMetrics.TokensIn.Add(float64(usage.PromptTokens))
-		}
-		if usage.CompletionTokens > 0 {
-			requestMetrics.TokensOut.Add(float64(usage.CompletionTokens))
-		}
-
-		// Compute and emit cost.
-		cost := models.Calculate(meta.Catalog, meta.Provider+"/"+meta.Model, models.Usage{
-			PromptTokens:     usage.PromptTokens,
-			CompletionTokens: usage.CompletionTokens,
-			ReasoningTokens:  usage.ReasoningTokens,
-			CacheReadTokens:  usage.CacheReadTokens,
-			CacheWriteTokens: usage.CacheWriteTokens,
-		})
-		if cost.TotalUSD > 0 {
-			requestMetrics.CostUSD.Add(cost.TotalUSD)
-		}
-
-		if meta.PublishFn != nil {
-			meta.PublishFn(ctx, events.CompletedRequest(
-				meta.TraceID,
-				meta.Provider,
-				meta.Model,
-				latency,
-				true,
-				usage.PromptTokens,
-				usage.CompletionTokens,
-				cost,
-				false,
-			))
-		}
-		if meta.SpanFinisher != nil {
-			meta.SpanFinisher.Finish(StreamOutcome{
-				TokensIn:    usage.PromptTokens,
-				TokensOut:   usage.CompletionTokens,
-				ReasoningIn: usage.ReasoningTokens,
-				Cost:        cost,
-				TTFTMs:      ttftMs,
-				TTLTMs:      ttltMs,
-			})
-		}
-		if meta.CircuitBreakerOutcome != nil {
-			meta.CircuitBreakerOutcome(nil)
-		}
+		finishStreamOnSuccess(ctx, meta, usage, ttftMs, ttltMs, latency)
 	}()
 
 	return out
+}
+
+// finishStreamOnError emits error metrics, invokes error hooks, finalises the
+// observability span, and records the circuit-breaker outcome. It is called
+// exactly once when the stream loop exits with a non-nil streamErr.
+func finishStreamOnError(
+	ctx context.Context,
+	meta MeterMeta,
+	usage providers.Usage,
+	ttftMs, ttltMs float64,
+	clientCanceled bool,
+	streamErr error,
+	latency time.Duration,
+) {
+	errType := "provider_error"
+	switch {
+	case clientCanceled:
+		errType = "client_canceled"
+	case errors.Is(streamErr, circuitbreaker.ErrCircuitOpen):
+		errType = "circuit_open"
+	}
+	requestMetrics := metrics.ForRequest(meta.Provider, meta.Model)
+	requestMetrics.Error.Inc()
+	metrics.ForProviderError(meta.Provider, errType).Inc()
+	if meta.PublishFn != nil {
+		meta.PublishFn(ctx, events.FailedRequest(
+			meta.TraceID,
+			meta.Provider,
+			meta.Model,
+			streamErr.Error(),
+			latency,
+			true,
+		))
+	}
+	if meta.ErrorFn != nil {
+		meta.ErrorFn(ctx, streamErr)
+	}
+	if meta.SpanFinisher != nil {
+		meta.SpanFinisher.Finish(StreamOutcome{
+			TokensIn:  usage.PromptTokens,
+			TokensOut: usage.CompletionTokens,
+			TTFTMs:    ttftMs,
+			TTLTMs:    ttltMs,
+			ErrorMsg:  streamErr.Error(),
+		})
+	}
+	if meta.CircuitBreakerOutcome != nil {
+		meta.CircuitBreakerOutcome(streamErr)
+	}
+}
+
+// handleCompletionFn invokes meta.CompletionFn when it is set. It returns
+// true if the caller (the Meter goroutine) should return immediately, which
+// happens when CompletionFn returns a non-nil error. On error it emits plugin
+// error metrics, forwards an error chunk on out, finalises the span, and
+// records a successful circuit-breaker outcome (the provider stream itself
+// completed successfully; only the plugin failed).
+func handleCompletionFn(
+	ctx context.Context,
+	meta MeterMeta,
+	usage providers.Usage,
+	ttftMs, ttltMs float64,
+	resp *providers.Response,
+	out chan<- providers.StreamChunk,
+) bool {
+	if meta.CompletionFn == nil {
+		return false
+	}
+	err := meta.CompletionFn(ctx, resp)
+	if err == nil {
+		return false
+	}
+	requestMetrics := metrics.ForRequest(meta.Provider, meta.Model)
+	requestMetrics.Error.Inc()
+	metrics.ForProviderError(meta.Provider, "plugin_error").Inc()
+	select {
+	case out <- providers.StreamChunk{Error: err}:
+	case <-ctx.Done():
+	}
+	if meta.SpanFinisher != nil {
+		meta.SpanFinisher.Finish(StreamOutcome{
+			TokensIn:  usage.PromptTokens,
+			TokensOut: usage.CompletionTokens,
+			TTFTMs:    ttftMs,
+			TTLTMs:    ttltMs,
+			ErrorMsg:  err.Error(),
+		})
+	}
+	// Provider stream completed; plugin failure must not block CB recovery.
+	if meta.CircuitBreakerOutcome != nil {
+		meta.CircuitBreakerOutcome(nil)
+	}
+	return true
+}
+
+// finishStreamOnSuccess emits success metrics, publishes the completion event,
+// finalises the observability span, and records a successful circuit-breaker
+// outcome. It mirrors what Gateway.Route() does for non-streaming requests.
+func finishStreamOnSuccess(
+	ctx context.Context,
+	meta MeterMeta,
+	usage providers.Usage,
+	ttftMs, ttltMs float64,
+	latency time.Duration,
+) {
+	requestMetrics := metrics.ForRequest(meta.Provider, meta.Model)
+	requestMetrics.Duration.Observe(latency.Seconds())
+	requestMetrics.Success.Inc()
+
+	if usage.PromptTokens > 0 {
+		requestMetrics.TokensIn.Add(float64(usage.PromptTokens))
+	}
+	if usage.CompletionTokens > 0 {
+		requestMetrics.TokensOut.Add(float64(usage.CompletionTokens))
+	}
+
+	// Compute and emit cost.
+	cost := models.Calculate(meta.Catalog, meta.Provider+"/"+meta.Model, models.Usage{
+		PromptTokens:     usage.PromptTokens,
+		CompletionTokens: usage.CompletionTokens,
+		ReasoningTokens:  usage.ReasoningTokens,
+		CacheReadTokens:  usage.CacheReadTokens,
+		CacheWriteTokens: usage.CacheWriteTokens,
+	})
+	if cost.TotalUSD > 0 {
+		requestMetrics.CostUSD.Add(cost.TotalUSD)
+	}
+
+	if meta.PublishFn != nil {
+		meta.PublishFn(ctx, events.CompletedRequest(
+			meta.TraceID,
+			meta.Provider,
+			meta.Model,
+			latency,
+			true,
+			usage.PromptTokens,
+			usage.CompletionTokens,
+			cost,
+			false,
+		))
+	}
+	if meta.SpanFinisher != nil {
+		meta.SpanFinisher.Finish(StreamOutcome{
+			TokensIn:    usage.PromptTokens,
+			TokensOut:   usage.CompletionTokens,
+			ReasoningIn: usage.ReasoningTokens,
+			Cost:        cost,
+			TTFTMs:      ttftMs,
+			TTLTMs:      ttltMs,
+		})
+	}
+	if meta.CircuitBreakerOutcome != nil {
+		meta.CircuitBreakerOutcome(nil)
+	}
 }
 
 func applyChunkToResponse(resp *providers.Response, chunk providers.StreamChunk) {

--- a/internal/streamwrap/wrap_test.go
+++ b/internal/streamwrap/wrap_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ferro-labs/ai-gateway/internal/events"
 	"github.com/ferro-labs/ai-gateway/internal/metrics"
 	"github.com/ferro-labs/ai-gateway/models"
+	"github.com/ferro-labs/ai-gateway/plugin"
 	"github.com/ferro-labs/ai-gateway/providers"
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
@@ -312,6 +313,34 @@ func TestMeter_CallsCircuitBreakerOutcome_OnSuccessAndError(t *testing.T) {
 			t.Fatalf("outcome = %v, want provider error", outcomes[0])
 		}
 	})
+}
+
+func TestMeter_CallsCircuitBreakerOutcome_OnAfterPluginError(t *testing.T) {
+	var outcomeErr error
+	pluginErr := &plugin.RejectionError{Plugin: "after", PluginType: plugin.TypeLogging, Stage: plugin.StageAfterRequest, Reason: "rejected"}
+	src := feed(
+		providers.StreamChunk{ID: "1", Choices: []providers.StreamChoice{{
+			Delta: providers.MessageDelta{Content: "ok"},
+		}}},
+	)
+
+	out := Meter(context.Background(), src, time.Now(), MeterMeta{
+		Provider: "openai",
+		Model:    "gpt-4o",
+		Catalog:  models.Catalog{},
+		CompletionFn: func(context.Context, *providers.Response) error {
+			return pluginErr
+		},
+		CircuitBreakerOutcome: func(err error) {
+			outcomeErr = err
+		},
+	})
+	for range out { //nolint:revive
+	}
+
+	if outcomeErr != nil {
+		t.Fatalf("circuit breaker outcome error = %v, want nil after successful provider stream", outcomeErr)
+	}
 }
 
 func TestMeter_NilPublishFn_NoPanic(t *testing.T) {

--- a/internal/streamwrap/wrap_test.go
+++ b/internal/streamwrap/wrap_test.go
@@ -204,6 +204,116 @@ type streamError struct{ msg string }
 
 func (e *streamError) Error() string { return e.msg }
 
+func TestMeter_CircuitBreakerOutcome_PreservesProviderErrorOnClientCancel(t *testing.T) {
+	providerErr := errors.New("provider blew up")
+	src := make(chan providers.StreamChunk)
+
+	sendErr := make(chan struct{})
+	go func() {
+		src <- providers.StreamChunk{ID: "1"}
+		<-sendErr
+		src <- providers.StreamChunk{Error: providerErr}
+		close(src)
+	}()
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	var mu sync.Mutex
+	var outcomes []error
+	outcomeFn := func(err error) {
+		mu.Lock()
+		outcomes = append(outcomes, err)
+		mu.Unlock()
+	}
+
+	out := Meter(ctx, src, time.Now(), MeterMeta{
+		Provider:              "openai",
+		Model:                 "gpt-4o",
+		Catalog:               models.Catalog{},
+		CircuitBreakerOutcome: outcomeFn,
+	})
+
+	if _, ok := <-out; !ok {
+		t.Fatal("expected first chunk")
+	}
+	cancel()
+	close(sendErr)
+
+	for range out { //nolint:revive
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(outcomes) != 1 {
+		t.Fatalf("outcomes len = %d, want 1", len(outcomes))
+	}
+	if !errors.Is(outcomes[0], providerErr) {
+		t.Fatalf("outcome = %v, want provider error", outcomes[0])
+	}
+}
+
+func TestMeter_CallsCircuitBreakerOutcome_OnSuccessAndError(t *testing.T) {
+	var mu sync.Mutex
+	var outcomes []error
+
+	outcomeFn := func(err error) {
+		mu.Lock()
+		outcomes = append(outcomes, err)
+		mu.Unlock()
+	}
+
+	t.Run("success", func(t *testing.T) {
+		mu.Lock()
+		outcomes = nil
+		mu.Unlock()
+
+		src := feed(providers.StreamChunk{ID: "1"})
+		out := Meter(context.Background(), src, time.Now(), MeterMeta{
+			Provider:              "openai",
+			Model:                 "gpt-4o",
+			Catalog:               models.Catalog{},
+			CircuitBreakerOutcome: outcomeFn,
+		})
+		for range out { //nolint:revive
+		}
+
+		mu.Lock()
+		defer mu.Unlock()
+		if len(outcomes) != 1 || outcomes[0] != nil {
+			t.Fatalf("outcomes = %v, want single nil", outcomes)
+		}
+	})
+
+	t.Run("provider error", func(t *testing.T) {
+		mu.Lock()
+		outcomes = nil
+		mu.Unlock()
+
+		providerErr := errors.New("provider blew up")
+		src := feed(
+			providers.StreamChunk{ID: "1"},
+			providers.StreamChunk{Error: providerErr},
+		)
+		out := Meter(context.Background(), src, time.Now(), MeterMeta{
+			Provider:              "openai",
+			Model:                 "gpt-4o",
+			Catalog:               models.Catalog{},
+			CircuitBreakerOutcome: outcomeFn,
+		})
+		for range out { //nolint:revive
+		}
+
+		mu.Lock()
+		defer mu.Unlock()
+		if len(outcomes) != 1 {
+			t.Fatalf("outcomes len = %d, want 1", len(outcomes))
+		}
+		if !errors.Is(outcomes[0], providerErr) {
+			t.Fatalf("outcome = %v, want provider error", outcomes[0])
+		}
+	})
+}
+
 func TestMeter_NilPublishFn_NoPanic(t *testing.T) {
 	t.Helper()
 	src := feed(providers.StreamChunk{ID: "1"})

--- a/models/catalog_test.go
+++ b/models/catalog_test.go
@@ -112,7 +112,7 @@ func TestCatalogURLForLog(t *testing.T) {
 	}{
 		{
 			name: "strips userinfo and query",
-			raw:  "https://user:super-secret@catalog.example.com/v1/catalog.json?token=abc123",
+			raw:  "https://user@catalog.example.com/v1/catalog.json?debug=true",
 			want: "https://catalog.example.com/v1/catalog.json",
 		},
 		{


### PR DESCRIPTION
## v1.1.3 — Streaming-correctness release

Merges the complete `release/v1.1.3` line into `main`. This release brings the **streaming routing path (`RouteStream`) to parity with non-streaming `Route`**: the post-request plugin pipeline, the per-provider circuit breaker, and least-latency / cost-optimized ordering now all apply to `stream: true` traffic. It also tightens fallback retry semantics and async-context propagation. No public API breaks.

See [`CHANGELOG.md` → 1.1.3](https://github.com/ferro-labs/ai-gateway/blob/release/v1.1.3/CHANGELOG.md) for the full notes.

## What's included (by issue)

| Issue | Area | Landed via |
|------|------|-----------|
| #135 | `RouteStream` skipped the post-request plugin pipeline (`RunAfter`/`RunOnError`, cache `Skip`) | #201 |
| #136 | Circuit breaker was a no-op for streaming-first traffic; mid-stream failures didn't count | #199 |
| #137 | Fallback strategy retried cancellations and open circuits | this branch |
| #138 | Streaming ignored least-latency / cost-optimized ordering | this branch |
| #181 | Detached goroutines used `context.Background()` (lost trace context) / a cancelled ctx; MCP init ignored shutdown | #202 |

### Highlights
- **Plugin pipeline for streams (#135):** `RunAfter` fires after the stream drains (response reconstructed from chunks so the response-cache can store it), `RunOnError` fires on resolution/provider/stream/after-plugin failures, and a cache hit short-circuits the provider into a single streamed chunk.
- **Streaming circuit breaker (#136):** success recorded at stream completion; startup and mid-stream failures count; open-circuit targets skipped so fallback advances. Caller-side cancel/deadline no longer trips the breaker, while provider-side deadlines on a live request context do.
- **Fallback retry hygiene (#137):** `context.Canceled` / `context.DeadlineExceeded` / `circuitbreaker.ErrCircuitOpen` are non-retryable, plus a `ctx.Err()` guard at the top of the retry loop.
- **Streaming latency/cost ordering (#138):** targets ordered by observed p50 (explore unsampled first) and catalog cost, mirroring non-streaming; stream latency samples recorded so least-latency converges.
- **Async context detachment (#181):** event hooks and the streaming observability event use `context.WithoutCancel(ctx)`; MCP init timeout parented on the gateway shutdown context.

## Closing
Closes #135
Closes #136
Closes #137
Closes #138
Closes #181

## Testing
- `golangci-lint run ./...` → 0 issues · `go vet ./...` clean · `go test -race ./...` green (CI: Lint / Test / CodeQL / Integration / Vuln Scan / Snyk passing on the release branch).
- New regression coverage for streaming after/on-error/cache-hit, streaming circuit-breaker startup+mid-stream, fallback retry sentinels, streaming latency/cost ordering, and hook/observability context detachment.

## Notes
- Under `cost-optimized` + `unpriced_strategy: skip`, streaming keeps unpriced providers as a last-resort fallback (errors only when *no* candidate is priced), unlike the non-streaming path which never selects unpriced. Intentional for the streaming fallback chain.
