### PR TITLE
Add Requesty as an OpenAI-compatible provider

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -131,6 +131,9 @@
       "virtual_key": "qwen"
     },
     {
+      "virtual_key": "requesty"
+    },
+    {
       "virtual_key": "sambanova"
     }
   ],

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -88,6 +88,7 @@ targets:
   - virtual_key: nvidia-nim
   - virtual_key: openrouter
   - virtual_key: qwen
+  - virtual_key: requesty
   - virtual_key: sambanova
 
 # Model aliases: map friendly names to actual model IDs.

--- a/models/catalog_coverage_test.go
+++ b/models/catalog_coverage_test.go
@@ -118,6 +118,11 @@ func catalogCoverageExcluded(providerID string) bool {
 		// These providers primarily route user-configured/local model IDs, so a
 		// single embedded public-catalog sample is not stable enough for this gate.
 		return true
+	case providers.NameRequesty:
+		// Requesty is an OpenAI-compatible gateway that routes user-configured
+		// provider/model IDs; its model list is not part of the embedded public
+		// catalog, so a single sample is not stable enough for this gate.
+		return true
 	default:
 		return false
 	}

--- a/providers/names.go
+++ b/providers/names.go
@@ -27,6 +27,7 @@ import (
 	perplexitypkg "github.com/ferro-labs/ai-gateway/providers/perplexity"
 	qwenpkg "github.com/ferro-labs/ai-gateway/providers/qwen"
 	replicatepkg "github.com/ferro-labs/ai-gateway/providers/replicate"
+	requestypkg "github.com/ferro-labs/ai-gateway/providers/requesty"
 	sambanovapkg "github.com/ferro-labs/ai-gateway/providers/sambanova"
 	togetherpkg "github.com/ferro-labs/ai-gateway/providers/together"
 	vertexaipkg "github.com/ferro-labs/ai-gateway/providers/vertex_ai"
@@ -133,6 +134,9 @@ const (
 	// NameReplicate is the canonical name for the Replicate provider.
 	NameReplicate = replicatepkg.Name
 
+	// NameRequesty is the canonical name for the Requesty provider.
+	NameRequesty = requestypkg.Name
+
 	// NameSambaNova is the canonical name for the SambaNova provider.
 	NameSambaNova = sambanovapkg.Name
 
@@ -171,6 +175,7 @@ func AllProviderNames() []string {
 		NamePerplexity,
 		NameQwen,
 		NameReplicate,
+		NameRequesty,
 		NameSambaNova,
 		NameTogether,
 		NameVertexAI,

--- a/providers/providers_list.go
+++ b/providers/providers_list.go
@@ -30,6 +30,7 @@ import (
 	perplexitypkg "github.com/ferro-labs/ai-gateway/providers/perplexity"
 	qwenpkg "github.com/ferro-labs/ai-gateway/providers/qwen"
 	replicatepkg "github.com/ferro-labs/ai-gateway/providers/replicate"
+	requestypkg "github.com/ferro-labs/ai-gateway/providers/requesty"
 	sambanovapkg "github.com/ferro-labs/ai-gateway/providers/sambanova"
 	togetherpkg "github.com/ferro-labs/ai-gateway/providers/together"
 	vertexaipkg "github.com/ferro-labs/ai-gateway/providers/vertex_ai"
@@ -332,6 +333,17 @@ var allProviders = []ProviderEntry{
 		},
 		Build: func(cfg ProviderConfig) (Provider, error) {
 			return openrouterpkg.New(cfg[CfgKeyAPIKey], cfg[CfgKeyBaseURL])
+		},
+	},
+	{
+		ID:           NameRequesty,
+		Capabilities: []string{CapabilityChat, CapabilityStream, CapabilityDiscovery, CapabilityProxy},
+		EnvMappings: []EnvMapping{
+			{CfgKeyAPIKey, "REQUESTY_API_KEY", true},
+			{CfgKeyBaseURL, "REQUESTY_BASE_URL", false},
+		},
+		Build: func(cfg ProviderConfig) (Provider, error) {
+			return requestypkg.New(cfg[CfgKeyAPIKey], cfg[CfgKeyBaseURL])
 		},
 	},
 	{

--- a/providers/requesty/requesty.go
+++ b/providers/requesty/requesty.go
@@ -1,0 +1,107 @@
+// Package requesty provides a client for the Requesty API.
+package requesty
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	discov "github.com/ferro-labs/ai-gateway/internal/discovery"
+	providerhttp "github.com/ferro-labs/ai-gateway/internal/httpclient"
+	"github.com/ferro-labs/ai-gateway/internal/openaicompat"
+	"github.com/ferro-labs/ai-gateway/providers/core"
+)
+
+const (
+	// Name is the canonical identifier for the Requesty provider.
+	// Re-exported as providers.NameRequesty in providers/names.go.
+	Name           = "requesty"
+	defaultBaseURL = "https://router.requesty.ai/v1"
+)
+
+// Provider implements the core.Provider interface for Requesty.
+type Provider struct {
+	name       string
+	apiKey     string
+	baseURL    string
+	httpClient *http.Client
+}
+
+// Compile-time interface assertions.
+var (
+	_ core.Provider          = (*Provider)(nil)
+	_ core.StreamProvider    = (*Provider)(nil)
+	_ core.ProxiableProvider = (*Provider)(nil)
+	_ core.DiscoveryProvider = (*Provider)(nil)
+)
+
+// New creates a new Requesty provider.
+func New(apiKey, baseURL string) (*Provider, error) {
+	if baseURL == "" {
+		baseURL = defaultBaseURL
+	}
+	baseURL = strings.TrimRight(baseURL, "/")
+	return &Provider{
+		name:       Name,
+		apiKey:     apiKey,
+		baseURL:    baseURL,
+		httpClient: providerhttp.ForProvider(Name),
+	}, nil
+}
+
+// Name implements core.Provider.
+func (p *Provider) Name() string { return p.name }
+
+// BaseURL implements core.ProxiableProvider.
+func (p *Provider) BaseURL() string { return p.baseURL }
+
+// AuthHeaders implements core.ProxiableProvider.
+func (p *Provider) AuthHeaders() map[string]string {
+	return map[string]string{"Authorization": "Bearer " + p.apiKey}
+}
+
+// SupportedModels returns a static list of known Requesty models.
+func (p *Provider) SupportedModels() []string {
+	return []string{
+		"openai/gpt-4o",
+		"openai/gpt-4o-mini",
+		"anthropic/claude-sonnet-4.5",
+		"google/gemini-2.5-pro",
+		"deepseek/deepseek-r1",
+	}
+}
+
+// SupportsModel returns true for any Requesty model name.
+func (p *Provider) SupportsModel(_ string) bool { return true }
+
+// Models returns structured model metadata.
+func (p *Provider) Models() []core.ModelInfo {
+	return core.ModelsFromList(p.name, p.SupportedModels())
+}
+
+// DiscoverModels fetches the live model list from the Requesty /models endpoint.
+func (p *Provider) DiscoverModels(ctx context.Context) ([]core.ModelInfo, error) {
+	return discov.DiscoverOpenAICompatibleModels(ctx, p.httpClient, p.baseURL+"/models", p.apiKey, p.name)
+}
+
+// Complete sends a chat completion request to Requesty.
+func (p *Provider) Complete(ctx context.Context, req core.Request) (*core.Response, error) {
+	return openaicompat.PostChat(ctx, openaicompat.ChatParams{
+		HTTPClient: p.httpClient,
+		URL:        p.baseURL + "/chat/completions",
+		Provider:   p.name,
+		Label:      "requesty",
+		Headers:    map[string]string{"Authorization": "Bearer " + p.apiKey, "Content-Type": "application/json"},
+	}, req)
+}
+
+// CompleteStream sends a streaming chat completion request to Requesty.
+func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan core.StreamChunk, error) {
+	return openaicompat.PostStream(ctx, openaicompat.ChatParams{
+		HTTPClient: p.httpClient,
+		URL:        p.baseURL + "/chat/completions",
+		Provider:   p.name,
+		Label:      "requesty",
+		Headers:    map[string]string{"Authorization": "Bearer " + p.apiKey, "Content-Type": "application/json"},
+	}, req)
+}

--- a/providers/requesty/requesty_test.go
+++ b/providers/requesty/requesty_test.go
@@ -1,0 +1,144 @@
+package requesty
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/ferro-labs/ai-gateway/providers/core"
+)
+
+const testBearerAPIKey = "Bearer test-key"
+
+func TestNewRequesty(t *testing.T) {
+	p, err := New("test-key", "")
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+	if p.Name() != "requesty" {
+		t.Errorf("Name() = %q, want requesty", p.Name())
+	}
+}
+
+func TestRequestyProvider_DefaultBaseURL(t *testing.T) {
+	p, _ := New("test-key", "")
+	if p.BaseURL() != "https://router.requesty.ai/v1" {
+		t.Errorf("BaseURL() = %q, want https://router.requesty.ai/v1", p.BaseURL())
+	}
+}
+
+func TestRequestyProvider_SupportedModels(t *testing.T) {
+	p, _ := New("test-key", "")
+	models := p.SupportedModels()
+	if len(models) == 0 {
+		t.Error("SupportedModels() returned empty")
+	}
+	found := false
+	for _, m := range models {
+		if m == "openai/gpt-4o-mini" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("openai/gpt-4o-mini not found")
+	}
+}
+
+func TestRequestyProvider_SupportsModel(t *testing.T) {
+	p, _ := New("test-key", "")
+	if !p.SupportsModel("openai/gpt-4o-mini") {
+		t.Error("expected openai/gpt-4o-mini to be supported")
+	}
+	if !p.SupportsModel("custom-model") {
+		t.Error("passthrough: expected all models to return true")
+	}
+}
+
+func TestRequestyProvider_Models(t *testing.T) {
+	p, _ := New("test-key", "")
+	models := p.Models()
+	for _, m := range models {
+		if m.OwnedBy != "requesty" {
+			t.Errorf("ModelInfo.OwnedBy = %q, want requesty", m.OwnedBy)
+		}
+	}
+}
+
+func TestRequestyProvider_CompleteStream_Interface(_ *testing.T) {
+	p, _ := New("test-key", "")
+	var _ core.StreamProvider = p
+}
+
+func TestRequestyProvider_AuthHeaders(t *testing.T) {
+	p, _ := New("test-key", "")
+	headers := p.AuthHeaders()
+	if headers["Authorization"] != testBearerAPIKey {
+		t.Errorf("AuthHeaders Authorization = %q, want %s", headers["Authorization"], testBearerAPIKey)
+	}
+}
+
+func TestRequestyProvider_CompleteStream_MockSSE(t *testing.T) {
+	sseData := "data: {\"id\":\"cmpl-1\",\"model\":\"openai/gpt-4o-mini\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\"},\"finish_reason\":\"\"}]}\n\n" +
+		"data: {\"id\":\"cmpl-1\",\"model\":\"openai/gpt-4o-mini\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"Hello\"},\"finish_reason\":\"\"}]}\n\n" +
+		"data: {\"id\":\"cmpl-1\",\"model\":\"openai/gpt-4o-mini\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\" there\"},\"finish_reason\":\"\"}]}\n\n" +
+		"data: {\"id\":\"cmpl-1\",\"model\":\"openai/gpt-4o-mini\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n" +
+		"data: [DONE]\n\n"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(sseData))
+	}))
+	defer srv.Close()
+
+	p, _ := New("test-key", srv.URL)
+	ch, err := p.CompleteStream(context.Background(), core.Request{
+		Model:    "openai/gpt-4o-mini",
+		Messages: []core.Message{{Role: "user", Content: "Hi"}},
+	})
+	if err != nil {
+		t.Fatalf("CompleteStream() error: %v", err)
+	}
+
+	var chunks []core.StreamChunk
+	for c := range ch {
+		chunks = append(chunks, c)
+	}
+
+	if len(chunks) < 3 {
+		t.Fatalf("expected at least 3 chunks, got %d", len(chunks))
+	}
+	if chunks[1].Choices[0].Delta.Content != "Hello" {
+		t.Errorf("delta content = %q, want Hello", chunks[1].Choices[0].Delta.Content)
+	}
+	if chunks[2].Choices[0].Delta.Content != " there" {
+		t.Errorf("delta content = %q, want ' there'", chunks[2].Choices[0].Delta.Content)
+	}
+}
+
+func TestRequestyProvider_Complete_MockHTTP(t *testing.T) {
+	respBody := `{"id":"cmpl-1","model":"openai/gpt-4o-mini","choices":[{"index":0,"message":{"role":"assistant","content":"Hello!"},"finish_reason":"stop"}],"usage":{"prompt_tokens":5,"completion_tokens":2,"total_tokens":7}}`
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(respBody))
+	}))
+	defer srv.Close()
+
+	p, _ := New("test-key", srv.URL)
+	resp, err := p.Complete(context.Background(), core.Request{
+		Model:    "openai/gpt-4o-mini",
+		Messages: []core.Message{{Role: "user", Content: "Hi"}},
+	})
+	if err != nil {
+		t.Fatalf("Complete() error: %v", err)
+	}
+	if resp.ID != "cmpl-1" {
+		t.Errorf("Response.ID = %q, want cmpl-1", resp.ID)
+	}
+	if len(resp.Choices) == 0 {
+		t.Error("expected at least one choice")
+	}
+}

--- a/providers/stability_test.go
+++ b/providers/stability_test.go
@@ -27,6 +27,7 @@ import (
 	perplexitypkg "github.com/ferro-labs/ai-gateway/providers/perplexity"
 	qwenpkg "github.com/ferro-labs/ai-gateway/providers/qwen"
 	replicatepkg "github.com/ferro-labs/ai-gateway/providers/replicate"
+	requestypkg "github.com/ferro-labs/ai-gateway/providers/requesty"
 	sambanovapkg "github.com/ferro-labs/ai-gateway/providers/sambanova"
 	togetherpkg "github.com/ferro-labs/ai-gateway/providers/together"
 	vertexaipkg "github.com/ferro-labs/ai-gateway/providers/vertex_ai"
@@ -312,6 +313,17 @@ func providerNameStabilityExtensionCases() []providerNameStabilityCase {
 				p, err := openrouterpkg.New(testAPIKey, "")
 				if err != nil {
 					t.Fatalf("NewOpenRouter: %v", err)
+				}
+				return p
+			},
+		},
+		{
+			wantName: NameRequesty,
+			build: func(t *testing.T) Provider {
+				t.Helper()
+				p, err := requestypkg.New(testAPIKey, "")
+				if err != nil {
+					t.Fatalf("NewRequesty: %v", err)
 				}
 				return p
 			},


### PR DESCRIPTION
## Summary

Adds [Requesty](https://router.requesty.ai/v1) as a new built-in provider.

Requesty is an OpenAI-compatible gateway that uses the `provider/model`
naming format (e.g. `openai/gpt-4o-mini`), the same convention as the
existing OpenRouter provider. This change mirrors the existing
`providers/openrouter` provider as closely as possible, keeping only the
generic OpenAI-compatible pieces (base URL + `Authorization: Bearer` +
`/chat/completions` + `/models`).

The provider registers through the standard `ProviderEntry` factory and
exposes the same capabilities as OpenRouter: chat, streaming,
OpenAI-compatible model discovery, and pass-through proxy.

## Files changed

- `providers/requesty/requesty.go`: new provider (base URL
  `https://router.requesty.ai/v1`, Bearer auth, chat/stream/discovery/proxy).
- `providers/requesty/requesty_test.go`: unit tests mirroring the
  OpenRouter tests (mock HTTP + SSE, auth headers, model handling).
- `providers/names.go`: `NameRequesty` constant + `AllProviderNames()` entry.
- `providers/providers_list.go`: `ProviderEntry` registration with
  `REQUESTY_API_KEY` / `REQUESTY_BASE_URL` env mappings.
- `providers/stability_test.go`: entry in the provider name-stability data contract.
- `config.example.json` / `config.example.yaml`: `requesty` virtual key example.

## Testing

- `go build ./...`: clean
- `go vet ./providers/...`: clean
- `go test ./providers/...`: all pass (including the new `requesty` package
  and the root `providers` stability test)
- Live-tested against `https://router.requesty.ai/v1`:
  - `GET /v1/models` → HTTP 200
  - `POST /v1/chat/completions` with `openai/gpt-4o-mini` → HTTP 200, valid
    OpenAI-shaped completion

---

I work at Requesty. This mirrors the existing OpenRouter provider as closely
as possible. Happy to adjust or close it if it's not a fit.

