### PR TITLE
Fix max_completion_tokens fallback handling

### DIFF
--- a/gateway.go
+++ b/gateway.go
@@ -400,6 +400,7 @@ func (g *Gateway) Route(ctx context.Context, req providers.Request) (*providers.
 
 	start := time.Now()
 	hooksEnabled := g.hasHooks()
+	req.NormalizeCompletionTokenLimits()
 
 	// Start the observability root span. NoOp provider makes this a
 	// zero-allocation call when tracing is disabled.
@@ -1166,6 +1167,7 @@ func (g *Gateway) RouteStream(ctx context.Context, req providers.Request) (<-cha
 
 	start := time.Now()
 	hooksEnabled := g.hasHooks()
+	req.NormalizeCompletionTokenLimits()
 	var err error
 
 	// Start the observability root span. End() is normally called by

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -37,10 +37,11 @@ const mockProviderName = "mock"
 
 // mockProvider is a test double for providers.Provider.
 type mockProvider struct {
-	name   string
-	models []string
-	resp   *providers.Response
-	err    error
+	name       string
+	models     []string
+	resp       *providers.Response
+	err        error
+	completeFn func(context.Context, providers.Request) (*providers.Response, error)
 }
 
 func (m *mockProvider) Name() string                  { return m.name }
@@ -54,7 +55,10 @@ func (m *mockProvider) SupportsModel(model string) bool {
 	}
 	return false
 }
-func (m *mockProvider) Complete(_ context.Context, _ providers.Request) (*providers.Response, error) {
+func (m *mockProvider) Complete(ctx context.Context, req providers.Request) (*providers.Response, error) {
+	if m.completeFn != nil {
+		return m.completeFn(ctx, req)
+	}
 	return m.resp, m.err
 }
 
@@ -133,6 +137,77 @@ func TestGateway_Route_Single(t *testing.T) {
 	}
 	if resp.ID != "r1" {
 		t.Errorf("got ID %q, want r1", resp.ID)
+	}
+}
+
+func TestGateway_Route_NormalizesCompletionTokenLimitsBeforePlugins(t *testing.T) {
+	gw, _ := New(Config{
+		Strategy: StrategyConfig{Mode: ModeSingle},
+		Targets:  []Target{{VirtualKey: mockProviderName}},
+		Plugins: []PluginConfig{
+			{
+				Name:    "max-token",
+				Enabled: true,
+				Stage:   "before_request",
+				Config:  map[string]interface{}{"max_tokens": 100},
+			},
+		},
+	})
+	gw.RegisterProvider(&mockProvider{
+		name:   mockProviderName,
+		models: []string{"gpt-4o"},
+		resp:   &providers.Response{ID: "r1", Model: "gpt-4o"},
+	})
+	if err := gw.LoadPlugins(); err != nil {
+		t.Fatalf("LoadPlugins failed: %v", err)
+	}
+
+	maxCompletionTokens := 200
+	_, err := gw.Route(context.Background(), providers.Request{
+		Model:               "gpt-4o",
+		Messages:            []providers.Message{{Role: "user", Content: "hi"}},
+		MaxCompletionTokens: &maxCompletionTokens,
+	})
+	if err == nil {
+		t.Fatal("expected max-token plugin rejection")
+	}
+	if !strings.Contains(err.Error(), "max_tokens 200 exceeds limit of 100") {
+		t.Fatalf("error = %q, want max-token rejection with normalized max_tokens", err.Error())
+	}
+}
+
+func TestGateway_Route_NormalizesCompletionTokenLimitsBeforeProvider(t *testing.T) {
+	var captured providers.Request
+	gw, _ := New(Config{
+		Strategy: StrategyConfig{Mode: ModeSingle},
+		Targets:  []Target{{VirtualKey: mockProviderName}},
+	})
+	gw.RegisterProvider(&mockProvider{
+		name:   mockProviderName,
+		models: []string{"gpt-4o"},
+		completeFn: func(_ context.Context, req providers.Request) (*providers.Response, error) {
+			captured = req
+			return &providers.Response{ID: "r1", Model: req.Model}, nil
+		},
+	})
+
+	maxCompletionTokens := 17
+	resp, err := gw.Route(context.Background(), providers.Request{
+		Model:               "gpt-4o",
+		Messages:            []providers.Message{{Role: "user", Content: "hi"}},
+		MaxCompletionTokens: &maxCompletionTokens,
+	})
+	if err != nil {
+		t.Fatalf("Route returned error: %v", err)
+	}
+	if resp.ID != "r1" {
+		t.Fatalf("response ID = %q, want r1", resp.ID)
+	}
+	if captured.MaxTokens == nil || *captured.MaxTokens != maxCompletionTokens {
+		t.Fatalf("captured MaxTokens = %v, want %d", captured.MaxTokens, maxCompletionTokens)
+	}
+	if captured.MaxCompletionTokens == nil || *captured.MaxCompletionTokens != maxCompletionTokens {
+		t.Fatalf("captured MaxCompletionTokens = %v, want preserved %d", captured.MaxCompletionTokens, maxCompletionTokens)
 	}
 }
 

--- a/providers/core/chat.go
+++ b/providers/core/chat.go
@@ -194,6 +194,16 @@ type Request struct {
 	LogitBias map[string]float64 `json:"logit_bias,omitempty"`
 }
 
+// NormalizeCompletionTokenLimits fills max_tokens from max_completion_tokens
+// when only the OpenAI-compatible completion-token field is provided. The
+// original max_completion_tokens value is preserved for providers that support
+// it natively.
+func (r *Request) NormalizeCompletionTokenLimits() {
+	if r.MaxTokens == nil && r.MaxCompletionTokens != nil {
+		r.MaxTokens = r.MaxCompletionTokens
+	}
+}
+
 // Validate returns an error if the request is missing required fields or
 // contains out-of-range parameter values.
 func (r Request) Validate() error {

--- a/providers/core/params_test.go
+++ b/providers/core/params_test.go
@@ -50,3 +50,35 @@ func TestParamPopulated_BooleanLogprobs(t *testing.T) {
 		t.Error("logprobs should be populated when true")
 	}
 }
+
+func TestNormalizeCompletionTokenLimits_FillsMaxTokensFromFallback(t *testing.T) {
+	maxCompletionTokens := 17
+	req := Request{MaxCompletionTokens: &maxCompletionTokens}
+
+	req.NormalizeCompletionTokenLimits()
+
+	if req.MaxTokens == nil || *req.MaxTokens != maxCompletionTokens {
+		t.Fatalf("MaxTokens = %v, want %d", req.MaxTokens, maxCompletionTokens)
+	}
+	if req.MaxCompletionTokens == nil || *req.MaxCompletionTokens != maxCompletionTokens {
+		t.Fatalf("MaxCompletionTokens = %v, want preserved %d", req.MaxCompletionTokens, maxCompletionTokens)
+	}
+}
+
+func TestNormalizeCompletionTokenLimits_PreservesExplicitMaxTokens(t *testing.T) {
+	maxTokens := 23
+	maxCompletionTokens := 17
+	req := Request{
+		MaxTokens:           &maxTokens,
+		MaxCompletionTokens: &maxCompletionTokens,
+	}
+
+	req.NormalizeCompletionTokenLimits()
+
+	if req.MaxTokens == nil || *req.MaxTokens != maxTokens {
+		t.Fatalf("MaxTokens = %v, want explicit %d", req.MaxTokens, maxTokens)
+	}
+	if req.MaxCompletionTokens == nil || *req.MaxCompletionTokens != maxCompletionTokens {
+		t.Fatalf("MaxCompletionTokens = %v, want preserved %d", req.MaxCompletionTokens, maxCompletionTokens)
+	}
+}

--- a/providers/ollama_cloud/ollama_cloud.go
+++ b/providers/ollama_cloud/ollama_cloud.go
@@ -339,10 +339,10 @@ type tagsResponse struct {
 
 func buildChatRequest(req core.Request, stream bool) chatRequest {
 	var maxTokens *int
-	if req.MaxCompletionTokens != nil {
-		maxTokens = req.MaxCompletionTokens
-	} else {
+	if req.MaxTokens != nil {
 		maxTokens = req.MaxTokens
+	} else {
+		maxTokens = req.MaxCompletionTokens
 	}
 
 	var options *chatOptions

--- a/providers/ollama_cloud/ollama_cloud_test.go
+++ b/providers/ollama_cloud/ollama_cloud_test.go
@@ -166,8 +166,8 @@ func assertCompleteRequest(t *testing.T, r *http.Request) {
 	if len(body.Messages) != 1 || body.Messages[0].Role != "user" || body.Messages[0].Content != "hello" {
 		t.Errorf("messages = %#v, want user hello", body.Messages)
 	}
-	if body.Options == nil || body.Options.NumPredict == nil || *body.Options.NumPredict != 8 {
-		t.Fatalf("num_predict = %#v, want 8", body.Options)
+	if body.Options == nil || body.Options.NumPredict == nil || *body.Options.NumPredict != 99 {
+		t.Fatalf("num_predict = %#v, want 99", body.Options)
 	}
 	if body.Options.Temperature == nil || *body.Options.Temperature != 0.25 {
 		t.Fatalf("temperature = %#v, want 0.25", body.Options.Temperature)


### PR DESCRIPTION
## Summary

Fixes `max_completion_tokens` fallback handling for non-OpenAI provider dispatch by normalizing the completion-token limit at the gateway seam while preserving the original request field.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] New provider
- [ ] New plugin
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Performance improvement
- [ ] Refactor / code quality
- [ ] Documentation / comments only
- [ ] CI / tooling

## Related issues

Closes #141

## Changes

- Add `Request.NormalizeCompletionTokenLimits()` to fill `MaxTokens` from `MaxCompletionTokens` only when `MaxTokens` is absent.
- Apply completion-token-limit normalization in `Gateway.Route` and `Gateway.RouteStream` before plugins and provider dispatch.
- Align `ollama_cloud` with the same precedence rule so explicit `max_tokens` wins over `max_completion_tokens`.
- Add focused coverage for normalization semantics, plugin-visible gateway normalization, provider dispatch, and `ollama_cloud` precedence.

## Testing

- [x] Existing tests pass (`go test ./...`)
- [x] New unit tests added (if applicable)
- [ ] Manually tested against a live provider (if provider change)

## Provider checklist (fill in only for new/updated providers)

- [ ] Provider file at `providers/<id>/<id>.go`
- [x] Test file at `providers/<id>/<id>_test.go`
- [ ] `ProviderEntry` added to `providers/providers_list.go`
- [ ] Name constant added to `providers/names.go`
- [ ] Models added to `ferro-labs/model-catalog` when catalog coverage changes
- [ ] `AllowedTools`, `MaxCallDepth` and streaming tested

## Plugin checklist (fill in only for new/updated plugins)

- [ ] Plugin file at `internal/plugins/<name>/`
- [ ] `Stage` (before/after request) correctly set
- [ ] Test coverage added
- [ ] Example config documented

## Breaking change notes

None.

## Screenshots / output (optional)

```sh
go test ./...
```
