### PR TITLE
Fix/issue 135

### DIFF
--- a/gateway.go
+++ b/gateway.go
@@ -1195,57 +1195,29 @@ func (g *Gateway) RouteStream(ctx context.Context, req providers.Request) (<-cha
 		if err != nil {
 			return nil, err
 		}
-		// Convert the completed Response into a buffered single-chunk channel.
-		// Preserve all choices so n>1 requests are handled correctly, and use
-		// the real FinishReason from each choice rather than hardcoding "stop".
-		ch := make(chan providers.StreamChunk, 1)
-		streamChoices := make([]providers.StreamChoice, len(resp.Choices))
-		for i, c := range resp.Choices {
-			streamChoices[i] = providers.StreamChoice{
-				Index: c.Index,
-				Delta: providers.MessageDelta{
-					Role:      c.Message.Role,
-					Content:   c.Message.Content,
-					ToolCalls: c.Message.ToolCalls,
-				},
-				FinishReason: c.FinishReason,
-			}
-		}
-		ch <- providers.StreamChunk{
-			ID:      resp.ID,
-			Object:  "chat.completion.chunk",
-			Created: resp.Created,
-			Model:   resp.Model,
-			Choices: streamChoices,
-			Usage:   &resp.Usage,
-		}
-		close(ch)
 		_ = start // latency already recorded inside Route()
-		return ch, nil
+		return responseStream(resp), nil
 	}
 
 	// Run before-request plugins (word-filter, max-token, rate-limit, etc.).
+	var pctx *plugin.Context
 	if g.plugins.HasPlugins() {
-		pctx := plugin.NewContext(&req)
+		pctx = plugin.NewContext(&req)
+		var early *providers.Response
 		trace.WithRegion(ctx, "gateway.route_stream.plugins.before", func() {
-			err = g.plugins.RunBefore(ctx, pctx)
+			early, err = g.runBeforePlugins(ctx, pctx, &req)
 		})
 		if err != nil {
 			plugin.PutContext(pctx)
+			pctx = nil
 			metrics.ForRequest("", req.Model).Rejected.Inc()
 			return nil, err
 		}
-		if pctx.Reject {
-			reason := pctx.Reason
+		if early != nil {
 			plugin.PutContext(pctx)
-			metrics.ForRequest("", req.Model).Rejected.Inc()
-			return nil, fmt.Errorf("request rejected by plugin: %s", reason)
+			pctx = nil
+			return responseStream(early), nil
 		}
-		// Propagate any modifications made by plugins (e.g., capped max_tokens).
-		if pctx.Request != nil {
-			req = *pctx.Request
-		}
-		plugin.PutContext(pctx)
 	}
 
 	// Resolve provider according to strategy mode.
@@ -1259,12 +1231,22 @@ func (g *Gateway) RouteStream(ctx context.Context, req providers.Request) (<-cha
 	if orderErr != nil {
 		err = orderErr
 		span.SetError(err)
+		if pctx != nil {
+			pctx.Error = err
+			g.plugins.RunOnError(ctx, pctx)
+			plugin.PutContext(pctx)
+		}
 		return nil, err
 	}
 
 	if sp == nil {
 		err = fmt.Errorf("no streaming-capable provider found for model: %s", req.Model)
 		span.SetError(err)
+		if pctx != nil {
+			pctx.Error = err
+			g.plugins.RunOnError(ctx, pctx)
+			plugin.PutContext(pctx)
+		}
 		return nil, err
 	}
 
@@ -1286,6 +1268,11 @@ func (g *Gateway) RouteStream(ctx context.Context, req providers.Request) (<-cha
 		errType := "provider_error"
 		if errors.Is(err, circuitbreaker.ErrCircuitOpen) {
 			errType = "circuit_open"
+		}
+		if pctx != nil {
+			pctx.Error = err
+			g.plugins.RunOnError(ctx, pctx)
+			plugin.PutContext(pctx)
 		}
 		metrics.ForRequest(providerName, req.Model).Error.Inc()
 		metrics.ForProviderError(providerName, errType).Inc()
@@ -1325,6 +1312,31 @@ func (g *Gateway) RouteStream(ctx context.Context, req providers.Request) (<-cha
 		cbName := wrapped.name
 		meta.CircuitBreakerOutcome = func(err error) {
 			recordStreamCircuitBreakerOutcome(ctx, cb, cbName, err)
+		}
+	}
+	if pctx != nil {
+		meta.CompletionFn = func(ctx context.Context, resp *providers.Response) error {
+			pctx.Response = resp
+			err := g.plugins.RunAfter(ctx, pctx)
+			if pctx.Response != nil {
+				*resp = *pctx.Response
+			}
+			if err != nil {
+				pctx.Error = err
+				g.plugins.RunOnError(ctx, pctx)
+			}
+			plugin.PutContext(pctx)
+			pctx = nil
+			return err
+		}
+		meta.ErrorFn = func(ctx context.Context, err error) {
+			if pctx == nil {
+				return
+			}
+			pctx.Error = err
+			g.plugins.RunOnError(ctx, pctx)
+			plugin.PutContext(pctx)
+			pctx = nil
 		}
 	}
 
@@ -1387,6 +1399,32 @@ func (g *Gateway) RouteStream(ctx context.Context, req providers.Request) (<-cha
 		}
 	})
 	return streamwrap.Meter(ctx, rawCh, start, meta), nil
+}
+
+func responseStream(resp *providers.Response) <-chan providers.StreamChunk {
+	ch := make(chan providers.StreamChunk, 1)
+	streamChoices := make([]providers.StreamChoice, len(resp.Choices))
+	for i, c := range resp.Choices {
+		streamChoices[i] = providers.StreamChoice{
+			Index: c.Index,
+			Delta: providers.MessageDelta{
+				Role:      c.Message.Role,
+				Content:   c.Message.Content,
+				ToolCalls: c.Message.ToolCalls,
+			},
+			FinishReason: c.FinishReason,
+		}
+	}
+	ch <- providers.StreamChunk{
+		ID:      resp.ID,
+		Object:  "chat.completion.chunk",
+		Created: resp.Created,
+		Model:   resp.Model,
+		Choices: streamChoices,
+		Usage:   &resp.Usage,
+	}
+	close(ch)
+	return ch
 }
 
 func (g *Gateway) resolveStreamingProviderLocked(req providers.Request) (providers.StreamProvider, error) {

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/ferro-labs/ai-gateway/internal/events"
 	"github.com/ferro-labs/ai-gateway/internal/logging"
 	"github.com/ferro-labs/ai-gateway/internal/metrics"
+	cacheplugin "github.com/ferro-labs/ai-gateway/internal/plugins/cache"
 	"github.com/ferro-labs/ai-gateway/mcp"
 	"github.com/ferro-labs/ai-gateway/models"
 	"github.com/ferro-labs/ai-gateway/plugin"
@@ -1388,6 +1389,294 @@ func TestGateway_RouteStream_BeforePluginCanSetNilRequest(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("expected error for missing streaming provider")
+	}
+}
+
+func TestGateway_RouteStream_RunAfterReceivesStreamResponse(t *testing.T) {
+	gw, _ := New(Config{
+		Strategy: StrategyConfig{Mode: ModeSingle},
+		Targets:  []Target{{VirtualKey: "mock"}},
+	})
+	gw.RegisterProvider(&mockStreamProvider{
+		mockProvider: mockProvider{name: "mock", models: []string{"gpt-4o"}},
+		streamFn: func(context.Context, providers.Request) (<-chan providers.StreamChunk, error) {
+			ch := make(chan providers.StreamChunk, 3)
+			ch <- providers.StreamChunk{
+				ID:      "chatcmpl-stream",
+				Object:  "chat.completion.chunk",
+				Created: 123,
+				Model:   "gpt-4o",
+				Choices: []providers.StreamChoice{{
+					Index: 0,
+					Delta: providers.MessageDelta{Role: "assistant", Content: "hello "},
+				}},
+			}
+			ch <- providers.StreamChunk{
+				ID:      "chatcmpl-stream",
+				Object:  "chat.completion.chunk",
+				Created: 123,
+				Model:   "gpt-4o",
+				Choices: []providers.StreamChoice{{
+					Index:        0,
+					Delta:        providers.MessageDelta{Content: "world"},
+					FinishReason: "stop",
+				}},
+			}
+			ch <- providers.StreamChunk{
+				ID:      "chatcmpl-stream",
+				Object:  "chat.completion.chunk",
+				Created: 123,
+				Model:   "gpt-4o",
+				Usage:   &providers.Usage{PromptTokens: 2, CompletionTokens: 3, TotalTokens: 5},
+			}
+			close(ch)
+			return ch, nil
+		},
+	})
+
+	var afterCalls int
+	_ = gw.RegisterPlugin(plugin.StageAfterRequest, &testPlugin{
+		name: "after",
+		typ:  plugin.TypeLogging,
+		execFn: func(_ context.Context, pctx *plugin.Context) error {
+			afterCalls++
+			if pctx.Request == nil {
+				t.Fatal("after plugin request is nil")
+			}
+			if pctx.Response == nil {
+				t.Fatal("after plugin response is nil")
+			}
+			if pctx.Response.Provider != "mock" {
+				t.Fatalf("after plugin provider = %q, want mock", pctx.Response.Provider)
+			}
+			if pctx.Response.Model != "gpt-4o" {
+				t.Fatalf("after plugin model = %q, want gpt-4o", pctx.Response.Model)
+			}
+			if pctx.Response.Usage.TotalTokens != 5 {
+				t.Fatalf("after plugin total tokens = %d, want 5", pctx.Response.Usage.TotalTokens)
+			}
+			if got := pctx.Response.Choices[0].Message.Content; got != "hello world" {
+				t.Fatalf("after plugin content = %q, want hello world", got)
+			}
+			return nil
+		},
+	})
+
+	ch, err := gw.RouteStream(context.Background(), providers.Request{
+		Model:    "gpt-4o",
+		Messages: []providers.Message{{Role: "user", Content: "hi"}},
+		Stream:   true,
+	})
+	if err != nil {
+		t.Fatalf("RouteStream: %v", err)
+	}
+	drainStream(t, ch)
+
+	if afterCalls != 1 {
+		t.Fatalf("after plugin calls = %d, want 1", afterCalls)
+	}
+}
+
+func TestGateway_RouteStream_RunOnErrorReceivesStreamError(t *testing.T) {
+	streamErr := errors.New("stream failed")
+	gw, _ := New(Config{
+		Strategy: StrategyConfig{Mode: ModeSingle},
+		Targets:  []Target{{VirtualKey: "mock"}},
+	})
+	gw.RegisterProvider(&mockStreamProvider{
+		mockProvider: mockProvider{name: "mock", models: []string{"gpt-4o"}},
+		streamFn: func(context.Context, providers.Request) (<-chan providers.StreamChunk, error) {
+			ch := make(chan providers.StreamChunk, 1)
+			ch <- providers.StreamChunk{Error: streamErr}
+			close(ch)
+			return ch, nil
+		},
+	})
+
+	var onErrorCalls int
+	_ = gw.RegisterPlugin(plugin.StageOnError, &testPlugin{
+		name: "on-error",
+		typ:  plugin.TypeLogging,
+		execFn: func(_ context.Context, pctx *plugin.Context) error {
+			onErrorCalls++
+			if !errors.Is(pctx.Error, streamErr) {
+				t.Fatalf("on-error plugin error = %v, want %v", pctx.Error, streamErr)
+			}
+			if pctx.Response != nil {
+				t.Fatalf("on-error plugin response = %#v, want nil", pctx.Response)
+			}
+			return nil
+		},
+	})
+
+	ch, err := gw.RouteStream(context.Background(), providers.Request{
+		Model:    "gpt-4o",
+		Messages: []providers.Message{{Role: "user", Content: "hi"}},
+		Stream:   true,
+	})
+	if err != nil {
+		t.Fatalf("RouteStream: %v", err)
+	}
+	for chunk := range ch {
+		if !errors.Is(chunk.Error, streamErr) {
+			t.Fatalf("stream chunk error = %v, want %v", chunk.Error, streamErr)
+		}
+	}
+
+	if onErrorCalls != 1 {
+		t.Fatalf("on-error plugin calls = %d, want 1", onErrorCalls)
+	}
+}
+
+func TestGateway_RouteStream_AfterPluginRejectRunsOnError(t *testing.T) {
+	gw, _ := New(Config{
+		Strategy: StrategyConfig{Mode: ModeSingle},
+		Targets:  []Target{{VirtualKey: "mock"}},
+	})
+	gw.RegisterProvider(&mockStreamProvider{
+		mockProvider: mockProvider{name: "mock", models: []string{"gpt-4o"}},
+		streamFn: func(context.Context, providers.Request) (<-chan providers.StreamChunk, error) {
+			ch := make(chan providers.StreamChunk, 2)
+			ch <- providers.StreamChunk{
+				Model: "gpt-4o",
+				Choices: []providers.StreamChoice{{
+					Index:        0,
+					Delta:        providers.MessageDelta{Role: "assistant", Content: "ok"},
+					FinishReason: "stop",
+				}},
+			}
+			ch <- providers.StreamChunk{
+				Usage: &providers.Usage{PromptTokens: 1, CompletionTokens: 1, TotalTokens: 2},
+			}
+			close(ch)
+			return ch, nil
+		},
+	})
+
+	var onErrorCalls int
+	_ = gw.RegisterPlugin(plugin.StageAfterRequest, &testPlugin{
+		name: "after",
+		typ:  plugin.TypeLogging,
+		execFn: func(_ context.Context, pctx *plugin.Context) error {
+			pctx.Reject = true
+			pctx.Reason = "after plugin rejected"
+			return nil
+		},
+	})
+	_ = gw.RegisterPlugin(plugin.StageOnError, &testPlugin{
+		name: "on-error",
+		typ:  plugin.TypeLogging,
+		execFn: func(_ context.Context, pctx *plugin.Context) error {
+			onErrorCalls++
+			var rejection *plugin.RejectionError
+			if !errors.As(pctx.Error, &rejection) {
+				t.Fatalf("on-error plugin error = %T(%v), want *plugin.RejectionError", pctx.Error, pctx.Error)
+			}
+			return nil
+		},
+	})
+
+	ch, err := gw.RouteStream(context.Background(), providers.Request{
+		Model:    "gpt-4o",
+		Messages: []providers.Message{{Role: "user", Content: "hi"}},
+		Stream:   true,
+	})
+	if err != nil {
+		t.Fatalf("RouteStream: %v", err)
+	}
+	var sawPluginErr bool
+	for chunk := range ch {
+		if chunk.Error != nil {
+			sawPluginErr = true
+		}
+	}
+	if !sawPluginErr {
+		t.Fatal("expected stream chunk carrying after plugin rejection error")
+	}
+	if onErrorCalls != 1 {
+		t.Fatalf("on-error plugin calls = %d, want 1", onErrorCalls)
+	}
+}
+
+func TestGateway_RouteStream_ResponseCacheHitSkipsProvider(t *testing.T) {
+	gw, _ := New(Config{
+		Strategy: StrategyConfig{Mode: ModeSingle},
+		Targets:  []Target{{VirtualKey: "mock"}},
+	})
+	var streamCalls atomic.Int32
+	gw.RegisterProvider(&mockStreamProvider{
+		mockProvider: mockProvider{name: "mock", models: []string{"gpt-4o"}},
+		streamFn: func(context.Context, providers.Request) (<-chan providers.StreamChunk, error) {
+			streamCalls.Add(1)
+			ch := make(chan providers.StreamChunk, 2)
+			ch <- providers.StreamChunk{
+				ID:      "chatcmpl-cacheable",
+				Object:  "chat.completion.chunk",
+				Created: 123,
+				Model:   "gpt-4o",
+				Choices: []providers.StreamChoice{{
+					Index:        0,
+					Delta:        providers.MessageDelta{Role: "assistant", Content: "cached"},
+					FinishReason: "stop",
+				}},
+			}
+			ch <- providers.StreamChunk{
+				ID:      "chatcmpl-cacheable",
+				Object:  "chat.completion.chunk",
+				Created: 123,
+				Model:   "gpt-4o",
+				Usage:   &providers.Usage{PromptTokens: 1, CompletionTokens: 1, TotalTokens: 2},
+			}
+			close(ch)
+			return ch, nil
+		},
+	})
+	cache := &cacheplugin.ResponseCache{}
+	if err := cache.Init(map[string]interface{}{"max_age": 60}); err != nil {
+		t.Fatalf("cache init: %v", err)
+	}
+	_ = gw.RegisterPlugin(plugin.StageBeforeRequest, cache)
+	_ = gw.RegisterPlugin(plugin.StageAfterRequest, cache)
+
+	req := providers.Request{
+		Model:    "gpt-4o",
+		Messages: []providers.Message{{Role: "user", Content: "hi"}},
+		Stream:   true,
+	}
+	first, err := gw.RouteStream(context.Background(), req)
+	if err != nil {
+		t.Fatalf("first RouteStream: %v", err)
+	}
+	drainStream(t, first)
+	if got := streamCalls.Load(); got != 1 {
+		t.Fatalf("stream calls after first request = %d, want 1", got)
+	}
+
+	second, err := gw.RouteStream(context.Background(), req)
+	if err != nil {
+		t.Fatalf("second RouteStream: %v", err)
+	}
+	var content string
+	var usage *providers.Usage
+	for chunk := range second {
+		if chunk.Error != nil {
+			t.Fatalf("cached stream chunk error: %v", chunk.Error)
+		}
+		for _, choice := range chunk.Choices {
+			content += choice.Delta.Content
+		}
+		if chunk.Usage != nil {
+			usage = chunk.Usage
+		}
+	}
+	if got := streamCalls.Load(); got != 1 {
+		t.Fatalf("stream calls after cache hit = %d, want 1", got)
+	}
+	if content != "cached" {
+		t.Fatalf("cached stream content = %q, want cached", content)
+	}
+	if usage == nil || usage.TotalTokens != 2 {
+		t.Fatalf("cached stream usage = %#v, want total tokens 2", usage)
 	}
 }
 

--- a/internal/streamwrap/wrap.go
+++ b/internal/streamwrap/wrap.go
@@ -43,6 +43,12 @@ type MeterMeta struct {
 	// type is intentionally a minimal local interface so streamwrap
 	// stays decoupled from the public observability package.
 	SpanFinisher SpanFinisher
+	// CompletionFn, if non-nil, is invoked once after the upstream stream closes
+	// successfully and before success metrics/events are emitted.
+	CompletionFn func(ctx context.Context, resp *providers.Response) error
+	// ErrorFn, if non-nil, is invoked once when the upstream stream fails or
+	// the downstream client cancels before the stream completes.
+	ErrorFn func(ctx context.Context, err error)
 	// CircuitBreakerOutcome, if non-nil, is invoked once when the stream
 	// finishes. err is nil on success; non-nil on provider/stream failure.
 	CircuitBreakerOutcome func(err error)
@@ -93,6 +99,11 @@ func Meter(ctx context.Context, src <-chan providers.StreamChunk, start time.Tim
 		var firstChunkAt time.Time
 		var lastChunkAt time.Time
 		clientCanceled := false
+		resp := providers.Response{
+			Object:   "chat.completion",
+			Provider: meta.Provider,
+			Model:    meta.Model,
+		}
 
 	loop:
 		for {
@@ -130,6 +141,7 @@ func Meter(ctx context.Context, src <-chan providers.StreamChunk, start time.Tim
 				if chunk.Usage != nil && (chunk.Usage.TotalTokens > 0 || chunk.Usage.PromptTokens > 0) {
 					usage = *chunk.Usage
 				}
+				applyChunkToResponse(&resp, chunk)
 				if chunk.Error != nil {
 					streamErr = chunk.Error
 				}
@@ -191,6 +203,9 @@ func Meter(ctx context.Context, src <-chan providers.StreamChunk, start time.Tim
 					true,
 				))
 			}
+			if meta.ErrorFn != nil {
+				meta.ErrorFn(ctx, streamErr)
+			}
 			if meta.SpanFinisher != nil {
 				meta.SpanFinisher.Finish(StreamOutcome{
 					TokensIn:  usage.PromptTokens,
@@ -208,6 +223,36 @@ func Meter(ctx context.Context, src <-chan providers.StreamChunk, start time.Tim
 
 		if meta.LatencyRecorder != nil && meta.Provider != "" {
 			meta.LatencyRecorder(meta.Provider, latency)
+		}
+
+		resp.Usage = usage
+		if resp.Usage.TotalTokens == 0 {
+			resp.Usage.TotalTokens = resp.Usage.PromptTokens + resp.Usage.CompletionTokens
+		}
+		if meta.CompletionFn != nil {
+			if err := meta.CompletionFn(ctx, &resp); err != nil {
+				requestMetrics := metrics.ForRequest(meta.Provider, meta.Model)
+				requestMetrics.Error.Inc()
+				metrics.ForProviderError(meta.Provider, "plugin_error").Inc()
+				select {
+				case out <- providers.StreamChunk{Error: err}:
+				case <-ctx.Done():
+				}
+				if meta.SpanFinisher != nil {
+					meta.SpanFinisher.Finish(StreamOutcome{
+						TokensIn:  usage.PromptTokens,
+						TokensOut: usage.CompletionTokens,
+						TTFTMs:    ttftMs,
+						TTLTMs:    ttltMs,
+						ErrorMsg:  err.Error(),
+					})
+				}
+				// Provider stream completed; plugin failure must not block CB recovery.
+				if meta.CircuitBreakerOutcome != nil {
+					meta.CircuitBreakerOutcome(nil)
+				}
+				return
+			}
 		}
 
 		// Success path: emit the same metrics as Gateway.Route().
@@ -263,4 +308,41 @@ func Meter(ctx context.Context, src <-chan providers.StreamChunk, start time.Tim
 	}()
 
 	return out
+}
+
+func applyChunkToResponse(resp *providers.Response, chunk providers.StreamChunk) {
+	if chunk.ID != "" && resp.ID == "" {
+		resp.ID = chunk.ID
+	}
+	if chunk.Created != 0 && resp.Created == 0 {
+		resp.Created = chunk.Created
+	}
+	if chunk.Model != "" {
+		resp.Model = chunk.Model
+	}
+	for _, streamChoice := range chunk.Choices {
+		idx := streamChoice.Index
+		if idx < 0 {
+			continue
+		}
+		for len(resp.Choices) <= idx {
+			resp.Choices = append(resp.Choices, providers.Choice{
+				Index: len(resp.Choices),
+				Message: providers.Message{
+					Role: "assistant",
+				},
+			})
+		}
+		choice := &resp.Choices[idx]
+		if streamChoice.Delta.Role != "" {
+			choice.Message.Role = streamChoice.Delta.Role
+		}
+		choice.Message.Content += streamChoice.Delta.Content
+		if len(streamChoice.Delta.ToolCalls) > 0 {
+			choice.Message.ToolCalls = append(choice.Message.ToolCalls, streamChoice.Delta.ToolCalls...)
+		}
+		if streamChoice.FinishReason != "" {
+			choice.FinishReason = streamChoice.FinishReason
+		}
+	}
 }

--- a/internal/streamwrap/wrap_test.go
+++ b/internal/streamwrap/wrap_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ferro-labs/ai-gateway/internal/events"
 	"github.com/ferro-labs/ai-gateway/internal/metrics"
 	"github.com/ferro-labs/ai-gateway/models"
+	"github.com/ferro-labs/ai-gateway/plugin"
 	"github.com/ferro-labs/ai-gateway/providers"
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
@@ -312,6 +313,34 @@ func TestMeter_CallsCircuitBreakerOutcome_OnSuccessAndError(t *testing.T) {
 			t.Fatalf("outcome = %v, want provider error", outcomes[0])
 		}
 	})
+}
+
+func TestMeter_CallsCircuitBreakerOutcome_OnAfterPluginError(t *testing.T) {
+	var outcomeErr error
+	pluginErr := &plugin.RejectionError{Plugin: "after", PluginType: plugin.TypeLogging, Stage: plugin.StageAfterRequest, Reason: "rejected"}
+	src := feed(
+		providers.StreamChunk{ID: "1", Choices: []providers.StreamChoice{{
+			Delta: providers.MessageDelta{Content: "ok"},
+		}}},
+	)
+
+	out := Meter(context.Background(), src, time.Now(), MeterMeta{
+		Provider: "openai",
+		Model:    "gpt-4o",
+		Catalog:  models.Catalog{},
+		CompletionFn: func(context.Context, *providers.Response) error {
+			return pluginErr
+		},
+		CircuitBreakerOutcome: func(err error) {
+			outcomeErr = err
+		},
+	})
+	for range out { //nolint:revive
+	}
+
+	if outcomeErr != nil {
+		t.Fatalf("circuit breaker outcome error = %v, want nil after successful provider stream", outcomeErr)
+	}
 }
 
 func TestMeter_NilPublishFn_NoPanic(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes the streaming route plugin lifecycle so `RouteStream` now honors cache skips and runs the same after/error plugin stages as non-streaming requests. This restores response-cache storage, request logging, and on-error hooks for streaming traffic.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] New provider
- [ ] New plugin
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Performance improvement
- [ ] Refactor / code quality
- [ ] Documentation / comments only
- [ ] CI / tooling

## Related issues

Fixes #135 

## Changes

- Runs the full plugin pipeline for `RouteStream`, including `RunAfter` after successful stream drain and `RunOnError` for stream/provider/plugin failures.
- Honors `pctx.Skip` for streaming cache hits by converting the cached response into a single streamed chunk instead of calling the provider.
- Extends stream metering so completion callbacks receive final stream usage, response, and error state without breaking circuit breaker accounting.
- Adds regression coverage for streaming after plugins, on-error plugins, after-plugin rejection, cache hits, and stream wrapper plugin callback behavior.

## Testing

- [x] Existing tests pass (`go test ./...`)
- [x] New unit tests added (if applicable)
- [ ] Manually tested against a live provider (if provider change)

## Plugin checklist (fill in only for new/updated plugins)

- [ ] Plugin file at `internal/plugins/<name>/`
- [ ] `Stage` (before/after request) correctly set
- [x] Test coverage added
- [ ] Example config documented

## Breaking change notes

None.
