### PR TITLE
fix(issue136): Add streaming circuit breaker and streaming success recording correctness

### DIFF
--- a/gateway.go
+++ b/gateway.go
@@ -1406,13 +1406,16 @@ func (g *Gateway) streamingProviderForTargetLocked(key, model string) (providers
 		return nil, false
 	}
 
-	// Apply circuit breaker if configured.
-	candidate := p
-	if cb, hasCB := g.circuitBreakers[key]; hasCB {
-		candidate = &cbProvider{Provider: p, cb: cb, name: key}
+	sp, ok := p.(providers.StreamProvider)
+	if !ok {
+		return nil, false
 	}
-	sp, ok := candidate.(providers.StreamProvider)
-	return sp, ok
+
+	// Apply circuit breaker if configured.
+	if cb, hasCB := g.circuitBreakers[key]; hasCB {
+		return &cbProvider{Provider: p, cb: cb, name: key}, true
+	}
+	return sp, true
 }
 
 func (g *Gateway) streamingTargetOrderLocked(req providers.Request) ([]string, error) {

--- a/gateway.go
+++ b/gateway.go
@@ -1027,7 +1027,7 @@ func (p *cbProvider) Complete(ctx context.Context, req providers.Request) (*prov
 	}
 	resp, err := p.Provider.Complete(ctx, req)
 	if err != nil {
-		if shouldRecordCircuitBreakerFailure(err) {
+		if shouldRecordCircuitBreakerFailure(ctx, err) {
 			p.cb.RecordFailure()
 			metrics.CircuitBreakerState.WithLabelValues(p.name).Set(float64(p.cb.State()))
 		}
@@ -1049,7 +1049,7 @@ func (p *cbProvider) CompleteStream(ctx context.Context, req providers.Request) 
 	}
 	ch, err := sp.CompleteStream(ctx, req)
 	if err != nil {
-		if shouldRecordCircuitBreakerFailure(err) {
+		if shouldRecordCircuitBreakerFailure(ctx, err) {
 			p.cb.RecordFailure()
 			metrics.CircuitBreakerState.WithLabelValues(p.name).Set(float64(p.cb.State()))
 		}
@@ -1059,13 +1059,15 @@ func (p *cbProvider) CompleteStream(ctx context.Context, req providers.Request) 
 }
 
 // shouldRecordCircuitBreakerFailure reports whether an error should count toward
-// opening the circuit. Client-side cancellation/deadlines and rate limits are
+// opening the circuit. Caller-side cancellation/deadlines and rate limits are
 // excluded so transient client behavior does not block healthy traffic.
-func shouldRecordCircuitBreakerFailure(err error) bool {
+// Provider-side timeouts that surface as context.DeadlineExceeded while the
+// request context is still active are counted as failures.
+func shouldRecordCircuitBreakerFailure(ctx context.Context, err error) bool {
 	if err == nil {
 		return false
 	}
-	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+	if ctx.Err() != nil && (errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)) {
 		return false
 	}
 	return !isRateLimitError(err)
@@ -1074,9 +1076,9 @@ func shouldRecordCircuitBreakerFailure(err error) bool {
 // recordStreamCircuitBreakerOutcome updates breaker state when a stream
 // finishes. Startup failures are recorded in cbProvider.CompleteStream;
 // this handles stream completion only.
-func recordStreamCircuitBreakerOutcome(cb *circuitbreaker.CircuitBreaker, name string, err error) {
+func recordStreamCircuitBreakerOutcome(ctx context.Context, cb *circuitbreaker.CircuitBreaker, name string, err error) {
 	if err != nil {
-		if !shouldRecordCircuitBreakerFailure(err) {
+		if !shouldRecordCircuitBreakerFailure(ctx, err) {
 			return
 		}
 		cb.RecordFailure()
@@ -1322,7 +1324,7 @@ func (g *Gateway) RouteStream(ctx context.Context, req providers.Request) (<-cha
 		cb := wrapped.cb
 		cbName := wrapped.name
 		meta.CircuitBreakerOutcome = func(err error) {
-			recordStreamCircuitBreakerOutcome(cb, cbName, err)
+			recordStreamCircuitBreakerOutcome(ctx, cb, cbName, err)
 		}
 	}
 

--- a/gateway.go
+++ b/gateway.go
@@ -1049,7 +1049,7 @@ func (p *cbProvider) CompleteStream(ctx context.Context, req providers.Request) 
 	}
 	ch, err := sp.CompleteStream(ctx, req)
 	if err != nil {
-		if !isRateLimitError(err) {
+		if shouldRecordCircuitBreakerFailure(err) {
 			p.cb.RecordFailure()
 			metrics.CircuitBreakerState.WithLabelValues(p.name).Set(float64(p.cb.State()))
 		}
@@ -1058,16 +1058,25 @@ func (p *cbProvider) CompleteStream(ctx context.Context, req providers.Request) 
 	return ch, nil
 }
 
+// shouldRecordCircuitBreakerFailure reports whether an error should count toward
+// opening the circuit. Client-side cancellation/deadlines and rate limits are
+// excluded so transient client behavior does not block healthy traffic.
+func shouldRecordCircuitBreakerFailure(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+	return !isRateLimitError(err)
+}
+
 // recordStreamCircuitBreakerOutcome updates breaker state when a stream
 // finishes. Startup failures are recorded in cbProvider.CompleteStream;
 // this handles stream completion only.
 func recordStreamCircuitBreakerOutcome(cb *circuitbreaker.CircuitBreaker, name string, err error) {
 	if err != nil {
-		// Client-side cancellation/deadlines are not provider failures.
-		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-			return
-		}
-		if isRateLimitError(err) {
+		if !shouldRecordCircuitBreakerFailure(err) {
 			return
 		}
 		cb.RecordFailure()
@@ -1383,10 +1392,20 @@ func (g *Gateway) resolveStreamingProviderLocked(req providers.Request) (provide
 	if err != nil {
 		return nil, err
 	}
+	var openCircuitTarget providers.StreamProvider
 	for _, key := range orderedKeys {
-		if sp, ok := g.streamingProviderForTargetLocked(key, req.Model); ok {
-			return sp, nil
+		sp, ok := g.streamingProviderForTargetLocked(key, req.Model)
+		if !ok {
+			continue
 		}
+		if wrapped, isCB := sp.(*cbProvider); isCB && !wrapped.cb.Allow() {
+			openCircuitTarget = sp
+			continue
+		}
+		return sp, nil
+	}
+	if openCircuitTarget != nil {
+		return openCircuitTarget, nil
 	}
 
 	// Fallback: any registered provider that supports this model and streaming.

--- a/gateway.go
+++ b/gateway.go
@@ -1063,7 +1063,8 @@ func (p *cbProvider) CompleteStream(ctx context.Context, req providers.Request) 
 // this handles stream completion only.
 func recordStreamCircuitBreakerOutcome(cb *circuitbreaker.CircuitBreaker, name string, err error) {
 	if err != nil {
-		if errors.Is(err, context.Canceled) {
+		// Client-side cancellation/deadlines are not provider failures.
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 			return
 		}
 		if isRateLimitError(err) {

--- a/gateway.go
+++ b/gateway.go
@@ -188,6 +188,10 @@ func New(cfg Config) (*Gateway, error) {
 		}()
 	}
 
+	gw.mu.Lock()
+	gw.ensureCircuitBreakersLocked()
+	gw.mu.Unlock()
+
 	return gw, nil
 }
 
@@ -822,6 +826,7 @@ func (g *Gateway) ReloadConfig(cfg Config) error {
 	g.streamingContent = streamingContent
 	g.strategy = nil // force rebuild on next request
 	g.circuitBreakers = make(map[string]*circuitbreaker.CircuitBreaker)
+	g.ensureCircuitBreakersLocked()
 
 	// Re-register MCP servers from the new config.
 	if len(cfg.MCPServers) > 0 {
@@ -875,18 +880,7 @@ func (g *Gateway) getStrategy() (strategies.Strategy, error) {
 		return g.strategy, nil
 	}
 
-	// Build circuit breakers for targets that have them configured.
-	for _, t := range g.config.Targets {
-		if t.CircuitBreaker == nil {
-			continue
-		}
-		if _, exists := g.circuitBreakers[t.VirtualKey]; exists {
-			continue
-		}
-		timeout, _ := time.ParseDuration(t.CircuitBreaker.Timeout)
-		cb := circuitbreaker.New(t.CircuitBreaker.FailureThreshold, t.CircuitBreaker.SuccessThreshold, timeout)
-		g.circuitBreakers[t.VirtualKey] = cb
-	}
+	g.ensureCircuitBreakersLocked()
 
 	// Snapshot both maps under the write lock already held. The lookup closure
 	// runs inside Strategy.Execute with no lock held, so capturing local copies
@@ -1061,9 +1055,45 @@ func (p *cbProvider) CompleteStream(ctx context.Context, req providers.Request) 
 		}
 		return nil, err
 	}
-	p.cb.RecordSuccess()
-	metrics.CircuitBreakerState.WithLabelValues(p.name).Set(0)
 	return ch, nil
+}
+
+// recordStreamCircuitBreakerOutcome updates breaker state when a stream
+// finishes. Startup failures are recorded in cbProvider.CompleteStream;
+// this handles stream completion only.
+func recordStreamCircuitBreakerOutcome(cb *circuitbreaker.CircuitBreaker, name string, err error) {
+	if err != nil {
+		if errors.Is(err, context.Canceled) {
+			return
+		}
+		if isRateLimitError(err) {
+			return
+		}
+		cb.RecordFailure()
+		metrics.CircuitBreakerState.WithLabelValues(name).Set(float64(cb.State()))
+		return
+	}
+	cb.RecordSuccess()
+	metrics.CircuitBreakerState.WithLabelValues(name).Set(0)
+}
+
+// ensureCircuitBreakersLocked creates circuit breakers for configured targets.
+// Caller must hold g.mu.
+func (g *Gateway) ensureCircuitBreakersLocked() {
+	for _, t := range g.config.Targets {
+		if t.CircuitBreaker == nil {
+			continue
+		}
+		if _, exists := g.circuitBreakers[t.VirtualKey]; exists {
+			continue
+		}
+		timeout, _ := time.ParseDuration(t.CircuitBreaker.Timeout)
+		g.circuitBreakers[t.VirtualKey] = circuitbreaker.New(
+			t.CircuitBreaker.FailureThreshold,
+			t.CircuitBreaker.SuccessThreshold,
+			timeout,
+		)
+	}
 }
 
 // isRateLimitError checks if the error is a 429 rate limit response.
@@ -1207,6 +1237,9 @@ func (g *Gateway) RouteStream(ctx context.Context, req providers.Request) (<-cha
 	}
 
 	// Resolve provider according to strategy mode.
+	g.mu.Lock()
+	g.ensureCircuitBreakersLocked()
+	g.mu.Unlock()
 	g.mu.RLock()
 	sp, orderErr := g.resolveStreamingProviderLocked(req)
 	g.mu.RUnlock()
@@ -1274,6 +1307,13 @@ func (g *Gateway) RouteStream(ctx context.Context, req providers.Request) (<-cha
 	}
 	if hooksEnabled {
 		meta.PublishFn = g.publishEvent
+	}
+	if wrapped, ok := sp.(*cbProvider); ok {
+		cb := wrapped.cb
+		cbName := wrapped.name
+		meta.CircuitBreakerOutcome = func(err error) {
+			recordStreamCircuitBreakerOutcome(cb, cbName, err)
+		}
 	}
 
 	// Hand the root span off to streamwrap so token, cost, and timing

--- a/gateway.go
+++ b/gateway.go
@@ -1027,7 +1027,7 @@ func (p *cbProvider) Complete(ctx context.Context, req providers.Request) (*prov
 	}
 	resp, err := p.Provider.Complete(ctx, req)
 	if err != nil {
-		if !isRateLimitError(err) {
+		if shouldRecordCircuitBreakerFailure(err) {
 			p.cb.RecordFailure()
 			metrics.CircuitBreakerState.WithLabelValues(p.name).Set(float64(p.cb.State()))
 		}

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -911,6 +911,56 @@ func TestGateway_RouteStream_StartupFailureTripsCircuitWithoutRoute(t *testing.T
 	}
 }
 
+func TestGateway_RouteStream_FallbackSkipsNonStreamingTargetWithCircuitBreaker(t *testing.T) {
+	var selected atomic.Value
+	gw, err := New(Config{
+		Strategy: StrategyConfig{Mode: ModeFallback},
+		Targets: []Target{
+			{
+				VirtualKey: "plain",
+				CircuitBreaker: &CircuitBreakerConfig{
+					FailureThreshold: 2,
+				},
+			},
+			{VirtualKey: "stream"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	gw.RegisterProvider(&mockProvider{
+		name:   "plain",
+		models: []string{"gpt-4o"},
+	})
+	gw.RegisterProvider(&mockStreamProvider{
+		mockProvider: mockProvider{
+			name:   "stream",
+			models: []string{"gpt-4o"},
+		},
+		streamFn: func(_ context.Context, _ providers.Request) (<-chan providers.StreamChunk, error) {
+			selected.Store("stream")
+			ch := make(chan providers.StreamChunk, 1)
+			ch <- providers.StreamChunk{
+				ID: "stream-ok",
+				Choices: []providers.StreamChoice{{
+					Delta: providers.MessageDelta{Content: "ok"},
+				}},
+			}
+			close(ch)
+			return ch, nil
+		},
+	})
+
+	ch, err := gw.RouteStream(context.Background(), streamTestRequest())
+	if err != nil {
+		t.Fatalf("RouteStream error = %v, want streaming fallback target", err)
+	}
+	drainMeteredStream(t, ch)
+	if got := selected.Load(); got != "stream" {
+		t.Fatalf("selected provider = %v, want stream", got)
+	}
+}
+
 func TestGateway_RouteStream_ClientDeadlineDoesNotTripCircuit(t *testing.T) {
 	gw, err := New(Config{
 		Strategy: StrategyConfig{Mode: ModeSingle},

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -979,14 +979,16 @@ func TestGateway_RouteStream_StartupCancellationDoesNotTripCircuit(t *testing.T)
 			name:   "flaky-stream",
 			models: []string{"gpt-4o"},
 		},
-		streamErr: context.DeadlineExceeded,
+		streamErr: context.Canceled,
 	})
 
 	req := streamTestRequest()
 	for i := 0; i < 3; i++ {
-		_, err := gw.RouteStream(context.Background(), req)
-		if !errors.Is(err, context.DeadlineExceeded) {
-			t.Fatalf("attempt %d: error = %v, want context.DeadlineExceeded", i+1, err)
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		_, err := gw.RouteStream(ctx, req)
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("attempt %d: error = %v, want context.Canceled", i+1, err)
 		}
 	}
 
@@ -998,6 +1000,136 @@ func TestGateway_RouteStream_StartupCancellationDoesNotTripCircuit(t *testing.T)
 	}
 	if cb.State() != circuitbreaker.StateClosed {
 		t.Fatalf("circuit state = %v, want closed after startup cancellations", cb.State())
+	}
+}
+
+func TestGateway_Route_ProviderTimeoutTripsCircuit(t *testing.T) {
+	gw, err := New(Config{
+		Strategy: StrategyConfig{Mode: ModeSingle},
+		Targets: []Target{{
+			VirtualKey: "slow",
+			CircuitBreaker: &CircuitBreakerConfig{
+				FailureThreshold: 2,
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	gw.RegisterProvider(&mockProvider{
+		name:   "slow",
+		models: []string{"gpt-4o"},
+		err:    context.DeadlineExceeded,
+	})
+
+	req := providers.Request{
+		Model:    "gpt-4o",
+		Messages: []providers.Message{{Role: "user", Content: "hi"}},
+	}
+	for i := 0; i < 2; i++ {
+		_, routeErr := gw.Route(context.Background(), req)
+		if !errors.Is(routeErr, context.DeadlineExceeded) {
+			t.Fatalf("attempt %d: error = %v, want context.DeadlineExceeded", i+1, routeErr)
+		}
+	}
+
+	_, routeErr := gw.Route(context.Background(), req)
+	if !errors.Is(routeErr, circuitbreaker.ErrCircuitOpen) {
+		t.Fatalf("expected circuit open after provider timeouts, got %v", routeErr)
+	}
+}
+
+func TestGateway_RouteStream_ProviderTimeoutTripsCircuit(t *testing.T) {
+	gw, err := New(Config{
+		Strategy: StrategyConfig{Mode: ModeSingle},
+		Targets: []Target{{
+			VirtualKey: "flaky-stream",
+			CircuitBreaker: &CircuitBreakerConfig{
+				FailureThreshold: 2,
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	gw.RegisterProvider(&mockStreamProvider{
+		mockProvider: mockProvider{
+			name:   "flaky-stream",
+			models: []string{"gpt-4o"},
+		},
+		streamErr: context.DeadlineExceeded,
+	})
+
+	req := streamTestRequest()
+	for i := 0; i < 2; i++ {
+		_, err := gw.RouteStream(context.Background(), req)
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("attempt %d: error = %v, want context.DeadlineExceeded", i+1, err)
+		}
+	}
+
+	_, err = gw.RouteStream(context.Background(), req)
+	if !errors.Is(err, circuitbreaker.ErrCircuitOpen) {
+		t.Fatalf("expected circuit open after provider timeouts, got %v", err)
+	}
+}
+
+func TestShouldRecordCircuitBreakerFailure(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		ctx  context.Context
+		err  error
+		want bool
+	}{
+		{
+			name: "nil error",
+			ctx:  context.Background(),
+			err:  nil,
+			want: false,
+		},
+		{
+			name: "provider timeout with live request context",
+			ctx:  context.Background(),
+			err:  context.DeadlineExceeded,
+			want: true,
+		},
+		{
+			name: "client deadline with canceled request context",
+			ctx: func() context.Context {
+				ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+				cancel()
+				return ctx
+			}(),
+			err:  context.DeadlineExceeded,
+			want: false,
+		},
+		{
+			name: "client cancel with canceled request context",
+			ctx: func() context.Context {
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel()
+				return ctx
+			}(),
+			err:  context.Canceled,
+			want: false,
+		},
+		{
+			name: "provider error with live request context",
+			ctx:  context.Background(),
+			err:  errors.New("upstream unavailable"),
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := shouldRecordCircuitBreakerFailure(tt.ctx, tt.err); got != tt.want {
+				t.Fatalf("shouldRecordCircuitBreakerFailure() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }
 

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -1062,6 +1062,63 @@ func TestGateway_RouteStream_FallbackSkipsOpenCircuitBreakerTarget(t *testing.T)
 	}
 }
 
+type slowCompleteProvider struct {
+	mockProvider
+}
+
+func (p *slowCompleteProvider) Complete(ctx context.Context, _ providers.Request) (*providers.Response, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-time.After(500 * time.Millisecond):
+		return &providers.Response{ID: "ok"}, nil
+	}
+}
+
+func TestGateway_Route_ClientDeadlineDoesNotTripCircuit(t *testing.T) {
+	gw, err := New(Config{
+		Strategy: StrategyConfig{Mode: ModeSingle},
+		Targets: []Target{{
+			VirtualKey: "slow",
+			CircuitBreaker: &CircuitBreakerConfig{
+				FailureThreshold: 2,
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	gw.RegisterProvider(&slowCompleteProvider{
+		mockProvider: mockProvider{
+			name:   "slow",
+			models: []string{"gpt-4o"},
+		},
+	})
+
+	req := providers.Request{
+		Model:    "gpt-4o",
+		Messages: []providers.Message{{Role: "user", Content: "hi"}},
+	}
+	for i := 0; i < 2; i++ {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+		_, routeErr := gw.Route(ctx, req)
+		cancel()
+		if !errors.Is(routeErr, context.DeadlineExceeded) {
+			t.Fatalf("attempt %d: error = %v, want context.DeadlineExceeded", i+1, routeErr)
+		}
+	}
+
+	gw.mu.RLock()
+	cb := gw.circuitBreakers["slow"]
+	gw.mu.RUnlock()
+	if cb == nil {
+		t.Fatal("expected circuit breaker for slow")
+	}
+	if cb.State() != circuitbreaker.StateClosed {
+		t.Fatalf("circuit state = %v, want closed after client deadlines", cb.State())
+	}
+}
+
 func TestGateway_RouteStream_ClientDeadlineDoesNotTripCircuit(t *testing.T) {
 	gw, err := New(Config{
 		Strategy: StrategyConfig{Mode: ModeSingle},

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -863,6 +863,101 @@ func TestGateway_RouteStream_ImmediateCircuitOpen_IncrementsCircuitOpenProviderE
 	}
 }
 
+func streamTestRequest() providers.Request {
+	return providers.Request{
+		Model:    "gpt-4o",
+		Messages: []providers.Message{{Role: "user", Content: "hi"}},
+	}
+}
+
+func drainMeteredStream(t *testing.T, ch <-chan providers.StreamChunk) {
+	t.Helper()
+	for range ch { //nolint:revive
+	}
+}
+
+func TestGateway_RouteStream_StartupFailureTripsCircuitWithoutRoute(t *testing.T) {
+	gw, err := New(Config{
+		Strategy: StrategyConfig{Mode: ModeSingle},
+		Targets: []Target{{
+			VirtualKey: "flaky-stream",
+			CircuitBreaker: &CircuitBreakerConfig{
+				FailureThreshold: 2,
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	gw.RegisterProvider(&mockStreamProvider{
+		mockProvider: mockProvider{
+			name:   "flaky-stream",
+			models: []string{"gpt-4o"},
+		},
+		streamErr: errors.New("stream startup failed"),
+	})
+
+	req := streamTestRequest()
+	for i := 0; i < 2; i++ {
+		_, err := gw.RouteStream(context.Background(), req)
+		if err == nil {
+			t.Fatalf("attempt %d: expected startup error", i+1)
+		}
+	}
+
+	_, err = gw.RouteStream(context.Background(), req)
+	if !errors.Is(err, circuitbreaker.ErrCircuitOpen) {
+		t.Fatalf("expected circuit open, got %v", err)
+	}
+}
+
+func TestGateway_RouteStream_MidStreamFailureTripsCircuit(t *testing.T) {
+	streamErr := errors.New("mid-stream provider failure")
+	gw, err := New(Config{
+		Strategy: StrategyConfig{Mode: ModeSingle},
+		Targets: []Target{{
+			VirtualKey: "flaky-stream",
+			CircuitBreaker: &CircuitBreakerConfig{
+				FailureThreshold: 2,
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	gw.RegisterProvider(&mockStreamProvider{
+		mockProvider: mockProvider{
+			name:   "flaky-stream",
+			models: []string{"gpt-4o"},
+		},
+		streamFn: func(_ context.Context, _ providers.Request) (<-chan providers.StreamChunk, error) {
+			ch := make(chan providers.StreamChunk, 2)
+			ch <- providers.StreamChunk{
+				Choices: []providers.StreamChoice{{
+					Delta: providers.MessageDelta{Content: "partial"},
+				}},
+			}
+			ch <- providers.StreamChunk{Error: streamErr}
+			close(ch)
+			return ch, nil
+		},
+	})
+
+	req := streamTestRequest()
+	for i := 0; i < 2; i++ {
+		ch, err := gw.RouteStream(context.Background(), req)
+		if err != nil {
+			t.Fatalf("attempt %d: RouteStream error = %v", i+1, err)
+		}
+		drainMeteredStream(t, ch)
+	}
+
+	_, err = gw.RouteStream(context.Background(), req)
+	if !errors.Is(err, circuitbreaker.ErrCircuitOpen) {
+		t.Fatalf("expected circuit open after mid-stream failures, got %v", err)
+	}
+}
+
 func TestGateway_RouteStream_BeforePluginCanSetNilRequest(t *testing.T) {
 	gw, _ := New(Config{
 		Strategy: StrategyConfig{Mode: ModeSingle},

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -911,6 +911,75 @@ func TestGateway_RouteStream_StartupFailureTripsCircuitWithoutRoute(t *testing.T
 	}
 }
 
+func TestGateway_RouteStream_ClientDeadlineDoesNotTripCircuit(t *testing.T) {
+	gw, err := New(Config{
+		Strategy: StrategyConfig{Mode: ModeSingle},
+		Targets: []Target{{
+			VirtualKey: "slow-stream",
+			CircuitBreaker: &CircuitBreakerConfig{
+				FailureThreshold: 2,
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	gw.RegisterProvider(&mockStreamProvider{
+		mockProvider: mockProvider{
+			name:   "slow-stream",
+			models: []string{"gpt-4o"},
+		},
+		streamFn: func(ctx context.Context, _ providers.Request) (<-chan providers.StreamChunk, error) {
+			ch := make(chan providers.StreamChunk)
+			go func() {
+				defer close(ch)
+				ticker := time.NewTicker(20 * time.Millisecond)
+				defer ticker.Stop()
+				for {
+					select {
+					case <-ctx.Done():
+						return
+					case <-ticker.C:
+						select {
+						case ch <- providers.StreamChunk{
+							Choices: []providers.StreamChoice{{
+								Delta: providers.MessageDelta{Content: "x"},
+							}},
+						}:
+						case <-ctx.Done():
+							return
+						}
+					}
+				}
+			}()
+			return ch, nil
+		},
+	})
+
+	req := streamTestRequest()
+	for i := 0; i < 2; i++ {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+		ch, streamErr := gw.RouteStream(ctx, req)
+		if streamErr != nil {
+			cancel()
+			t.Fatalf("attempt %d: RouteStream error = %v", i+1, streamErr)
+		}
+		for range ch { //nolint:revive
+		}
+		cancel()
+	}
+
+	gw.mu.RLock()
+	cb := gw.circuitBreakers["slow-stream"]
+	gw.mu.RUnlock()
+	if cb == nil {
+		t.Fatal("expected circuit breaker for slow-stream")
+	}
+	if cb.State() != circuitbreaker.StateClosed {
+		t.Fatalf("circuit state = %v, want closed after client deadlines", cb.State())
+	}
+}
+
 func TestGateway_RouteStream_MidStreamFailureTripsCircuit(t *testing.T) {
 	streamErr := errors.New("mid-stream provider failure")
 	gw, err := New(Config{

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -961,6 +961,107 @@ func TestGateway_RouteStream_FallbackSkipsNonStreamingTargetWithCircuitBreaker(t
 	}
 }
 
+func TestGateway_RouteStream_StartupCancellationDoesNotTripCircuit(t *testing.T) {
+	gw, err := New(Config{
+		Strategy: StrategyConfig{Mode: ModeSingle},
+		Targets: []Target{{
+			VirtualKey: "flaky-stream",
+			CircuitBreaker: &CircuitBreakerConfig{
+				FailureThreshold: 2,
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	gw.RegisterProvider(&mockStreamProvider{
+		mockProvider: mockProvider{
+			name:   "flaky-stream",
+			models: []string{"gpt-4o"},
+		},
+		streamErr: context.DeadlineExceeded,
+	})
+
+	req := streamTestRequest()
+	for i := 0; i < 3; i++ {
+		_, err := gw.RouteStream(context.Background(), req)
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("attempt %d: error = %v, want context.DeadlineExceeded", i+1, err)
+		}
+	}
+
+	gw.mu.RLock()
+	cb := gw.circuitBreakers["flaky-stream"]
+	gw.mu.RUnlock()
+	if cb == nil {
+		t.Fatal("expected circuit breaker for flaky-stream")
+	}
+	if cb.State() != circuitbreaker.StateClosed {
+		t.Fatalf("circuit state = %v, want closed after startup cancellations", cb.State())
+	}
+}
+
+func TestGateway_RouteStream_FallbackSkipsOpenCircuitBreakerTarget(t *testing.T) {
+	var selected atomic.Value
+	gw, err := New(Config{
+		Strategy: StrategyConfig{Mode: ModeFallback},
+		Targets: []Target{
+			{
+				VirtualKey: "flaky-stream",
+				CircuitBreaker: &CircuitBreakerConfig{
+					FailureThreshold: 2,
+				},
+			},
+			{VirtualKey: "healthy-stream"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	gw.RegisterProvider(&mockStreamProvider{
+		mockProvider: mockProvider{
+			name:   "flaky-stream",
+			models: []string{"gpt-4o"},
+		},
+		streamErr: errors.New("stream startup failed"),
+	})
+	gw.RegisterProvider(&mockStreamProvider{
+		mockProvider: mockProvider{
+			name:   "healthy-stream",
+			models: []string{"gpt-4o"},
+		},
+		streamFn: func(_ context.Context, _ providers.Request) (<-chan providers.StreamChunk, error) {
+			selected.Store("healthy-stream")
+			ch := make(chan providers.StreamChunk, 1)
+			ch <- providers.StreamChunk{
+				ID: "healthy-ok",
+				Choices: []providers.StreamChoice{{
+					Delta: providers.MessageDelta{Content: "ok"},
+				}},
+			}
+			close(ch)
+			return ch, nil
+		},
+	})
+
+	req := streamTestRequest()
+	for i := 0; i < 2; i++ {
+		_, err := gw.RouteStream(context.Background(), req)
+		if err == nil {
+			t.Fatalf("attempt %d: expected startup error to trip breaker", i+1)
+		}
+	}
+
+	ch, err := gw.RouteStream(context.Background(), req)
+	if err != nil {
+		t.Fatalf("RouteStream error = %v, want healthy-stream fallback", err)
+	}
+	drainMeteredStream(t, ch)
+	if got := selected.Load(); got != "healthy-stream" {
+		t.Fatalf("selected provider = %v, want healthy-stream", got)
+	}
+}
+
 func TestGateway_RouteStream_ClientDeadlineDoesNotTripCircuit(t *testing.T) {
 	gw, err := New(Config{
 		Strategy: StrategyConfig{Mode: ModeSingle},

--- a/internal/streamwrap/wrap.go
+++ b/internal/streamwrap/wrap.go
@@ -43,6 +43,9 @@ type MeterMeta struct {
 	// type is intentionally a minimal local interface so streamwrap
 	// stays decoupled from the public observability package.
 	SpanFinisher SpanFinisher
+	// CircuitBreakerOutcome, if non-nil, is invoked once when the stream
+	// finishes. err is nil on success; non-nil on provider/stream failure.
+	CircuitBreakerOutcome func(err error)
 }
 
 // StreamOutcome bundles the values stamped onto the observability span
@@ -187,6 +190,9 @@ func Meter(ctx context.Context, src <-chan providers.StreamChunk, start time.Tim
 					ErrorMsg:  streamErr.Error(),
 				})
 			}
+			if meta.CircuitBreakerOutcome != nil {
+				meta.CircuitBreakerOutcome(streamErr)
+			}
 			return
 		}
 
@@ -240,6 +246,9 @@ func Meter(ctx context.Context, src <-chan providers.StreamChunk, start time.Tim
 				TTFTMs:      ttftMs,
 				TTLTMs:      ttltMs,
 			})
+		}
+		if meta.CircuitBreakerOutcome != nil {
+			meta.CircuitBreakerOutcome(nil)
 		}
 	}()
 

--- a/internal/streamwrap/wrap.go
+++ b/internal/streamwrap/wrap.go
@@ -105,8 +105,13 @@ func Meter(ctx context.Context, src <-chan providers.StreamChunk, start time.Tim
 				// MUST close src eventually for this to terminate; that is
 				// the existing contract for every CompleteStream impl.
 				clientCanceled = true
-				streamErr = ctx.Err()
-				for range src { //nolint:revive
+				if streamErr == nil {
+					streamErr = ctx.Err()
+				}
+				for chunk := range src {
+					if chunk.Error != nil {
+						streamErr = chunk.Error
+					}
 				}
 				break loop
 			case chunk, ok := <-src:
@@ -135,8 +140,13 @@ func Meter(ctx context.Context, src <-chan providers.StreamChunk, start time.Tim
 				case out <- chunk:
 				case <-ctx.Done():
 					clientCanceled = true
-					streamErr = ctx.Err()
-					for range src { //nolint:revive
+					if streamErr == nil {
+						streamErr = ctx.Err()
+					}
+					for chunk := range src {
+						if chunk.Error != nil {
+							streamErr = chunk.Error
+						}
 					}
 					break loop
 				}

--- a/internal/streamwrap/wrap_test.go
+++ b/internal/streamwrap/wrap_test.go
@@ -204,6 +204,68 @@ type streamError struct{ msg string }
 
 func (e *streamError) Error() string { return e.msg }
 
+func TestMeter_CallsCircuitBreakerOutcome_OnSuccessAndError(t *testing.T) {
+	var mu sync.Mutex
+	var outcomes []error
+
+	outcomeFn := func(err error) {
+		mu.Lock()
+		outcomes = append(outcomes, err)
+		mu.Unlock()
+	}
+
+	t.Run("success", func(t *testing.T) {
+		mu.Lock()
+		outcomes = nil
+		mu.Unlock()
+
+		src := feed(providers.StreamChunk{ID: "1"})
+		out := Meter(context.Background(), src, time.Now(), MeterMeta{
+			Provider:              "openai",
+			Model:                 "gpt-4o",
+			Catalog:               models.Catalog{},
+			CircuitBreakerOutcome: outcomeFn,
+		})
+		for range out { //nolint:revive
+		}
+
+		mu.Lock()
+		defer mu.Unlock()
+		if len(outcomes) != 1 || outcomes[0] != nil {
+			t.Fatalf("outcomes = %v, want single nil", outcomes)
+		}
+	})
+
+	t.Run("provider error", func(t *testing.T) {
+		mu.Lock()
+		outcomes = nil
+		mu.Unlock()
+
+		providerErr := errors.New("provider blew up")
+		src := feed(
+			providers.StreamChunk{ID: "1"},
+			providers.StreamChunk{Error: providerErr},
+		)
+		out := Meter(context.Background(), src, time.Now(), MeterMeta{
+			Provider:              "openai",
+			Model:                 "gpt-4o",
+			Catalog:               models.Catalog{},
+			CircuitBreakerOutcome: outcomeFn,
+		})
+		for range out { //nolint:revive
+		}
+
+		mu.Lock()
+		defer mu.Unlock()
+		if len(outcomes) != 1 {
+			t.Fatalf("outcomes len = %d, want 1", len(outcomes))
+		}
+		if !errors.Is(outcomes[0], providerErr) {
+			t.Fatalf("outcome = %v, want provider error", outcomes[0])
+		}
+	})
+}
+
 func TestMeter_NilPublishFn_NoPanic(t *testing.T) {
 	t.Helper()
 	src := feed(providers.StreamChunk{ID: "1"})

--- a/internal/streamwrap/wrap_test.go
+++ b/internal/streamwrap/wrap_test.go
@@ -204,6 +204,54 @@ type streamError struct{ msg string }
 
 func (e *streamError) Error() string { return e.msg }
 
+func TestMeter_CircuitBreakerOutcome_PreservesProviderErrorOnClientCancel(t *testing.T) {
+	providerErr := errors.New("provider blew up")
+	src := make(chan providers.StreamChunk)
+
+	sendErr := make(chan struct{})
+	go func() {
+		src <- providers.StreamChunk{ID: "1"}
+		<-sendErr
+		src <- providers.StreamChunk{Error: providerErr}
+		close(src)
+	}()
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	var mu sync.Mutex
+	var outcomes []error
+	outcomeFn := func(err error) {
+		mu.Lock()
+		outcomes = append(outcomes, err)
+		mu.Unlock()
+	}
+
+	out := Meter(ctx, src, time.Now(), MeterMeta{
+		Provider:              "openai",
+		Model:                 "gpt-4o",
+		Catalog:               models.Catalog{},
+		CircuitBreakerOutcome: outcomeFn,
+	})
+
+	if _, ok := <-out; !ok {
+		t.Fatal("expected first chunk")
+	}
+	cancel()
+	close(sendErr)
+
+	for range out { //nolint:revive
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(outcomes) != 1 {
+		t.Fatalf("outcomes len = %d, want 1", len(outcomes))
+	}
+	if !errors.Is(outcomes[0], providerErr) {
+		t.Fatalf("outcome = %v, want provider error", outcomes[0])
+	}
+}
+
 func TestMeter_CallsCircuitBreakerOutcome_OnSuccessAndError(t *testing.T) {
 	var mu sync.Mutex
 	var outcomes []error


### PR DESCRIPTION
## Summary

Fixes streaming circuit breaker handling for release v1.1.3 by ensuring streaming-only traffic initializes circuit breakers and records provider stream outcomes when the stream finishes.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] New provider
- [ ] New plugin
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Performance improvement
- [ ] Refactor / code quality
- [ ] Documentation / comments only
- [ ] CI / tooling

## Related issues

Closes #136 

## Changes

- Initialize configured circuit breakers independently of non-streaming strategy construction so `RouteStream` traffic is protected.
- Record circuit breaker success/failure after metered stream completion, including mid-stream provider errors.
- Avoid tripping the circuit breaker for client-side cancellation/deadline cases.
- Add regression coverage for streaming startup failures, mid-stream failures, cancellation handling, and streamwrap outcome callbacks.

## Testing

- [x] Existing tests pass (`go test ./...`)
- [x] New unit tests added (if applicable)
- [ ] Manually tested against a live provider (if provider change)