### PR TITLE
fix: preserve tool calling across providers

### DIFF
--- a/internal/openaicompat/request_test.go
+++ b/internal/openaicompat/request_test.go
@@ -17,8 +17,19 @@ func ptrI64(i int64) *int64   { return &i }
 // the old {model,messages,temperature,max_tokens} subset.
 func TestBuildBody_ForwardsEverySamplingParam(t *testing.T) {
 	req := core.Request{
-		Model:               "some-model",
-		Messages:            []core.Message{{Role: "user", Content: "hi"}},
+		Model: "some-model",
+		Messages: []core.Message{
+			{Role: "user", Content: "hi"},
+			{
+				Role: "assistant",
+				ToolCalls: []core.ToolCall{{
+					ID:       "call_1",
+					Type:     "function",
+					Function: core.FunctionCall{Name: "lookup", Arguments: `{"city":"SF"}`},
+				}},
+			},
+			{Role: "tool", ToolCallID: "call_1", Content: `{"temp":"72F"}`},
+		},
 		Temperature:         ptrF(0.7),
 		TopP:                ptrF(0.9),
 		N:                   ptrI(2),
@@ -28,11 +39,20 @@ func TestBuildBody_ForwardsEverySamplingParam(t *testing.T) {
 		PresencePenalty:     ptrF(0.5),
 		FrequencyPenalty:    ptrF(0.25),
 		Stop:                []string{"END"},
-		ResponseFormat:      &core.ResponseFormat{Type: "json_object"},
-		TopLogProbs:         ptrI(3),
-		LogProbs:            true,
-		User:                "user-123",
-		LogitBias:           map[string]float64{"50256": -100},
+		Tools: []core.Tool{{
+			Type: "function",
+			Function: core.Function{
+				Name:        "lookup",
+				Description: "Look up weather",
+				Parameters:  json.RawMessage(`{"type":"object","properties":{"city":{"type":"string"}}}`),
+			},
+		}},
+		ToolChoice:     map[string]interface{}{"type": "function", "function": map[string]interface{}{"name": "lookup"}},
+		ResponseFormat: &core.ResponseFormat{Type: "json_object"},
+		TopLogProbs:    ptrI(3),
+		LogProbs:       true,
+		User:           "user-123",
+		LogitBias:      map[string]float64{"50256": -100},
 	}
 
 	body, _, release, err := BuildBody(req, false)
@@ -54,13 +74,33 @@ func TestBuildBody_ForwardsEverySamplingParam(t *testing.T) {
 	mustHave := []string{
 		"model", "messages", "temperature", "top_p", "n", "seed",
 		"max_tokens", "max_completion_tokens", "presence_penalty",
-		"frequency_penalty", "stop", "response_format", "logprobs",
+		"frequency_penalty", "stop", "tools", "tool_choice", "response_format", "logprobs",
 		"top_logprobs", "user", "logit_bias",
 	}
 	for _, k := range mustHave {
 		if _, ok := got[k]; !ok {
 			t.Errorf("field %q was dropped by BuildBody; body=%s", k, raw)
 		}
+	}
+
+	var decoded struct {
+		Messages []core.Message `json:"messages"`
+		Tools    []core.Tool    `json:"tools"`
+	}
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatalf("unmarshal typed body: %v", err)
+	}
+	if len(decoded.Tools) != 1 || decoded.Tools[0].Function.Name != "lookup" {
+		t.Fatalf("tools = %#v, want lookup tool", decoded.Tools)
+	}
+	if len(decoded.Messages) != 3 {
+		t.Fatalf("messages len = %d, want 3", len(decoded.Messages))
+	}
+	if len(decoded.Messages[1].ToolCalls) != 1 || decoded.Messages[1].ToolCalls[0].Function.Name != "lookup" {
+		t.Fatalf("assistant tool_calls = %#v, want lookup call", decoded.Messages[1].ToolCalls)
+	}
+	if decoded.Messages[2].ToolCallID != "call_1" {
+		t.Fatalf("tool_call_id = %q, want call_1", decoded.Messages[2].ToolCallID)
 	}
 }
 
@@ -95,5 +135,45 @@ func TestBuildBody_StreamFlag(t *testing.T) {
 	}
 	if !on.Stream {
 		t.Errorf("stream should be true; body=%s", raw2)
+	}
+}
+
+func TestDecodeStreamChunk_ForwardsToolCallDeltas(t *testing.T) {
+	chunk, err := DecodeStreamChunk([]byte(`{
+		"id":"chatcmpl-1",
+		"object":"chat.completion.chunk",
+		"created":123,
+		"model":"some-model",
+		"choices":[{
+			"index":0,
+			"delta":{
+				"role":"assistant",
+				"tool_calls":[{
+					"id":"call_1",
+					"type":"function",
+					"function":{"name":"lookup","arguments":"{\"city\":\"SF\"}"}
+				}]
+			},
+			"finish_reason":"tool_calls"
+		}]
+	}`))
+	if err != nil {
+		t.Fatalf("DecodeStreamChunk returned error: %v", err)
+	}
+	if chunk.ID != "chatcmpl-1" || chunk.Model != "some-model" {
+		t.Fatalf("chunk id/model = %q/%q, want chatcmpl-1/some-model", chunk.ID, chunk.Model)
+	}
+	if len(chunk.Choices) != 1 {
+		t.Fatalf("choices len = %d, want 1", len(chunk.Choices))
+	}
+	got := chunk.Choices[0].Delta.ToolCalls
+	if len(got) != 1 {
+		t.Fatalf("tool_calls len = %d, want 1", len(got))
+	}
+	if got[0].ID != "call_1" || got[0].Function.Name != "lookup" || got[0].Function.Arguments != `{"city":"SF"}` {
+		t.Fatalf("tool call = %#v, want lookup call", got[0])
+	}
+	if chunk.Choices[0].FinishReason != core.FinishReasonToolCalls {
+		t.Fatalf("finish_reason = %q, want %q", chunk.Choices[0].FinishReason, core.FinishReasonToolCalls)
 	}
 }

--- a/internal/openaicompat/request_test.go
+++ b/internal/openaicompat/request_test.go
@@ -149,6 +149,7 @@ func TestDecodeStreamChunk_ForwardsToolCallDeltas(t *testing.T) {
 			"delta":{
 				"role":"assistant",
 				"tool_calls":[{
+					"index":0,
 					"id":"call_1",
 					"type":"function",
 					"function":{"name":"lookup","arguments":"{\"city\":\"SF\"}"}
@@ -169,6 +170,9 @@ func TestDecodeStreamChunk_ForwardsToolCallDeltas(t *testing.T) {
 	got := chunk.Choices[0].Delta.ToolCalls
 	if len(got) != 1 {
 		t.Fatalf("tool_calls len = %d, want 1", len(got))
+	}
+	if got[0].Index == nil || *got[0].Index != 0 {
+		t.Fatalf("tool call index = %#v, want 0", got[0].Index)
 	}
 	if got[0].ID != "call_1" || got[0].Function.Name != "lookup" || got[0].Function.Arguments != `{"city":"SF"}` {
 		t.Fatalf("tool call = %#v, want lookup call", got[0])

--- a/internal/openaicompat/stream.go
+++ b/internal/openaicompat/stream.go
@@ -1,0 +1,20 @@
+package openaicompat
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/ferro-labs/ai-gateway/providers/core"
+)
+
+// DecodeStreamChunk decodes an OpenAI-compatible chat completion stream chunk
+// into the gateway's canonical stream type. Providers should use this instead
+// of local role/content-only structs so deltas like tool_calls, usage, and
+// reasoning_content are preserved consistently.
+func DecodeStreamChunk(data []byte) (core.StreamChunk, error) {
+	var chunk core.StreamChunk
+	if err := json.Unmarshal(data, &chunk); err != nil {
+		return core.StreamChunk{}, fmt.Errorf("failed to unmarshal stream chunk: %w", err)
+	}
+	return chunk, nil
+}

--- a/providers/ai21/ai21.go
+++ b/providers/ai21/ai21.go
@@ -259,19 +259,6 @@ func (p *Provider) completeJurassic(ctx context.Context, req core.Request) (*cor
 	}, nil
 }
 
-type ai21StreamResponse struct {
-	ID      string `json:"id"`
-	Model   string `json:"model"`
-	Choices []struct {
-		Index int `json:"index"`
-		Delta struct {
-			Role    string `json:"role,omitempty"`
-			Content string `json:"content,omitempty"`
-		} `json:"delta"`
-		FinishReason string `json:"finish_reason,omitempty"`
-	} `json:"choices"`
-}
-
 // CompleteStream sends a streaming chat completion request to AI21.
 // Only Jamba models support streaming via the OpenAI-compatible endpoint.
 func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan core.StreamChunk, error) {
@@ -323,23 +310,12 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 				return
 			}
 
-			var chunk ai21StreamResponse
-			if json.Unmarshal([]byte(data), &chunk) != nil {
+			chunk, err := openaicompat.DecodeStreamChunk([]byte(data))
+			if err != nil {
 				continue
 			}
 
-			sc := core.StreamChunk{ID: chunk.ID, Model: chunk.Model}
-			for _, c := range chunk.Choices {
-				sc.Choices = append(sc.Choices, core.StreamChoice{
-					Index: c.Index,
-					Delta: core.MessageDelta{
-						Role:    c.Delta.Role,
-						Content: c.Delta.Content,
-					},
-					FinishReason: c.FinishReason,
-				})
-			}
-			ch <- sc
+			ch <- chunk
 		}
 		if err := scanner.Err(); err != nil {
 			ch <- core.StreamChunk{Error: err}

--- a/providers/anthropic/anthropic.go
+++ b/providers/anthropic/anthropic.go
@@ -135,20 +135,31 @@ type anthropicRequest struct {
 	MaxTokens     int                `json:"max_tokens"`
 	System        string             `json:"system,omitempty"`
 	Messages      []anthropicMessage `json:"messages"`
+	Tools         []anthropicTool    `json:"tools,omitempty"`
+	ToolChoice    interface{}        `json:"tool_choice,omitempty"`
 	Temperature   *float64           `json:"temperature,omitempty"`
 	TopP          *float64           `json:"top_p,omitempty"`
 	StopSequences []string           `json:"stop_sequences,omitempty"`
 	Stream        bool               `json:"stream,omitempty"`
 }
 
+type anthropicTool struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description,omitempty"`
+	InputSchema json.RawMessage `json:"input_schema,omitempty"`
+}
+
 // anthropicSupportedParams lists the OpenAI parameters the Anthropic Messages
 // API can express. Anything else the caller sets is warn-and-dropped (#140).
 // Native tool calling is tracked separately in #139.
-var anthropicSupportedParams = []string{"temperature", "top_p", "max_tokens", "stop"}
+var anthropicSupportedParams = []string{"temperature", "top_p", "max_tokens", "stop", "tools", "tool_choice"}
 
 type anthropicContentBlock struct {
-	Type string `json:"type"`
-	Text string `json:"text"`
+	Type  string          `json:"type"`
+	Text  string          `json:"text"`
+	ID    string          `json:"id"`
+	Name  string          `json:"name"`
+	Input json.RawMessage `json:"input"`
 }
 
 type anthropicUsage struct {
@@ -260,6 +271,56 @@ func buildContent(msg core.Message) any {
 	return blocks
 }
 
+func anthropicTools(tools []core.Tool) []anthropicTool {
+	if len(tools) == 0 {
+		return nil
+	}
+	out := make([]anthropicTool, 0, len(tools))
+	for _, t := range tools {
+		schema := t.Function.Parameters
+		if len(schema) == 0 {
+			schema = json.RawMessage(`{"type":"object","properties":{}}`)
+		}
+		out = append(out, anthropicTool{
+			Name:        t.Function.Name,
+			Description: t.Function.Description,
+			InputSchema: schema,
+		})
+	}
+	return out
+}
+
+func anthropicToolChoice(choice interface{}) interface{} {
+	switch v := choice.(type) {
+	case nil:
+		return nil
+	case string:
+		switch v {
+		case "auto", "none":
+			return map[string]string{"type": v}
+		case "required":
+			return map[string]string{"type": "any"}
+		default:
+			return nil
+		}
+	default:
+		raw, err := json.Marshal(v)
+		if err != nil {
+			return nil
+		}
+		var named struct {
+			Type     string `json:"type"`
+			Function struct {
+				Name string `json:"name"`
+			} `json:"function"`
+		}
+		if err := json.Unmarshal(raw, &named); err == nil && named.Type == "function" && named.Function.Name != "" {
+			return map[string]string{"type": "tool", "name": named.Function.Name}
+		}
+		return v
+	}
+}
+
 // imageBlock maps an OpenAI image_url (data URI or remote URL) to an Anthropic
 // image content block.
 func imageBlock(url string) anthropicReqBlock {
@@ -317,6 +378,8 @@ func (p *Provider) Complete(ctx context.Context, req core.Request) (*core.Respon
 		TopP:          req.TopP,
 		StopSequences: req.Stop,
 		System:        system,
+		Tools:         anthropicTools(req.Tools),
+		ToolChoice:    anthropicToolChoice(req.ToolChoice),
 	}
 
 	bodyReader, _, release, err := core.JSONBodyReader(aReq)
@@ -358,9 +421,25 @@ func (p *Provider) Complete(ctx context.Context, req core.Request) (*core.Respon
 	}
 
 	var content strings.Builder
+	var toolCalls []core.ToolCall
 	for _, block := range aResp.Content {
 		if block.Type == "text" {
 			content.WriteString(block.Text)
+			continue
+		}
+		if block.Type == "tool_use" {
+			args := string(block.Input)
+			if args == "" {
+				args = "{}"
+			}
+			toolCalls = append(toolCalls, core.ToolCall{
+				ID:   block.ID,
+				Type: "function",
+				Function: core.FunctionCall{
+					Name:      block.Name,
+					Arguments: args,
+				},
+			})
 		}
 	}
 
@@ -373,8 +452,9 @@ func (p *Provider) Complete(ctx context.Context, req core.Request) (*core.Respon
 			{
 				Index: 0,
 				Message: core.Message{
-					Role:    aResp.Role,
-					Content: content.String(),
+					Role:      aResp.Role,
+					Content:   content.String(),
+					ToolCalls: toolCalls,
 				},
 				FinishReason: core.NormalizeFinishReason(aResp.StopReason),
 			},
@@ -435,6 +515,8 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 		TopP:          req.TopP,
 		StopSequences: req.Stop,
 		System:        system,
+		Tools:         anthropicTools(req.Tools),
+		ToolChoice:    anthropicToolChoice(req.ToolChoice),
 		Stream:        true,
 	}
 

--- a/providers/anthropic/anthropic.go
+++ b/providers/anthropic/anthropic.go
@@ -572,6 +572,8 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 
 		var msgID, model string
 		var promptTokens, cacheReadTokens, cacheWriteTokens int
+		toolCallIndexes := make(map[int]int)
+		nextToolCallIndex := 0
 		scanner := core.NewSSEScanner(httpResp.Body)
 		for scanner.Scan() {
 			line := scanner.Text()
@@ -601,16 +603,19 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 			case "content_block_start":
 				var evt anthropicStreamContentBlockStart
 				if json.Unmarshal([]byte(data), &evt) == nil && evt.ContentBlock.Type == "tool_use" {
+					toolCallIndex := nextToolCallIndex
+					toolCallIndexes[evt.Index] = toolCallIndex
+					nextToolCallIndex++
 					ch <- core.StreamChunk{
 						ID:    msgID,
 						Model: model,
 						Choices: []core.StreamChoice{
 							{
-								Index: evt.Index,
+								Index: toolCallIndex,
 								Delta: core.MessageDelta{
 									ToolCalls: []core.ToolCall{
 										{
-											Index: streamIndexPtr(evt.Index),
+											Index: streamIndexPtr(toolCallIndex),
 											ID:    evt.ContentBlock.ID,
 											Type:  "function",
 											Function: core.FunctionCall{
@@ -627,16 +632,20 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 				var evt anthropicStreamContentDelta
 				if json.Unmarshal([]byte(data), &evt) == nil {
 					if evt.Delta.Type == "input_json_delta" {
+						toolCallIndex, ok := toolCallIndexes[evt.Index]
+						if !ok {
+							toolCallIndex = evt.Index
+						}
 						ch <- core.StreamChunk{
 							ID:    msgID,
 							Model: model,
 							Choices: []core.StreamChoice{
 								{
-									Index: evt.Index,
+									Index: toolCallIndex,
 									Delta: core.MessageDelta{
 										ToolCalls: []core.ToolCall{
 											{
-												Index: streamIndexPtr(evt.Index),
+												Index: streamIndexPtr(toolCallIndex),
 												Type:  "function",
 												Function: core.FunctionCall{
 													Arguments: evt.Delta.PartialJSON,

--- a/providers/anthropic/anthropic.go
+++ b/providers/anthropic/anthropic.go
@@ -611,7 +611,7 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 						Model: model,
 						Choices: []core.StreamChoice{
 							{
-								Index: toolCallIndex,
+								Index: 0,
 								Delta: core.MessageDelta{
 									ToolCalls: []core.ToolCall{
 										{
@@ -641,7 +641,7 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 							Model: model,
 							Choices: []core.StreamChoice{
 								{
-									Index: toolCallIndex,
+									Index: 0,
 									Delta: core.MessageDelta{
 										ToolCalls: []core.ToolCall{
 											{

--- a/providers/anthropic/anthropic.go
+++ b/providers/anthropic/anthropic.go
@@ -483,9 +483,21 @@ type anthropicStreamContentDelta struct {
 	Type  string `json:"type"`
 	Index int    `json:"index"`
 	Delta struct {
-		Type string `json:"type"`
-		Text string `json:"text"`
+		Type        string `json:"type"`
+		Text        string `json:"text"`
+		PartialJSON string `json:"partial_json"`
 	} `json:"delta"`
+}
+
+type anthropicStreamContentBlockStart struct {
+	Type         string `json:"type"`
+	Index        int    `json:"index"`
+	ContentBlock struct {
+		Type  string          `json:"type"`
+		ID    string          `json:"id"`
+		Name  string          `json:"name"`
+		Input json.RawMessage `json:"input"`
+	} `json:"content_block"`
 }
 
 type anthropicStreamMessageDelta struct {
@@ -494,6 +506,10 @@ type anthropicStreamMessageDelta struct {
 		StopReason string `json:"stop_reason"`
 	} `json:"delta"`
 	Usage anthropicUsage `json:"usage"`
+}
+
+func streamIndexPtr(i int) *int {
+	return &i
 }
 
 // CompleteStream sends a streaming chat completion request to Anthropic.
@@ -582,9 +598,60 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 					cacheReadTokens = evt.Message.Usage.CacheReadInputTokens
 					cacheWriteTokens = evt.Message.Usage.CacheCreationInputTokens
 				}
+			case "content_block_start":
+				var evt anthropicStreamContentBlockStart
+				if json.Unmarshal([]byte(data), &evt) == nil && evt.ContentBlock.Type == "tool_use" {
+					ch <- core.StreamChunk{
+						ID:    msgID,
+						Model: model,
+						Choices: []core.StreamChoice{
+							{
+								Index: evt.Index,
+								Delta: core.MessageDelta{
+									ToolCalls: []core.ToolCall{
+										{
+											Index: streamIndexPtr(evt.Index),
+											ID:    evt.ContentBlock.ID,
+											Type:  "function",
+											Function: core.FunctionCall{
+												Name: evt.ContentBlock.Name,
+											},
+										},
+									},
+								},
+							},
+						},
+					}
+				}
 			case "content_block_delta":
 				var evt anthropicStreamContentDelta
 				if json.Unmarshal([]byte(data), &evt) == nil {
+					if evt.Delta.Type == "input_json_delta" {
+						ch <- core.StreamChunk{
+							ID:    msgID,
+							Model: model,
+							Choices: []core.StreamChoice{
+								{
+									Index: evt.Index,
+									Delta: core.MessageDelta{
+										ToolCalls: []core.ToolCall{
+											{
+												Index: streamIndexPtr(evt.Index),
+												Type:  "function",
+												Function: core.FunctionCall{
+													Arguments: evt.Delta.PartialJSON,
+												},
+											},
+										},
+									},
+								},
+							},
+						}
+						continue
+					}
+					if evt.Delta.Type != "text_delta" {
+						continue
+					}
 					ch <- core.StreamChunk{
 						ID:    msgID,
 						Model: model,

--- a/providers/anthropic/anthropic_messages_test.go
+++ b/providers/anthropic/anthropic_messages_test.go
@@ -178,6 +178,68 @@ func TestBuildMessages_ToolRoundTrip(t *testing.T) {
 	}
 }
 
+func TestComplete_ForwardsToolsAndDecodesToolUse(t *testing.T) {
+	var captured map[string]json.RawMessage
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(b, &captured)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{
+			"id":"msg_1",
+			"type":"message",
+			"role":"assistant",
+			"content":[{"type":"tool_use","id":"toolu_1","name":"lookup","input":{"city":"SF"}}],
+			"model":"claude",
+			"stop_reason":"tool_use",
+			"usage":{"input_tokens":1,"output_tokens":1}
+		}`)
+	}))
+	defer srv.Close()
+
+	p, err := New("test-key", srv.URL)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	resp, err := p.Complete(context.Background(), core.Request{
+		Model:    "claude-3-5-sonnet",
+		Messages: []core.Message{{Role: core.RoleUser, Content: "weather?"}},
+		Tools: []core.Tool{{
+			Type: "function",
+			Function: core.Function{
+				Name:        "lookup",
+				Description: "Lookup weather",
+				Parameters:  json.RawMessage(`{"type":"object","properties":{"city":{"type":"string"}}}`),
+			},
+		}},
+		ToolChoice: "required",
+	})
+	if err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+
+	var tools []map[string]json.RawMessage
+	if err := json.Unmarshal(captured["tools"], &tools); err != nil {
+		t.Fatalf("decode tools: %v", err)
+	}
+	if len(tools) != 1 || str(tools[0]["name"]) != "lookup" {
+		t.Fatalf("tools = %#v, want lookup", tools)
+	}
+	var choice map[string]string
+	if err := json.Unmarshal(captured["tool_choice"], &choice); err != nil {
+		t.Fatalf("decode tool_choice: %v", err)
+	}
+	if choice["type"] != "any" {
+		t.Fatalf("tool_choice = %#v, want any", choice)
+	}
+	if len(resp.Choices) != 1 || len(resp.Choices[0].Message.ToolCalls) != 1 {
+		t.Fatalf("tool calls = %#v, want one", resp.Choices)
+	}
+	tc := resp.Choices[0].Message.ToolCalls[0]
+	if tc.ID != "toolu_1" || tc.Function.Name != "lookup" || tc.Function.Arguments != `{"city":"SF"}` {
+		t.Fatalf("tool call = %#v, want lookup", tc)
+	}
+}
+
 // TestBuildMessages_PlainTextStaysString verifies the common path is unchanged:
 // a plain-text turn still serializes content as a JSON string.
 func TestBuildMessages_PlainTextStaysString(t *testing.T) {

--- a/providers/anthropic/anthropic_messages_test.go
+++ b/providers/anthropic/anthropic_messages_test.go
@@ -240,6 +240,63 @@ func TestComplete_ForwardsToolsAndDecodesToolUse(t *testing.T) {
 	}
 }
 
+func TestComplete_ForwardsToolResultAndDecodesFinalAnswer(t *testing.T) {
+	var captured map[string]json.RawMessage
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(b, &captured)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{
+			"id":"msg_2",
+			"type":"message",
+			"role":"assistant",
+			"content":[{"type":"text","text":"It is 72F in SF."}],
+			"model":"claude",
+			"stop_reason":"end_turn",
+			"usage":{"input_tokens":2,"output_tokens":3}
+		}`)
+	}))
+	defer srv.Close()
+
+	p, err := New("test-key", srv.URL)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	resp, err := p.Complete(context.Background(), core.Request{
+		Model: "claude-3-5-sonnet",
+		Messages: []core.Message{
+			{Role: core.RoleUser, Content: "weather?"},
+			{Role: core.RoleAssistant, ToolCalls: []core.ToolCall{{
+				ID:       "toolu_1",
+				Type:     "function",
+				Function: core.FunctionCall{Name: "lookup", Arguments: `{"city":"SF"}`},
+			}}},
+			{Role: core.RoleTool, ToolCallID: "toolu_1", Content: `{"temp":"72F"}`},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+
+	msgs := decodeMessages(t, captured)
+	if len(msgs) != 3 {
+		t.Fatalf("messages len = %d, want 3", len(msgs))
+	}
+	var resultBlocks []map[string]json.RawMessage
+	if err := json.Unmarshal(msgs[2]["content"], &resultBlocks); err != nil {
+		t.Fatalf("decode tool result blocks: %v", err)
+	}
+	if str(msgs[2]["role"]) != core.RoleUser || str(resultBlocks[0]["type"]) != "tool_result" || str(resultBlocks[0]["tool_use_id"]) != "toolu_1" {
+		t.Fatalf("tool result message = %#v blocks=%#v", msgs[2], resultBlocks)
+	}
+	if got := resp.Choices[0].Message.Content; got != "It is 72F in SF." {
+		t.Fatalf("final answer = %q, want weather answer", got)
+	}
+	if len(resp.Choices[0].Message.ToolCalls) != 0 {
+		t.Fatalf("final answer tool calls = %#v, want none", resp.Choices[0].Message.ToolCalls)
+	}
+}
+
 // TestBuildMessages_PlainTextStaysString verifies the common path is unchanged:
 // a plain-text turn still serializes content as a JSON string.
 func TestBuildMessages_PlainTextStaysString(t *testing.T) {

--- a/providers/anthropic/anthropic_test.go
+++ b/providers/anthropic/anthropic_test.go
@@ -214,6 +214,57 @@ data: {"type":"message_delta","delta":{"stop_reason":"tool_use"}}
 	}
 }
 
+func TestAnthropicProvider_CompleteStream_MapsContentBlockIndexToToolCallIndex(t *testing.T) {
+	sseData := `event: message_start
+data: {"type":"message_start","message":{"id":"msg_123","model":"claude-3-haiku-20240307","role":"assistant"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Let me check."}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_1","name":"lookup","input":{}}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\"city\""}}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"tool_use"}}
+
+`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(sseData))
+	}))
+	defer srv.Close()
+
+	p, _ := New("sk-test-key", srv.URL)
+	ch, err := p.CompleteStream(context.Background(), core.Request{
+		Model:    "claude-3-haiku-20240307",
+		Messages: []core.Message{{Role: core.RoleUser, Content: "weather?"}},
+	})
+	if err != nil {
+		t.Fatalf("CompleteStream() error: %v", err)
+	}
+
+	var chunks []core.StreamChunk
+	for c := range ch {
+		chunks = append(chunks, c)
+	}
+
+	if len(chunks) != 4 {
+		t.Fatalf("chunks len = %d, want 4: %#v", len(chunks), chunks)
+	}
+	start := chunks[1].Choices[0].Delta.ToolCalls[0]
+	if start.Index == nil || *start.Index != 0 {
+		t.Fatalf("tool call index = %#v, want OpenAI tool index 0", start.Index)
+	}
+	args := chunks[2].Choices[0].Delta.ToolCalls[0]
+	if args.Index == nil || *args.Index != 0 || args.Function.Arguments != `{"city"` {
+		t.Fatalf("args delta = %#v, want tool index 0 with city fragment", args)
+	}
+}
+
 // TestAnthropicProvider_Complete_Integration tests actual API calls.
 // This test only runs if ANTHROPIC_API_KEY environment variable is set.
 func TestAnthropicProvider_Complete_Integration(t *testing.T) {

--- a/providers/anthropic/anthropic_test.go
+++ b/providers/anthropic/anthropic_test.go
@@ -227,6 +227,12 @@ data: {"type":"content_block_start","index":1,"content_block":{"type":"tool_use"
 event: content_block_delta
 data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\"city\""}}
 
+event: content_block_start
+data: {"type":"content_block_start","index":2,"content_block":{"type":"tool_use","id":"toolu_2","name":"lookup_time","input":{}}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":2,"delta":{"type":"input_json_delta","partial_json":"{\"city\""}}
+
 event: message_delta
 data: {"type":"message_delta","delta":{"stop_reason":"tool_use"}}
 
@@ -252,16 +258,33 @@ data: {"type":"message_delta","delta":{"stop_reason":"tool_use"}}
 		chunks = append(chunks, c)
 	}
 
-	if len(chunks) != 4 {
-		t.Fatalf("chunks len = %d, want 4: %#v", len(chunks), chunks)
+	if len(chunks) != 6 {
+		t.Fatalf("chunks len = %d, want 6: %#v", len(chunks), chunks)
 	}
 	start := chunks[1].Choices[0].Delta.ToolCalls[0]
+	if chunks[1].Choices[0].Index != 0 {
+		t.Fatalf("choice index = %d, want sole completion index 0", chunks[1].Choices[0].Index)
+	}
 	if start.Index == nil || *start.Index != 0 {
 		t.Fatalf("tool call index = %#v, want OpenAI tool index 0", start.Index)
 	}
 	args := chunks[2].Choices[0].Delta.ToolCalls[0]
 	if args.Index == nil || *args.Index != 0 || args.Function.Arguments != `{"city"` {
 		t.Fatalf("args delta = %#v, want tool index 0 with city fragment", args)
+	}
+	secondStart := chunks[3].Choices[0].Delta.ToolCalls[0]
+	if chunks[3].Choices[0].Index != 0 {
+		t.Fatalf("second choice index = %d, want sole completion index 0", chunks[3].Choices[0].Index)
+	}
+	if secondStart.Index == nil || *secondStart.Index != 1 {
+		t.Fatalf("second tool call index = %#v, want OpenAI tool index 1", secondStart.Index)
+	}
+	secondArgs := chunks[4].Choices[0].Delta.ToolCalls[0]
+	if chunks[4].Choices[0].Index != 0 {
+		t.Fatalf("second args choice index = %d, want sole completion index 0", chunks[4].Choices[0].Index)
+	}
+	if secondArgs.Index == nil || *secondArgs.Index != 1 || secondArgs.Function.Arguments != `{"city"` {
+		t.Fatalf("second args delta = %#v, want tool index 1 with city fragment", secondArgs)
 	}
 }
 

--- a/providers/anthropic/anthropic_test.go
+++ b/providers/anthropic/anthropic_test.go
@@ -151,6 +151,69 @@ data: {"type":"message_stop"}
 	}
 }
 
+func TestAnthropicProvider_CompleteStream_ForwardsToolUseDeltas(t *testing.T) {
+	sseData := `event: message_start
+data: {"type":"message_start","message":{"id":"msg_123","model":"claude-3-haiku-20240307","role":"assistant"}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_1","name":"lookup","input":{}}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"city\""}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":":\"SF\"}"}}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"tool_use"}}
+
+`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(sseData))
+	}))
+	defer srv.Close()
+
+	p, _ := New("sk-test-key", srv.URL)
+	ch, err := p.CompleteStream(context.Background(), core.Request{
+		Model:    "claude-3-haiku-20240307",
+		Messages: []core.Message{{Role: core.RoleUser, Content: "weather?"}},
+		Tools: []core.Tool{{
+			Type: "function",
+			Function: core.Function{
+				Name: "lookup",
+			},
+		}},
+		ToolChoice: "required",
+	})
+	if err != nil {
+		t.Fatalf("CompleteStream() error: %v", err)
+	}
+
+	var chunks []core.StreamChunk
+	for c := range ch {
+		chunks = append(chunks, c)
+	}
+
+	if len(chunks) != 4 {
+		t.Fatalf("chunks len = %d, want 4: %#v", len(chunks), chunks)
+	}
+	start := chunks[0].Choices[0].Delta.ToolCalls[0]
+	if start.Index == nil || *start.Index != 0 || start.ID != "toolu_1" || start.Function.Name != "lookup" {
+		t.Fatalf("start tool call = %#v, want lookup at index 0", start)
+	}
+	if chunks[1].Choices[0].Delta.ToolCalls[0].Function.Arguments != `{"city"` {
+		t.Fatalf("first args delta = %#v", chunks[1].Choices[0].Delta.ToolCalls)
+	}
+	if chunks[2].Choices[0].Delta.ToolCalls[0].Function.Arguments != `:"SF"}` {
+		t.Fatalf("second args delta = %#v", chunks[2].Choices[0].Delta.ToolCalls)
+	}
+	if chunks[3].Choices[0].FinishReason != core.FinishReasonToolCalls {
+		t.Fatalf("finish_reason = %q, want %q", chunks[3].Choices[0].FinishReason, core.FinishReasonToolCalls)
+	}
+}
+
 // TestAnthropicProvider_Complete_Integration tests actual API calls.
 // This test only runs if ANTHROPIC_API_KEY environment variable is set.
 func TestAnthropicProvider_Complete_Integration(t *testing.T) {

--- a/providers/azure_foundry/azure_foundry.go
+++ b/providers/azure_foundry/azure_foundry.go
@@ -148,19 +148,6 @@ func (p *Provider) Complete(ctx context.Context, req core.Request) (*core.Respon
 	}, nil
 }
 
-type azureFoundryStreamResponse struct {
-	ID      string `json:"id"`
-	Model   string `json:"model"`
-	Choices []struct {
-		Index int `json:"index"`
-		Delta struct {
-			Role    string `json:"role,omitempty"`
-			Content string `json:"content,omitempty"`
-		} `json:"delta"`
-		FinishReason string `json:"finish_reason,omitempty"`
-	} `json:"choices"`
-}
-
 // CompleteStream sends a streaming chat completion request to Azure AI Foundry.
 func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan core.StreamChunk, error) {
 	bodyReader, _, release, err := openaicompat.BuildBody(req, true)
@@ -207,23 +194,12 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 				return
 			}
 
-			var chunk azureFoundryStreamResponse
-			if json.Unmarshal([]byte(data), &chunk) != nil {
+			chunk, err := openaicompat.DecodeStreamChunk([]byte(data))
+			if err != nil {
 				continue
 			}
 
-			sc := core.StreamChunk{ID: chunk.ID, Model: chunk.Model}
-			for _, c := range chunk.Choices {
-				sc.Choices = append(sc.Choices, core.StreamChoice{
-					Index: c.Index,
-					Delta: core.MessageDelta{
-						Role:    c.Delta.Role,
-						Content: c.Delta.Content,
-					},
-					FinishReason: c.FinishReason,
-				})
-			}
-			ch <- sc
+			ch <- chunk
 		}
 		if err := scanner.Err(); err != nil {
 			ch <- core.StreamChunk{Error: err}

--- a/providers/azure_openai/azure_openai.go
+++ b/providers/azure_openai/azure_openai.go
@@ -156,19 +156,6 @@ func (p *Provider) Complete(ctx context.Context, req core.Request) (*core.Respon
 	}, nil
 }
 
-type azureOpenAIStreamResponse struct {
-	ID      string `json:"id"`
-	Model   string `json:"model"`
-	Choices []struct {
-		Index int `json:"index"`
-		Delta struct {
-			Role    string `json:"role,omitempty"`
-			Content string `json:"content,omitempty"`
-		} `json:"delta"`
-		FinishReason string `json:"finish_reason,omitempty"`
-	} `json:"choices"`
-}
-
 // CompleteStream sends a streaming chat completion request to Azure OpenAI.
 func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan core.StreamChunk, error) {
 	req.PreferCompletionTokens()
@@ -216,26 +203,12 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 				return
 			}
 
-			var chunk azureOpenAIStreamResponse
-			if json.Unmarshal([]byte(data), &chunk) != nil {
+			chunk, err := openaicompat.DecodeStreamChunk([]byte(data))
+			if err != nil {
 				continue
 			}
 
-			sc := core.StreamChunk{
-				ID:    chunk.ID,
-				Model: chunk.Model,
-			}
-			for _, c := range chunk.Choices {
-				sc.Choices = append(sc.Choices, core.StreamChoice{
-					Index: c.Index,
-					Delta: core.MessageDelta{
-						Role:    c.Delta.Role,
-						Content: c.Delta.Content,
-					},
-					FinishReason: c.FinishReason,
-				})
-			}
-			ch <- sc
+			ch <- chunk
 		}
 		if err := scanner.Err(); err != nil {
 			ch <- core.StreamChunk{Error: err}

--- a/providers/bedrock/bedrock.go
+++ b/providers/bedrock/bedrock.go
@@ -161,13 +161,36 @@ func (p *Provider) Models() []core.ModelInfo {
 // ── Anthropic Claude on Bedrock ───────────────────────────────────────────────
 
 type bedrockAnthropicRequest struct {
-	AnthropicVersion string         `json:"anthropic_version"`
-	MaxTokens        int            `json:"max_tokens"`
-	Messages         []core.Message `json:"messages"`
-	Temperature      *float64       `json:"temperature,omitempty"`
-	TopP             *float64       `json:"top_p,omitempty"`
-	StopSequences    []string       `json:"stop_sequences,omitempty"`
-	System           string         `json:"system,omitempty"`
+	AnthropicVersion string                    `json:"anthropic_version"`
+	MaxTokens        int                       `json:"max_tokens"`
+	Messages         []bedrockAnthropicMessage `json:"messages"`
+	Tools            []bedrockAnthropicTool    `json:"tools,omitempty"`
+	ToolChoice       interface{}               `json:"tool_choice,omitempty"`
+	Temperature      *float64                  `json:"temperature,omitempty"`
+	TopP             *float64                  `json:"top_p,omitempty"`
+	StopSequences    []string                  `json:"stop_sequences,omitempty"`
+	System           string                    `json:"system,omitempty"`
+}
+
+type bedrockAnthropicMessage struct {
+	Role    string      `json:"role"`
+	Content interface{} `json:"content"`
+}
+
+type bedrockAnthropicBlock struct {
+	Type      string          `json:"type"`
+	Text      string          `json:"text,omitempty"`
+	ID        string          `json:"id,omitempty"`
+	Name      string          `json:"name,omitempty"`
+	Input     json.RawMessage `json:"input,omitempty"`
+	ToolUseID string          `json:"tool_use_id,omitempty"`
+	Content   string          `json:"content,omitempty"`
+}
+
+type bedrockAnthropicTool struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description,omitempty"`
+	InputSchema json.RawMessage `json:"input_schema,omitempty"`
 }
 
 type bedrockAnthropicResponse struct {
@@ -175,8 +198,11 @@ type bedrockAnthropicResponse struct {
 	Type    string `json:"type"`
 	Role    string `json:"role"`
 	Content []struct {
-		Type string `json:"type"`
-		Text string `json:"text"`
+		Type  string          `json:"type"`
+		Text  string          `json:"text"`
+		ID    string          `json:"id"`
+		Name  string          `json:"name"`
+		Input json.RawMessage `json:"input"`
 	} `json:"content"`
 	StopReason string `json:"stop_reason"`
 	Usage      struct {
@@ -447,13 +473,107 @@ func isBedrockCohereEmbeddingModel(model string) bool {
 func bedrockSupportedParams(modelID string) []string {
 	switch {
 	case strings.HasPrefix(modelID, "anthropic."):
-		return []string{"temperature", "top_p", "max_tokens", "stop"}
+		return []string{"temperature", "top_p", "max_tokens", "stop", "tools", "tool_choice"}
 	case strings.HasPrefix(modelID, "amazon.titan"):
 		return []string{"temperature", "top_p", "max_tokens", "stop"}
 	case strings.HasPrefix(modelID, "meta.llama"):
 		return []string{"temperature", "top_p", "max_tokens"}
 	default:
 		return nil
+	}
+}
+
+func bedrockBuildAnthropicMessages(req core.Request) ([]bedrockAnthropicMessage, string) {
+	var systemParts []string
+	var messages []bedrockAnthropicMessage
+	for _, msg := range req.Messages {
+		switch msg.Role {
+		case core.RoleSystem:
+			systemParts = append(systemParts, msg.Content)
+		case core.RoleTool:
+			block := bedrockAnthropicBlock{
+				Type:      "tool_result",
+				ToolUseID: msg.ToolCallID,
+				Content:   msg.Content,
+			}
+			messages = append(messages, bedrockAnthropicMessage{Role: core.RoleUser, Content: []bedrockAnthropicBlock{block}})
+		default:
+			messages = append(messages, bedrockAnthropicMessage{Role: msg.Role, Content: bedrockAnthropicContent(msg)})
+		}
+	}
+	return messages, strings.Join(systemParts, "\n")
+}
+
+func bedrockAnthropicContent(msg core.Message) interface{} {
+	var blocks []bedrockAnthropicBlock
+	if msg.Content != "" {
+		blocks = append(blocks, bedrockAnthropicBlock{Type: "text", Text: msg.Content})
+	}
+	for _, tc := range msg.ToolCalls {
+		input := json.RawMessage(tc.Function.Arguments)
+		if len(input) == 0 || !json.Valid(input) {
+			input = json.RawMessage(`{}`)
+		}
+		blocks = append(blocks, bedrockAnthropicBlock{
+			Type:  "tool_use",
+			ID:    tc.ID,
+			Name:  tc.Function.Name,
+			Input: input,
+		})
+	}
+	if len(msg.ToolCalls) == 0 {
+		return msg.Content
+	}
+	return blocks
+}
+
+func bedrockAnthropicTools(tools []core.Tool) []bedrockAnthropicTool {
+	if len(tools) == 0 {
+		return nil
+	}
+	out := make([]bedrockAnthropicTool, 0, len(tools))
+	for _, t := range tools {
+		schema := t.Function.Parameters
+		if len(schema) == 0 {
+			schema = json.RawMessage(`{"type":"object","properties":{}}`)
+		}
+		out = append(out, bedrockAnthropicTool{
+			Name:        t.Function.Name,
+			Description: t.Function.Description,
+			InputSchema: schema,
+		})
+	}
+	return out
+}
+
+func bedrockAnthropicToolChoice(choice interface{}) interface{} {
+	switch v := choice.(type) {
+	case nil:
+		return nil
+	case string:
+		switch v {
+		case "auto", "none":
+			return map[string]string{"type": v}
+		case "required":
+			return map[string]string{"type": "any"}
+		default:
+			return nil
+		}
+	default:
+		raw, err := json.Marshal(v)
+		if err != nil {
+			return nil
+		}
+		var named struct {
+			Type     string `json:"type"`
+			Function struct {
+				Name string `json:"name"`
+			} `json:"function"`
+		}
+		if err := json.Unmarshal(raw, &named); err == nil && named.Type == "function" && named.Function.Name != "" {
+			return map[string]string{"type": "tool", "name": named.Function.Name}
+		}
+		return v
 	}
 }
 
@@ -480,20 +600,14 @@ func (p *Provider) completeAnthropic(ctx context.Context, req core.Request) (*co
 		maxTokens = *req.MaxTokens
 	}
 
-	var system string
-	var messages []core.Message
-	for _, msg := range req.Messages {
-		if msg.Role == core.RoleSystem {
-			system = msg.Content
-		} else {
-			messages = append(messages, msg)
-		}
-	}
+	messages, system := bedrockBuildAnthropicMessages(req)
 
 	anthropicReq := bedrockAnthropicRequest{
 		AnthropicVersion: "bedrock-2023-05-31",
 		MaxTokens:        maxTokens,
 		Messages:         messages,
+		Tools:            bedrockAnthropicTools(req.Tools),
+		ToolChoice:       bedrockAnthropicToolChoice(req.ToolChoice),
 		Temperature:      req.Temperature,
 		TopP:             req.TopP,
 		StopSequences:    req.Stop,
@@ -520,9 +634,25 @@ func (p *Provider) completeAnthropic(ctx context.Context, req core.Request) (*co
 	}
 
 	text := ""
+	var toolCalls []core.ToolCall
 	for _, c := range anthropicResp.Content {
 		if c.Type == "text" {
 			text += c.Text
+			continue
+		}
+		if c.Type == "tool_use" {
+			args := string(c.Input)
+			if args == "" {
+				args = "{}"
+			}
+			toolCalls = append(toolCalls, core.ToolCall{
+				ID:   c.ID,
+				Type: "function",
+				Function: core.FunctionCall{
+					Name:      c.Name,
+					Arguments: args,
+				},
+			})
 		}
 	}
 
@@ -532,7 +662,7 @@ func (p *Provider) completeAnthropic(ctx context.Context, req core.Request) (*co
 		Provider: p.name,
 		Choices: []core.Choice{{
 			Index:        0,
-			Message:      core.Message{Role: core.RoleAssistant, Content: text},
+			Message:      core.Message{Role: core.RoleAssistant, Content: text, ToolCalls: toolCalls},
 			FinishReason: core.NormalizeFinishReason(anthropicResp.StopReason),
 		}},
 		Usage: core.Usage{
@@ -669,20 +799,14 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 		maxTokens = *req.MaxTokens
 	}
 
-	var system string
-	var messages []core.Message
-	for _, msg := range req.Messages {
-		if msg.Role == core.RoleSystem {
-			system = msg.Content
-		} else {
-			messages = append(messages, msg)
-		}
-	}
+	messages, system := bedrockBuildAnthropicMessages(req)
 
 	anthropicReq := bedrockAnthropicRequest{
 		AnthropicVersion: "bedrock-2023-05-31",
 		MaxTokens:        maxTokens,
 		Messages:         messages,
+		Tools:            bedrockAnthropicTools(req.Tools),
+		ToolChoice:       bedrockAnthropicToolChoice(req.ToolChoice),
 		Temperature:      req.Temperature,
 		TopP:             req.TopP,
 		StopSequences:    req.Stop,

--- a/providers/bedrock/bedrock.go
+++ b/providers/bedrock/bedrock.go
@@ -870,7 +870,7 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 					ch <- core.StreamChunk{
 						Model: req.Model,
 						Choices: []core.StreamChoice{{
-							Index: toolCallIndex,
+							Index: 0,
 							Delta: core.MessageDelta{
 								ToolCalls: []core.ToolCall{{
 									Index: bedrockStreamIndexPtr(toolCallIndex),
@@ -903,7 +903,7 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 						ch <- core.StreamChunk{
 							Model: req.Model,
 							Choices: []core.StreamChoice{{
-								Index: toolCallIndex,
+								Index: 0,
 								Delta: core.MessageDelta{
 									ToolCalls: []core.ToolCall{{
 										Index: bedrockStreamIndexPtr(toolCallIndex),

--- a/providers/bedrock/bedrock.go
+++ b/providers/bedrock/bedrock.go
@@ -496,6 +496,13 @@ func bedrockBuildAnthropicMessages(req core.Request) ([]bedrockAnthropicMessage,
 				ToolUseID: msg.ToolCallID,
 				Content:   msg.Content,
 			}
+			if n := len(messages); n > 0 && messages[n-1].Role == core.RoleUser {
+				if blocks, ok := messages[n-1].Content.([]bedrockAnthropicBlock); ok {
+					blocks = append(blocks, block)
+					messages[n-1].Content = blocks
+					continue
+				}
+			}
 			messages = append(messages, bedrockAnthropicMessage{Role: core.RoleUser, Content: []bedrockAnthropicBlock{block}})
 		default:
 			messages = append(messages, bedrockAnthropicMessage{Role: msg.Role, Content: bedrockAnthropicContent(msg)})
@@ -833,6 +840,8 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 		stream := output.GetStream()
 		defer func() { _ = stream.Close() }()
 
+		toolCallIndexes := make(map[int]int)
+		nextToolCallIndex := 0
 		for event := range stream.Events() {
 			if e, ok := event.(*types.ResponseStreamMemberChunk); ok {
 				var eventType struct {
@@ -855,13 +864,16 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 					if err := json.Unmarshal(e.Value.Bytes, &start); err != nil || start.ContentBlock.Type != "tool_use" {
 						continue
 					}
+					toolCallIndex := nextToolCallIndex
+					toolCallIndexes[start.Index] = toolCallIndex
+					nextToolCallIndex++
 					ch <- core.StreamChunk{
 						Model: req.Model,
 						Choices: []core.StreamChoice{{
-							Index: start.Index,
+							Index: toolCallIndex,
 							Delta: core.MessageDelta{
 								ToolCalls: []core.ToolCall{{
-									Index: bedrockStreamIndexPtr(start.Index),
+									Index: bedrockStreamIndexPtr(toolCallIndex),
 									ID:    start.ContentBlock.ID,
 									Type:  "function",
 									Function: core.FunctionCall{
@@ -884,13 +896,17 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 						continue
 					}
 					if delta.Delta.Type == "input_json_delta" {
+						toolCallIndex, ok := toolCallIndexes[delta.Index]
+						if !ok {
+							toolCallIndex = delta.Index
+						}
 						ch <- core.StreamChunk{
 							Model: req.Model,
 							Choices: []core.StreamChoice{{
-								Index: delta.Index,
+								Index: toolCallIndex,
 								Delta: core.MessageDelta{
 									ToolCalls: []core.ToolCall{{
-										Index: bedrockStreamIndexPtr(delta.Index),
+										Index: bedrockStreamIndexPtr(toolCallIndex),
 										Type:  "function",
 										Function: core.FunctionCall{
 											Arguments: delta.Delta.PartialJSON,

--- a/providers/bedrock/bedrock.go
+++ b/providers/bedrock/bedrock.go
@@ -835,23 +835,96 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 
 		for event := range stream.Events() {
 			if e, ok := event.(*types.ResponseStreamMemberChunk); ok {
-				var delta struct {
-					Type  string `json:"type"`
-					Index int    `json:"index"`
-					Delta struct {
-						Type string `json:"type"`
-						Text string `json:"text"`
-					} `json:"delta"`
+				var eventType struct {
+					Type string `json:"type"`
 				}
-				if err := json.Unmarshal(e.Value.Bytes, &delta); err != nil {
+				if err := json.Unmarshal(e.Value.Bytes, &eventType); err != nil {
 					continue
 				}
-				if delta.Type == "content_block_delta" && delta.Delta.Type == "text_delta" {
+
+				switch eventType.Type {
+				case "content_block_start":
+					var start struct {
+						Index        int `json:"index"`
+						ContentBlock struct {
+							Type string `json:"type"`
+							ID   string `json:"id"`
+							Name string `json:"name"`
+						} `json:"content_block"`
+					}
+					if err := json.Unmarshal(e.Value.Bytes, &start); err != nil || start.ContentBlock.Type != "tool_use" {
+						continue
+					}
+					ch <- core.StreamChunk{
+						Model: req.Model,
+						Choices: []core.StreamChoice{{
+							Index: start.Index,
+							Delta: core.MessageDelta{
+								ToolCalls: []core.ToolCall{{
+									Index: bedrockStreamIndexPtr(start.Index),
+									ID:    start.ContentBlock.ID,
+									Type:  "function",
+									Function: core.FunctionCall{
+										Name: start.ContentBlock.Name,
+									},
+								}},
+							},
+						}},
+					}
+				case "content_block_delta":
+					var delta struct {
+						Index int `json:"index"`
+						Delta struct {
+							Type        string `json:"type"`
+							Text        string `json:"text"`
+							PartialJSON string `json:"partial_json"`
+						} `json:"delta"`
+					}
+					if err := json.Unmarshal(e.Value.Bytes, &delta); err != nil {
+						continue
+					}
+					if delta.Delta.Type == "input_json_delta" {
+						ch <- core.StreamChunk{
+							Model: req.Model,
+							Choices: []core.StreamChoice{{
+								Index: delta.Index,
+								Delta: core.MessageDelta{
+									ToolCalls: []core.ToolCall{{
+										Index: bedrockStreamIndexPtr(delta.Index),
+										Type:  "function",
+										Function: core.FunctionCall{
+											Arguments: delta.Delta.PartialJSON,
+										},
+									}},
+								},
+							}},
+						}
+						continue
+					}
+					if delta.Delta.Type != "text_delta" {
+						continue
+					}
 					ch <- core.StreamChunk{
 						Model: req.Model,
 						Choices: []core.StreamChoice{{
 							Index: delta.Index,
 							Delta: core.MessageDelta{Content: delta.Delta.Text},
+						}},
+					}
+				case "message_delta":
+					var delta struct {
+						Delta struct {
+							StopReason string `json:"stop_reason"`
+						} `json:"delta"`
+					}
+					if err := json.Unmarshal(e.Value.Bytes, &delta); err != nil {
+						continue
+					}
+					ch <- core.StreamChunk{
+						Model: req.Model,
+						Choices: []core.StreamChoice{{
+							Index:        0,
+							FinishReason: core.NormalizeFinishReason(delta.Delta.StopReason),
 						}},
 					}
 				}
@@ -863,4 +936,8 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 	}()
 
 	return ch, nil
+}
+
+func bedrockStreamIndexPtr(i int) *int {
+	return &i
 }

--- a/providers/bedrock/bedrock_test.go
+++ b/providers/bedrock/bedrock_test.go
@@ -442,6 +442,8 @@ func TestBedrockProvider_CompleteStreamAnthropic_MapsContentBlockIndexToToolCall
 			[]byte(`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Let me check."}}`),
 			[]byte(`{"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_1","name":"lookup","input":{}}}`),
 			[]byte(`{"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\"city\""}}`),
+			[]byte(`{"type":"content_block_start","index":2,"content_block":{"type":"tool_use","id":"toolu_2","name":"lookup_time","input":{}}}`),
+			[]byte(`{"type":"content_block_delta","index":2,"delta":{"type":"input_json_delta","partial_json":"{\"city\""}}`),
 			[]byte(`{"type":"message_delta","delta":{"stop_reason":"tool_use"}}`),
 		},
 	}
@@ -460,16 +462,36 @@ func TestBedrockProvider_CompleteStreamAnthropic_MapsContentBlockIndexToToolCall
 		chunks = append(chunks, c)
 	}
 
-	if len(chunks) != 4 {
-		t.Fatalf("chunks len = %d, want 4: %#v", len(chunks), chunks)
+	if len(chunks) != 6 {
+		t.Fatalf("chunks len = %d, want 6: %#v", len(chunks), chunks)
 	}
 	start := chunks[1].Choices[0].Delta.ToolCalls[0]
+	if chunks[1].Choices[0].Index != 0 {
+		t.Fatalf("choice index = %d, want sole completion index 0", chunks[1].Choices[0].Index)
+	}
 	if start.Index == nil || *start.Index != 0 {
 		t.Fatalf("tool call index = %#v, want OpenAI tool index 0", start.Index)
 	}
 	args := chunks[2].Choices[0].Delta.ToolCalls[0]
+	if chunks[2].Choices[0].Index != 0 {
+		t.Fatalf("args choice index = %d, want sole completion index 0", chunks[2].Choices[0].Index)
+	}
 	if args.Index == nil || *args.Index != 0 || args.Function.Arguments != `{"city"` {
 		t.Fatalf("args delta = %#v, want tool index 0 with city fragment", args)
+	}
+	secondStart := chunks[3].Choices[0].Delta.ToolCalls[0]
+	if chunks[3].Choices[0].Index != 0 {
+		t.Fatalf("second choice index = %d, want sole completion index 0", chunks[3].Choices[0].Index)
+	}
+	if secondStart.Index == nil || *secondStart.Index != 1 {
+		t.Fatalf("second tool call index = %#v, want OpenAI tool index 1", secondStart.Index)
+	}
+	secondArgs := chunks[4].Choices[0].Delta.ToolCalls[0]
+	if chunks[4].Choices[0].Index != 0 {
+		t.Fatalf("second args choice index = %d, want sole completion index 0", chunks[4].Choices[0].Index)
+	}
+	if secondArgs.Index == nil || *secondArgs.Index != 1 || secondArgs.Function.Arguments != `{"city"` {
+		t.Fatalf("second args delta = %#v, want tool index 1 with city fragment", secondArgs)
 	}
 }
 

--- a/providers/bedrock/bedrock_test.go
+++ b/providers/bedrock/bedrock_test.go
@@ -334,6 +334,59 @@ func TestBedrockProvider_CompleteAnthropic_ForwardsToolResultAndDecodesFinalAnsw
 	}
 }
 
+func TestBedrockProvider_CompleteAnthropic_MergesParallelToolResults(t *testing.T) {
+	fake := &fakeBedrockRuntimeClient{
+		responses: [][]byte{
+			[]byte(`{
+				"id":"msg_2",
+				"type":"message",
+				"role":"assistant",
+				"content":[{"type":"text","text":"done"}],
+				"stop_reason":"end_turn",
+				"usage":{"input_tokens":2,"output_tokens":3}
+			}`),
+		},
+	}
+	p := &Provider{name: Name, client: fake}
+
+	_, err := p.Complete(context.Background(), core.Request{
+		Model: "anthropic.claude-3-5-sonnet-20241022-v2:0",
+		Messages: []core.Message{
+			{Role: core.RoleUser, Content: "weather and time?"},
+			{Role: core.RoleAssistant, ToolCalls: []core.ToolCall{
+				{ID: "toolu_weather", Type: "function", Function: core.FunctionCall{Name: "weather", Arguments: `{"city":"SF"}`}},
+				{ID: "toolu_time", Type: "function", Function: core.FunctionCall{Name: "time", Arguments: `{"city":"SF"}`}},
+			}},
+			{Role: core.RoleTool, ToolCallID: "toolu_weather", Content: `{"temp":"72F"}`},
+			{Role: core.RoleTool, ToolCallID: "toolu_time", Content: `{"time":"10:00"}`},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Complete() error: %v", err)
+	}
+
+	var body struct {
+		Messages []struct {
+			Role    string          `json:"role"`
+			Content json.RawMessage `json:"content"`
+		} `json:"messages"`
+	}
+	mustUnmarshalBody(t, fake.invokeCalls[0].Body, &body)
+	if len(body.Messages) != 3 {
+		t.Fatalf("messages len = %d, want 3 with merged tool results", len(body.Messages))
+	}
+	var resultBlocks []map[string]json.RawMessage
+	if err := json.Unmarshal(body.Messages[2].Content, &resultBlocks); err != nil {
+		t.Fatalf("decode tool result blocks: %v", err)
+	}
+	if body.Messages[2].Role != core.RoleUser || len(resultBlocks) != 2 {
+		t.Fatalf("tool result message = %#v blocks=%#v, want one user turn with two tool results", body.Messages[2], resultBlocks)
+	}
+	if jsonString(resultBlocks[0]["tool_use_id"]) != "toolu_weather" || jsonString(resultBlocks[1]["tool_use_id"]) != "toolu_time" {
+		t.Fatalf("tool result ids = %#v, want weather/time", resultBlocks)
+	}
+}
+
 func TestBedrockProvider_CompleteStreamAnthropic_ForwardsToolUseDeltas(t *testing.T) {
 	fake := &fakeBedrockRuntimeClient{
 		streamResponses: [][]byte{
@@ -380,6 +433,43 @@ func TestBedrockProvider_CompleteStreamAnthropic_ForwardsToolUseDeltas(t *testin
 	}
 	if chunks[3].Choices[0].FinishReason != core.FinishReasonToolCalls {
 		t.Fatalf("finish_reason = %q, want %q", chunks[3].Choices[0].FinishReason, core.FinishReasonToolCalls)
+	}
+}
+
+func TestBedrockProvider_CompleteStreamAnthropic_MapsContentBlockIndexToToolCallIndex(t *testing.T) {
+	fake := &fakeBedrockRuntimeClient{
+		streamResponses: [][]byte{
+			[]byte(`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Let me check."}}`),
+			[]byte(`{"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_1","name":"lookup","input":{}}}`),
+			[]byte(`{"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\"city\""}}`),
+			[]byte(`{"type":"message_delta","delta":{"stop_reason":"tool_use"}}`),
+		},
+	}
+	p := &Provider{name: Name, client: fake}
+
+	ch, err := p.CompleteStream(context.Background(), core.Request{
+		Model:    "anthropic.claude-3-5-sonnet-20241022-v2:0",
+		Messages: []core.Message{{Role: core.RoleUser, Content: "weather?"}},
+	})
+	if err != nil {
+		t.Fatalf("CompleteStream() error: %v", err)
+	}
+
+	var chunks []core.StreamChunk
+	for c := range ch {
+		chunks = append(chunks, c)
+	}
+
+	if len(chunks) != 4 {
+		t.Fatalf("chunks len = %d, want 4: %#v", len(chunks), chunks)
+	}
+	start := chunks[1].Choices[0].Delta.ToolCalls[0]
+	if start.Index == nil || *start.Index != 0 {
+		t.Fatalf("tool call index = %#v, want OpenAI tool index 0", start.Index)
+	}
+	args := chunks[2].Choices[0].Delta.ToolCalls[0]
+	if args.Index == nil || *args.Index != 0 || args.Function.Arguments != `{"city"` {
+		t.Fatalf("args delta = %#v, want tool index 0 with city fragment", args)
 	}
 }
 

--- a/providers/bedrock/bedrock_test.go
+++ b/providers/bedrock/bedrock_test.go
@@ -226,6 +226,55 @@ func TestBedrockProvider_Embed_CohereV4MapsTypedFloatResponse(t *testing.T) {
 	}
 }
 
+func TestBedrockProvider_CompleteAnthropic_ForwardsToolsAndDecodesToolUse(t *testing.T) {
+	fake := &fakeBedrockRuntimeClient{
+		responses: [][]byte{
+			[]byte(`{
+				"id":"msg_1",
+				"type":"message",
+				"role":"assistant",
+				"content":[{"type":"tool_use","id":"toolu_1","name":"lookup","input":{"city":"SF"}}],
+				"stop_reason":"tool_use",
+				"usage":{"input_tokens":1,"output_tokens":1}
+			}`),
+		},
+	}
+	p := &Provider{name: Name, client: fake}
+
+	resp, err := p.Complete(context.Background(), core.Request{
+		Model:    "anthropic.claude-3-5-sonnet-20241022-v2:0",
+		Messages: []core.Message{{Role: core.RoleUser, Content: "weather?"}},
+		Tools: []core.Tool{{
+			Type: "function",
+			Function: core.Function{
+				Name:        "lookup",
+				Description: "Lookup weather",
+				Parameters:  json.RawMessage(`{"type":"object","properties":{"city":{"type":"string"}}}`),
+			},
+		}},
+		ToolChoice: "required",
+	})
+	if err != nil {
+		t.Fatalf("Complete() error: %v", err)
+	}
+	var body bedrockAnthropicRequest
+	mustUnmarshalBody(t, fake.invokeCalls[0].Body, &body)
+	if len(body.Tools) != 1 || body.Tools[0].Name != "lookup" {
+		t.Fatalf("tools = %#v, want lookup", body.Tools)
+	}
+	choice, ok := body.ToolChoice.(map[string]interface{})
+	if !ok || choice["type"] != "any" {
+		t.Fatalf("tool_choice = %#v, want type any", body.ToolChoice)
+	}
+	if len(resp.Choices) != 1 || len(resp.Choices[0].Message.ToolCalls) != 1 {
+		t.Fatalf("tool calls = %#v, want one", resp.Choices)
+	}
+	tc := resp.Choices[0].Message.ToolCalls[0]
+	if tc.ID != "toolu_1" || tc.Function.Name != "lookup" || tc.Function.Arguments != `{"city":"SF"}` {
+		t.Fatalf("tool call = %#v, want lookup", tc)
+	}
+}
+
 func TestBedrockProvider_Embed_Validation(t *testing.T) {
 	cases := []struct {
 		name string

--- a/providers/bedrock/bedrock_test.go
+++ b/providers/bedrock/bedrock_test.go
@@ -4,11 +4,14 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"reflect"
 	"strings"
 	"testing"
+	"unsafe"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime"
+	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime/types"
 
 	"github.com/ferro-labs/ai-gateway/providers/core"
 )
@@ -275,6 +278,111 @@ func TestBedrockProvider_CompleteAnthropic_ForwardsToolsAndDecodesToolUse(t *tes
 	}
 }
 
+func TestBedrockProvider_CompleteAnthropic_ForwardsToolResultAndDecodesFinalAnswer(t *testing.T) {
+	fake := &fakeBedrockRuntimeClient{
+		responses: [][]byte{
+			[]byte(`{
+				"id":"msg_2",
+				"type":"message",
+				"role":"assistant",
+				"content":[{"type":"text","text":"It is 72F in SF."}],
+				"stop_reason":"end_turn",
+				"usage":{"input_tokens":2,"output_tokens":3}
+			}`),
+		},
+	}
+	p := &Provider{name: Name, client: fake}
+
+	resp, err := p.Complete(context.Background(), core.Request{
+		Model: "anthropic.claude-3-5-sonnet-20241022-v2:0",
+		Messages: []core.Message{
+			{Role: core.RoleUser, Content: "weather?"},
+			{Role: core.RoleAssistant, ToolCalls: []core.ToolCall{{
+				ID:       "toolu_1",
+				Type:     "function",
+				Function: core.FunctionCall{Name: "lookup", Arguments: `{"city":"SF"}`},
+			}}},
+			{Role: core.RoleTool, ToolCallID: "toolu_1", Content: `{"temp":"72F"}`},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Complete() error: %v", err)
+	}
+
+	var body struct {
+		Messages []struct {
+			Role    string          `json:"role"`
+			Content json.RawMessage `json:"content"`
+		} `json:"messages"`
+	}
+	mustUnmarshalBody(t, fake.invokeCalls[0].Body, &body)
+	if len(body.Messages) != 3 {
+		t.Fatalf("messages len = %d, want 3", len(body.Messages))
+	}
+	var resultBlocks []map[string]json.RawMessage
+	if err := json.Unmarshal(body.Messages[2].Content, &resultBlocks); err != nil {
+		t.Fatalf("decode tool result blocks: %v", err)
+	}
+	if body.Messages[2].Role != core.RoleUser || jsonString(resultBlocks[0]["type"]) != "tool_result" || jsonString(resultBlocks[0]["tool_use_id"]) != "toolu_1" {
+		t.Fatalf("tool result message = %#v blocks=%#v", body.Messages[2], resultBlocks)
+	}
+	if got := resp.Choices[0].Message.Content; got != "It is 72F in SF." {
+		t.Fatalf("final answer = %q, want weather answer", got)
+	}
+	if len(resp.Choices[0].Message.ToolCalls) != 0 {
+		t.Fatalf("final answer tool calls = %#v, want none", resp.Choices[0].Message.ToolCalls)
+	}
+}
+
+func TestBedrockProvider_CompleteStreamAnthropic_ForwardsToolUseDeltas(t *testing.T) {
+	fake := &fakeBedrockRuntimeClient{
+		streamResponses: [][]byte{
+			[]byte(`{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_1","name":"lookup","input":{}}}`),
+			[]byte(`{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"city\""}}`),
+			[]byte(`{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":":\"SF\"}"}}`),
+			[]byte(`{"type":"message_delta","delta":{"stop_reason":"tool_use"}}`),
+		},
+	}
+	p := &Provider{name: Name, client: fake}
+
+	ch, err := p.CompleteStream(context.Background(), core.Request{
+		Model:    "anthropic.claude-3-5-sonnet-20241022-v2:0",
+		Messages: []core.Message{{Role: core.RoleUser, Content: "weather?"}},
+		Tools: []core.Tool{{
+			Type: "function",
+			Function: core.Function{
+				Name: "lookup",
+			},
+		}},
+		ToolChoice: "required",
+	})
+	if err != nil {
+		t.Fatalf("CompleteStream() error: %v", err)
+	}
+
+	var chunks []core.StreamChunk
+	for c := range ch {
+		chunks = append(chunks, c)
+	}
+
+	if len(chunks) != 4 {
+		t.Fatalf("chunks len = %d, want 4: %#v", len(chunks), chunks)
+	}
+	start := chunks[0].Choices[0].Delta.ToolCalls[0]
+	if start.Index == nil || *start.Index != 0 || start.ID != "toolu_1" || start.Function.Name != "lookup" {
+		t.Fatalf("start tool call = %#v, want lookup at index 0", start)
+	}
+	if chunks[1].Choices[0].Delta.ToolCalls[0].Function.Arguments != `{"city"` {
+		t.Fatalf("first args delta = %#v", chunks[1].Choices[0].Delta.ToolCalls)
+	}
+	if chunks[2].Choices[0].Delta.ToolCalls[0].Function.Arguments != `:"SF"}` {
+		t.Fatalf("second args delta = %#v", chunks[2].Choices[0].Delta.ToolCalls)
+	}
+	if chunks[3].Choices[0].FinishReason != core.FinishReasonToolCalls {
+		t.Fatalf("finish_reason = %q, want %q", chunks[3].Choices[0].FinishReason, core.FinishReasonToolCalls)
+	}
+}
+
 func TestBedrockProvider_Embed_Validation(t *testing.T) {
 	cases := []struct {
 		name string
@@ -334,9 +442,11 @@ func TestBedrockProvider_Embed_Validation(t *testing.T) {
 }
 
 type fakeBedrockRuntimeClient struct {
-	invokeCalls []*bedrockruntime.InvokeModelInput
-	responses   [][]byte
-	err         error
+	invokeCalls       []*bedrockruntime.InvokeModelInput
+	invokeStreamCalls []*bedrockruntime.InvokeModelWithResponseStreamInput
+	responses         [][]byte
+	streamResponses   [][]byte
+	err               error
 }
 
 func (f *fakeBedrockRuntimeClient) InvokeModel(_ context.Context, input *bedrockruntime.InvokeModelInput, _ ...func(*bedrockruntime.Options)) (*bedrockruntime.InvokeModelOutput, error) {
@@ -353,8 +463,44 @@ func (f *fakeBedrockRuntimeClient) InvokeModel(_ context.Context, input *bedrock
 	return &bedrockruntime.InvokeModelOutput{Body: f.responses[idx]}, nil
 }
 
-func (f *fakeBedrockRuntimeClient) InvokeModelWithResponseStream(context.Context, *bedrockruntime.InvokeModelWithResponseStreamInput, ...func(*bedrockruntime.Options)) (*bedrockruntime.InvokeModelWithResponseStreamOutput, error) {
-	return nil, fmt.Errorf("streaming not implemented in fake")
+func (f *fakeBedrockRuntimeClient) InvokeModelWithResponseStream(_ context.Context, input *bedrockruntime.InvokeModelWithResponseStreamInput, _ ...func(*bedrockruntime.Options)) (*bedrockruntime.InvokeModelWithResponseStreamOutput, error) {
+	copied := *input
+	copied.Body = append([]byte(nil), input.Body...)
+	f.invokeStreamCalls = append(f.invokeStreamCalls, &copied)
+	if f.err != nil {
+		return nil, f.err
+	}
+	events := make(chan types.ResponseStream, len(f.streamResponses))
+	for _, body := range f.streamResponses {
+		events <- &types.ResponseStreamMemberChunk{Value: types.PayloadPart{Bytes: body}}
+	}
+	close(events)
+	output := &bedrockruntime.InvokeModelWithResponseStreamOutput{}
+	setFakeBedrockEventStream(output, bedrockruntime.NewInvokeModelWithResponseStreamEventStream(func(es *bedrockruntime.InvokeModelWithResponseStreamEventStream) {
+		es.Reader = fakeBedrockResponseStreamReader{events: events}
+	}))
+	return output, nil
+}
+
+func setFakeBedrockEventStream(output *bedrockruntime.InvokeModelWithResponseStreamOutput, stream *bedrockruntime.InvokeModelWithResponseStreamEventStream) {
+	field := reflect.ValueOf(output).Elem().FieldByName("eventStream")
+	reflect.NewAt(field.Type(), unsafe.Pointer(field.UnsafeAddr())).Elem().Set(reflect.ValueOf(stream))
+}
+
+type fakeBedrockResponseStreamReader struct {
+	events <-chan types.ResponseStream
+}
+
+func (f fakeBedrockResponseStreamReader) Events() <-chan types.ResponseStream {
+	return f.events
+}
+
+func (f fakeBedrockResponseStreamReader) Close() error {
+	return nil
+}
+
+func (f fakeBedrockResponseStreamReader) Err() error {
+	return nil
 }
 
 func mustUnmarshalBody(t *testing.T, body []byte, out interface{}) {
@@ -374,3 +520,9 @@ func containsString(values []string, target string) bool {
 }
 
 func intPtr(v int) *int { return &v }
+
+func jsonString(raw json.RawMessage) string {
+	var s string
+	_ = json.Unmarshal(raw, &s)
+	return s
+}

--- a/providers/cerebras/cerebras.go
+++ b/providers/cerebras/cerebras.go
@@ -104,19 +104,6 @@ type errorResponse struct {
 	Error errorDetail `json:"error"`
 }
 
-type streamResponse struct {
-	ID      string `json:"id"`
-	Model   string `json:"model"`
-	Choices []struct {
-		Index int `json:"index"`
-		Delta struct {
-			Role    string `json:"role,omitempty"`
-			Content string `json:"content,omitempty"`
-		} `json:"delta"`
-		FinishReason string `json:"finish_reason,omitempty"`
-	} `json:"choices"`
-}
-
 // Complete sends a chat completion request to Cerebras.
 func (p *Provider) Complete(ctx context.Context, req core.Request) (*core.Response, error) {
 	bodyReader, _, release, err := openaicompat.BuildBody(req, false)
@@ -211,29 +198,13 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 				return
 			}
 
-			var sr streamResponse
-			if err := json.Unmarshal([]byte(data), &sr); err != nil {
-				ch <- core.StreamChunk{Error: fmt.Errorf("failed to unmarshal stream chunk: %w", err)}
+			chunk, err := openaicompat.DecodeStreamChunk([]byte(data))
+			if err != nil {
+				ch <- core.StreamChunk{Error: err}
 				return
 			}
 
-			choices := make([]core.StreamChoice, len(sr.Choices))
-			for i, c := range sr.Choices {
-				choices[i] = core.StreamChoice{
-					Index:        c.Index,
-					FinishReason: c.FinishReason,
-					Delta: core.MessageDelta{
-						Role:    c.Delta.Role,
-						Content: c.Delta.Content,
-					},
-				}
-			}
-
-			ch <- core.StreamChunk{
-				ID:      sr.ID,
-				Model:   sr.Model,
-				Choices: choices,
-			}
+			ch <- chunk
 		}
 		if err := scanner.Err(); err != nil {
 			ch <- core.StreamChunk{Error: fmt.Errorf("stream read error: %w", err)}

--- a/providers/cloudflare/cloudflare.go
+++ b/providers/cloudflare/cloudflare.go
@@ -102,19 +102,6 @@ type errorResponse struct {
 	Error errorDetail `json:"error"`
 }
 
-type streamResponse struct {
-	ID      string `json:"id"`
-	Model   string `json:"model"`
-	Choices []struct {
-		Index int `json:"index"`
-		Delta struct {
-			Role    string `json:"role,omitempty"`
-			Content string `json:"content,omitempty"`
-		} `json:"delta"`
-		FinishReason string `json:"finish_reason,omitempty"`
-	} `json:"choices"`
-}
-
 // Complete sends a chat completion request to Cloudflare Workers AI.
 func (p *Provider) Complete(ctx context.Context, req core.Request) (*core.Response, error) {
 	bodyReader, _, release, err := openaicompat.BuildBody(req, false)
@@ -209,29 +196,13 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 				return
 			}
 
-			var sr streamResponse
-			if err := json.Unmarshal([]byte(data), &sr); err != nil {
-				ch <- core.StreamChunk{Error: fmt.Errorf("failed to unmarshal stream chunk: %w", err)}
+			chunk, err := openaicompat.DecodeStreamChunk([]byte(data))
+			if err != nil {
+				ch <- core.StreamChunk{Error: err}
 				return
 			}
 
-			choices := make([]core.StreamChoice, len(sr.Choices))
-			for i, c := range sr.Choices {
-				choices[i] = core.StreamChoice{
-					Index:        c.Index,
-					FinishReason: c.FinishReason,
-					Delta: core.MessageDelta{
-						Role:    c.Delta.Role,
-						Content: c.Delta.Content,
-					},
-				}
-			}
-
-			ch <- core.StreamChunk{
-				ID:      sr.ID,
-				Model:   sr.Model,
-				Choices: choices,
-			}
+			ch <- chunk
 		}
 		if err := scanner.Err(); err != nil {
 			ch <- core.StreamChunk{Error: fmt.Errorf("stream read error: %w", err)}

--- a/providers/cohere/cohere.go
+++ b/providers/cohere/cohere.go
@@ -94,6 +94,8 @@ func (p *Provider) Models() []core.ModelInfo {
 type cohereRequest struct {
 	Model            string         `json:"model"`
 	Messages         []core.Message `json:"messages"`
+	Tools            []core.Tool    `json:"tools,omitempty"`
+	ToolChoice       string         `json:"tool_choice,omitempty"`
 	Temperature      *float64       `json:"temperature,omitempty"`
 	MaxTokens        *int           `json:"max_tokens,omitempty"`
 	P                *float64       `json:"p,omitempty"`
@@ -109,7 +111,7 @@ type cohereRequest struct {
 // tool calling is tracked separately in #139.
 var cohereSupportedParams = []string{
 	"temperature", "top_p", "max_tokens", "stop",
-	"seed", "presence_penalty", "frequency_penalty",
+	"seed", "presence_penalty", "frequency_penalty", "tools", "tool_choice",
 }
 
 type cohereContentBlock struct {
@@ -118,8 +120,9 @@ type cohereContentBlock struct {
 }
 
 type cohereMessage struct {
-	Role    string               `json:"role"`
-	Content []cohereContentBlock `json:"content"`
+	Role      string               `json:"role"`
+	Content   []cohereContentBlock `json:"content"`
+	ToolCalls []core.ToolCall      `json:"tool_calls,omitempty"`
 }
 
 type cohereBilledUnits struct {
@@ -148,6 +151,24 @@ type cohereErrorResponse struct {
 	Message string `json:"message"`
 }
 
+func cohereToolChoice(choice interface{}) string {
+	switch v := choice.(type) {
+	case nil:
+		return ""
+	case string:
+		switch v {
+		case "required":
+			return "REQUIRED"
+		case "none":
+			return "NONE"
+		default:
+			return ""
+		}
+	default:
+		return "REQUIRED"
+	}
+}
+
 // Complete sends a chat completion request to Cohere.
 func (p *Provider) Complete(ctx context.Context, req core.Request) (*core.Response, error) {
 	core.WarnUnsupportedParams(ctx, p.Name(), req.Model, req, cohereSupportedParams...)
@@ -155,6 +176,8 @@ func (p *Provider) Complete(ctx context.Context, req core.Request) (*core.Respon
 	cohReq := cohereRequest{
 		Model:            req.Model,
 		Messages:         req.Messages,
+		Tools:            req.Tools,
+		ToolChoice:       cohereToolChoice(req.ToolChoice),
 		Temperature:      req.Temperature,
 		MaxTokens:        req.MaxTokens,
 		P:                req.TopP,
@@ -216,8 +239,9 @@ func (p *Provider) Complete(ctx context.Context, req core.Request) (*core.Respon
 			{
 				Index: 0,
 				Message: core.Message{
-					Role:    cohResp.Message.Role,
-					Content: strings.Join(contentParts, ""),
+					Role:      cohResp.Message.Role,
+					Content:   strings.Join(contentParts, ""),
+					ToolCalls: cohResp.Message.ToolCalls,
 				},
 				FinishReason: core.NormalizeFinishReason(cohResp.FinishReason),
 			},
@@ -255,6 +279,8 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 	cohReq := cohereRequest{
 		Model:            req.Model,
 		Messages:         req.Messages,
+		Tools:            req.Tools,
+		ToolChoice:       cohereToolChoice(req.ToolChoice),
 		Temperature:      req.Temperature,
 		MaxTokens:        req.MaxTokens,
 		P:                req.TopP,

--- a/providers/cohere/cohere.go
+++ b/providers/cohere/cohere.go
@@ -428,7 +428,7 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 					ID: event.ID,
 					Choices: []core.StreamChoice{
 						{
-							Index: event.Index,
+							Index: 0,
 							Delta: core.MessageDelta{
 								ToolCalls: []core.ToolCall{tc},
 							},
@@ -448,7 +448,7 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 					ID: event.ID,
 					Choices: []core.StreamChoice{
 						{
-							Index: event.Index,
+							Index: 0,
 							Delta: core.MessageDelta{
 								ToolCalls: []core.ToolCall{tc},
 							},

--- a/providers/cohere/cohere.go
+++ b/providers/cohere/cohere.go
@@ -92,18 +92,18 @@ func (p *Provider) Models() []core.ModelInfo {
 }
 
 type cohereRequest struct {
-	Model            string         `json:"model"`
-	Messages         []core.Message `json:"messages"`
-	Tools            []core.Tool    `json:"tools,omitempty"`
-	ToolChoice       string         `json:"tool_choice,omitempty"`
-	Temperature      *float64       `json:"temperature,omitempty"`
-	MaxTokens        *int           `json:"max_tokens,omitempty"`
-	P                *float64       `json:"p,omitempty"`
-	Seed             *int64         `json:"seed,omitempty"`
-	PresencePenalty  *float64       `json:"presence_penalty,omitempty"`
-	FrequencyPenalty *float64       `json:"frequency_penalty,omitempty"`
-	StopSequences    []string       `json:"stop_sequences,omitempty"`
-	Stream           bool           `json:"stream,omitempty"`
+	Model            string                 `json:"model"`
+	Messages         []cohereRequestMessage `json:"messages"`
+	Tools            []core.Tool            `json:"tools,omitempty"`
+	ToolChoice       string                 `json:"tool_choice,omitempty"`
+	Temperature      *float64               `json:"temperature,omitempty"`
+	MaxTokens        *int                   `json:"max_tokens,omitempty"`
+	P                *float64               `json:"p,omitempty"`
+	Seed             *int64                 `json:"seed,omitempty"`
+	PresencePenalty  *float64               `json:"presence_penalty,omitempty"`
+	FrequencyPenalty *float64               `json:"frequency_penalty,omitempty"`
+	StopSequences    []string               `json:"stop_sequences,omitempty"`
+	Stream           bool                   `json:"stream,omitempty"`
 }
 
 // cohereSupportedParams lists the OpenAI parameters mappable onto the Cohere v2
@@ -112,6 +112,22 @@ type cohereRequest struct {
 var cohereSupportedParams = []string{
 	"temperature", "top_p", "max_tokens", "stop",
 	"seed", "presence_penalty", "frequency_penalty", "tools", "tool_choice",
+}
+
+type cohereRequestMessage struct {
+	Role       string          `json:"role"`
+	Content    any             `json:"content,omitempty"`
+	ToolCalls  []core.ToolCall `json:"tool_calls,omitempty"`
+	ToolCallID string          `json:"tool_call_id,omitempty"`
+}
+
+type cohereToolResultBlock struct {
+	Type     string                   `json:"type"`
+	Document cohereToolResultDocument `json:"document"`
+}
+
+type cohereToolResultDocument struct {
+	Data string `json:"data"`
 }
 
 type cohereContentBlock struct {
@@ -169,13 +185,36 @@ func cohereToolChoice(choice interface{}) string {
 	}
 }
 
+func cohereMessages(messages []core.Message) []cohereRequestMessage {
+	out := make([]cohereRequestMessage, 0, len(messages))
+	for _, msg := range messages {
+		cohMsg := cohereRequestMessage{
+			Role:       msg.Role,
+			ToolCalls:  msg.ToolCalls,
+			ToolCallID: msg.ToolCallID,
+		}
+		if msg.Role == core.RoleTool {
+			cohMsg.Content = []cohereToolResultBlock{{
+				Type: "document",
+				Document: cohereToolResultDocument{
+					Data: msg.Content,
+				},
+			}}
+		} else {
+			cohMsg.Content = msg.Content
+		}
+		out = append(out, cohMsg)
+	}
+	return out
+}
+
 // Complete sends a chat completion request to Cohere.
 func (p *Provider) Complete(ctx context.Context, req core.Request) (*core.Response, error) {
 	core.WarnUnsupportedParams(ctx, p.Name(), req.Model, req, cohereSupportedParams...)
 
 	cohReq := cohereRequest{
 		Model:            req.Model,
-		Messages:         req.Messages,
+		Messages:         cohereMessages(req.Messages),
 		Tools:            req.Tools,
 		ToolChoice:       cohereToolChoice(req.ToolChoice),
 		Temperature:      req.Temperature,
@@ -340,7 +379,7 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 
 	cohReq := cohereRequest{
 		Model:            req.Model,
-		Messages:         req.Messages,
+		Messages:         cohereMessages(req.Messages),
 		Tools:            req.Tools,
 		ToolChoice:       cohereToolChoice(req.ToolChoice),
 		Temperature:      req.Temperature,

--- a/providers/cohere/cohere.go
+++ b/providers/cohere/cohere.go
@@ -256,6 +256,8 @@ func (p *Provider) Complete(ctx context.Context, req core.Request) (*core.Respon
 
 type cohereStreamEvent struct {
 	Type  string          `json:"type"`
+	ID    string          `json:"id,omitempty"`
+	Index int             `json:"index,omitempty"`
 	Delta json.RawMessage `json:"delta"`
 }
 
@@ -270,6 +272,66 @@ type cohereContentDelta struct {
 type cohereMessageEndDelta struct {
 	FinishReason string      `json:"finish_reason"`
 	Usage        cohereUsage `json:"usage"`
+}
+
+type cohereToolCallStartDelta struct {
+	Message struct {
+		ToolCalls json.RawMessage `json:"tool_calls"`
+	} `json:"message"`
+}
+
+type cohereToolCallDelta struct {
+	Message struct {
+		ToolCalls json.RawMessage `json:"tool_calls"`
+	} `json:"message"`
+}
+
+type cohereToolCallDeltaPayload struct {
+	Function struct {
+		Arguments string `json:"arguments"`
+	} `json:"function"`
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func cohereStreamToolCallStart(raw json.RawMessage, index int) (core.ToolCall, bool) {
+	var calls []core.ToolCall
+	if err := json.Unmarshal(raw, &calls); err == nil && len(calls) > 0 {
+		calls[0].Index = intPtr(index)
+		return calls[0], true
+	}
+	var call core.ToolCall
+	if err := json.Unmarshal(raw, &call); err == nil && (call.ID != "" || call.Function.Name != "") {
+		call.Index = intPtr(index)
+		return call, true
+	}
+	return core.ToolCall{}, false
+}
+
+func cohereStreamToolCallDelta(raw json.RawMessage, index int) (core.ToolCall, bool) {
+	var payload cohereToolCallDeltaPayload
+	if err := json.Unmarshal(raw, &payload); err == nil && payload.Function.Arguments != "" {
+		return core.ToolCall{
+			Index: intPtr(index),
+			Type:  "function",
+			Function: core.FunctionCall{
+				Arguments: payload.Function.Arguments,
+			},
+		}, true
+	}
+	var payloads []cohereToolCallDeltaPayload
+	if err := json.Unmarshal(raw, &payloads); err == nil && len(payloads) > 0 && payloads[0].Function.Arguments != "" {
+		return core.ToolCall{
+			Index: intPtr(index),
+			Type:  "function",
+			Function: core.FunctionCall{
+				Arguments: payloads[0].Function.Arguments,
+			},
+		}, true
+	}
+	return core.ToolCall{}, false
 }
 
 // CompleteStream sends a streaming chat completion request to Cohere.
@@ -349,6 +411,46 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 							Index: 0,
 							Delta: core.MessageDelta{
 								Content: delta.Message.Content.Text,
+							},
+						},
+					},
+				}
+			case "tool-call-start":
+				var delta cohereToolCallStartDelta
+				if json.Unmarshal(event.Delta, &delta) != nil {
+					continue
+				}
+				tc, ok := cohereStreamToolCallStart(delta.Message.ToolCalls, event.Index)
+				if !ok {
+					continue
+				}
+				ch <- core.StreamChunk{
+					ID: event.ID,
+					Choices: []core.StreamChoice{
+						{
+							Index: event.Index,
+							Delta: core.MessageDelta{
+								ToolCalls: []core.ToolCall{tc},
+							},
+						},
+					},
+				}
+			case "tool-call-delta":
+				var delta cohereToolCallDelta
+				if json.Unmarshal(event.Delta, &delta) != nil {
+					continue
+				}
+				tc, ok := cohereStreamToolCallDelta(delta.Message.ToolCalls, event.Index)
+				if !ok {
+					continue
+				}
+				ch <- core.StreamChunk{
+					ID: event.ID,
+					Choices: []core.StreamChoice{
+						{
+							Index: event.Index,
+							Delta: core.MessageDelta{
+								ToolCalls: []core.ToolCall{tc},
 							},
 						},
 					},

--- a/providers/cohere/cohere_test.go
+++ b/providers/cohere/cohere_test.go
@@ -128,6 +128,12 @@ data: {"type":"tool-call-delta","index":0,"delta":{"message":{"tool_calls":{"fun
 
 data: {"type":"tool-call-end","index":0}
 
+data: {"type":"tool-call-start","index":1,"delta":{"message":{"tool_calls":[{"id":"call_2","type":"function","function":{"name":"lookup_time","arguments":""}}]}}}
+
+data: {"type":"tool-call-delta","index":1,"delta":{"message":{"tool_calls":{"function":{"arguments":"{\"city\""}}}}}
+
+data: {"type":"tool-call-end","index":1}
+
 data: {"type":"message-end","delta":{"finish_reason":"TOOL_CALL","usage":{"tokens":{"input_tokens":5,"output_tokens":2}}}}
 
 `
@@ -160,21 +166,44 @@ data: {"type":"message-end","delta":{"finish_reason":"TOOL_CALL","usage":{"token
 		chunks = append(chunks, c)
 	}
 
-	if len(chunks) != 4 {
-		t.Fatalf("chunks len = %d, want 4: %#v", len(chunks), chunks)
+	if len(chunks) != 6 {
+		t.Fatalf("chunks len = %d, want 6: %#v", len(chunks), chunks)
 	}
 	start := chunks[0].Choices[0].Delta.ToolCalls[0]
+	if chunks[0].Choices[0].Index != 0 {
+		t.Fatalf("choice index = %d, want sole completion index 0", chunks[0].Choices[0].Index)
+	}
 	if start.Index == nil || *start.Index != 0 || start.ID != "call_1" || start.Function.Name != "lookup" {
 		t.Fatalf("start tool call = %#v, want lookup call at index 0", start)
+	}
+	if chunks[1].Choices[0].Index != 0 {
+		t.Fatalf("args choice index = %d, want sole completion index 0", chunks[1].Choices[0].Index)
 	}
 	if chunks[1].Choices[0].Delta.ToolCalls[0].Function.Arguments != `{"city"` {
 		t.Fatalf("first args delta = %#v", chunks[1].Choices[0].Delta.ToolCalls)
 	}
+	if chunks[2].Choices[0].Index != 0 {
+		t.Fatalf("second args choice index = %d, want sole completion index 0", chunks[2].Choices[0].Index)
+	}
 	if chunks[2].Choices[0].Delta.ToolCalls[0].Function.Arguments != `:"SF"}` {
 		t.Fatalf("second args delta = %#v", chunks[2].Choices[0].Delta.ToolCalls)
 	}
-	if chunks[3].Choices[0].FinishReason != core.FinishReasonToolCalls {
-		t.Fatalf("finish_reason = %q, want %q", chunks[3].Choices[0].FinishReason, core.FinishReasonToolCalls)
+	secondStart := chunks[3].Choices[0].Delta.ToolCalls[0]
+	if chunks[3].Choices[0].Index != 0 {
+		t.Fatalf("second tool choice index = %d, want sole completion index 0", chunks[3].Choices[0].Index)
+	}
+	if secondStart.Index == nil || *secondStart.Index != 1 || secondStart.ID != "call_2" || secondStart.Function.Name != "lookup_time" {
+		t.Fatalf("second start tool call = %#v, want lookup_time call at index 1", secondStart)
+	}
+	secondArgs := chunks[4].Choices[0].Delta.ToolCalls[0]
+	if chunks[4].Choices[0].Index != 0 {
+		t.Fatalf("second tool args choice index = %d, want sole completion index 0", chunks[4].Choices[0].Index)
+	}
+	if secondArgs.Index == nil || *secondArgs.Index != 1 || secondArgs.Function.Arguments != `{"city"` {
+		t.Fatalf("second tool args delta = %#v, want index 1 city fragment", secondArgs)
+	}
+	if chunks[5].Choices[0].FinishReason != core.FinishReasonToolCalls {
+		t.Fatalf("finish_reason = %q, want %q", chunks[5].Choices[0].FinishReason, core.FinishReasonToolCalls)
 	}
 }
 

--- a/providers/cohere/cohere_test.go
+++ b/providers/cohere/cohere_test.go
@@ -117,6 +117,61 @@ func TestCohereProvider_CompleteStream_MockSSE(t *testing.T) {
 	}
 }
 
+func TestCohereProvider_Complete_ForwardsToolsAndDecodesToolCalls(t *testing.T) {
+	var captured cohereRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{
+			"id":"chat-1",
+			"finish_reason":"TOOL_CALL",
+			"message":{
+				"role":"assistant",
+				"content":[],
+				"tool_calls":[{"id":"call_1","type":"function","function":{"name":"lookup","arguments":"{\"city\":\"SF\"}"}}]
+			},
+			"usage":{"tokens":{"input_tokens":1,"output_tokens":1}}
+		}`)
+	}))
+	defer srv.Close()
+
+	p, _ := New("test-key", srv.URL)
+	resp, err := p.Complete(context.Background(), core.Request{
+		Model:    "command-r-plus",
+		Messages: []core.Message{{Role: core.RoleUser, Content: "weather?"}},
+		Tools: []core.Tool{{
+			Type: "function",
+			Function: core.Function{
+				Name:        "lookup",
+				Description: "Lookup weather",
+				Parameters:  json.RawMessage(`{"type":"object","properties":{"city":{"type":"string"}}}`),
+			},
+		}},
+		ToolChoice: "required",
+	})
+	if err != nil {
+		t.Fatalf("Complete() error: %v", err)
+	}
+	if len(captured.Tools) != 1 || captured.Tools[0].Function.Name != "lookup" {
+		t.Fatalf("tools = %#v, want lookup", captured.Tools)
+	}
+	if captured.ToolChoice != "REQUIRED" {
+		t.Fatalf("tool_choice = %q, want REQUIRED", captured.ToolChoice)
+	}
+	if len(resp.Choices) != 1 || len(resp.Choices[0].Message.ToolCalls) != 1 {
+		t.Fatalf("tool calls = %#v, want one", resp.Choices)
+	}
+	tc := resp.Choices[0].Message.ToolCalls[0]
+	if tc.ID != "call_1" || tc.Function.Name != "lookup" || tc.Function.Arguments != `{"city":"SF"}` {
+		t.Fatalf("tool call = %#v, want lookup", tc)
+	}
+	if resp.Choices[0].FinishReason != core.FinishReasonToolCalls {
+		t.Fatalf("finish reason = %q, want tool_calls", resp.Choices[0].FinishReason)
+	}
+}
+
 func TestCohereProvider_Embed_StringInput_MockHTTP(t *testing.T) {
 	const apiKey = "test-key"
 	seenRequest := false

--- a/providers/cohere/cohere_test.go
+++ b/providers/cohere/cohere_test.go
@@ -117,6 +117,67 @@ func TestCohereProvider_CompleteStream_MockSSE(t *testing.T) {
 	}
 }
 
+func TestCohereProvider_CompleteStream_ForwardsToolCallDeltas(t *testing.T) {
+	sseData := `data: {"type":"message-start","id":"chat-1","delta":{"message":{"role":"assistant"}}}
+
+data: {"type":"tool-call-start","index":0,"delta":{"message":{"tool_calls":[{"id":"call_1","type":"function","function":{"name":"lookup","arguments":""}}]}}}
+
+data: {"type":"tool-call-delta","index":0,"delta":{"message":{"tool_calls":{"function":{"arguments":"{\"city\""}}}}}
+
+data: {"type":"tool-call-delta","index":0,"delta":{"message":{"tool_calls":{"function":{"arguments":":\"SF\"}"}}}}}
+
+data: {"type":"tool-call-end","index":0}
+
+data: {"type":"message-end","delta":{"finish_reason":"TOOL_CALL","usage":{"tokens":{"input_tokens":5,"output_tokens":2}}}}
+
+`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(sseData))
+	}))
+	defer srv.Close()
+
+	p, _ := New("test-key", srv.URL)
+	ch, err := p.CompleteStream(context.Background(), core.Request{
+		Model:    "command-r-plus",
+		Messages: []core.Message{{Role: core.RoleUser, Content: "weather?"}},
+		Tools: []core.Tool{{
+			Type: "function",
+			Function: core.Function{
+				Name:       "lookup",
+				Parameters: json.RawMessage(`{"type":"object","properties":{"city":{"type":"string"}}}`),
+			},
+		}},
+		ToolChoice: "required",
+	})
+	if err != nil {
+		t.Fatalf("CompleteStream() error: %v", err)
+	}
+
+	var chunks []core.StreamChunk
+	for c := range ch {
+		chunks = append(chunks, c)
+	}
+
+	if len(chunks) != 4 {
+		t.Fatalf("chunks len = %d, want 4: %#v", len(chunks), chunks)
+	}
+	start := chunks[0].Choices[0].Delta.ToolCalls[0]
+	if start.Index == nil || *start.Index != 0 || start.ID != "call_1" || start.Function.Name != "lookup" {
+		t.Fatalf("start tool call = %#v, want lookup call at index 0", start)
+	}
+	if chunks[1].Choices[0].Delta.ToolCalls[0].Function.Arguments != `{"city"` {
+		t.Fatalf("first args delta = %#v", chunks[1].Choices[0].Delta.ToolCalls)
+	}
+	if chunks[2].Choices[0].Delta.ToolCalls[0].Function.Arguments != `:"SF"}` {
+		t.Fatalf("second args delta = %#v", chunks[2].Choices[0].Delta.ToolCalls)
+	}
+	if chunks[3].Choices[0].FinishReason != core.FinishReasonToolCalls {
+		t.Fatalf("finish_reason = %q, want %q", chunks[3].Choices[0].FinishReason, core.FinishReasonToolCalls)
+	}
+}
+
 func TestCohereProvider_Complete_ForwardsToolsAndDecodesToolCalls(t *testing.T) {
 	var captured cohereRequest
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -169,6 +230,59 @@ func TestCohereProvider_Complete_ForwardsToolsAndDecodesToolCalls(t *testing.T) 
 	}
 	if resp.Choices[0].FinishReason != core.FinishReasonToolCalls {
 		t.Fatalf("finish reason = %q, want tool_calls", resp.Choices[0].FinishReason)
+	}
+}
+
+func TestCohereProvider_Complete_ForwardsToolResultAndDecodesFinalAnswer(t *testing.T) {
+	var captured cohereRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{
+			"id":"chat-2",
+			"finish_reason":"COMPLETE",
+			"message":{
+				"role":"assistant",
+				"content":[{"type":"text","text":"It is 72F in SF."}]
+			},
+			"usage":{"tokens":{"input_tokens":2,"output_tokens":3}}
+		}`)
+	}))
+	defer srv.Close()
+
+	p, _ := New("test-key", srv.URL)
+	resp, err := p.Complete(context.Background(), core.Request{
+		Model: "command-r-plus",
+		Messages: []core.Message{
+			{Role: core.RoleUser, Content: "weather?"},
+			{Role: core.RoleAssistant, ToolCalls: []core.ToolCall{{
+				ID:       "call_1",
+				Type:     "function",
+				Function: core.FunctionCall{Name: "lookup", Arguments: `{"city":"SF"}`},
+			}}},
+			{Role: core.RoleTool, ToolCallID: "call_1", Content: `{"temp":"72F"}`},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Complete() error: %v", err)
+	}
+
+	if len(captured.Messages) != 3 {
+		t.Fatalf("messages len = %d, want 3", len(captured.Messages))
+	}
+	if len(captured.Messages[1].ToolCalls) != 1 || captured.Messages[1].ToolCalls[0].ID != "call_1" {
+		t.Fatalf("assistant tool calls = %#v, want call_1", captured.Messages[1].ToolCalls)
+	}
+	if captured.Messages[2].Role != core.RoleTool || captured.Messages[2].ToolCallID != "call_1" {
+		t.Fatalf("tool result message = %#v, want role tool with call_1", captured.Messages[2])
+	}
+	if got := resp.Choices[0].Message.Content; got != "It is 72F in SF." {
+		t.Fatalf("final answer = %q, want weather answer", got)
+	}
+	if len(resp.Choices[0].Message.ToolCalls) != 0 {
+		t.Fatalf("final answer tool calls = %#v, want none", resp.Choices[0].Message.ToolCalls)
 	}
 }
 

--- a/providers/cohere/cohere_test.go
+++ b/providers/cohere/cohere_test.go
@@ -263,7 +263,14 @@ func TestCohereProvider_Complete_ForwardsToolsAndDecodesToolCalls(t *testing.T) 
 }
 
 func TestCohereProvider_Complete_ForwardsToolResultAndDecodesFinalAnswer(t *testing.T) {
-	var captured cohereRequest
+	var captured struct {
+		Messages []struct {
+			Role       string          `json:"role"`
+			ToolCallID string          `json:"tool_call_id,omitempty"`
+			Content    json.RawMessage `json:"content,omitempty"`
+			ToolCalls  []core.ToolCall `json:"tool_calls,omitempty"`
+		} `json:"messages"`
+	}
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
 			t.Fatalf("decode request: %v", err)
@@ -306,6 +313,20 @@ func TestCohereProvider_Complete_ForwardsToolResultAndDecodesFinalAnswer(t *test
 	}
 	if captured.Messages[2].Role != core.RoleTool || captured.Messages[2].ToolCallID != "call_1" {
 		t.Fatalf("tool result message = %#v, want role tool with call_1", captured.Messages[2])
+	}
+	var toolContent []struct {
+		Type     string `json:"type"`
+		Document struct {
+			Data string `json:"data"`
+		} `json:"document"`
+	}
+	if err := json.Unmarshal(captured.Messages[2].Content, &toolContent); err != nil {
+		t.Fatalf("decode tool content: %v", err)
+	}
+	if len(toolContent) != 1 ||
+		toolContent[0].Type != "document" ||
+		toolContent[0].Document.Data != `{"temp":"72F"}` {
+		t.Fatalf("tool result content = %#v, want document block", toolContent)
 	}
 	if got := resp.Choices[0].Message.Content; got != "It is 72F in SF." {
 		t.Fatalf("final answer = %q, want weather answer", got)

--- a/providers/core/chat.go
+++ b/providers/core/chat.go
@@ -37,15 +37,15 @@ type Function struct {
 // ToolCall is a function invocation returned by the model in its response.
 type ToolCall struct {
 	Index    *int         `json:"index,omitempty"` // present on streaming deltas
-	ID       string       `json:"id"`
-	Type     string       `json:"type"` // "function"
+	ID       string       `json:"id,omitempty"`
+	Type     string       `json:"type,omitempty"` // "function"
 	Function FunctionCall `json:"function"`
 }
 
 // FunctionCall holds the name and arguments of a model-generated function call.
 type FunctionCall struct {
-	Name      string `json:"name"`
-	Arguments string `json:"arguments"` // JSON-encoded argument object
+	Name      string `json:"name,omitempty"`
+	Arguments string `json:"arguments,omitempty"` // JSON-encoded argument object
 }
 
 // ResponseFormat instructs the model how to format its output.

--- a/providers/core/chat.go
+++ b/providers/core/chat.go
@@ -36,6 +36,7 @@ type Function struct {
 
 // ToolCall is a function invocation returned by the model in its response.
 type ToolCall struct {
+	Index    *int         `json:"index,omitempty"` // present on streaming deltas
 	ID       string       `json:"id"`
 	Type     string       `json:"type"` // "function"
 	Function FunctionCall `json:"function"`

--- a/providers/core/chat_test.go
+++ b/providers/core/chat_test.go
@@ -1,0 +1,50 @@
+package core
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestStreamToolCallDeltaOmitsEmptyMetadata(t *testing.T) {
+	index := 0
+	chunk := StreamChunk{
+		Choices: []StreamChoice{{
+			Delta: MessageDelta{
+				ToolCalls: []ToolCall{{
+					Index: &index,
+					Function: FunctionCall{
+						Arguments: `{"city"`,
+					},
+				}},
+			},
+		}},
+	}
+
+	raw, err := json.Marshal(chunk)
+	if err != nil {
+		t.Fatalf("marshal stream chunk: %v", err)
+	}
+	var decoded struct {
+		Choices []struct {
+			Delta struct {
+				ToolCalls []json.RawMessage `json:"tool_calls"`
+			} `json:"delta"`
+		} `json:"choices"`
+	}
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatalf("unmarshal stream chunk: %v", err)
+	}
+	if len(decoded.Choices) != 1 || len(decoded.Choices[0].Delta.ToolCalls) != 1 {
+		t.Fatalf("tool call delta missing from %s", raw)
+	}
+	body := string(decoded.Choices[0].Delta.ToolCalls[0])
+	for _, emptyField := range []string{`"id":""`, `"type":""`, `"name":""`} {
+		if strings.Contains(body, emptyField) {
+			t.Fatalf("stream tool-call delta leaked empty metadata field %s in %s", emptyField, body)
+		}
+	}
+	if !strings.Contains(body, `"arguments":"{\"city\""`) {
+		t.Fatalf("stream tool-call delta dropped arguments: %s", body)
+	}
+}

--- a/providers/databricks/databricks.go
+++ b/providers/databricks/databricks.go
@@ -127,19 +127,6 @@ type errorResponse struct {
 	Error errorDetail `json:"error"`
 }
 
-type streamResponse struct {
-	ID      string `json:"id"`
-	Model   string `json:"model"`
-	Choices []struct {
-		Index int `json:"index"`
-		Delta struct {
-			Role    string `json:"role,omitempty"`
-			Content string `json:"content,omitempty"`
-		} `json:"delta"`
-		FinishReason string `json:"finish_reason,omitempty"`
-	} `json:"choices"`
-}
-
 // Complete sends a chat completion request to Databricks.
 func (p *Provider) Complete(ctx context.Context, req core.Request) (*core.Response, error) {
 	bodyReader, _, release, err := openaicompat.BuildBody(req, false)
@@ -336,29 +323,13 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 				return
 			}
 
-			var sr streamResponse
-			if err := json.Unmarshal([]byte(data), &sr); err != nil {
-				ch <- core.StreamChunk{Error: fmt.Errorf("failed to unmarshal stream chunk: %w", err)}
+			chunk, err := openaicompat.DecodeStreamChunk([]byte(data))
+			if err != nil {
+				ch <- core.StreamChunk{Error: err}
 				return
 			}
 
-			choices := make([]core.StreamChoice, len(sr.Choices))
-			for i, c := range sr.Choices {
-				choices[i] = core.StreamChoice{
-					Index:        c.Index,
-					FinishReason: c.FinishReason,
-					Delta: core.MessageDelta{
-						Role:    c.Delta.Role,
-						Content: c.Delta.Content,
-					},
-				}
-			}
-
-			ch <- core.StreamChunk{
-				ID:      sr.ID,
-				Model:   sr.Model,
-				Choices: choices,
-			}
+			ch <- chunk
 		}
 		if err := scanner.Err(); err != nil {
 			ch <- core.StreamChunk{Error: fmt.Errorf("stream read error: %w", err)}

--- a/providers/deepinfra/deepinfra.go
+++ b/providers/deepinfra/deepinfra.go
@@ -95,19 +95,6 @@ type errorResponse struct {
 	Error errorDetail `json:"error"`
 }
 
-type streamResponse struct {
-	ID      string `json:"id"`
-	Model   string `json:"model"`
-	Choices []struct {
-		Index int `json:"index"`
-		Delta struct {
-			Role    string `json:"role,omitempty"`
-			Content string `json:"content,omitempty"`
-		} `json:"delta"`
-		FinishReason string `json:"finish_reason,omitempty"`
-	} `json:"choices"`
-}
-
 // Complete sends a chat completion request to DeepInfra.
 func (p *Provider) Complete(ctx context.Context, req core.Request) (*core.Response, error) {
 	bodyReader, _, release, err := openaicompat.BuildBody(req, false)
@@ -202,29 +189,13 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 				return
 			}
 
-			var sr streamResponse
-			if err := json.Unmarshal([]byte(data), &sr); err != nil {
-				ch <- core.StreamChunk{Error: fmt.Errorf("failed to unmarshal stream chunk: %w", err)}
+			chunk, err := openaicompat.DecodeStreamChunk([]byte(data))
+			if err != nil {
+				ch <- core.StreamChunk{Error: err}
 				return
 			}
 
-			choices := make([]core.StreamChoice, len(sr.Choices))
-			for i, c := range sr.Choices {
-				choices[i] = core.StreamChoice{
-					Index:        c.Index,
-					FinishReason: c.FinishReason,
-					Delta: core.MessageDelta{
-						Role:    c.Delta.Role,
-						Content: c.Delta.Content,
-					},
-				}
-			}
-
-			ch <- core.StreamChunk{
-				ID:      sr.ID,
-				Model:   sr.Model,
-				Choices: choices,
-			}
+			ch <- chunk
 		}
 		if err := scanner.Err(); err != nil {
 			ch <- core.StreamChunk{Error: fmt.Errorf("stream read error: %w", err)}

--- a/providers/deepseek/deepseek.go
+++ b/providers/deepseek/deepseek.go
@@ -128,20 +128,6 @@ type errorResponse struct {
 	Error errorDetail `json:"error"`
 }
 
-type streamResponse struct {
-	ID      string `json:"id"`
-	Model   string `json:"model"`
-	Choices []struct {
-		Index int `json:"index"`
-		Delta struct {
-			Role             string `json:"role,omitempty"`
-			Content          string `json:"content,omitempty"`
-			ReasoningContent string `json:"reasoning_content,omitempty"`
-		} `json:"delta"`
-		FinishReason string `json:"finish_reason,omitempty"`
-	} `json:"choices"`
-}
-
 // Complete sends a chat completion request to DeepSeek.
 func (p *Provider) Complete(ctx context.Context, req core.Request) (*core.Response, error) {
 	bodyReader, _, release, err := openaicompat.BuildBody(req, false)
@@ -236,24 +222,12 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 				return
 			}
 
-			var chunk streamResponse
-			if json.Unmarshal([]byte(data), &chunk) != nil {
+			chunk, err := openaicompat.DecodeStreamChunk([]byte(data))
+			if err != nil {
 				continue
 			}
 
-			sc := core.StreamChunk{ID: chunk.ID, Model: chunk.Model}
-			for _, c := range chunk.Choices {
-				sc.Choices = append(sc.Choices, core.StreamChoice{
-					Index: c.Index,
-					Delta: core.MessageDelta{
-						Role:             c.Delta.Role,
-						Content:          c.Delta.Content,
-						ReasoningContent: c.Delta.ReasoningContent,
-					},
-					FinishReason: c.FinishReason,
-				})
-			}
-			ch <- sc
+			ch <- chunk
 		}
 		if err := scanner.Err(); err != nil {
 			ch <- core.StreamChunk{Error: err}

--- a/providers/fireworks/fireworks.go
+++ b/providers/fireworks/fireworks.go
@@ -120,19 +120,6 @@ type errorResponse struct {
 	Error errorDetail `json:"error"`
 }
 
-type streamResponse struct {
-	ID      string `json:"id"`
-	Model   string `json:"model"`
-	Choices []struct {
-		Index int `json:"index"`
-		Delta struct {
-			Role    string `json:"role,omitempty"`
-			Content string `json:"content,omitempty"`
-		} `json:"delta"`
-		FinishReason string `json:"finish_reason,omitempty"`
-	} `json:"choices"`
-}
-
 // Complete sends a chat completion request to Fireworks AI.
 func (p *Provider) Complete(ctx context.Context, req core.Request) (*core.Response, error) {
 	bodyReader, _, release, err := openaicompat.BuildBody(req, false)
@@ -227,23 +214,12 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 				return
 			}
 
-			var chunk streamResponse
-			if json.Unmarshal([]byte(data), &chunk) != nil {
+			chunk, err := openaicompat.DecodeStreamChunk([]byte(data))
+			if err != nil {
 				continue
 			}
 
-			sc := core.StreamChunk{ID: chunk.ID, Model: chunk.Model}
-			for _, c := range chunk.Choices {
-				sc.Choices = append(sc.Choices, core.StreamChoice{
-					Index: c.Index,
-					Delta: core.MessageDelta{
-						Role:    c.Delta.Role,
-						Content: c.Delta.Content,
-					},
-					FinishReason: c.FinishReason,
-				})
-			}
-			ch <- sc
+			ch <- chunk
 		}
 		if err := scanner.Err(); err != nil {
 			ch <- core.StreamChunk{Error: err}

--- a/providers/gemini/gemini.go
+++ b/providers/gemini/gemini.go
@@ -94,7 +94,21 @@ func (p *Provider) Models() []core.ModelInfo {
 }
 
 type geminiPart struct {
-	Text string `json:"text"`
+	Text             string                  `json:"text,omitempty"`
+	FunctionCall     *geminiFunctionCall     `json:"functionCall,omitempty"`
+	FunctionResponse *geminiFunctionResponse `json:"functionResponse,omitempty"`
+}
+
+type geminiFunctionCall struct {
+	ID   string          `json:"id,omitempty"`
+	Name string          `json:"name"`
+	Args json.RawMessage `json:"args,omitempty"`
+}
+
+type geminiFunctionResponse struct {
+	ID       string          `json:"id,omitempty"`
+	Name     string          `json:"name"`
+	Response json.RawMessage `json:"response"`
 }
 
 type geminiContent struct {
@@ -126,6 +140,27 @@ type geminiRequest struct {
 	Contents          []geminiContent         `json:"contents"`
 	SystemInstruction *geminiContent          `json:"systemInstruction,omitempty"`
 	GenerationConfig  *geminiGenerationConfig `json:"generationConfig,omitempty"`
+	Tools             []geminiTool            `json:"tools,omitempty"`
+	ToolConfig        *geminiToolConfig       `json:"toolConfig,omitempty"`
+}
+
+type geminiTool struct {
+	FunctionDeclarations []geminiFunctionDeclaration `json:"functionDeclarations,omitempty"`
+}
+
+type geminiFunctionDeclaration struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description,omitempty"`
+	Parameters  json.RawMessage `json:"parameters,omitempty"`
+}
+
+type geminiToolConfig struct {
+	FunctionCallingConfig *geminiFunctionCallingConfig `json:"functionCallingConfig,omitempty"`
+}
+
+type geminiFunctionCallingConfig struct {
+	Mode                 string   `json:"mode,omitempty"`
+	AllowedFunctionNames []string `json:"allowedFunctionNames,omitempty"`
 }
 
 type geminiResponse struct {
@@ -197,6 +232,7 @@ type geminiStreamResponse struct {
 // rather than smuggling them into a user turn. Multiple system messages are
 // joined with newlines and preserved regardless of turn order (#144).
 func convertToGemini(messages []core.Message) (contents []geminiContent, systemText string) {
+	toolCallNames := make(map[string]string)
 	for _, msg := range messages {
 		if msg.Role == core.RoleSystem {
 			if systemText != "" {
@@ -209,15 +245,56 @@ func convertToGemini(messages []core.Message) (contents []geminiContent, systemT
 		role := msg.Role
 		if role == "assistant" {
 			role = "model"
+		} else if role == core.RoleTool {
+			role = core.RoleUser
 		}
 
 		contents = append(contents, geminiContent{
 			Role:  role,
-			Parts: []geminiPart{{Text: msg.Content}},
+			Parts: geminiParts(msg, toolCallNames),
 		})
+
+		for _, tc := range msg.ToolCalls {
+			if tc.ID != "" && tc.Function.Name != "" {
+				toolCallNames[tc.ID] = tc.Function.Name
+			}
+		}
 	}
 
 	return contents, systemText
+}
+
+func geminiParts(msg core.Message, toolCallNames map[string]string) []geminiPart {
+	if msg.Role == core.RoleTool {
+		response := json.RawMessage(msg.Content)
+		if len(response) == 0 || !json.Valid(response) {
+			response, _ = json.Marshal(map[string]string{"result": msg.Content})
+		}
+		return []geminiPart{{FunctionResponse: &geminiFunctionResponse{
+			ID:       msg.ToolCallID,
+			Name:     toolCallNames[msg.ToolCallID],
+			Response: response,
+		}}}
+	}
+	var parts []geminiPart
+	if msg.Content != "" {
+		parts = append(parts, geminiPart{Text: msg.Content})
+	}
+	for _, tc := range msg.ToolCalls {
+		args := json.RawMessage(tc.Function.Arguments)
+		if len(args) == 0 || !json.Valid(args) {
+			args = json.RawMessage(`{}`)
+		}
+		parts = append(parts, geminiPart{FunctionCall: &geminiFunctionCall{
+			ID:   tc.ID,
+			Name: tc.Function.Name,
+			Args: args,
+		}})
+	}
+	if len(parts) == 0 {
+		return []geminiPart{{Text: ""}}
+	}
+	return parts
 }
 
 // mapFinishReason maps Gemini finish reasons to OpenAI-style reasons.
@@ -266,7 +343,71 @@ func buildRequest(req core.Request) (geminiRequest, error) {
 	if hasConfig {
 		r.GenerationConfig = &cfg
 	}
+	if tools := geminiTools(req.Tools); len(tools) > 0 {
+		r.Tools = tools
+	}
+	if tc := geminiToolConfigFor(req.ToolChoice); tc != nil {
+		r.ToolConfig = tc
+	}
 	return r, nil
+}
+
+func geminiTools(tools []core.Tool) []geminiTool {
+	if len(tools) == 0 {
+		return nil
+	}
+	decls := make([]geminiFunctionDeclaration, 0, len(tools))
+	for _, t := range tools {
+		params := t.Function.Parameters
+		if len(params) == 0 {
+			params = json.RawMessage(`{"type":"object","properties":{}}`)
+		}
+		decls = append(decls, geminiFunctionDeclaration{
+			Name:        t.Function.Name,
+			Description: t.Function.Description,
+			Parameters:  params,
+		})
+	}
+	return []geminiTool{{FunctionDeclarations: decls}}
+}
+
+func geminiToolConfigFor(choice interface{}) *geminiToolConfig {
+	switch v := choice.(type) {
+	case nil:
+		return nil
+	case string:
+		mode := ""
+		switch v {
+		case "auto":
+			mode = "AUTO"
+		case "none":
+			mode = "NONE"
+		case "required":
+			mode = "ANY"
+		}
+		if mode == "" {
+			return nil
+		}
+		return &geminiToolConfig{FunctionCallingConfig: &geminiFunctionCallingConfig{Mode: mode}}
+	default:
+		raw, err := json.Marshal(v)
+		if err != nil {
+			return nil
+		}
+		var named struct {
+			Type     string `json:"type"`
+			Function struct {
+				Name string `json:"name"`
+			} `json:"function"`
+		}
+		if err := json.Unmarshal(raw, &named); err == nil && named.Type == "function" && named.Function.Name != "" {
+			return &geminiToolConfig{FunctionCallingConfig: &geminiFunctionCallingConfig{
+				Mode:                 "ANY",
+				AllowedFunctionNames: []string{named.Function.Name},
+			}}
+		}
+		return nil
+	}
 }
 
 func embeddingInputs(input any) ([]string, error) {
@@ -436,14 +577,34 @@ func (p *Provider) Complete(ctx context.Context, req core.Request) (*core.Respon
 	var choices []core.Choice
 	for i, candidate := range geminiResp.Candidates {
 		var text string
+		var toolCalls []core.ToolCall
 		for _, part := range candidate.Content.Parts {
 			text += part.Text
+			if part.FunctionCall != nil {
+				args := string(part.FunctionCall.Args)
+				if args == "" {
+					args = "{}"
+				}
+				id := part.FunctionCall.ID
+				if id == "" {
+					id = fmt.Sprintf("call_%d_%d", i, len(toolCalls))
+				}
+				toolCalls = append(toolCalls, core.ToolCall{
+					ID:   id,
+					Type: "function",
+					Function: core.FunctionCall{
+						Name:      part.FunctionCall.Name,
+						Arguments: args,
+					},
+				})
+			}
 		}
 		choices = append(choices, core.Choice{
 			Index: i,
 			Message: core.Message{
-				Role:    "assistant",
-				Content: text,
+				Role:      "assistant",
+				Content:   text,
+				ToolCalls: toolCalls,
 			},
 			FinishReason: mapFinishReason(candidate.FinishReason),
 		})
@@ -519,14 +680,34 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 			}
 			for i, candidate := range chunk.Candidates {
 				var text string
+				var toolCalls []core.ToolCall
 				for _, part := range candidate.Content.Parts {
 					text += part.Text
+					if part.FunctionCall != nil {
+						args := string(part.FunctionCall.Args)
+						if args == "" {
+							args = "{}"
+						}
+						id := part.FunctionCall.ID
+						if id == "" {
+							id = fmt.Sprintf("call_%d_%d", i, len(toolCalls))
+						}
+						toolCalls = append(toolCalls, core.ToolCall{
+							ID:   id,
+							Type: "function",
+							Function: core.FunctionCall{
+								Name:      part.FunctionCall.Name,
+								Arguments: args,
+							},
+						})
+					}
 				}
 				sc.Choices = append(sc.Choices, core.StreamChoice{
 					Index: i,
 					Delta: core.MessageDelta{
-						Role:    "assistant",
-						Content: text,
+						Role:      "assistant",
+						Content:   text,
+						ToolCalls: toolCalls,
 					},
 					FinishReason: mapFinishReason(candidate.FinishReason),
 				})

--- a/providers/gemini/gemini.go
+++ b/providers/gemini/gemini.go
@@ -266,9 +266,12 @@ func convertToGemini(messages []core.Message) (contents []geminiContent, systemT
 
 func geminiParts(msg core.Message, toolCallNames map[string]string) []geminiPart {
 	if msg.Role == core.RoleTool {
-		response := json.RawMessage(msg.Content)
+		trimmedContent := strings.TrimSpace(msg.Content)
+		response := json.RawMessage(trimmedContent)
 		if len(response) == 0 || !json.Valid(response) {
 			response, _ = json.Marshal(map[string]string{"result": msg.Content})
+		} else if !strings.HasPrefix(trimmedContent, "{") {
+			response, _ = json.Marshal(map[string]json.RawMessage{"result": response})
 		}
 		return []geminiPart{{FunctionResponse: &geminiFunctionResponse{
 			ID:       msg.ToolCallID,

--- a/providers/gemini/gemini.go
+++ b/providers/gemini/gemini.go
@@ -304,14 +304,21 @@ func geminiParts(msg core.Message, toolCallNames map[string]string) []geminiPart
 func mapFinishReason(reason string) string {
 	switch reason {
 	case "STOP":
-		return "stop"
+		return core.FinishReasonStop
 	case "MAX_TOKENS":
-		return "length"
+		return core.FinishReasonLength
 	case "SAFETY":
-		return "content_filter"
+		return core.FinishReasonContentFilter
 	default:
 		return reason
 	}
+}
+
+func geminiFinishReason(reason string, toolCalls []core.ToolCall) string {
+	if len(toolCalls) > 0 {
+		return core.FinishReasonToolCalls
+	}
+	return mapFinishReason(reason)
 }
 
 func buildRequest(req core.Request) (geminiRequest, error) {
@@ -609,7 +616,7 @@ func (p *Provider) Complete(ctx context.Context, req core.Request) (*core.Respon
 				Content:   text,
 				ToolCalls: toolCalls,
 			},
-			FinishReason: mapFinishReason(candidate.FinishReason),
+			FinishReason: geminiFinishReason(candidate.FinishReason, toolCalls),
 		})
 	}
 
@@ -715,7 +722,7 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 						Content:   text,
 						ToolCalls: toolCalls,
 					},
-					FinishReason: mapFinishReason(candidate.FinishReason),
+					FinishReason: geminiFinishReason(candidate.FinishReason, toolCalls),
 				})
 			}
 			ch <- sc

--- a/providers/gemini/gemini.go
+++ b/providers/gemini/gemini.go
@@ -684,6 +684,8 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 				for _, part := range candidate.Content.Parts {
 					text += part.Text
 					if part.FunctionCall != nil {
+						toolCallIndex := len(toolCalls)
+						toolCallIndexPtr := toolCallIndex
 						args := string(part.FunctionCall.Args)
 						if args == "" {
 							args = "{}"
@@ -693,8 +695,9 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 							id = fmt.Sprintf("call_%d_%d", i, len(toolCalls))
 						}
 						toolCalls = append(toolCalls, core.ToolCall{
-							ID:   id,
-							Type: "function",
+							Index: &toolCallIndexPtr,
+							ID:    id,
+							Type:  "function",
 							Function: core.FunctionCall{
 								Name:      part.FunctionCall.Name,
 								Arguments: args,

--- a/providers/gemini/gemini_test.go
+++ b/providers/gemini/gemini_test.go
@@ -404,3 +404,58 @@ func TestGeminiProvider_Complete_ForwardsToolResultWithFunctionName(t *testing.T
 		t.Fatalf("function response = %#v, want lookup call_1", got)
 	}
 }
+
+func TestGeminiProvider_Complete_WrapsNonObjectToolResult(t *testing.T) {
+	var captured struct {
+		Contents []struct {
+			Role  string `json:"role"`
+			Parts []struct {
+				FunctionResponse *struct {
+					ID       string          `json:"id"`
+					Name     string          `json:"name"`
+					Response json.RawMessage `json:"response"`
+				} `json:"functionResponse"`
+			} `json:"parts"`
+		} `json:"contents"`
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"candidates":[{"content":{"role":"model","parts":[{"text":"done"}]}}]}`))
+	}))
+	defer srv.Close()
+
+	p, _ := New("test-key", srv.URL)
+	_, err := p.Complete(context.Background(), core.Request{
+		Model: "gemini-2.0-flash",
+		Messages: []core.Message{
+			{Role: core.RoleUser, Content: "status?"},
+			{Role: core.RoleAssistant, ToolCalls: []core.ToolCall{{
+				ID:   "call_1",
+				Type: "function",
+				Function: core.FunctionCall{
+					Name:      "lookup",
+					Arguments: `{}`,
+				},
+			}}},
+			{Role: core.RoleTool, ToolCallID: "call_1", Content: `"ok"`},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Complete() error: %v", err)
+	}
+
+	if len(captured.Contents) != 3 {
+		t.Fatalf("contents len = %d, want 3", len(captured.Contents))
+	}
+	toolResult := captured.Contents[2]
+	if toolResult.Role != core.RoleUser || len(toolResult.Parts) != 1 || toolResult.Parts[0].FunctionResponse == nil {
+		t.Fatalf("tool result content = %#v, want user functionResponse", toolResult)
+	}
+	got := toolResult.Parts[0].FunctionResponse
+	if got.ID != "call_1" || got.Name != "lookup" || string(got.Response) != `{"result":"ok"}` {
+		t.Fatalf("function response = %#v, want wrapped lookup call_1", got)
+	}
+}

--- a/providers/gemini/gemini_test.go
+++ b/providers/gemini/gemini_test.go
@@ -243,3 +243,124 @@ func TestGeminiProvider_CompleteStream_MockSSE(t *testing.T) {
 		t.Errorf("delta content = %q, want ' there'", chunks[1].Choices[0].Delta.Content)
 	}
 }
+
+func TestGeminiProvider_Complete_ForwardsToolsAndDecodesFunctionCall(t *testing.T) {
+	var captured map[string]json.RawMessage
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"candidates":[{
+				"content":{"role":"model","parts":[{"functionCall":{"id":"call_1","name":"lookup","args":{"city":"SF"}}}]},
+				"finishReason":"STOP"
+			}],
+			"usageMetadata":{"promptTokenCount":1,"candidatesTokenCount":1,"totalTokenCount":2}
+		}`))
+	}))
+	defer srv.Close()
+
+	p, _ := New("test-key", srv.URL)
+	resp, err := p.Complete(context.Background(), core.Request{
+		Model:    "gemini-2.0-flash",
+		Messages: []core.Message{{Role: core.RoleUser, Content: "weather?"}},
+		Tools: []core.Tool{{
+			Type: "function",
+			Function: core.Function{
+				Name:        "lookup",
+				Description: "Lookup weather",
+				Parameters:  json.RawMessage(`{"type":"object","properties":{"city":{"type":"string"}}}`),
+			},
+		}},
+		ToolChoice: "required",
+	})
+	if err != nil {
+		t.Fatalf("Complete() error: %v", err)
+	}
+
+	var body struct {
+		Tools []struct {
+			FunctionDeclarations []struct {
+				Name string `json:"name"`
+			} `json:"functionDeclarations"`
+		} `json:"tools"`
+		ToolConfig struct {
+			FunctionCallingConfig struct {
+				Mode string `json:"mode"`
+			} `json:"functionCallingConfig"`
+		} `json:"toolConfig"`
+	}
+	raw, _ := json.Marshal(captured)
+	if err := json.Unmarshal(raw, &body); err != nil {
+		t.Fatalf("decode captured body: %v", err)
+	}
+	if len(body.Tools) != 1 || len(body.Tools[0].FunctionDeclarations) != 1 || body.Tools[0].FunctionDeclarations[0].Name != "lookup" {
+		t.Fatalf("tools = %#v, want lookup", body.Tools)
+	}
+	if body.ToolConfig.FunctionCallingConfig.Mode != "ANY" {
+		t.Fatalf("tool config mode = %q, want ANY", body.ToolConfig.FunctionCallingConfig.Mode)
+	}
+	if len(resp.Choices) != 1 || len(resp.Choices[0].Message.ToolCalls) != 1 {
+		t.Fatalf("tool calls = %#v, want one", resp.Choices)
+	}
+	tc := resp.Choices[0].Message.ToolCalls[0]
+	if tc.ID != "call_1" || tc.Function.Name != "lookup" || tc.Function.Arguments != `{"city":"SF"}` {
+		t.Fatalf("tool call = %#v, want lookup", tc)
+	}
+}
+
+func TestGeminiProvider_Complete_ForwardsToolResultWithFunctionName(t *testing.T) {
+	var captured struct {
+		Contents []struct {
+			Role  string `json:"role"`
+			Parts []struct {
+				FunctionResponse *struct {
+					ID       string          `json:"id"`
+					Name     string          `json:"name"`
+					Response json.RawMessage `json:"response"`
+				} `json:"functionResponse"`
+			} `json:"parts"`
+		} `json:"contents"`
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"candidates":[{"content":{"role":"model","parts":[{"text":"done"}]}}]}`))
+	}))
+	defer srv.Close()
+
+	p, _ := New("test-key", srv.URL)
+	_, err := p.Complete(context.Background(), core.Request{
+		Model: "gemini-2.0-flash",
+		Messages: []core.Message{
+			{Role: core.RoleUser, Content: "weather?"},
+			{Role: core.RoleAssistant, ToolCalls: []core.ToolCall{{
+				ID:   "call_1",
+				Type: "function",
+				Function: core.FunctionCall{
+					Name:      "lookup",
+					Arguments: `{"city":"SF"}`,
+				},
+			}}},
+			{Role: core.RoleTool, ToolCallID: "call_1", Content: `{"temp":72}`},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Complete() error: %v", err)
+	}
+
+	if len(captured.Contents) != 3 {
+		t.Fatalf("contents len = %d, want 3", len(captured.Contents))
+	}
+	toolResult := captured.Contents[2]
+	if toolResult.Role != core.RoleUser || len(toolResult.Parts) != 1 || toolResult.Parts[0].FunctionResponse == nil {
+		t.Fatalf("tool result content = %#v, want user functionResponse", toolResult)
+	}
+	got := toolResult.Parts[0].FunctionResponse
+	if got.ID != "call_1" || got.Name != "lookup" || string(got.Response) != `{"temp":72}` {
+		t.Fatalf("function response = %#v, want lookup call_1", got)
+	}
+}

--- a/providers/gemini/gemini_test.go
+++ b/providers/gemini/gemini_test.go
@@ -244,6 +244,46 @@ func TestGeminiProvider_CompleteStream_MockSSE(t *testing.T) {
 	}
 }
 
+func TestGeminiProvider_CompleteStream_IndexesFunctionCalls(t *testing.T) {
+	sseData := `data: {"candidates":[{"content":{"role":"model","parts":[{"functionCall":{"id":"call_1","name":"lookup_weather","args":{"city":"SF"}}},{"functionCall":{"id":"call_2","name":"lookup_time","args":{"city":"SF"}}}]},"finishReason":"STOP"}]}
+
+`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(sseData))
+	}))
+	defer srv.Close()
+
+	p, _ := New("test-key", srv.URL)
+	ch, err := p.CompleteStream(context.Background(), core.Request{
+		Model:    "gemini-2.0-flash",
+		Messages: []core.Message{{Role: core.RoleUser, Content: "weather and time?"}},
+	})
+	if err != nil {
+		t.Fatalf("CompleteStream() error: %v", err)
+	}
+
+	var chunks []core.StreamChunk
+	for c := range ch {
+		chunks = append(chunks, c)
+	}
+
+	if len(chunks) != 1 || len(chunks[0].Choices) != 1 {
+		t.Fatalf("chunks = %#v, want one candidate chunk", chunks)
+	}
+	toolCalls := chunks[0].Choices[0].Delta.ToolCalls
+	if len(toolCalls) != 2 {
+		t.Fatalf("tool calls len = %d, want 2", len(toolCalls))
+	}
+	if toolCalls[0].Index == nil || *toolCalls[0].Index != 0 {
+		t.Fatalf("first tool index = %#v, want 0", toolCalls[0].Index)
+	}
+	if toolCalls[1].Index == nil || *toolCalls[1].Index != 1 {
+		t.Fatalf("second tool index = %#v, want 1", toolCalls[1].Index)
+	}
+}
+
 func TestGeminiProvider_Complete_ForwardsToolsAndDecodesFunctionCall(t *testing.T) {
 	var captured map[string]json.RawMessage
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/providers/gemini/gemini_test.go
+++ b/providers/gemini/gemini_test.go
@@ -282,6 +282,9 @@ func TestGeminiProvider_CompleteStream_IndexesFunctionCalls(t *testing.T) {
 	if toolCalls[1].Index == nil || *toolCalls[1].Index != 1 {
 		t.Fatalf("second tool index = %#v, want 1", toolCalls[1].Index)
 	}
+	if chunks[0].Choices[0].FinishReason != core.FinishReasonToolCalls {
+		t.Fatalf("finish reason = %q, want tool_calls", chunks[0].Choices[0].FinishReason)
+	}
 }
 
 func TestGeminiProvider_Complete_ForwardsToolsAndDecodesFunctionCall(t *testing.T) {
@@ -347,6 +350,9 @@ func TestGeminiProvider_Complete_ForwardsToolsAndDecodesFunctionCall(t *testing.
 	tc := resp.Choices[0].Message.ToolCalls[0]
 	if tc.ID != "call_1" || tc.Function.Name != "lookup" || tc.Function.Arguments != `{"city":"SF"}` {
 		t.Fatalf("tool call = %#v, want lookup", tc)
+	}
+	if resp.Choices[0].FinishReason != core.FinishReasonToolCalls {
+		t.Fatalf("finish reason = %q, want tool_calls", resp.Choices[0].FinishReason)
 	}
 }
 

--- a/providers/groq/groq.go
+++ b/providers/groq/groq.go
@@ -104,19 +104,6 @@ type errorResponse struct {
 	Error errorDetail `json:"error"`
 }
 
-type streamResponse struct {
-	ID      string `json:"id"`
-	Model   string `json:"model"`
-	Choices []struct {
-		Index int `json:"index"`
-		Delta struct {
-			Role    string `json:"role,omitempty"`
-			Content string `json:"content,omitempty"`
-		} `json:"delta"`
-		FinishReason string `json:"finish_reason,omitempty"`
-	} `json:"choices"`
-}
-
 // Complete sends a chat completion request to Groq.
 func (p *Provider) Complete(ctx context.Context, req core.Request) (*core.Response, error) {
 	bodyReader, _, release, err := openaicompat.BuildBody(req, false)
@@ -211,23 +198,12 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 				return
 			}
 
-			var chunk streamResponse
-			if json.Unmarshal([]byte(data), &chunk) != nil {
+			chunk, err := openaicompat.DecodeStreamChunk([]byte(data))
+			if err != nil {
 				continue
 			}
 
-			sc := core.StreamChunk{ID: chunk.ID, Model: chunk.Model}
-			for _, c := range chunk.Choices {
-				sc.Choices = append(sc.Choices, core.StreamChoice{
-					Index: c.Index,
-					Delta: core.MessageDelta{
-						Role:    c.Delta.Role,
-						Content: c.Delta.Content,
-					},
-					FinishReason: c.FinishReason,
-				})
-			}
-			ch <- sc
+			ch <- chunk
 		}
 		if err := scanner.Err(); err != nil {
 			ch <- core.StreamChunk{Error: err}

--- a/providers/hugging_face/hugging_face.go
+++ b/providers/hugging_face/hugging_face.go
@@ -148,19 +148,6 @@ func (p *Provider) Complete(ctx context.Context, req core.Request) (*core.Respon
 	}, nil
 }
 
-type huggingFaceStreamResponse struct {
-	ID      string `json:"id"`
-	Model   string `json:"model"`
-	Choices []struct {
-		Index int `json:"index"`
-		Delta struct {
-			Role    string `json:"role,omitempty"`
-			Content string `json:"content,omitempty"`
-		} `json:"delta"`
-		FinishReason string `json:"finish_reason,omitempty"`
-	} `json:"choices"`
-}
-
 // CompleteStream sends a streaming chat completion request to Hugging Face.
 func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan core.StreamChunk, error) {
 	bodyReader, _, release, err := openaicompat.BuildBody(req, true)
@@ -207,23 +194,12 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 				return
 			}
 
-			var chunk huggingFaceStreamResponse
-			if json.Unmarshal([]byte(data), &chunk) != nil {
+			chunk, err := openaicompat.DecodeStreamChunk([]byte(data))
+			if err != nil {
 				continue
 			}
 
-			sc := core.StreamChunk{ID: chunk.ID, Model: chunk.Model}
-			for _, c := range chunk.Choices {
-				sc.Choices = append(sc.Choices, core.StreamChoice{
-					Index: c.Index,
-					Delta: core.MessageDelta{
-						Role:    c.Delta.Role,
-						Content: c.Delta.Content,
-					},
-					FinishReason: c.FinishReason,
-				})
-			}
-			ch <- sc
+			ch <- chunk
 		}
 		if err := scanner.Err(); err != nil {
 			ch <- core.StreamChunk{Error: err}

--- a/providers/mistral/mistral.go
+++ b/providers/mistral/mistral.go
@@ -108,19 +108,6 @@ type errorResponse struct {
 	Error errorDetail `json:"error"`
 }
 
-type streamResponse struct {
-	ID      string `json:"id"`
-	Model   string `json:"model"`
-	Choices []struct {
-		Index int `json:"index"`
-		Delta struct {
-			Role    string `json:"role,omitempty"`
-			Content string `json:"content,omitempty"`
-		} `json:"delta"`
-		FinishReason string `json:"finish_reason,omitempty"`
-	} `json:"choices"`
-}
-
 // Complete sends a chat completion request to Mistral.
 func (p *Provider) Complete(ctx context.Context, req core.Request) (*core.Response, error) {
 	bodyReader, _, release, err := openaicompat.BuildBody(req, false)
@@ -215,23 +202,12 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 				return
 			}
 
-			var chunk streamResponse
-			if json.Unmarshal([]byte(data), &chunk) != nil {
+			chunk, err := openaicompat.DecodeStreamChunk([]byte(data))
+			if err != nil {
 				continue
 			}
 
-			sc := core.StreamChunk{ID: chunk.ID, Model: chunk.Model}
-			for _, c := range chunk.Choices {
-				sc.Choices = append(sc.Choices, core.StreamChoice{
-					Index: c.Index,
-					Delta: core.MessageDelta{
-						Role:    c.Delta.Role,
-						Content: c.Delta.Content,
-					},
-					FinishReason: c.FinishReason,
-				})
-			}
-			ch <- sc
+			ch <- chunk
 		}
 		if err := scanner.Err(); err != nil {
 			ch <- core.StreamChunk{Error: err}

--- a/providers/moonshot/moonshot.go
+++ b/providers/moonshot/moonshot.go
@@ -95,19 +95,6 @@ type errorResponse struct {
 	Error errorDetail `json:"error"`
 }
 
-type streamResponse struct {
-	ID      string `json:"id"`
-	Model   string `json:"model"`
-	Choices []struct {
-		Index int `json:"index"`
-		Delta struct {
-			Role    string `json:"role,omitempty"`
-			Content string `json:"content,omitempty"`
-		} `json:"delta"`
-		FinishReason string `json:"finish_reason,omitempty"`
-	} `json:"choices"`
-}
-
 // Complete sends a chat completion request to Moonshot.
 func (p *Provider) Complete(ctx context.Context, req core.Request) (*core.Response, error) {
 	bodyReader, _, release, err := openaicompat.BuildBody(req, false)
@@ -202,29 +189,13 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 				return
 			}
 
-			var sr streamResponse
-			if err := json.Unmarshal([]byte(data), &sr); err != nil {
-				ch <- core.StreamChunk{Error: fmt.Errorf("failed to unmarshal stream chunk: %w", err)}
+			chunk, err := openaicompat.DecodeStreamChunk([]byte(data))
+			if err != nil {
+				ch <- core.StreamChunk{Error: err}
 				return
 			}
 
-			choices := make([]core.StreamChoice, len(sr.Choices))
-			for i, c := range sr.Choices {
-				choices[i] = core.StreamChoice{
-					Index:        c.Index,
-					FinishReason: c.FinishReason,
-					Delta: core.MessageDelta{
-						Role:    c.Delta.Role,
-						Content: c.Delta.Content,
-					},
-				}
-			}
-
-			ch <- core.StreamChunk{
-				ID:      sr.ID,
-				Model:   sr.Model,
-				Choices: choices,
-			}
+			ch <- chunk
 		}
 		if err := scanner.Err(); err != nil {
 			ch <- core.StreamChunk{Error: fmt.Errorf("stream read error: %w", err)}

--- a/providers/novita/novita.go
+++ b/providers/novita/novita.go
@@ -107,19 +107,6 @@ type errorResponse struct {
 	Error errorDetail `json:"error"`
 }
 
-type streamResponse struct {
-	ID      string `json:"id"`
-	Model   string `json:"model"`
-	Choices []struct {
-		Index int `json:"index"`
-		Delta struct {
-			Role    string `json:"role,omitempty"`
-			Content string `json:"content,omitempty"`
-		} `json:"delta"`
-		FinishReason string `json:"finish_reason,omitempty"`
-	} `json:"choices"`
-}
-
 // Complete sends a chat completion request to Novita.
 func (p *Provider) Complete(ctx context.Context, req core.Request) (*core.Response, error) {
 	bodyReader, _, release, err := openaicompat.BuildBody(req, false)
@@ -214,29 +201,13 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 				return
 			}
 
-			var sr streamResponse
-			if err := json.Unmarshal([]byte(data), &sr); err != nil {
-				ch <- core.StreamChunk{Error: fmt.Errorf("failed to unmarshal stream chunk: %w", err)}
+			chunk, err := openaicompat.DecodeStreamChunk([]byte(data))
+			if err != nil {
+				ch <- core.StreamChunk{Error: err}
 				return
 			}
 
-			choices := make([]core.StreamChoice, len(sr.Choices))
-			for i, c := range sr.Choices {
-				choices[i] = core.StreamChoice{
-					Index:        c.Index,
-					FinishReason: c.FinishReason,
-					Delta: core.MessageDelta{
-						Role:    c.Delta.Role,
-						Content: c.Delta.Content,
-					},
-				}
-			}
-
-			ch <- core.StreamChunk{
-				ID:      sr.ID,
-				Model:   sr.Model,
-				Choices: choices,
-			}
+			ch <- chunk
 		}
 		if err := scanner.Err(); err != nil {
 			ch <- core.StreamChunk{Error: fmt.Errorf("stream read error: %w", err)}

--- a/providers/nvidia_nim/nvidia_nim.go
+++ b/providers/nvidia_nim/nvidia_nim.go
@@ -96,19 +96,6 @@ type errorResponse struct {
 	Error errorDetail `json:"error"`
 }
 
-type streamResponse struct {
-	ID      string `json:"id"`
-	Model   string `json:"model"`
-	Choices []struct {
-		Index int `json:"index"`
-		Delta struct {
-			Role    string `json:"role,omitempty"`
-			Content string `json:"content,omitempty"`
-		} `json:"delta"`
-		FinishReason string `json:"finish_reason,omitempty"`
-	} `json:"choices"`
-}
-
 // Complete sends a chat completion request to NVIDIA NIM.
 func (p *Provider) Complete(ctx context.Context, req core.Request) (*core.Response, error) {
 	bodyReader, _, release, err := openaicompat.BuildBody(req, false)
@@ -203,29 +190,13 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 				return
 			}
 
-			var sr streamResponse
-			if err := json.Unmarshal([]byte(data), &sr); err != nil {
-				ch <- core.StreamChunk{Error: fmt.Errorf("failed to unmarshal stream chunk: %w", err)}
+			chunk, err := openaicompat.DecodeStreamChunk([]byte(data))
+			if err != nil {
+				ch <- core.StreamChunk{Error: err}
 				return
 			}
 
-			choices := make([]core.StreamChoice, len(sr.Choices))
-			for i, c := range sr.Choices {
-				choices[i] = core.StreamChoice{
-					Index:        c.Index,
-					FinishReason: c.FinishReason,
-					Delta: core.MessageDelta{
-						Role:    c.Delta.Role,
-						Content: c.Delta.Content,
-					},
-				}
-			}
-
-			ch <- core.StreamChunk{
-				ID:      sr.ID,
-				Model:   sr.Model,
-				Choices: choices,
-			}
+			ch <- chunk
 		}
 		if err := scanner.Err(); err != nil {
 			ch <- core.StreamChunk{Error: fmt.Errorf("stream read error: %w", err)}

--- a/providers/ollama/ollama.go
+++ b/providers/ollama/ollama.go
@@ -136,19 +136,6 @@ func (p *Provider) Complete(ctx context.Context, req core.Request) (*core.Respon
 	}, nil
 }
 
-type ollamaStreamResponse struct {
-	ID      string `json:"id"`
-	Model   string `json:"model"`
-	Choices []struct {
-		Index int `json:"index"`
-		Delta struct {
-			Role    string `json:"role,omitempty"`
-			Content string `json:"content,omitempty"`
-		} `json:"delta"`
-		FinishReason string `json:"finish_reason,omitempty"`
-	} `json:"choices"`
-}
-
 // CompleteStream sends a streaming chat completion request to Ollama.
 func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan core.StreamChunk, error) {
 	bodyReader, _, release, err := openaicompat.BuildBody(req, true)
@@ -194,26 +181,12 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 				return
 			}
 
-			var chunk ollamaStreamResponse
-			if json.Unmarshal([]byte(data), &chunk) != nil {
+			chunk, err := openaicompat.DecodeStreamChunk([]byte(data))
+			if err != nil {
 				continue
 			}
 
-			sc := core.StreamChunk{
-				ID:    chunk.ID,
-				Model: chunk.Model,
-			}
-			for _, c := range chunk.Choices {
-				sc.Choices = append(sc.Choices, core.StreamChoice{
-					Index: c.Index,
-					Delta: core.MessageDelta{
-						Role:    c.Delta.Role,
-						Content: c.Delta.Content,
-					},
-					FinishReason: c.FinishReason,
-				})
-			}
-			ch <- sc
+			ch <- chunk
 		}
 		if err := scanner.Err(); err != nil {
 			ch <- core.StreamChunk{Error: err}

--- a/providers/openai/openai.go
+++ b/providers/openai/openai.go
@@ -562,9 +562,11 @@ func openAIStreamToolCalls(in []oai.ChatCompletionChunkChoiceDeltaToolCall) []co
 	}
 	out := make([]core.ToolCall, 0, len(in))
 	for _, tc := range in {
+		index := int(tc.Index)
 		out = append(out, core.ToolCall{
-			ID:   tc.ID,
-			Type: tc.Type,
+			Index: &index,
+			ID:    tc.ID,
+			Type:  tc.Type,
 			Function: core.FunctionCall{
 				Name:      tc.Function.Name,
 				Arguments: tc.Function.Arguments,

--- a/providers/openai/openai.go
+++ b/providers/openai/openai.go
@@ -352,8 +352,9 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 				sc.Choices = append(sc.Choices, core.StreamChoice{
 					Index: int(c.Index),
 					Delta: core.MessageDelta{
-						Role:    c.Delta.Role,
-						Content: c.Delta.Content,
+						Role:      c.Delta.Role,
+						Content:   c.Delta.Content,
+						ToolCalls: openAIStreamToolCalls(c.Delta.ToolCalls),
 					},
 					FinishReason: c.FinishReason,
 				})
@@ -423,7 +424,23 @@ func buildMessages(msgs []core.Message) []oai.ChatCompletionMessageParamUnion {
 		case core.RoleUser:
 			out = append(out, oai.UserMessage(msg.Content))
 		case core.RoleAssistant:
-			out = append(out, oai.AssistantMessage(msg.Content))
+			assistant := oai.ChatCompletionAssistantMessageParam{}
+			if msg.Content != "" {
+				assistant.Content.OfString = oai.String(msg.Content)
+			}
+			if len(msg.ToolCalls) > 0 {
+				assistant.ToolCalls = make([]oai.ChatCompletionMessageToolCallParam, 0, len(msg.ToolCalls))
+				for _, tc := range msg.ToolCalls {
+					assistant.ToolCalls = append(assistant.ToolCalls, oai.ChatCompletionMessageToolCallParam{
+						ID: tc.ID,
+						Function: oai.ChatCompletionMessageToolCallFunctionParam{
+							Name:      tc.Function.Name,
+							Arguments: tc.Function.Arguments,
+						},
+					})
+				}
+			}
+			out = append(out, oai.ChatCompletionMessageParamUnion{OfAssistant: &assistant})
 		case core.RoleSystem:
 			out = append(out, oai.SystemMessage(msg.Content))
 		case core.RoleTool:
@@ -515,4 +532,44 @@ func applyParams(params *oai.ChatCompletionNewParams, req core.Request) {
 		}
 		params.Tools = tools
 	}
+	if req.ToolChoice != nil {
+		if choice, ok := openAIToolChoice(req.ToolChoice); ok {
+			params.ToolChoice = choice
+		}
+	}
+}
+
+func openAIToolChoice(choice interface{}) (oai.ChatCompletionToolChoiceOptionUnionParam, bool) {
+	switch v := choice.(type) {
+	case string:
+		return oai.ChatCompletionToolChoiceOptionUnionParam{OfAuto: oai.String(v)}, true
+	default:
+		raw, err := json.Marshal(v)
+		if err != nil {
+			return oai.ChatCompletionToolChoiceOptionUnionParam{}, false
+		}
+		var parsed oai.ChatCompletionToolChoiceOptionUnionParam
+		if err := json.Unmarshal(raw, &parsed); err != nil {
+			return oai.ChatCompletionToolChoiceOptionUnionParam{}, false
+		}
+		return parsed, true
+	}
+}
+
+func openAIStreamToolCalls(in []oai.ChatCompletionChunkChoiceDeltaToolCall) []core.ToolCall {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]core.ToolCall, 0, len(in))
+	for _, tc := range in {
+		out = append(out, core.ToolCall{
+			ID:   tc.ID,
+			Type: tc.Type,
+			Function: core.FunctionCall{
+				Name:      tc.Function.Name,
+				Arguments: tc.Function.Arguments,
+			},
+		})
+	}
+	return out
 }

--- a/providers/openai/openai_test.go
+++ b/providers/openai/openai_test.go
@@ -228,6 +228,34 @@ func TestOpenAIProvider_Complete_MockHTTP(t *testing.T) {
 	}
 }
 
+func TestBuildMessages_AssistantToolCalls(t *testing.T) {
+	msgs := buildMessages([]core.Message{
+		{Role: core.RoleAssistant, ToolCalls: []core.ToolCall{{
+			ID:       "call_1",
+			Type:     "function",
+			Function: core.FunctionCall{Name: "lookup", Arguments: `{"city":"SF"}`},
+		}}},
+		{Role: core.RoleTool, ToolCallID: "call_1", Content: "72F"},
+	})
+	raw, err := json.Marshal(msgs)
+	if err != nil {
+		t.Fatalf("marshal messages: %v", err)
+	}
+	var got []core.Message
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("unmarshal messages: %v\n%s", err, raw)
+	}
+	if len(got) != 2 {
+		t.Fatalf("messages len = %d, want 2", len(got))
+	}
+	if len(got[0].ToolCalls) != 1 || got[0].ToolCalls[0].Function.Name != "lookup" {
+		t.Fatalf("assistant tool_calls = %#v, want lookup", got[0].ToolCalls)
+	}
+	if got[1].ToolCallID != "call_1" {
+		t.Fatalf("tool_call_id = %q, want call_1", got[1].ToolCallID)
+	}
+}
+
 func TestOpenAIProvider_Complete_DrainsSuccessfulResponseBody(t *testing.T) {
 	var newConnections atomic.Int32
 	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {

--- a/providers/openai/openai_test.go
+++ b/providers/openai/openai_test.go
@@ -378,6 +378,58 @@ func TestOpenAIProvider_CompleteStream_MockSSE(t *testing.T) {
 	}
 }
 
+func TestOpenAIProvider_CompleteStream_ForwardsToolCallIndex(t *testing.T) {
+	sseData := "data: {\"id\":\"chatcmpl-1\",\"object\":\"chat.completion.chunk\",\"created\":1234567890,\"model\":\"gpt-4o\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"tool_calls\":[{\"index\":0,\"id\":\"call_1\",\"type\":\"function\",\"function\":{\"name\":\"lookup\",\"arguments\":\"\"}}]},\"finish_reason\":null}]}\n\n" +
+		"data: {\"id\":\"chatcmpl-1\",\"object\":\"chat.completion.chunk\",\"created\":1234567890,\"model\":\"gpt-4o\",\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\"{\\\"city\\\"\"}}]},\"finish_reason\":null}]}\n\n" +
+		"data: {\"id\":\"chatcmpl-1\",\"object\":\"chat.completion.chunk\",\"created\":1234567890,\"model\":\"gpt-4o\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"tool_calls\"}]}\n\n" +
+		"data: [DONE]\n\n"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(sseData))
+	}))
+	defer srv.Close()
+
+	provider, _ := New("sk-test-key", srv.URL)
+	ch, err := provider.CompleteStream(context.Background(), core.Request{
+		Model:    "gpt-4o",
+		Messages: []core.Message{{Role: core.RoleUser, Content: "weather?"}},
+		Tools: []core.Tool{{
+			Type: "function",
+			Function: core.Function{
+				Name: "lookup",
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("CompleteStream() error: %v", err)
+	}
+
+	var chunks []core.StreamChunk
+	for c := range ch {
+		if c.Error != nil {
+			t.Fatalf("stream error: %v", c.Error)
+		}
+		chunks = append(chunks, c)
+	}
+
+	if len(chunks) != 3 {
+		t.Fatalf("chunks len = %d, want 3: %#v", len(chunks), chunks)
+	}
+	start := chunks[0].Choices[0].Delta.ToolCalls[0]
+	if start.Index == nil || *start.Index != 0 || start.ID != "call_1" || start.Function.Name != "lookup" {
+		t.Fatalf("start tool call = %#v, want lookup at index 0", start)
+	}
+	delta := chunks[1].Choices[0].Delta.ToolCalls[0]
+	if delta.Index == nil || *delta.Index != 0 || delta.Function.Arguments != `{"city"` {
+		t.Fatalf("args delta = %#v, want index 0 city fragment", delta)
+	}
+	if chunks[2].Choices[0].FinishReason != core.FinishReasonToolCalls {
+		t.Fatalf("finish_reason = %q, want %q", chunks[2].Choices[0].FinishReason, core.FinishReasonToolCalls)
+	}
+}
+
 // ── Embed() validation tests ─────────────────────────────────────────────────
 
 func TestOpenAIProvider_Embed_InvalidInputType(t *testing.T) {

--- a/providers/openrouter/openrouter.go
+++ b/providers/openrouter/openrouter.go
@@ -104,19 +104,6 @@ type errorResponse struct {
 	Error errorDetail `json:"error"`
 }
 
-type streamResponse struct {
-	ID      string `json:"id"`
-	Model   string `json:"model"`
-	Choices []struct {
-		Index int `json:"index"`
-		Delta struct {
-			Role    string `json:"role,omitempty"`
-			Content string `json:"content,omitempty"`
-		} `json:"delta"`
-		FinishReason string `json:"finish_reason,omitempty"`
-	} `json:"choices"`
-}
-
 // Complete sends a chat completion request to OpenRouter.
 func (p *Provider) Complete(ctx context.Context, req core.Request) (*core.Response, error) {
 	bodyReader, _, release, err := openaicompat.BuildBody(req, false)
@@ -211,29 +198,13 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 				return
 			}
 
-			var sr streamResponse
-			if err := json.Unmarshal([]byte(data), &sr); err != nil {
-				ch <- core.StreamChunk{Error: fmt.Errorf("failed to unmarshal stream chunk: %w", err)}
+			chunk, err := openaicompat.DecodeStreamChunk([]byte(data))
+			if err != nil {
+				ch <- core.StreamChunk{Error: err}
 				return
 			}
 
-			choices := make([]core.StreamChoice, len(sr.Choices))
-			for i, c := range sr.Choices {
-				choices[i] = core.StreamChoice{
-					Index:        c.Index,
-					FinishReason: c.FinishReason,
-					Delta: core.MessageDelta{
-						Role:    c.Delta.Role,
-						Content: c.Delta.Content,
-					},
-				}
-			}
-
-			ch <- core.StreamChunk{
-				ID:      sr.ID,
-				Model:   sr.Model,
-				Choices: choices,
-			}
+			ch <- chunk
 		}
 		if err := scanner.Err(); err != nil {
 			ch <- core.StreamChunk{Error: fmt.Errorf("stream read error: %w", err)}

--- a/providers/perplexity/perplexity.go
+++ b/providers/perplexity/perplexity.go
@@ -107,19 +107,6 @@ type errorResponse struct {
 	Error errorDetail `json:"error"`
 }
 
-type streamResponse struct {
-	ID      string `json:"id"`
-	Model   string `json:"model"`
-	Choices []struct {
-		Index int `json:"index"`
-		Delta struct {
-			Role    string `json:"role,omitempty"`
-			Content string `json:"content,omitempty"`
-		} `json:"delta"`
-		FinishReason string `json:"finish_reason,omitempty"`
-	} `json:"choices"`
-}
-
 // Complete sends a chat completion request to Perplexity.
 func (p *Provider) Complete(ctx context.Context, req core.Request) (*core.Response, error) {
 	bodyReader, _, release, err := openaicompat.BuildBody(req, false)
@@ -214,23 +201,12 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 				return
 			}
 
-			var chunk streamResponse
-			if json.Unmarshal([]byte(data), &chunk) != nil {
+			chunk, err := openaicompat.DecodeStreamChunk([]byte(data))
+			if err != nil {
 				continue
 			}
 
-			sc := core.StreamChunk{ID: chunk.ID, Model: chunk.Model}
-			for _, c := range chunk.Choices {
-				sc.Choices = append(sc.Choices, core.StreamChoice{
-					Index: c.Index,
-					Delta: core.MessageDelta{
-						Role:    c.Delta.Role,
-						Content: c.Delta.Content,
-					},
-					FinishReason: c.FinishReason,
-				})
-			}
-			ch <- sc
+			ch <- chunk
 		}
 		if err := scanner.Err(); err != nil {
 			ch <- core.StreamChunk{Error: err}

--- a/providers/qwen/qwen.go
+++ b/providers/qwen/qwen.go
@@ -95,19 +95,6 @@ type errorResponse struct {
 	Error errorDetail `json:"error"`
 }
 
-type streamResponse struct {
-	ID      string `json:"id"`
-	Model   string `json:"model"`
-	Choices []struct {
-		Index int `json:"index"`
-		Delta struct {
-			Role    string `json:"role,omitempty"`
-			Content string `json:"content,omitempty"`
-		} `json:"delta"`
-		FinishReason string `json:"finish_reason,omitempty"`
-	} `json:"choices"`
-}
-
 // Complete sends a chat completion request to Qwen.
 func (p *Provider) Complete(ctx context.Context, req core.Request) (*core.Response, error) {
 	bodyReader, _, release, err := openaicompat.BuildBody(req, false)
@@ -202,29 +189,13 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 				return
 			}
 
-			var sr streamResponse
-			if err := json.Unmarshal([]byte(data), &sr); err != nil {
-				ch <- core.StreamChunk{Error: fmt.Errorf("failed to unmarshal stream chunk: %w", err)}
+			chunk, err := openaicompat.DecodeStreamChunk([]byte(data))
+			if err != nil {
+				ch <- core.StreamChunk{Error: err}
 				return
 			}
 
-			choices := make([]core.StreamChoice, len(sr.Choices))
-			for i, c := range sr.Choices {
-				choices[i] = core.StreamChoice{
-					Index:        c.Index,
-					FinishReason: c.FinishReason,
-					Delta: core.MessageDelta{
-						Role:    c.Delta.Role,
-						Content: c.Delta.Content,
-					},
-				}
-			}
-
-			ch <- core.StreamChunk{
-				ID:      sr.ID,
-				Model:   sr.Model,
-				Choices: choices,
-			}
+			ch <- chunk
 		}
 		if err := scanner.Err(); err != nil {
 			ch <- core.StreamChunk{Error: fmt.Errorf("stream read error: %w", err)}

--- a/providers/sambanova/sambanova.go
+++ b/providers/sambanova/sambanova.go
@@ -95,19 +95,6 @@ type errorResponse struct {
 	Error errorDetail `json:"error"`
 }
 
-type streamResponse struct {
-	ID      string `json:"id"`
-	Model   string `json:"model"`
-	Choices []struct {
-		Index int `json:"index"`
-		Delta struct {
-			Role    string `json:"role,omitempty"`
-			Content string `json:"content,omitempty"`
-		} `json:"delta"`
-		FinishReason string `json:"finish_reason,omitempty"`
-	} `json:"choices"`
-}
-
 // Complete sends a chat completion request to SambaNova.
 func (p *Provider) Complete(ctx context.Context, req core.Request) (*core.Response, error) {
 	bodyReader, _, release, err := openaicompat.BuildBody(req, false)
@@ -202,29 +189,13 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 				return
 			}
 
-			var sr streamResponse
-			if err := json.Unmarshal([]byte(data), &sr); err != nil {
-				ch <- core.StreamChunk{Error: fmt.Errorf("failed to unmarshal stream chunk: %w", err)}
+			chunk, err := openaicompat.DecodeStreamChunk([]byte(data))
+			if err != nil {
+				ch <- core.StreamChunk{Error: err}
 				return
 			}
 
-			choices := make([]core.StreamChoice, len(sr.Choices))
-			for i, c := range sr.Choices {
-				choices[i] = core.StreamChoice{
-					Index:        c.Index,
-					FinishReason: c.FinishReason,
-					Delta: core.MessageDelta{
-						Role:    c.Delta.Role,
-						Content: c.Delta.Content,
-					},
-				}
-			}
-
-			ch <- core.StreamChunk{
-				ID:      sr.ID,
-				Model:   sr.Model,
-				Choices: choices,
-			}
+			ch <- chunk
 		}
 		if err := scanner.Err(); err != nil {
 			ch <- core.StreamChunk{Error: fmt.Errorf("stream read error: %w", err)}

--- a/providers/together/together.go
+++ b/providers/together/together.go
@@ -109,19 +109,6 @@ type errorResponse struct {
 	Error errorDetail `json:"error"`
 }
 
-type streamResponse struct {
-	ID      string `json:"id"`
-	Model   string `json:"model"`
-	Choices []struct {
-		Index int `json:"index"`
-		Delta struct {
-			Role    string `json:"role,omitempty"`
-			Content string `json:"content,omitempty"`
-		} `json:"delta"`
-		FinishReason string `json:"finish_reason,omitempty"`
-	} `json:"choices"`
-}
-
 // Complete sends a chat completion request to Together AI.
 func (p *Provider) Complete(ctx context.Context, req core.Request) (*core.Response, error) {
 	bodyReader, _, release, err := openaicompat.BuildBody(req, false)
@@ -216,23 +203,12 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 				return
 			}
 
-			var chunk streamResponse
-			if json.Unmarshal([]byte(data), &chunk) != nil {
+			chunk, err := openaicompat.DecodeStreamChunk([]byte(data))
+			if err != nil {
 				continue
 			}
 
-			sc := core.StreamChunk{ID: chunk.ID, Model: chunk.Model}
-			for _, c := range chunk.Choices {
-				sc.Choices = append(sc.Choices, core.StreamChoice{
-					Index: c.Index,
-					Delta: core.MessageDelta{
-						Role:    c.Delta.Role,
-						Content: c.Delta.Content,
-					},
-					FinishReason: c.FinishReason,
-				})
-			}
-			ch <- sc
+			ch <- chunk
 		}
 		if err := scanner.Err(); err != nil {
 			ch <- core.StreamChunk{Error: err}

--- a/providers/vertex_ai/vertex_ai.go
+++ b/providers/vertex_ai/vertex_ai.go
@@ -411,19 +411,6 @@ func (p *Provider) Complete(ctx context.Context, req core.Request) (*core.Respon
 	}, nil
 }
 
-type vertexAIStreamResponse struct {
-	ID      string `json:"id"`
-	Model   string `json:"model"`
-	Choices []struct {
-		Index int `json:"index"`
-		Delta struct {
-			Role    string `json:"role,omitempty"`
-			Content string `json:"content,omitempty"`
-		} `json:"delta"`
-		FinishReason string `json:"finish_reason,omitempty"`
-	} `json:"choices"`
-}
-
 // CompleteStream sends a streaming chat completion request to Vertex AI.
 func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan core.StreamChunk, error) {
 	bodyReader, _, release, err := openaicompat.BuildBody(req, true)
@@ -472,23 +459,12 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 				return
 			}
 
-			var chunk vertexAIStreamResponse
-			if json.Unmarshal([]byte(data), &chunk) != nil {
+			chunk, err := openaicompat.DecodeStreamChunk([]byte(data))
+			if err != nil {
 				continue
 			}
 
-			sc := core.StreamChunk{ID: chunk.ID, Model: chunk.Model}
-			for _, c := range chunk.Choices {
-				sc.Choices = append(sc.Choices, core.StreamChoice{
-					Index: c.Index,
-					Delta: core.MessageDelta{
-						Role:    c.Delta.Role,
-						Content: c.Delta.Content,
-					},
-					FinishReason: c.FinishReason,
-				})
-			}
-			ch <- sc
+			ch <- chunk
 		}
 		if err := scanner.Err(); err != nil {
 			ch <- core.StreamChunk{Error: err}

--- a/providers/xai/xai.go
+++ b/providers/xai/xai.go
@@ -104,19 +104,6 @@ type errorBody struct {
 	} `json:"error"`
 }
 
-type streamResponse struct {
-	ID      string `json:"id"`
-	Model   string `json:"model"`
-	Choices []struct {
-		Index int `json:"index"`
-		Delta struct {
-			Role    string `json:"role,omitempty"`
-			Content string `json:"content,omitempty"`
-		} `json:"delta"`
-		FinishReason string `json:"finish_reason,omitempty"`
-	} `json:"choices"`
-}
-
 // Complete sends a chat completion request to xAI.
 func (p *Provider) Complete(ctx context.Context, req core.Request) (*core.Response, error) {
 	bodyReader, _, release, err := openaicompat.BuildBody(req, false)
@@ -211,23 +198,12 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 				return
 			}
 
-			var chunk streamResponse
-			if json.Unmarshal([]byte(data), &chunk) != nil {
+			chunk, err := openaicompat.DecodeStreamChunk([]byte(data))
+			if err != nil {
 				continue
 			}
 
-			sc := core.StreamChunk{ID: chunk.ID, Model: chunk.Model}
-			for _, c := range chunk.Choices {
-				sc.Choices = append(sc.Choices, core.StreamChoice{
-					Index: c.Index,
-					Delta: core.MessageDelta{
-						Role:    c.Delta.Role,
-						Content: c.Delta.Content,
-					},
-					FinishReason: c.FinishReason,
-				})
-			}
-			ch <- sc
+			ch <- chunk
 		}
 		if err := scanner.Err(); err != nil {
 			ch <- core.StreamChunk{Error: err}


### PR DESCRIPTION
## Summary

Fixes tool/function calling preservation across OpenAI-compatible and native provider paths for issue #139. Native providers now forward tool definitions/results and stream tool-call deltas instead of returning text-only responses.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] New provider
- [ ] New plugin
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Performance improvement
- [x] Refactor / code quality
- [ ] Documentation / comments only
- [ ] CI / tooling

## Related issues

Fixes #139

## Changes

- Preserve assistant tool calls and tool-result round trips for OpenAI, Anthropic, Gemini, Bedrock Anthropic, and Cohere paths.
- Forward `tools` / `tool_choice` for native Anthropic, Gemini, Bedrock Anthropic, and Cohere requests.
- Preserve streamed OpenAI-compatible `tool_calls` deltas, including `tool_calls[].index` for fragment assembly.
- Decode native streaming tool-call deltas for Anthropic, Bedrock Anthropic, and Cohere.
- Centralize OpenAI-compatible stream chunk decoding so compatible providers stop dropping non-content deltas.

## Testing

- [x] Existing tests pass (`go test ./...`)
- [x] New unit tests added (if applicable)
- [ ] Manually tested against a live provider (if provider change)

Focused checks run:

```sh
go test ./internal/openaicompat ./providers/openai ./providers/anthropic ./providers/bedrock ./providers/cohere ./providers/gemini
go test ./...
```

## Provider checklist (fill in only for new/updated providers)

- [x] Provider file at `providers/<id>/<id>.go`
- [x] Test file at `providers/<id>/<id>_test.go`
- [ ] `ProviderEntry` added to `providers/providers_list.go`
- [ ] Name constant added to `providers/names.go`
- [ ] Models added to `ferro-labs/model-catalog` when catalog coverage changes
- [x] `AllowedTools`, `MaxCallDepth` and streaming tested

No new provider registration or catalog changes were needed.

## Plugin checklist (fill in only for new/updated plugins)

Not applicable.

## Breaking change notes

None.

## Screenshots / output (optional)

All tests passed locally.
