### PR TITLE
feat(gateway): detach async event/hook contexts with WithoutCancel (#181)

### DIFF
--- a/gateway.go
+++ b/gateway.go
@@ -177,7 +177,10 @@ func New(cfg Config) (*Gateway, error) {
 		gw.mcpInitDone = done
 		go func() {
 			defer close(done)
-			ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+			// Parent the init timeout on the gateway shutdown context so a slow
+			// MCP handshake is cancelled by Close() instead of lingering up to
+			// the full timeout after shutdown.
+			ctx, cancel := context.WithTimeout(gw.shutdownCtx, 60*time.Second)
 			defer cancel()
 			reg.InitializeAll(ctx, func(name string, initErr error) {
 				slog.Error("mcp: server initialization failed",
@@ -685,9 +688,17 @@ func (g *Gateway) publishEvent(ctx context.Context, event events.HookEvent) {
 		return
 	}
 
+	// Detach from the request lifecycle: hooks are dispatched asynchronously
+	// and usually run after the HTTP handler has returned and ctx is already
+	// cancelled. WithoutCancel drops cancellation (so ctx-aware hook work like
+	// DB writes / outbound calls is not dead-on-arrival) while preserving the
+	// request's trace context and values. Worker shutdown is governed by
+	// g.shutdownCtx, not this context.
+	detachedCtx := context.WithoutCancel(ctx)
+
 	for _, hook := range hooks {
 		dispatch := hookDispatch{
-			ctx:   ctx,
+			ctx:   detachedCtx,
 			event: event,
 			hook:  hook,
 		}
@@ -846,7 +857,10 @@ func (g *Gateway) ReloadConfig(cfg Config) error {
 		g.mcpInitDone = done
 		go func() {
 			defer close(done)
-			ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+			// Parent the init timeout on the gateway shutdown context so a slow
+			// MCP handshake is cancelled by Close() instead of lingering up to
+			// the full timeout after shutdown.
+			ctx, cancel := context.WithTimeout(g.shutdownCtx, 60*time.Second)
 			defer cancel()
 			reg.InitializeAll(ctx, func(name string, initErr error) {
 				slog.Error("mcp: server initialization failed after reload",
@@ -1392,10 +1406,12 @@ func (g *Gateway) RouteStream(ctx context.Context, req providers.Request) (<-cha
 					false,
 				)
 			}
-			// Use a detached context: this closure runs in the streamwrap
-			// goroutine after the HTTP handler has returned and the
-			// request ctx is already cancelled.
-			obsProvider.RecordEvent(context.Background(), obsEventFromHook(he))
+			// Detach from the request lifecycle: this closure runs in the
+			// streamwrap goroutine after the HTTP handler has returned and the
+			// request ctx is already cancelled. WithoutCancel drops cancellation
+			// while preserving the request's trace context, so the recorded
+			// event stays linked to the originating trace.
+			obsProvider.RecordEvent(context.WithoutCancel(ctx), obsEventFromHook(he))
 		}
 	})
 	return streamwrap.Meter(ctx, rawCh, start, meta), nil

--- a/gateway_observability_test.go
+++ b/gateway_observability_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/ferro-labs/ai-gateway/observability"
 	"github.com/ferro-labs/ai-gateway/providers"
@@ -19,13 +20,24 @@ type eventCapturingProvider struct {
 	fakeProvider
 	mu              sync.Mutex
 	events          []observability.Event
+	eventCtxs       []context.Context
 	recordingActive bool
 }
 
-func (p *eventCapturingProvider) RecordEvent(_ context.Context, evt observability.Event) {
+func (p *eventCapturingProvider) RecordEvent(ctx context.Context, evt observability.Event) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.events = append(p.events, evt)
+	p.eventCtxs = append(p.eventCtxs, ctx)
+}
+
+func (p *eventCapturingProvider) lastEventCtx() context.Context {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if len(p.eventCtxs) == 0 {
+		return nil
+	}
+	return p.eventCtxs[len(p.eventCtxs)-1]
 }
 
 func (p *eventCapturingProvider) RecordingEnabled() bool {
@@ -280,6 +292,60 @@ func TestGateway_RouteStream_StampsRoutingAttrs(t *testing.T) {
 	}
 	if s, ok := got.(string); !ok || s == "" {
 		t.Errorf("ferro.routing.target_key must be a non-empty string, got %T(%v)", got, got)
+	}
+}
+
+// TestGateway_RouteStream_EventContextDetachedButTraced covers issue #181: the
+// observability event recorded from the streamwrap goroutine must be detached
+// from request cancellation (so it is not dead-on-arrival once the HTTP handler
+// returns) while still carrying the request's trace context / values via
+// context.WithoutCancel.
+func TestGateway_RouteStream_EventContextDetachedButTraced(t *testing.T) {
+	gw, _ := New(Config{
+		Strategy: StrategyConfig{Mode: ModeSingle},
+		Targets:  []Target{{VirtualKey: "mock"}},
+	})
+	ep := &eventCapturingProvider{recordingActive: true}
+	gw.SetObservability(ep)
+
+	gw.RegisterProvider(&mockStreamProvider{
+		mockProvider: mockProvider{name: "mock", models: []string{testModel}},
+	})
+
+	type ctxKey string
+	const marker ctxKey = "trace-marker"
+	reqCtx, cancel := context.WithCancel(context.WithValue(context.Background(), marker, "trace-xyz"))
+
+	ch, err := gw.RouteStream(reqCtx, providers.Request{
+		Model:    testModel,
+		Stream:   true,
+		Messages: []providers.Message{{Role: "user", Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("RouteStream: %v", err)
+	}
+	// Simulate the HTTP handler returning before the streamwrap goroutine
+	// records its completion event.
+	cancel()
+	//nolint:revive // intentionally draining the stream channel to completion
+	for range ch {
+	}
+
+	var evtCtx context.Context
+	for range 200 {
+		if evtCtx = ep.lastEventCtx(); evtCtx != nil {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if evtCtx == nil {
+		t.Fatal("no observability event was recorded")
+	}
+	if err := evtCtx.Err(); err != nil {
+		t.Fatalf("event ctx should be detached from cancellation, got %v", err)
+	}
+	if v, _ := evtCtx.Value(marker).(string); v != "trace-xyz" {
+		t.Fatalf("event ctx lost request trace value: got %q, want trace-xyz", v)
 	}
 }
 

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -1799,6 +1799,44 @@ func completedHookEvent(traceID string) events.HookEvent {
 	)
 }
 
+// TestGateway_PublishEvent_DetachesCancellationButPreservesValues covers
+// issue #181: async event hooks must run with a context that has shed the
+// request's cancellation (they fire after the HTTP handler returns) yet still
+// carry the request's trace context / values via context.WithoutCancel.
+func TestGateway_PublishEvent_DetachesCancellationButPreservesValues(t *testing.T) {
+	gw, err := New(Config{})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { _ = gw.Close() })
+
+	type ctxKey string
+	const marker ctxKey = "trace-marker"
+
+	got := make(chan context.Context, 1)
+	gw.AddHook(func(ctx context.Context, _ string, _ map[string]any) {
+		got <- ctx
+	})
+
+	// The request context is already cancelled by the time the hook runs.
+	reqCtx, cancel := context.WithCancel(context.WithValue(context.Background(), marker, "trace-xyz"))
+	cancel()
+
+	gw.publishEvent(reqCtx, completedHookEvent("trace-1"))
+
+	select {
+	case hookCtx := <-got:
+		if err := hookCtx.Err(); err != nil {
+			t.Fatalf("hook ctx should be detached from cancellation, got %v", err)
+		}
+		if v, _ := hookCtx.Value(marker).(string); v != "trace-xyz" {
+			t.Fatalf("hook ctx lost request trace value: got %q, want trace-xyz", v)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("hook was not dispatched")
+	}
+}
+
 func runWithPanicCapture(t *testing.T, fn func()) any {
 	t.Helper()
 	done := make(chan any, 1)


### PR DESCRIPTION
## Summary
Fixes three background paths that detached from the request context incorrectly (issue #181) — continuing the v1.1.3 context-correctness theme.

- **Async event hooks ran on a cancelled ctx.** `publishEvent` stored the request `ctx` into `hookDispatch`; by the time a worker invoked the hook the HTTP handler had returned and `ctx` was cancelled, so any ctx-aware hook work (DB write, outbound call) was dead-on-arrival. Now dispatches with `context.WithoutCancel(ctx)`.
- **Streaming observability lost trace linkage.** The streamwrap completion closure called `obsProvider.RecordEvent(context.Background(), …)` — dropping the request's trace context on the observability path. Now uses `context.WithoutCancel(ctx)`.
- **MCP init ignored shutdown.** `New` and `ReloadConfig` ran `reg.InitializeAll` under `WithTimeout(context.Background(), 60s)`, so a slow handshake could linger up to 60s after `Close()`. Now parented on the gateway shutdown context.

`context.WithoutCancel` (Go 1.21+) keeps request values / trace context while dropping cancellation — the right tool for fire-and-forget work that outlives the request.

## Type of change
- [x] Bug fix / correctness (non-breaking)
- [ ] New feature
- [ ] Breaking change

## Related issues
Closes #181

## Testing
- `TestGateway_PublishEvent_DetachesCancellationButPreservesValues` — hook ctx is not cancelled and still carries request values.
- `TestGateway_RouteStream_EventContextDetachedButTraced` — streaming event ctx is detached yet trace-linked.
- `go test -race ./...` green; `golangci-lint run ./...` → 0 issues; `go vet ./...` clean.

## Notes
- Finding #3 (MCP shutdown) is a 2-line reparent on `shutdownCtx`; not covered by a dedicated test (would require an MCP stub server that blocks during init) — verified by inspection + existing MCP construction tests still pass.
- Base is `release/v1.1.3` to ride the in-flight v1.1.3 cut.