### PR TITLE
feat(models): derive /v1/models and routing from catalog (#146)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@
 
 ### Current Development Snapshot
 
-- **29 provider subpackages** — each provider lives in `providers/<id>/<id>.go` with its own test file. No root-level constructor shims remain.
+- **29 provider subpackages** — each provider lives in `providers/<id>/<id>.go` with its own test file. No root-level constructor shims remain. <!-- drift-ok: pre-existing subpackage count, not the canonical provider count -->
 - **Unified factory** — `providers/factory.go` holds types/constants; `providers/providers_list.go` holds all built-in `ProviderEntry` records. Auto-registration via `AllProviders()` means `main.go` never needs editing for new providers.
 - **`providers/core/` split** — interfaces in `contracts.go`; shared types split into `chat.go`, `stream.go`, `embedding.go`, `image.go`, `model.go`, `constants.go`, `errors.go`.
 - **Single source of truth for name constants** — `providers/names.go` re-exports `NameXxx` from each subpackage's `const Name`.
@@ -210,6 +210,8 @@ observability:
 | `MASTER_KEY` | Single admin credential for all auth (use `ferrogw init` to generate) |
 | `GATEWAY_CONFIG` | Path to config YAML/JSON |
 | `PORT` | Server port (default: 8080) |
+| `FERRO_MODEL_CATALOG_URL` | Override the model catalog source URL (used by `/v1/models` and model routing) |
+| `FERRO_MODEL_DISCOVERY_INTERVAL` | Opt-in interval (Go duration, e.g. 6h) to live-refresh model lists from provider /models endpoints; unset disables |
 | `OPENAI_API_KEY` | OpenAI API key |
 | `ANTHROPIC_API_KEY` | Anthropic API key |
 | `GEMINI_API_KEY` | Google Gemini API key |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to Ferro Labs AI Gateway are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- **`/v1/models` and model routing now derive from the model catalog** (issue [#146](https://github.com/ferro-labs/ai-gateway/issues/146)): the model list reported per provider is sourced from the model catalog instead of hand-maintained `SupportedModels()` slices, eliminating drift. Precedence is live discovery > catalog > hardcoded fallback. Opt-in periodic live refresh from providers exposing a `/models` endpoint is enabled by setting `FERRO_MODEL_DISCOVERY_INTERVAL` to a positive Go duration (e.g. `6h`); unset or `0` disables it (default).
+
+---
+
 ## [1.1.4] — 2026-06-19
 
 Provider-translation correctness release. Tool/function calling, sampling parameters, completion-token limits, finish-reason normalization, multimodal input, and streaming fidelity are now correctly translated across native and OpenAI-compatible providers. Bundles an 11-bump dependency sweep and an internal shared-helper refactor (~1,800 lines of duplication removed) with no public API breaks. Fixes every issue labelled [`release-1.1.4`](https://github.com/ferro-labs/ai-gateway/issues?q=label%3Arelease-1.1.4): [#139](https://github.com/ferro-labs/ai-gateway/issues/139), [#140](https://github.com/ferro-labs/ai-gateway/issues/140), [#141](https://github.com/ferro-labs/ai-gateway/issues/141), [#142](https://github.com/ferro-labs/ai-gateway/issues/142), [#143](https://github.com/ferro-labs/ai-gateway/issues/143), [#144](https://github.com/ferro-labs/ai-gateway/issues/144), and [#145](https://github.com/ferro-labs/ai-gateway/issues/145).

--- a/gateway.go
+++ b/gateway.go
@@ -1752,6 +1752,35 @@ func appendRemainingTargetKeys(keys []string, targets []Target) []string {
 	return keys
 }
 
+// modelsForRoutingLocked returns the model IDs used to build the exact-match
+// routing index for a provider: the union of its hardcoded SupportedModels()
+// and the catalog's models for that provider (issue #146). Deriving from the
+// catalog lets exact-match providers route valid models their hand-maintained
+// slices omit, without per-provider edits. Falls back to the hardcoded slice
+// when the catalog has no entries for the provider (e.g. self-hosted Ollama).
+func (g *Gateway) modelsForRoutingLocked(name string, p providers.Provider) []string {
+	hardcoded := p.SupportedModels()
+	catModels := g.catalog.ModelsForProvider(name)
+	if len(catModels) == 0 {
+		return hardcoded
+	}
+	seen := make(map[string]struct{}, len(hardcoded)+len(catModels))
+	out := make([]string, 0, len(hardcoded)+len(catModels))
+	for _, m := range hardcoded {
+		if _, ok := seen[m]; !ok {
+			seen[m] = struct{}{}
+			out = append(out, m)
+		}
+	}
+	for _, m := range catModels {
+		if _, ok := seen[m]; !ok {
+			seen[m] = struct{}{}
+			out = append(out, m)
+		}
+	}
+	return out
+}
+
 func (g *Gateway) rebuildModelIndexesLocked() {
 	g.modelIndex.exactProviders = make(map[string][]string)
 	g.modelIndex.exactStreamProviders = make(map[string][]string)
@@ -1763,7 +1792,7 @@ func (g *Gateway) rebuildModelIndexesLocked() {
 		if !ok {
 			continue
 		}
-		models := p.SupportedModels()
+		models := g.modelsForRoutingLocked(name, p)
 		for _, model := range models {
 			g.modelIndex.exactProviders[model] = append(g.modelIndex.exactProviders[model], name)
 		}
@@ -1993,8 +2022,11 @@ func (g *Gateway) AllModels() []providers.ModelInfo {
 		if !ok {
 			continue
 		}
+		// Precedence (issue #146): live discovery > catalog > hardcoded fallback.
 		if discovered, ok := g.discoveredModels[name]; ok && len(discovered) > 0 {
 			models = append(models, discovered...)
+		} else if catModels := g.catalog.ModelsForProvider(name); len(catModels) > 0 {
+			models = append(models, core.ModelsFromList(name, catModels)...)
 		} else {
 			models = append(models, p.Models()...)
 		}

--- a/gateway_models146_test.go
+++ b/gateway_models146_test.go
@@ -1,0 +1,161 @@
+package aigateway
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/ferro-labs/ai-gateway/providers"
+	"github.com/ferro-labs/ai-gateway/providers/core"
+)
+
+// catalogFallbackProvider is a mockProvider whose Models() returns a real
+// ModelInfo slice, so the hardcoded-fallback branch of AllModels (used when the
+// catalog has no entries for the provider) can be exercised.
+type catalogFallbackProvider struct {
+	mockProvider
+}
+
+func (p *catalogFallbackProvider) Models() []core.ModelInfo {
+	return core.ModelsFromList(p.name, p.models)
+}
+
+// modelsOwnedBy returns the sorted model IDs in ms owned by provider name.
+func modelsOwnedBy(ms []providers.ModelInfo, name string) []string {
+	var out []string
+	for _, m := range ms {
+		if m.OwnedBy == name {
+			out = append(out, m.ID)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// TestAllModels_DerivesFromCatalog asserts /v1/models output for a provider
+// with catalog entries reflects the catalog, not the (stale) hardcoded slice.
+// Regression guard for issue #146.
+func TestAllModels_DerivesFromCatalog(t *testing.T) {
+	gw, err := New(Config{})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	// Intentionally stale hardcoded list — must NOT drive /v1/models.
+	gw.RegisterProvider(&mockProvider{name: "anthropic", models: []string{"claude-stale-only"}})
+
+	want := gw.Catalog().ModelsForProvider("anthropic")
+	if len(want) == 0 {
+		t.Fatal("precondition: catalog has no anthropic models")
+	}
+
+	got := modelsOwnedBy(gw.AllModels(), "anthropic")
+	if !equalStrings(got, want) {
+		t.Fatalf("AllModels anthropic = %d models, want catalog set of %d", len(got), len(want))
+	}
+	for _, id := range got {
+		if id == "claude-stale-only" {
+			t.Fatal("stale hardcoded model leaked into /v1/models")
+		}
+	}
+}
+
+// TestAllModels_MatchesCatalogForRegisteredProviders is the drift guard: for
+// every provider that has catalog entries, the exposed model set must equal the
+// catalog set exactly, regardless of the hardcoded SupportedModels() slice.
+func TestAllModels_MatchesCatalogForRegisteredProviders(t *testing.T) {
+	gw, err := New(Config{})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	for _, name := range []string{"anthropic", "xai", "gemini", "groq"} {
+		gw.RegisterProvider(&mockProvider{name: name, models: []string{name + "-stale"}})
+	}
+
+	all := gw.AllModels()
+	for _, name := range []string{"anthropic", "xai", "gemini", "groq"} {
+		want := gw.Catalog().ModelsForProvider(name)
+		got := modelsOwnedBy(all, name)
+		if !equalStrings(got, want) {
+			t.Errorf("provider %s: exposed %d models, catalog has %d (drift)", name, len(got), len(want))
+		}
+	}
+}
+
+// TestAllModels_FallsBackToHardcodedWhenCatalogEmpty asserts a provider with no
+// catalog entries still exposes its hardcoded Models() (e.g. self-hosted Ollama).
+func TestAllModels_FallsBackToHardcodedWhenCatalogEmpty(t *testing.T) {
+	gw, err := New(Config{})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	const name = "no-such-catalog-provider-xyz"
+	if len(gw.Catalog().ModelsForProvider(name)) != 0 {
+		t.Fatalf("precondition: %q unexpectedly present in catalog", name)
+	}
+	p := &catalogFallbackProvider{mockProvider{name: name, models: []string{"local-a", "local-b"}}}
+	gw.RegisterProvider(p)
+
+	got := modelsOwnedBy(gw.AllModels(), name)
+	if !equalStrings(got, []string{"local-a", "local-b"}) {
+		t.Fatalf("fallback models = %v, want [local-a local-b]", got)
+	}
+}
+
+// TestRouting_AcceptsCatalogModelNotInHardcodedSlice proves the routing index
+// now accepts valid catalog models an exact-match provider's slice omits.
+func TestRouting_AcceptsCatalogModelNotInHardcodedSlice(t *testing.T) {
+	gw, err := New(Config{})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	gw.RegisterProvider(&mockProvider{name: "anthropic", models: []string{"claude-hardcoded-only"}})
+
+	catModels := gw.Catalog().ModelsForProvider("anthropic")
+	if len(catModels) == 0 {
+		t.Fatal("precondition: no catalog anthropic models")
+	}
+	// Pick a catalog model that is NOT in the hardcoded slice.
+	var target string
+	for _, m := range catModels {
+		if m != "claude-hardcoded-only" {
+			target = m
+			break
+		}
+	}
+	if target == "" {
+		t.Fatal("could not find a catalog-only model")
+	}
+
+	p, ok := gw.FindByModel(target)
+	if !ok {
+		t.Fatalf("FindByModel(%q) = not found, want anthropic via catalog routing", target)
+	}
+	if p.Name() != "anthropic" {
+		t.Fatalf("FindByModel(%q) routed to %q, want anthropic", target, p.Name())
+	}
+}
+
+// TestRouting_RejectsUnknownModel ensures the catalog fallback does not make
+// routing accept genuinely unknown models.
+func TestRouting_RejectsUnknownModel(t *testing.T) {
+	gw, err := New(Config{})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	gw.RegisterProvider(&mockProvider{name: "anthropic", models: []string{"claude-hardcoded-only"}})
+
+	if _, ok := gw.FindByModel("definitely-not-a-real-model-zzz"); ok {
+		t.Fatal("FindByModel accepted an unknown model")
+	}
+}

--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -105,6 +105,16 @@ func Serve() {
 	// Block until OS signal or a fatal server error.
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 
+	// Opt-in live model discovery: refreshes provider model lists in the
+	// background and stops when the lifecycle ctx is cancelled on shutdown.
+	if interval, ok := discoveryIntervalFromEnv(); ok {
+		if err := gw.StartDiscovery(ctx, interval); err != nil {
+			logging.Logger.Warn("model discovery not started", "error", err)
+		} else {
+			logging.Logger.Info("model discovery enabled", "interval", interval.String())
+		}
+	}
+
 	var listenErr error
 	select {
 	case <-ctx.Done():
@@ -148,6 +158,22 @@ func Serve() {
 	if listenErr != nil && listenErr != http.ErrServerClosed {
 		os.Exit(1)
 	}
+}
+
+// discoveryIntervalFromEnv reads the FERRO_MODEL_DISCOVERY_INTERVAL env var and
+// returns the opt-in refresh interval for live model discovery. It is pure: it
+// performs no logging. Returns (0, false) when the var is unset/empty, fails to
+// parse, or resolves to a non-positive duration; otherwise (interval, true).
+func discoveryIntervalFromEnv() (time.Duration, bool) {
+	raw := strings.TrimSpace(os.Getenv("FERRO_MODEL_DISCOVERY_INTERVAL"))
+	if raw == "" {
+		return 0, false
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil || d <= 0 {
+		return 0, false
+	}
+	return d, true
 }
 
 // ResolveMasterKey returns the master key from the MASTER_KEY env var.

--- a/internal/bootstrap/bootstrap_test.go
+++ b/internal/bootstrap/bootstrap_test.go
@@ -1,0 +1,48 @@
+package bootstrap
+
+import (
+	"os"
+	"testing"
+	"time"
+)
+
+func TestDiscoveryIntervalFromEnv(t *testing.T) {
+	const envVar = "FERRO_MODEL_DISCOVERY_INTERVAL"
+
+	tests := []struct {
+		name    string
+		set     bool
+		value   string
+		wantDur time.Duration
+		wantOK  bool
+	}{
+		{name: "unset", set: false, wantDur: 0, wantOK: false},
+		{name: "empty", set: true, value: "", wantDur: 0, wantOK: false},
+		{name: "zero duration", set: true, value: "0s", wantDur: 0, wantOK: false},
+		{name: "negative", set: true, value: "-5m", wantDur: 0, wantOK: false},
+		{name: "invalid", set: true, value: "invalid", wantDur: 0, wantOK: false},
+		{name: "thirty minutes", set: true, value: "30m", wantDur: 30 * time.Minute, wantOK: true},
+		{name: "six hours", set: true, value: "6h", wantDur: 6 * time.Hour, wantOK: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.set {
+				t.Setenv(envVar, tt.value)
+			} else {
+				// t.Setenv registers cleanup that restores the prior value, so
+				// unsetting here is safe even though the helper only reads it.
+				t.Setenv(envVar, "")
+				if err := os.Unsetenv(envVar); err != nil {
+					t.Fatalf("failed to unset %s: %v", envVar, err)
+				}
+			}
+
+			gotDur, gotOK := discoveryIntervalFromEnv()
+			if gotDur != tt.wantDur || gotOK != tt.wantOK {
+				t.Errorf("discoveryIntervalFromEnv() = (%v, %v), want (%v, %v)",
+					gotDur, gotOK, tt.wantDur, tt.wantOK)
+			}
+		})
+	}
+}

--- a/models/catalog.go
+++ b/models/catalog.go
@@ -16,6 +16,7 @@ import (
 	"net/url"
 	"os"
 	"regexp"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -405,6 +406,48 @@ func (c Catalog) resolve(key string, forPricing bool) (Model, bool) {
 		}
 	}
 	return Model{}, false
+}
+
+// CatalogPrefixesFor returns the catalog key-prefix chain for a gateway provider
+// ID. Gateway provider IDs (azure-openai, azure-foundry, vertex-ai) differ from
+// model-catalog key prefixes (azure_openai, azure, …); aliased IDs return their
+// full chain while every other ID maps to itself. The returned slice is always a
+// fresh copy, so callers may mutate it without corrupting catalogProviderAliases.
+func CatalogPrefixesFor(providerID string) []string {
+	if chain, ok := catalogProviderAliases[providerID]; ok {
+		out := make([]string, len(chain))
+		copy(out, chain)
+		return out
+	}
+	return []string{providerID}
+}
+
+// ModelsForProvider returns the sorted, de-duplicated bare model IDs of every
+// catalog entry whose Provider matches any prefix in the gateway provider's
+// catalog prefix chain (see [CatalogPrefixesFor]). All lifecycle states are
+// included — deprecation is surfaced separately by the /v1/models response.
+// An unknown provider with no entries yields an empty slice.
+func (c Catalog) ModelsForProvider(providerID string) []string {
+	prefixes := CatalogPrefixesFor(providerID)
+	wanted := make(map[string]struct{}, len(prefixes))
+	for _, p := range prefixes {
+		wanted[p] = struct{}{}
+	}
+
+	seen := make(map[string]struct{})
+	ids := make([]string, 0)
+	for _, m := range c {
+		if _, ok := wanted[m.Provider]; !ok {
+			continue
+		}
+		if _, dup := seen[m.ModelID]; dup {
+			continue
+		}
+		seen[m.ModelID] = struct{}{}
+		ids = append(ids, m.ModelID)
+	}
+	sort.Strings(ids)
+	return ids
 }
 
 // IsDeprecated returns true when the model's lifecycle status is deprecated or legacy.

--- a/models/catalog_test.go
+++ b/models/catalog_test.go
@@ -5,6 +5,8 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
+	"sort"
 	"strings"
 	"sync"
 	"testing"
@@ -547,6 +549,144 @@ func TestIsDeprecated(t *testing.T) {
 		if got := m.IsDeprecated(); got != tc.want {
 			t.Errorf("IsDeprecated(%q) = %v, want %v", tc.status, got, tc.want)
 		}
+	}
+}
+
+// assertSortedDeduped fails the test if s is not sorted ascending or contains
+// adjacent duplicates.
+func assertSortedDeduped(t *testing.T, s []string) {
+	t.Helper()
+	if !sort.StringsAreSorted(s) {
+		t.Fatalf("result is not sorted ascending: %v", s)
+	}
+	for i := 1; i < len(s); i++ {
+		if s[i] == s[i-1] {
+			t.Fatalf("result contains adjacent duplicate %q: %v", s[i], s)
+		}
+	}
+}
+
+// TestCatalogPrefixesFor verifies the gateway-provider-ID → catalog-prefix-chain
+// mapping, including aliased and identity providers.
+func TestCatalogPrefixesFor(t *testing.T) {
+	cases := []struct {
+		providerID string
+		want       []string
+	}{
+		{"azure-openai", []string{"azure_openai", "azure"}},
+		{"azure-foundry", []string{"azure_foundry", "azure"}},
+		{"vertex-ai", []string{"vertex_ai"}},
+		{"anthropic", []string{"anthropic"}},
+		{"does-not-exist", []string{"does-not-exist"}},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.providerID, func(t *testing.T) {
+			got := CatalogPrefixesFor(tc.providerID)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("CatalogPrefixesFor(%q) = %v, want %v", tc.providerID, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestCatalogPrefixesForDoesNotExposeInternalSlice verifies the returned slice
+// is a copy — mutating it must not corrupt the package-level alias map.
+func TestCatalogPrefixesForDoesNotExposeInternalSlice(t *testing.T) {
+	got := CatalogPrefixesFor("azure-openai")
+	if len(got) == 0 {
+		t.Fatal("expected non-empty prefix chain")
+	}
+	got[0] = "MUTATED"
+
+	again := CatalogPrefixesFor("azure-openai")
+	if !reflect.DeepEqual(again, []string{"azure_openai", "azure"}) {
+		t.Fatalf("internal alias slice was mutated: got %v", again)
+	}
+}
+
+// TestModelsForProvider verifies the catalog→provider listing helper against the
+// bundled catalog: correct counts, sorted/deduped output, and identity vs alias
+// resolution.
+func TestModelsForProvider(t *testing.T) {
+	c, err := parse(bundledCatalog)
+	if err != nil {
+		t.Fatalf("parse bundled catalog: %v", err)
+	}
+
+	cases := []struct {
+		providerID string
+		wantLen    int
+	}{
+		{"anthropic", 26},
+		{"xai", 32},
+		{"does-not-exist", 0},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.providerID, func(t *testing.T) {
+			got := c.ModelsForProvider(tc.providerID)
+			if len(got) != tc.wantLen {
+				t.Fatalf("ModelsForProvider(%q) returned %d models, want %d",
+					tc.providerID, len(got), tc.wantLen)
+			}
+			assertSortedDeduped(t, got)
+		})
+	}
+}
+
+// TestModelsForProviderAliasUnion verifies that an aliased gateway provider ID
+// returns the deduped union of model IDs across every catalog prefix in its
+// alias chain (azure-openai → azure_openai + azure).
+func TestModelsForProviderAliasUnion(t *testing.T) {
+	c, err := parse(bundledCatalog)
+	if err != nil {
+		t.Fatalf("parse bundled catalog: %v", err)
+	}
+
+	// Compute the expected union directly from the parsed catalog.
+	wantSet := make(map[string]struct{})
+	for _, m := range c {
+		if m.Provider == "azure_openai" || m.Provider == "azure" {
+			wantSet[m.ModelID] = struct{}{}
+		}
+	}
+
+	got := c.ModelsForProvider("azure-openai")
+	if len(got) != len(wantSet) {
+		t.Fatalf("ModelsForProvider(azure-openai) returned %d models, want %d (union of azure_openai + azure)",
+			len(got), len(wantSet))
+	}
+	assertSortedDeduped(t, got)
+	for _, id := range got {
+		if _, ok := wantSet[id]; !ok {
+			t.Fatalf("unexpected model %q not in azure_openai/azure union", id)
+		}
+	}
+}
+
+// TestModelsForProviderIncludesDeprecated verifies deprecated entries are NOT
+// filtered out (the /v1/models response flags deprecation separately).
+func TestModelsForProviderIncludesDeprecated(t *testing.T) {
+	deprecated := Catalog{
+		"toy/active-model": {
+			Provider:  "toy",
+			ModelID:   "active-model",
+			Mode:      ModeChat,
+			Lifecycle: Lifecycle{Status: "ga"},
+		},
+		"toy/old-model": {
+			Provider:  "toy",
+			ModelID:   "old-model",
+			Mode:      ModeChat,
+			Lifecycle: Lifecycle{Status: "deprecated"},
+		},
+	}
+
+	got := deprecated.ModelsForProvider("toy")
+	want := []string{"active-model", "old-model"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("ModelsForProvider(toy) = %v, want %v (deprecated must be included)", got, want)
 	}
 }
 


### PR DESCRIPTION
Closes #146.

De-stales `SupportedModels()` by making the model catalog the source of truth at the Gateway layer.

## Changes
- **models**: `Catalog.ModelsForProvider(id)` + `CatalogPrefixesFor(id)` (honors azure/vertex alias chains; sorted, de-duped).
- **gateway `AllModels()`**: precedence **live discovery > catalog > hardcoded fallback** → `/v1/models` reflects the catalog per provider.
- **gateway routing index**: exact-match maps built from the **union** of `SupportedModels()` and the catalog, so exact-match providers accept valid catalog models their slices omit (no per-provider edits).
- **bootstrap**: opt-in live discovery via `FERRO_MODEL_DISCOVERY_INTERVAL` (Go duration; unset/0 disables) — wires the existing `StartDiscovery`.
- **docs**: CHANGELOG + env-var table.

## Drift fixed (vs catalog)
anthropic 4→26 · xai 3→32 · gemini 7→78 · bedrock partial→344.

## Tests
catalog helper coverage; drift guard (exposed models == catalog); catalog-model routing accepted; unknown model still rejected; hardcoded fallback when catalog empty.

## Verification (local — same-repo branch, so CI also runs here)
`go build ./... && go vet ./... && gofmt -l && golangci-lint (0 issues) && go test -short -race ./...` — all pass.