### PR TITLE
feat(providers): close capability gaps vs upstream APIs (#148)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Capability parity with upstream provider APIs** (issue [#148](https://github.com/ferro-labs/ai-gateway/issues/148)): implemented missing optional interfaces — embeddings on `deepinfra`, `qwen`, `nvidia-nim`, and `ollama`; live model discovery (`/v1/models`) on `anthropic`, `mistral`, `groq`, and `together`; `azure-openai` embeddings and image generation; and image generation on `bedrock` (Nova Canvas / Titan Image / SDXL), `gemini` and `vertex-ai` (Imagen), and `xai` (grok image). The shared discovery helper now supports custom auth headers (for Anthropic's `x-api-key`) and tolerates both wrapped and bare-array `/models` responses. (AI21 embeddings were excluded — AI21 exposes no embeddings endpoint.)
+
 ### Changed
 
 - **`/v1/models` and model routing now derive from the model catalog** (issue [#146](https://github.com/ferro-labs/ai-gateway/issues/146)): the model list reported per provider is sourced from the model catalog instead of hand-maintained `SupportedModels()` slices, eliminating drift. Precedence is live discovery > catalog > hardcoded fallback. Opt-in periodic live refresh from providers exposing a `/models` endpoint is enabled by setting `FERRO_MODEL_DISCOVERY_INTERVAL` to a positive Go duration (e.g. `6h`); unset or `0` disables it (default).

--- a/internal/discovery/openai_compat.go
+++ b/internal/discovery/openai_compat.go
@@ -3,6 +3,7 @@
 package discovery
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -12,28 +13,51 @@ import (
 	"github.com/ferro-labs/ai-gateway/providers/core"
 )
 
-// openAIModelList mirrors the OpenAI /v1/models response schema.
-type openAIModelList struct {
-	Object string `json:"object"`
-	Data   []struct {
-		ID      string `json:"id"`
-		Object  string `json:"object"`
-		Created int64  `json:"created"`
-		OwnedBy string `json:"owned_by"`
-	} `json:"data"`
+// modelItem mirrors a single entry in an OpenAI-compatible /models response.
+type modelItem struct {
+	ID      string `json:"id"`
+	Object  string `json:"object"`
+	Created int64  `json:"created"`
+	OwnedBy string `json:"owned_by"`
 }
 
-// DiscoverOpenAICompatibleModels fetches a live model list from any provider
-// that exposes an OpenAI-compatible GET /v1/models (or similar) endpoint.
-// If apiKey is empty the Authorization header is omitted (for unauthenticated
-// endpoints such as local Ollama instances).
-func DiscoverOpenAICompatibleModels(ctx context.Context, client *http.Client, url, apiKey, providerName string) ([]core.ModelInfo, error) {
+// openAIModelList mirrors the wrapped OpenAI /v1/models response schema.
+type openAIModelList struct {
+	Object string      `json:"object"`
+	Data   []modelItem `json:"data"`
+}
+
+// parseModelItems decodes an OpenAI-compatible model list. It tolerates both the
+// standard wrapped shape ({"object":...,"data":[...]}) and a bare JSON array
+// ([...]) returned by some providers (e.g. Together AI).
+func parseModelItems(body []byte) ([]modelItem, error) {
+	trimmed := bytes.TrimSpace(body)
+	if len(trimmed) > 0 && trimmed[0] == '[' {
+		var items []modelItem
+		if err := json.Unmarshal(trimmed, &items); err != nil {
+			return nil, fmt.Errorf("failed to parse model list: %w", err)
+		}
+		return items, nil
+	}
+
+	var list openAIModelList
+	if err := json.Unmarshal(body, &list); err != nil {
+		return nil, fmt.Errorf("failed to parse model list: %w", err)
+	}
+	return list.Data, nil
+}
+
+// DiscoverModelsWithHeaders fetches a live model list from any provider that
+// exposes an OpenAI-compatible GET /v1/models (or similar) endpoint, setting the
+// supplied headers on the request. It tolerates both the wrapped {"data":[...]}
+// shape and a bare JSON array. Items missing owned_by fall back to providerName.
+func DiscoverModelsWithHeaders(ctx context.Context, client *http.Client, url string, headers map[string]string, providerName string) ([]core.ModelInfo, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create discovery request: %w", err)
 	}
-	if apiKey != "" {
-		req.Header.Set("Authorization", "Bearer "+apiKey)
+	for k, v := range headers {
+		req.Header.Set(k, v)
 	}
 
 	resp, err := client.Do(req)
@@ -51,13 +75,13 @@ func DiscoverOpenAICompatibleModels(ctx context.Context, client *http.Client, ur
 		return nil, fmt.Errorf("discovery request returned %d: %s", resp.StatusCode, string(body))
 	}
 
-	var list openAIModelList
-	if err := json.Unmarshal(body, &list); err != nil {
-		return nil, fmt.Errorf("failed to parse model list: %w", err)
+	items, err := parseModelItems(body)
+	if err != nil {
+		return nil, err
 	}
 
-	models := make([]core.ModelInfo, 0, len(list.Data))
-	for _, m := range list.Data {
+	models := make([]core.ModelInfo, 0, len(items))
+	for _, m := range items {
 		ownedBy := m.OwnedBy
 		if ownedBy == "" {
 			ownedBy = providerName
@@ -70,4 +94,16 @@ func DiscoverOpenAICompatibleModels(ctx context.Context, client *http.Client, ur
 		})
 	}
 	return models, nil
+}
+
+// DiscoverOpenAICompatibleModels fetches a live model list from any provider
+// that exposes an OpenAI-compatible GET /v1/models (or similar) endpoint using
+// Bearer authentication. If apiKey is empty the Authorization header is omitted
+// (for unauthenticated endpoints such as local Ollama instances).
+func DiscoverOpenAICompatibleModels(ctx context.Context, client *http.Client, url, apiKey, providerName string) ([]core.ModelInfo, error) {
+	var headers map[string]string
+	if apiKey != "" {
+		headers = map[string]string{"Authorization": "Bearer " + apiKey}
+	}
+	return DiscoverModelsWithHeaders(ctx, client, url, headers, providerName)
 }

--- a/internal/discovery/openai_compat_test.go
+++ b/internal/discovery/openai_compat_test.go
@@ -84,3 +84,86 @@ func TestDiscoverOpenAICompatibleModels_BadURL(t *testing.T) {
 		t.Fatal("expected error for bad URL, got nil")
 	}
 }
+
+func TestDiscoverModelsWithHeaders_WrappedBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"object":"list","data":[{"id":"m-1","owned_by":"acme"},{"id":"m-2"}]}`))
+	}))
+	defer srv.Close()
+
+	models, err := DiscoverModelsWithHeaders(context.Background(), srv.Client(), srv.URL, nil, "fallback")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(models) != 2 {
+		t.Fatalf("expected 2 models, got %d", len(models))
+	}
+	if models[0].ID != "m-1" || models[0].OwnedBy != "acme" {
+		t.Errorf("unexpected model[0]: %+v", models[0])
+	}
+	if models[1].OwnedBy != "fallback" {
+		t.Errorf("model[1] owned_by = %q, want fallback", models[1].OwnedBy)
+	}
+}
+
+func TestDiscoverModelsWithHeaders_BareArrayBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`[{"id":"bare-1"},{"id":"bare-2","owned_by":"x"}]`))
+	}))
+	defer srv.Close()
+
+	models, err := DiscoverModelsWithHeaders(context.Background(), srv.Client(), srv.URL, nil, "fallback")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(models) != 2 {
+		t.Fatalf("expected 2 models, got %d", len(models))
+	}
+	if models[0].ID != "bare-1" || models[0].OwnedBy != "fallback" {
+		t.Errorf("unexpected model[0]: %+v", models[0])
+	}
+	if models[1].ID != "bare-2" || models[1].OwnedBy != "x" {
+		t.Errorf("unexpected model[1]: %+v", models[1])
+	}
+}
+
+func TestDiscoverModelsWithHeaders_SendsCustomHeaders(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("x-api-key") != "secret" {
+			t.Errorf("expected x-api-key 'secret', got %q", r.Header.Get("x-api-key"))
+		}
+		if r.Header.Get("anthropic-version") != "2023-06-01" {
+			t.Errorf("expected anthropic-version '2023-06-01', got %q", r.Header.Get("anthropic-version"))
+		}
+		if r.Header.Get("Authorization") != "" {
+			t.Errorf("expected no Authorization header, got %q", r.Header.Get("Authorization"))
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"data":[{"id":"m-1"}]}`))
+	}))
+	defer srv.Close()
+
+	headers := map[string]string{"x-api-key": "secret", "anthropic-version": "2023-06-01"}
+	models, err := DiscoverModelsWithHeaders(context.Background(), srv.Client(), srv.URL, headers, "p")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(models) != 1 || models[0].ID != "m-1" {
+		t.Errorf("unexpected models: %+v", models)
+	}
+}
+
+func TestDiscoverModelsWithHeaders_Non200Status(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte("forbidden"))
+	}))
+	defer srv.Close()
+
+	_, err := DiscoverModelsWithHeaders(context.Background(), srv.Client(), srv.URL, nil, "p")
+	if err == nil {
+		t.Fatal("expected error for non-200 status, got nil")
+	}
+}

--- a/providers/anthropic/anthropic.go
+++ b/providers/anthropic/anthropic.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/ferro-labs/ai-gateway/internal/anthropicwire"
+	"github.com/ferro-labs/ai-gateway/internal/discovery"
 	providerhttp "github.com/ferro-labs/ai-gateway/internal/httpclient"
 	"github.com/ferro-labs/ai-gateway/providers/core"
 )
@@ -28,6 +29,10 @@ const Name = "anthropic"
 
 const defaultBaseURL = "https://api.anthropic.com"
 
+// anthropicVersion is the API version sent on every request via the
+// anthropic-version header.
+const anthropicVersion = "2023-06-01"
+
 // Provider implements the Anthropic API client.
 type Provider struct {
 	name       string
@@ -41,6 +46,7 @@ var (
 	_ core.Provider          = (*Provider)(nil)
 	_ core.StreamProvider    = (*Provider)(nil)
 	_ core.ProxiableProvider = (*Provider)(nil)
+	_ core.DiscoveryProvider = (*Provider)(nil)
 )
 
 // New creates a new Anthropic provider.
@@ -70,8 +76,18 @@ func (p *Provider) BaseURL() string { return p.baseURL }
 func (p *Provider) AuthHeaders() map[string]string {
 	return map[string]string{
 		"x-api-key":         p.apiKey,
-		"anthropic-version": "2023-06-01",
+		"anthropic-version": anthropicVersion,
 	}
+}
+
+// DiscoverModels fetches the live model list from the Anthropic /v1/models
+// endpoint, which uses x-api-key + anthropic-version headers rather than Bearer.
+func (p *Provider) DiscoverModels(ctx context.Context) ([]core.ModelInfo, error) {
+	headers := map[string]string{
+		"x-api-key":         p.apiKey,
+		"anthropic-version": anthropicVersion,
+	}
+	return discovery.DiscoverModelsWithHeaders(ctx, p.httpClient, p.baseURL+"/v1/models", headers, p.name)
 }
 
 // SupportedModels returns the list of models supported by this provider.
@@ -359,7 +375,7 @@ func (p *Provider) Complete(ctx context.Context, req core.Request) (*core.Respon
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
 	httpReq.Header.Set("x-api-key", p.apiKey)
-	httpReq.Header.Set("anthropic-version", "2023-06-01")
+	httpReq.Header.Set("anthropic-version", anthropicVersion)
 	httpReq.Header.Set("content-type", "application/json")
 
 	httpResp, err := p.httpClient.Do(httpReq) //nolint:gosec // baseURL validated in New()
@@ -509,7 +525,7 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
 	httpReq.Header.Set("x-api-key", p.apiKey)
-	httpReq.Header.Set("anthropic-version", "2023-06-01")
+	httpReq.Header.Set("anthropic-version", anthropicVersion)
 	httpReq.Header.Set("content-type", "application/json")
 
 	httpResp, err := p.httpClient.Do(httpReq) //nolint:gosec // baseURL validated in New()

--- a/providers/anthropic/anthropic_test.go
+++ b/providers/anthropic/anthropic_test.go
@@ -10,6 +10,47 @@ import (
 	"time"
 )
 
+// TestAnthropicProvider_DiscoverModels verifies live model discovery uses the
+// x-api-key + anthropic-version headers (not Bearer) and maps the response.
+func TestAnthropicProvider_DiscoverModels(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("method = %q, want GET", r.Method)
+		}
+		if r.URL.Path != "/v1/models" {
+			t.Errorf("path = %q, want /v1/models", r.URL.Path)
+		}
+		if r.Header.Get("x-api-key") != "sk-test-key" {
+			t.Errorf("x-api-key = %q, want sk-test-key", r.Header.Get("x-api-key"))
+		}
+		if r.Header.Get("anthropic-version") != "2023-06-01" {
+			t.Errorf("anthropic-version = %q, want 2023-06-01", r.Header.Get("anthropic-version"))
+		}
+		if r.Header.Get("Authorization") != "" {
+			t.Errorf("Authorization = %q, want empty (anthropic uses x-api-key)", r.Header.Get("Authorization"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"object":"list","data":[{"id":"claude-sonnet-4-20250514","object":"model","created":1700000000,"owned_by":"anthropic"},{"id":"claude-3-haiku-20240307","object":"model"}]}`))
+	}))
+	defer srv.Close()
+
+	p, _ := New("sk-test-key", srv.URL)
+	models, err := p.DiscoverModels(context.Background())
+	if err != nil {
+		t.Fatalf("DiscoverModels() error: %v", err)
+	}
+	if len(models) != 2 {
+		t.Fatalf("expected 2 models, got %d", len(models))
+	}
+	if models[0].ID != "claude-sonnet-4-20250514" || models[0].OwnedBy != "anthropic" {
+		t.Errorf("unexpected model[0]: %+v", models[0])
+	}
+	if models[1].ID != "claude-3-haiku-20240307" || models[1].OwnedBy != "anthropic" {
+		t.Errorf("model[1] owned_by fallback = %q, want anthropic", models[1].OwnedBy)
+	}
+}
+
 // TestNewAnthropic tests the Anthropic provider constructor.
 func TestNewAnthropic(t *testing.T) {
 	provider, err := New("sk-test-key", "")

--- a/providers/azure_openai/azure_openai.go
+++ b/providers/azure_openai/azure_openai.go
@@ -34,6 +34,8 @@ var (
 	_ core.Provider          = (*Provider)(nil)
 	_ core.StreamProvider    = (*Provider)(nil)
 	_ core.ProxiableProvider = (*Provider)(nil)
+	_ core.EmbeddingProvider = (*Provider)(nil)
+	_ core.ImageProvider     = (*Provider)(nil)
 )
 
 // New creates a new Azure OpenAI provider.
@@ -88,6 +90,29 @@ func (p *Provider) Models() []core.ModelInfo {
 func (p *Provider) endpoint() string {
 	return fmt.Sprintf("%s/openai/deployments/%s/chat/completions?api-version=%s",
 		p.baseURL, p.deploymentName, p.apiVersion)
+}
+
+// opEndpoint builds an Azure OpenAI URL for an arbitrary deployment+operation,
+// e.g. op "embeddings" or "images/generations".
+func (p *Provider) opEndpoint(deployment, op string) string {
+	return fmt.Sprintf("%s/openai/deployments/%s/%s?api-version=%s",
+		p.baseURL, deployment, op, p.apiVersion)
+}
+
+// deploymentFor selects the deployment to target for a request. Azure routes
+// by deployment name in the URL (not by a body "model" field), so callers may
+// override the configured deployment per request by setting req.Model.
+//
+// NOTE: Complete/CompleteStream intentionally keep using p.deploymentName
+// (via endpoint()) rather than deploymentFor — the chat path is pinned to the
+// single configured chat deployment, whereas Embed/GenerateImage allow the
+// caller to target a different embedding/image deployment by model. This
+// asymmetry is deliberate.
+func (p *Provider) deploymentFor(model string) string {
+	if model != "" {
+		return model
+	}
+	return p.deploymentName
 }
 
 type azureOpenAIResponse struct {

--- a/providers/azure_openai/azure_openai_test.go
+++ b/providers/azure_openai/azure_openai_test.go
@@ -2,12 +2,21 @@ package azureopenai
 
 import (
 	"context"
+	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/ferro-labs/ai-gateway/providers/core"
 )
+
+func TestAzureOpenAIProvider_CapabilityInterfaces(_ *testing.T) {
+	p, _ := New("test-key", "https://myresource.openai.azure.com", "gpt-4o", "")
+	var _ core.EmbeddingProvider = p
+	var _ core.ImageProvider = p
+}
 
 func TestNewAzureOpenAI(t *testing.T) {
 	p, err := New("test-key", "https://myresource.openai.azure.com", "gpt-4o", "")
@@ -106,5 +115,209 @@ func TestAzureOpenAIProvider_CompleteStream_MockSSE(t *testing.T) {
 	}
 	if chunks[2].Choices[0].Delta.Content != " world" {
 		t.Errorf("delta content = %q, want ' world'", chunks[2].Choices[0].Delta.Content)
+	}
+}
+
+func TestAzureOpenAIProvider_Embed(t *testing.T) {
+	var gotPath, gotQuery, gotAPIKey string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotQuery = r.URL.RawQuery
+		gotAPIKey = r.Header.Get("api-key")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"object":"list","model":"text-embedding-3-small","data":[{"object":"embedding","index":0,"embedding":[0.1,0.2,0.3]}],"usage":{"prompt_tokens":4,"total_tokens":4}}`))
+	}))
+	defer srv.Close()
+
+	p, _ := New("test-key", srv.URL, "gpt-4o", "2024-10-21")
+	resp, err := p.Embed(context.Background(), core.EmbeddingRequest{
+		Model: "text-embedding-3-small",
+		Input: "hello world",
+	})
+	if err != nil {
+		t.Fatalf("Embed() error: %v", err)
+	}
+
+	if gotPath != "/openai/deployments/text-embedding-3-small/embeddings" {
+		t.Errorf("path = %q, want /openai/deployments/text-embedding-3-small/embeddings", gotPath)
+	}
+	if !strings.Contains(gotQuery, "api-version=2024-10-21") {
+		t.Errorf("query = %q, want api-version=2024-10-21", gotQuery)
+	}
+	if gotAPIKey != "test-key" {
+		t.Errorf("api-key header = %q, want test-key", gotAPIKey)
+	}
+	if len(resp.Data) != 1 || len(resp.Data[0].Embedding) != 3 {
+		t.Fatalf("unexpected embedding data: %+v", resp.Data)
+	}
+	if resp.Data[0].Embedding[0] != 0.1 {
+		t.Errorf("embedding[0] = %v, want 0.1", resp.Data[0].Embedding[0])
+	}
+	if resp.Usage.TotalTokens != 4 {
+		t.Errorf("usage.TotalTokens = %d, want 4", resp.Usage.TotalTokens)
+	}
+}
+
+func TestAzureOpenAIProvider_Embed_FallbackDeployment(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"object":"list","data":[],"usage":{}}`))
+	}))
+	defer srv.Close()
+
+	p, _ := New("test-key", srv.URL, "configured-deployment", "2024-10-21")
+	if _, err := p.Embed(context.Background(), core.EmbeddingRequest{Input: "x"}); err != nil {
+		t.Fatalf("Embed() error: %v", err)
+	}
+	if gotPath != "/openai/deployments/configured-deployment/embeddings" {
+		t.Errorf("path = %q, want fallback to configured-deployment", gotPath)
+	}
+}
+
+func TestAzureOpenAIProvider_Embed_InputValidation(t *testing.T) {
+	var called bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+	p, _ := New("test-key", srv.URL, "gpt-4o", "2024-10-21")
+
+	cases := []struct {
+		name string
+		req  core.EmbeddingRequest
+	}{
+		{"nil input", core.EmbeddingRequest{Input: nil}},
+		{"empty slice", core.EmbeddingRequest{Input: []string{}}},
+		{"non-string element", core.EmbeddingRequest{Input: []interface{}{1}}},
+		{"bad encoding_format", core.EmbeddingRequest{Input: "x", EncodingFormat: "binary"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := p.Embed(context.Background(), tc.req); err == nil {
+				t.Fatal("expected error, got nil")
+			}
+		})
+	}
+	if called {
+		t.Error("expected no HTTP call on validation failure")
+	}
+}
+
+func TestAzureOpenAIProvider_Embed_Base64EncodingAllowed(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"object":"list","data":[],"usage":{}}`))
+	}))
+	defer srv.Close()
+	p, _ := New("test-key", srv.URL, "gpt-4o", "2024-10-21")
+	if _, err := p.Embed(context.Background(), core.EmbeddingRequest{Input: "x", EncodingFormat: "base64"}); err != nil {
+		t.Fatalf("Embed() with base64 error: %v", err)
+	}
+}
+
+func TestAzureOpenAIProvider_Embed_APIError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":{"message":"bad deployment","type":"invalid_request_error"}}`))
+	}))
+	defer srv.Close()
+	p, _ := New("test-key", srv.URL, "gpt-4o", "2024-10-21")
+	_, err := p.Embed(context.Background(), core.EmbeddingRequest{Input: "x"})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "bad deployment") || !strings.Contains(err.Error(), "400") {
+		t.Errorf("error = %q, want wrapped 400 + message", err.Error())
+	}
+}
+
+func TestAzureOpenAIProvider_GenerateImage(t *testing.T) {
+	var gotPath, gotQuery, gotAPIKey string
+	var sentModel bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotQuery = r.URL.RawQuery
+		gotAPIKey = r.Header.Get("api-key")
+		body, _ := io.ReadAll(r.Body)
+		var m map[string]interface{}
+		_ = json.Unmarshal(body, &m)
+		_, sentModel = m["model"]
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"created":1700000000,"data":[{"b64_json":"aGVsbG8=","revised_prompt":"a cat"}]}`))
+	}))
+	defer srv.Close()
+
+	p, _ := New("test-key", srv.URL, "gpt-4o", "2024-10-21")
+	resp, err := p.GenerateImage(context.Background(), core.ImageRequest{
+		Model:          "dall-e-3",
+		Prompt:         "a cat",
+		ResponseFormat: "b64_json",
+	})
+	if err != nil {
+		t.Fatalf("GenerateImage() error: %v", err)
+	}
+
+	if gotPath != "/openai/deployments/dall-e-3/images/generations" {
+		t.Errorf("path = %q, want /openai/deployments/dall-e-3/images/generations", gotPath)
+	}
+	if !strings.Contains(gotQuery, "api-version=2024-10-21") {
+		t.Errorf("query = %q, want api-version=2024-10-21", gotQuery)
+	}
+	if gotAPIKey != "test-key" {
+		t.Errorf("api-key header = %q, want test-key", gotAPIKey)
+	}
+	if sentModel {
+		t.Error("image request body must not contain a model field")
+	}
+	if resp.Created != 1700000000 {
+		t.Errorf("created = %d, want 1700000000", resp.Created)
+	}
+	if len(resp.Data) != 1 || resp.Data[0].B64JSON != "aGVsbG8=" {
+		t.Fatalf("unexpected image data: %+v", resp.Data)
+	}
+	if resp.Data[0].RevisedPrompt != "a cat" {
+		t.Errorf("revised_prompt = %q, want 'a cat'", resp.Data[0].RevisedPrompt)
+	}
+}
+
+func TestAzureOpenAIProvider_GenerateImage_FallbackDeployment(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"created":1,"data":[]}`))
+	}))
+	defer srv.Close()
+
+	p, _ := New("test-key", srv.URL, "img-deployment", "2024-10-21")
+	if _, err := p.GenerateImage(context.Background(), core.ImageRequest{Prompt: "x"}); err != nil {
+		t.Fatalf("GenerateImage() error: %v", err)
+	}
+	if gotPath != "/openai/deployments/img-deployment/images/generations" {
+		t.Errorf("path = %q, want fallback to img-deployment", gotPath)
+	}
+}
+
+func TestAzureOpenAIProvider_GenerateImage_APIError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":{"message":"content policy violation","type":"server_error"}}`))
+	}))
+	defer srv.Close()
+	p, _ := New("test-key", srv.URL, "gpt-4o", "2024-10-21")
+	_, err := p.GenerateImage(context.Background(), core.ImageRequest{Prompt: "x"})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "content policy violation") || !strings.Contains(err.Error(), "500") {
+		t.Errorf("error = %q, want wrapped 500 + message", err.Error())
 	}
 }

--- a/providers/azure_openai/embedding.go
+++ b/providers/azure_openai/embedding.go
@@ -1,0 +1,126 @@
+package azureopenai
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/ferro-labs/ai-gateway/providers/core"
+)
+
+// embeddingRequest is the OpenAI-shaped body Azure OpenAI accepts on the
+// /embeddings endpoint. The deployment in the URL is authoritative, so "model"
+// is ignored by Azure but harmless to send.
+type embeddingRequest struct {
+	Model          string      `json:"model,omitempty"`
+	Input          interface{} `json:"input"`
+	EncodingFormat string      `json:"encoding_format,omitempty"`
+	Dimensions     *int        `json:"dimensions,omitempty"`
+	User           string      `json:"user,omitempty"`
+}
+
+// embeddingResponse mirrors the OpenAI-shaped embedding response.
+type embeddingResponse struct {
+	Object string              `json:"object"`
+	Data   []core.Embedding    `json:"data"`
+	Model  string              `json:"model"`
+	Usage  core.EmbeddingUsage `json:"usage"`
+}
+
+// Embed sends an embedding request to Azure OpenAI. The request targets the
+// deployment named by req.Model, falling back to the configured deployment.
+func (p *Provider) Embed(ctx context.Context, req core.EmbeddingRequest) (*core.EmbeddingResponse, error) {
+	input, err := normalizeEmbeddingInput(req.Input)
+	if err != nil {
+		return nil, err
+	}
+	switch req.EncodingFormat {
+	case "", "float", "base64":
+		// accepted
+	default:
+		return nil, fmt.Errorf("embed: unsupported encoding_format %q; valid values are \"float\" and \"base64\"", req.EncodingFormat)
+	}
+
+	pReq := embeddingRequest{
+		Model:          req.Model,
+		Input:          input,
+		EncodingFormat: req.EncodingFormat,
+		Dimensions:     req.Dimensions,
+		User:           req.User,
+	}
+	bodyReader, _, release, err := core.JSONBodyReader(pReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal embedding request: %w", err)
+	}
+	defer release()
+
+	url := p.opEndpoint(p.deploymentFor(req.Model), "embeddings")
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bodyReader)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	httpReq.Header.Set("api-key", p.apiKey)
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	httpResp, err := p.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer func() { _ = httpResp.Body.Close() }()
+
+	respBody, err := io.ReadAll(httpResp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+	if httpResp.StatusCode != http.StatusOK {
+		var errResp azureOpenAIErrorResponse
+		if json.Unmarshal(respBody, &errResp) == nil && errResp.Error.Message != "" {
+			return nil, fmt.Errorf("azure openai API error (%d): %s", httpResp.StatusCode, errResp.Error.Message)
+		}
+		return nil, fmt.Errorf("azure openai API error (%d): %s", httpResp.StatusCode, string(respBody))
+	}
+
+	var pResp embeddingResponse
+	if err := json.Unmarshal(respBody, &pResp); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal embedding response: %w", err)
+	}
+	return &core.EmbeddingResponse{
+		Object: pResp.Object,
+		Data:   pResp.Data,
+		Model:  pResp.Model,
+		Usage:  pResp.Usage,
+	}, nil
+}
+
+// normalizeEmbeddingInput validates and normalizes the polymorphic Input field
+// into a string or []string, rejecting empty/nil/non-string inputs.
+func normalizeEmbeddingInput(input interface{}) (interface{}, error) {
+	switch v := input.(type) {
+	case string:
+		return v, nil
+	case []string:
+		if len(v) == 0 {
+			return nil, fmt.Errorf("embed: Input must not be an empty array")
+		}
+		return v, nil
+	case []interface{}:
+		if len(v) == 0 {
+			return nil, fmt.Errorf("embed: Input must not be an empty array")
+		}
+		strs := make([]string, 0, len(v))
+		for i, item := range v {
+			s, ok := item.(string)
+			if !ok {
+				return nil, fmt.Errorf("embed: Input[%d] is %T, want string", i, item)
+			}
+			strs = append(strs, s)
+		}
+		return strs, nil
+	case nil:
+		return nil, fmt.Errorf("embed: Input must not be nil")
+	default:
+		return nil, fmt.Errorf("embed: unsupported Input type %T; want string or []string", input)
+	}
+}

--- a/providers/azure_openai/image.go
+++ b/providers/azure_openai/image.go
@@ -1,0 +1,85 @@
+package azureopenai
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/ferro-labs/ai-gateway/providers/core"
+)
+
+// imageRequest is the body Azure OpenAI accepts on the images/generations
+// endpoint. Azure routes by deployment in the URL, so "model" is not sent.
+type imageRequest struct {
+	Prompt         string `json:"prompt"`
+	N              *int   `json:"n,omitempty"`
+	Size           string `json:"size,omitempty"`
+	ResponseFormat string `json:"response_format,omitempty"`
+	Quality        string `json:"quality,omitempty"`
+	Style          string `json:"style,omitempty"`
+	User           string `json:"user,omitempty"`
+}
+
+// imageResponse mirrors the synchronous OpenAI-shaped image response.
+type imageResponse struct {
+	Created int64                 `json:"created"`
+	Data    []core.GeneratedImage `json:"data"`
+}
+
+// GenerateImage sends an image generation request to Azure OpenAI. The request
+// targets the deployment named by req.Model, falling back to the configured
+// deployment. Azure (api-version 2024-10-21) returns the result synchronously —
+// no async polling is required.
+func (p *Provider) GenerateImage(ctx context.Context, req core.ImageRequest) (*core.ImageResponse, error) {
+	pReq := imageRequest{
+		Prompt:         req.Prompt,
+		N:              req.N,
+		Size:           req.Size,
+		ResponseFormat: req.ResponseFormat,
+		Quality:        req.Quality,
+		Style:          req.Style,
+		User:           req.User,
+	}
+	bodyReader, _, release, err := core.JSONBodyReader(pReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal image request: %w", err)
+	}
+	defer release()
+
+	url := p.opEndpoint(p.deploymentFor(req.Model), "images/generations")
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bodyReader)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	httpReq.Header.Set("api-key", p.apiKey)
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	httpResp, err := p.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer func() { _ = httpResp.Body.Close() }()
+
+	respBody, err := io.ReadAll(httpResp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+	if httpResp.StatusCode != http.StatusOK {
+		var errResp azureOpenAIErrorResponse
+		if json.Unmarshal(respBody, &errResp) == nil && errResp.Error.Message != "" {
+			return nil, fmt.Errorf("azure openai API error (%d): %s", httpResp.StatusCode, errResp.Error.Message)
+		}
+		return nil, fmt.Errorf("azure openai API error (%d): %s", httpResp.StatusCode, string(respBody))
+	}
+
+	var pResp imageResponse
+	if err := json.Unmarshal(respBody, &pResp); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal image response: %w", err)
+	}
+	return &core.ImageResponse{
+		Created: pResp.Created,
+		Data:    pResp.Data,
+	}, nil
+}

--- a/providers/bedrock/bedrock.go
+++ b/providers/bedrock/bedrock.go
@@ -70,6 +70,7 @@ var (
 	_ core.Provider          = (*Provider)(nil)
 	_ core.StreamProvider    = (*Provider)(nil)
 	_ core.EmbeddingProvider = (*Provider)(nil)
+	_ core.ImageProvider     = (*Provider)(nil)
 	_ core.ProxiableProvider = (*Provider)(nil)
 )
 
@@ -155,6 +156,10 @@ func (p *Provider) SupportedModels() []string {
 		"cohere.embed-english-v3",
 		"cohere.embed-multilingual-v3",
 		"cohere.embed-v4:0",
+		"amazon.nova-canvas-v1:0",
+		"amazon.titan-image-generator-v1",
+		"amazon.titan-image-generator-v2:0",
+		"stability.stable-diffusion-xl-v1",
 	}
 }
 
@@ -166,6 +171,12 @@ func (p *Provider) SupportsModel(model string) bool {
 		if model == supported {
 			return true
 		}
+	}
+	// Image families are matched here so the Nova-text exclusion guard below does
+	// not reject amazon.nova-canvas. The "amazon.titan-image-" prefix is distinct
+	// from the "amazon.titan-embed-image-" embeddings family.
+	if isBedrockImageModel(model) {
+		return true
 	}
 	for _, prefix := range []string{
 		"anthropic.claude-",

--- a/providers/bedrock/bedrock_test.go
+++ b/providers/bedrock/bedrock_test.go
@@ -150,8 +150,9 @@ func TestBedrockProvider_SupportsModel_NovaTextModels(t *testing.T) {
 		})
 	}
 
+	// amazon.nova-canvas is an image-generation model (see image.go); it is
+	// intentionally not in the Nova-text set but IS a supported image model.
 	for _, model := range []string{
-		"amazon.nova-canvas-v1:0",
 		"amazon.nova-reel-v1:0",
 		"amazon.nova-2-multimodal-embeddings-v1:0",
 	} {

--- a/providers/bedrock/image.go
+++ b/providers/bedrock/image.go
@@ -1,0 +1,156 @@
+package bedrock
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/ferro-labs/ai-gateway/providers/core"
+)
+
+// ── Amazon Nova Canvas + Titan Image (shared TEXT_IMAGE shape) ────────────────
+
+type bedrockImageTitanRequest struct {
+	TaskType              string                        `json:"taskType"`
+	TextToImageParams     bedrockImageTextToImageParams `json:"textToImageParams"`
+	ImageGenerationConfig bedrockImageGenerationConfig  `json:"imageGenerationConfig"`
+}
+
+type bedrockImageTextToImageParams struct {
+	Text         string `json:"text"`
+	NegativeText string `json:"negativeText,omitempty"`
+}
+
+type bedrockImageGenerationConfig struct {
+	NumberOfImages int      `json:"numberOfImages,omitempty"`
+	Width          int      `json:"width,omitempty"`
+	Height         int      `json:"height,omitempty"`
+	CfgScale       *float64 `json:"cfgScale,omitempty"`
+	Seed           *int     `json:"seed,omitempty"`
+	Quality        string   `json:"quality,omitempty"`
+}
+
+type bedrockImageTitanResponse struct {
+	Images []string `json:"images"`
+	Error  string   `json:"error,omitempty"`
+}
+
+// ── Stability Stable Diffusion XL (legacy text_prompts shape) ─────────────────
+
+type bedrockImageStabilityRequest struct {
+	TextPrompts []bedrockImageStabilityPrompt `json:"text_prompts"`
+	CfgScale    *float64                      `json:"cfg_scale,omitempty"`
+	Seed        *int                          `json:"seed,omitempty"`
+	Steps       *int                          `json:"steps,omitempty"`
+}
+
+type bedrockImageStabilityPrompt struct {
+	Text string `json:"text"`
+}
+
+type bedrockImageStabilityResponse struct {
+	Artifacts []struct {
+		Base64       string `json:"base64"`
+		FinishReason string `json:"finishReason"`
+	} `json:"artifacts"`
+}
+
+// isBedrockImageModel reports whether the routing model ID belongs to a Bedrock
+// image-generation family. Kept distinct from the embeddings prefixes:
+// "amazon.titan-image-" must NOT capture "amazon.titan-embed-image-".
+func isBedrockImageModel(model string) bool {
+	for _, prefix := range []string{
+		"amazon.nova-canvas",
+		"amazon.titan-image-",
+		"stability.",
+	} {
+		if strings.HasPrefix(model, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// GenerateImage sends a text-to-image request to AWS Bedrock, dispatching to the
+// model family (Nova Canvas / Titan Image, or Stability SDXL) that matches the
+// routing prefix. The original req.Model is passed to InvokeModel so cross-region
+// inference-profile IDs (us./eu./apac./global./region/) are preserved upstream.
+func (p *Provider) GenerateImage(ctx context.Context, req core.ImageRequest) (*core.ImageResponse, error) {
+	id := bedrockModelRoutingID(req.Model)
+	switch {
+	case strings.HasPrefix(id, "amazon.nova-canvas"), strings.HasPrefix(id, "amazon.titan-image-"):
+		return p.generateImageTitanNova(ctx, req)
+	case strings.HasPrefix(id, "stability.stable-diffusion-xl"):
+		return p.generateImageStability(ctx, req)
+	default:
+		return nil, fmt.Errorf("unsupported Bedrock image model: %s", req.Model)
+	}
+}
+
+func (p *Provider) generateImageTitanNova(ctx context.Context, req core.ImageRequest) (*core.ImageResponse, error) {
+	config := bedrockImageGenerationConfig{Quality: req.Quality}
+	if req.N != nil {
+		config.NumberOfImages = *req.N
+	}
+	if req.Size != "" {
+		var w, h int
+		// Skip unparseable sizes rather than failing; Bedrock applies model defaults.
+		if n, _ := fmt.Sscanf(req.Size, "%dx%d", &w, &h); n == 2 && w > 0 && h > 0 {
+			config.Width = w
+			config.Height = h
+		}
+	}
+
+	body := bedrockImageTitanRequest{
+		TaskType:              "TEXT_IMAGE",
+		TextToImageParams:     bedrockImageTextToImageParams{Text: req.Prompt},
+		ImageGenerationConfig: config,
+	}
+
+	var resp bedrockImageTitanResponse
+	if err := p.invokeModelJSON(ctx, req.Model, body, &resp); err != nil {
+		return nil, err
+	}
+	if resp.Error != "" {
+		return nil, fmt.Errorf("bedrock image generation failed: %s", resp.Error)
+	}
+	if len(resp.Images) == 0 {
+		return nil, fmt.Errorf("bedrock image generation returned no images")
+	}
+	return bedrockImageResponseFromBase64(resp.Images), nil
+}
+
+func (p *Provider) generateImageStability(ctx context.Context, req core.ImageRequest) (*core.ImageResponse, error) {
+	body := bedrockImageStabilityRequest{
+		TextPrompts: []bedrockImageStabilityPrompt{{Text: req.Prompt}},
+	}
+
+	var resp bedrockImageStabilityResponse
+	if err := p.invokeModelJSON(ctx, req.Model, body, &resp); err != nil {
+		return nil, err
+	}
+
+	images := make([]string, 0, len(resp.Artifacts))
+	for _, artifact := range resp.Artifacts {
+		if artifact.FinishReason == "CONTENT_FILTERED" || artifact.FinishReason == "ERROR" {
+			return nil, fmt.Errorf("bedrock image generation failed: finish reason %s", artifact.FinishReason)
+		}
+		images = append(images, artifact.Base64)
+	}
+	if len(images) == 0 {
+		return nil, fmt.Errorf("bedrock image generation returned no images")
+	}
+	return bedrockImageResponseFromBase64(images), nil
+}
+
+func bedrockImageResponseFromBase64(images []string) *core.ImageResponse {
+	data := make([]core.GeneratedImage, len(images))
+	for i, img := range images {
+		data[i] = core.GeneratedImage{B64JSON: img}
+	}
+	return &core.ImageResponse{
+		Created: time.Now().Unix(),
+		Data:    data,
+	}
+}

--- a/providers/bedrock/image_test.go
+++ b/providers/bedrock/image_test.go
@@ -1,0 +1,202 @@
+package bedrock
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+
+	"github.com/ferro-labs/ai-gateway/providers/core"
+)
+
+func TestBedrockProvider_GenerateImage_Interface(_ *testing.T) {
+	var _ core.ImageProvider = (*Provider)(nil)
+}
+
+func TestBedrockProvider_SupportsImageModels(t *testing.T) {
+	p := &Provider{name: Name}
+
+	for _, want := range []string{
+		"amazon.nova-canvas-v1:0",
+		"amazon.titan-image-generator-v1",
+		"amazon.titan-image-generator-v2:0",
+		"stability.stable-diffusion-xl-v1",
+	} {
+		if !containsString(p.SupportedModels(), want) {
+			t.Errorf("SupportedModels() missing %q", want)
+		}
+		if !p.SupportsModel(want) {
+			t.Errorf("SupportsModel(%q) = false, want true", want)
+		}
+	}
+
+	// Cross-region inference-profile and region-prefixed forms must also match.
+	for _, want := range []string{
+		"us.amazon.nova-canvas-v1:0",
+		"global.amazon.titan-image-generator-v2:0",
+		"us-gov-west-1/stability.stable-diffusion-xl-v1",
+	} {
+		if !p.SupportsModel(want) {
+			t.Errorf("SupportsModel(%q) = false, want true", want)
+		}
+	}
+
+	// The titan-image prefix must NOT capture the titan-embed-image family.
+	if p.SupportsModel("amazon.titan-embed-image-v1") {
+		t.Error("SupportsModel(amazon.titan-embed-image-v1) = true, want false (embeddings, not image)")
+	}
+}
+
+func TestBedrockProvider_GenerateImage_NovaCanvas(t *testing.T) {
+	fake := &fakeBedrockRuntimeClient{
+		responses: [][]byte{[]byte(`{"images":["aGk="]}`)},
+	}
+	p := &Provider{name: Name, client: fake}
+	n := 1
+
+	resp, err := p.GenerateImage(context.Background(), core.ImageRequest{
+		Model:  "amazon.nova-canvas-v1:0",
+		Prompt: "a red bicycle",
+		N:      &n,
+		Size:   "1024x768",
+	})
+	if err != nil {
+		t.Fatalf("GenerateImage() error: %v", err)
+	}
+	if len(fake.invokeCalls) != 1 {
+		t.Fatalf("InvokeModel calls = %d, want 1", len(fake.invokeCalls))
+	}
+	if got := aws.ToString(fake.invokeCalls[0].ModelId); got != "amazon.nova-canvas-v1:0" {
+		t.Errorf("ModelId = %q, want original model ID", got)
+	}
+
+	var body bedrockImageTitanRequest
+	mustUnmarshalBody(t, fake.invokeCalls[0].Body, &body)
+	if body.TaskType != "TEXT_IMAGE" {
+		t.Errorf("taskType = %q, want TEXT_IMAGE", body.TaskType)
+	}
+	if body.TextToImageParams.Text != "a red bicycle" {
+		t.Errorf("text = %q, want prompt", body.TextToImageParams.Text)
+	}
+	if body.ImageGenerationConfig.NumberOfImages != 1 {
+		t.Errorf("numberOfImages = %d, want 1", body.ImageGenerationConfig.NumberOfImages)
+	}
+	if body.ImageGenerationConfig.Width != 1024 || body.ImageGenerationConfig.Height != 768 {
+		t.Errorf("width/height = %d/%d, want 1024/768", body.ImageGenerationConfig.Width, body.ImageGenerationConfig.Height)
+	}
+
+	if len(resp.Data) != 1 || resp.Data[0].B64JSON != "aGk=" {
+		t.Errorf("data = %+v, want single base64 image aGk=", resp.Data)
+	}
+	if resp.Created == 0 {
+		t.Error("Created = 0, want unix timestamp")
+	}
+}
+
+func TestBedrockProvider_GenerateImage_TitanImage(t *testing.T) {
+	fake := &fakeBedrockRuntimeClient{
+		responses: [][]byte{[]byte(`{"images":["aGk="]}`)},
+	}
+	p := &Provider{name: Name, client: fake}
+
+	resp, err := p.GenerateImage(context.Background(), core.ImageRequest{
+		Model:  "amazon.titan-image-generator-v2:0",
+		Prompt: "a blue cat",
+	})
+	if err != nil {
+		t.Fatalf("GenerateImage() error: %v", err)
+	}
+	if got := aws.ToString(fake.invokeCalls[0].ModelId); got != "amazon.titan-image-generator-v2:0" {
+		t.Errorf("ModelId = %q, want original model ID", got)
+	}
+	var body bedrockImageTitanRequest
+	mustUnmarshalBody(t, fake.invokeCalls[0].Body, &body)
+	if body.TaskType != "TEXT_IMAGE" || body.TextToImageParams.Text != "a blue cat" {
+		t.Errorf("body = %+v, want TEXT_IMAGE shape with prompt", body)
+	}
+	if len(resp.Data) != 1 || resp.Data[0].B64JSON != "aGk=" {
+		t.Errorf("data = %+v, want single base64 image aGk=", resp.Data)
+	}
+}
+
+func TestBedrockProvider_GenerateImage_StabilitySDXL(t *testing.T) {
+	fake := &fakeBedrockRuntimeClient{
+		responses: [][]byte{[]byte(`{"artifacts":[{"base64":"aGk=","finishReason":"SUCCESS"}]}`)},
+	}
+	p := &Provider{name: Name, client: fake}
+
+	resp, err := p.GenerateImage(context.Background(), core.ImageRequest{
+		Model:  "stability.stable-diffusion-xl-v1",
+		Prompt: "a green tree",
+	})
+	if err != nil {
+		t.Fatalf("GenerateImage() error: %v", err)
+	}
+	if got := aws.ToString(fake.invokeCalls[0].ModelId); got != "stability.stable-diffusion-xl-v1" {
+		t.Errorf("ModelId = %q, want original model ID", got)
+	}
+	var body bedrockImageStabilityRequest
+	mustUnmarshalBody(t, fake.invokeCalls[0].Body, &body)
+	if len(body.TextPrompts) != 1 || body.TextPrompts[0].Text != "a green tree" {
+		t.Errorf("text_prompts = %+v, want single prompt", body.TextPrompts)
+	}
+	if len(resp.Data) != 1 || resp.Data[0].B64JSON != "aGk=" {
+		t.Errorf("data = %+v, want single base64 image aGk=", resp.Data)
+	}
+}
+
+func TestBedrockProvider_GenerateImage_StabilityContentFilteredErrors(t *testing.T) {
+	fake := &fakeBedrockRuntimeClient{
+		responses: [][]byte{[]byte(`{"artifacts":[{"base64":"","finishReason":"CONTENT_FILTERED"}]}`)},
+	}
+	p := &Provider{name: Name, client: fake}
+
+	_, err := p.GenerateImage(context.Background(), core.ImageRequest{
+		Model:  "stability.stable-diffusion-xl-v1",
+		Prompt: "blocked",
+	})
+	if err == nil {
+		t.Fatal("GenerateImage() error = nil, want content-filtered error")
+	}
+	if !strings.Contains(err.Error(), "CONTENT_FILTERED") {
+		t.Errorf("error = %q, want CONTENT_FILTERED mention", err.Error())
+	}
+}
+
+func TestBedrockProvider_GenerateImage_NovaErrorFieldFails(t *testing.T) {
+	fake := &fakeBedrockRuntimeClient{
+		responses: [][]byte{[]byte(`{"images":[],"error":"prompt rejected"}`)},
+	}
+	p := &Provider{name: Name, client: fake}
+
+	_, err := p.GenerateImage(context.Background(), core.ImageRequest{
+		Model:  "amazon.nova-canvas-v1:0",
+		Prompt: "blocked",
+	})
+	if err == nil {
+		t.Fatal("GenerateImage() error = nil, want error from response error field")
+	}
+	if !strings.Contains(err.Error(), "prompt rejected") {
+		t.Errorf("error = %q, want response error message", err.Error())
+	}
+}
+
+func TestBedrockProvider_GenerateImage_UnsupportedModel(t *testing.T) {
+	fake := &fakeBedrockRuntimeClient{}
+	p := &Provider{name: Name, client: fake}
+
+	_, err := p.GenerateImage(context.Background(), core.ImageRequest{
+		Model:  "anthropic.claude-3-5-sonnet-20241022-v2:0",
+		Prompt: "hello",
+	})
+	if err == nil {
+		t.Fatal("GenerateImage() error = nil, want unsupported-model error")
+	}
+	if !strings.Contains(err.Error(), "unsupported Bedrock image model") {
+		t.Errorf("error = %q, want unsupported model message", err.Error())
+	}
+	if len(fake.invokeCalls) != 0 {
+		t.Errorf("InvokeModel calls = %d, want 0 for unsupported model", len(fake.invokeCalls))
+	}
+}

--- a/providers/deepinfra/deepinfra.go
+++ b/providers/deepinfra/deepinfra.go
@@ -30,6 +30,7 @@ var (
 	_ core.Provider          = (*Provider)(nil)
 	_ core.StreamProvider    = (*Provider)(nil)
 	_ core.ProxiableProvider = (*Provider)(nil)
+	_ core.EmbeddingProvider = (*Provider)(nil)
 )
 
 // New creates a new DeepInfra provider.

--- a/providers/deepinfra/deepinfra_test.go
+++ b/providers/deepinfra/deepinfra_test.go
@@ -2,14 +2,18 @@ package deepinfra
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"testing"
 
 	"github.com/ferro-labs/ai-gateway/providers/core"
 )
 
 const testBearerAPIKey = "Bearer test-key"
+
+const testEmbeddingModel = "BAAI/bge-base-en-v1.5"
 
 func TestNewDeepInfra(t *testing.T) {
 	p, err := New("test-key", "")
@@ -136,5 +140,65 @@ func TestDeepInfraProvider_Complete_MockHTTP(t *testing.T) {
 	}
 	if len(resp.Choices) == 0 {
 		t.Error("expected at least one choice")
+	}
+}
+
+func TestDeepInfraProvider_Embed_Interface(_ *testing.T) {
+	p, _ := New("test-key", "")
+	var _ core.EmbeddingProvider = p
+}
+
+func TestDeepInfraProvider_Embed_MockHTTP(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+		if r.URL.Path != "/embeddings" {
+			t.Errorf("path = %q, want /embeddings", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != testBearerAPIKey {
+			t.Errorf("Authorization = %q, want %s", got, testBearerAPIKey)
+		}
+		var body map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		if body["model"] != testEmbeddingModel {
+			t.Errorf("model = %v, want %s", body["model"], testEmbeddingModel)
+		}
+		if body["input"] != "hello world" {
+			t.Errorf("input = %v, want hello world", body["input"])
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"object":"list","data":[{"object":"embedding","embedding":[0.1,0.2],"index":0}],"model":"` + testEmbeddingModel + `","usage":{"prompt_tokens":3,"total_tokens":3}}`))
+	}))
+	defer srv.Close()
+
+	p, _ := New("test-key", srv.URL)
+	resp, err := p.Embed(context.Background(), core.EmbeddingRequest{Model: testEmbeddingModel, Input: "hello world"})
+	if err != nil {
+		t.Fatalf("Embed() error: %v", err)
+	}
+	if resp.Object != "list" || resp.Model != testEmbeddingModel {
+		t.Errorf("resp = %+v, want list/%s", resp, testEmbeddingModel)
+	}
+	if len(resp.Data) != 1 || resp.Data[0].Index != 0 || !reflect.DeepEqual(resp.Data[0].Embedding, []float64{0.1, 0.2}) {
+		t.Errorf("Data = %+v, want one embedding at index 0", resp.Data)
+	}
+	if resp.Usage.PromptTokens != 3 || resp.Usage.TotalTokens != 3 {
+		t.Errorf("Usage = %+v, want prompt=3 total=3", resp.Usage)
+	}
+}
+
+func TestDeepInfraProvider_Embed_InvalidEncodingFormat(t *testing.T) {
+	p, _ := New("test-key", "http://127.0.0.1:0")
+	_, err := p.Embed(context.Background(), core.EmbeddingRequest{
+		Model:          testEmbeddingModel,
+		Input:          "hi",
+		EncodingFormat: "base64",
+	})
+	if err == nil {
+		t.Fatal("Embed() error = nil, want unsupported encoding_format error")
 	}
 }

--- a/providers/deepinfra/embedding.go
+++ b/providers/deepinfra/embedding.go
@@ -1,0 +1,124 @@
+package deepinfra
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/ferro-labs/ai-gateway/providers/core"
+)
+
+type embeddingRequest struct {
+	Model          string      `json:"model"`
+	Input          interface{} `json:"input"`
+	EncodingFormat string      `json:"encoding_format,omitempty"`
+	Dimensions     *int        `json:"dimensions,omitempty"`
+	User           string      `json:"user,omitempty"`
+}
+
+type embeddingResponse struct {
+	Object string              `json:"object"`
+	Data   []core.Embedding    `json:"data"`
+	Model  string              `json:"model"`
+	Usage  core.EmbeddingUsage `json:"usage"`
+}
+
+type embeddingErrorDetail struct {
+	Message string `json:"message"`
+	Type    string `json:"type"`
+}
+
+type embeddingErrorResponse struct {
+	Error embeddingErrorDetail `json:"error"`
+}
+
+// Embed sends an OpenAI-compatible embedding request to DeepInfra.
+func (p *Provider) Embed(ctx context.Context, req core.EmbeddingRequest) (*core.EmbeddingResponse, error) {
+	input, err := normalizeEmbeddingInput(req.Input)
+	if err != nil {
+		return nil, err
+	}
+	if req.EncodingFormat != "" && req.EncodingFormat != "float" {
+		return nil, fmt.Errorf("embed: unsupported encoding_format %q; valid value is \"float\"", req.EncodingFormat)
+	}
+
+	pReq := embeddingRequest{
+		Model:          req.Model,
+		Input:          input,
+		EncodingFormat: req.EncodingFormat,
+		Dimensions:     req.Dimensions,
+		User:           req.User,
+	}
+	bodyReader, _, release, err := core.JSONBodyReader(pReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal embedding request: %w", err)
+	}
+	defer release()
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, p.baseURL+"/embeddings", bodyReader) //nolint:gosec // baseURL validated in New()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	httpReq.Header.Set("Authorization", "Bearer "+p.apiKey)
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	httpResp, err := p.httpClient.Do(httpReq) //nolint:gosec // baseURL validated in New()
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer func() { _ = httpResp.Body.Close() }()
+
+	respBody, err := io.ReadAll(httpResp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+	if httpResp.StatusCode < http.StatusOK || httpResp.StatusCode >= http.StatusMultipleChoices {
+		var errResp embeddingErrorResponse
+		if json.Unmarshal(respBody, &errResp) == nil && errResp.Error.Message != "" {
+			return nil, fmt.Errorf("deepinfra API error (%d): %s", httpResp.StatusCode, errResp.Error.Message)
+		}
+		return nil, fmt.Errorf("deepinfra API error (%d): %s", httpResp.StatusCode, string(respBody))
+	}
+
+	var pResp embeddingResponse
+	if err := json.Unmarshal(respBody, &pResp); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal embedding response: %w", err)
+	}
+	return &core.EmbeddingResponse{
+		Object: pResp.Object,
+		Data:   pResp.Data,
+		Model:  pResp.Model,
+		Usage:  pResp.Usage,
+	}, nil
+}
+
+func normalizeEmbeddingInput(input interface{}) (interface{}, error) {
+	switch v := input.(type) {
+	case string:
+		return v, nil
+	case []string:
+		if len(v) == 0 {
+			return nil, fmt.Errorf("embed: Input must not be an empty array")
+		}
+		return v, nil
+	case []interface{}:
+		if len(v) == 0 {
+			return nil, fmt.Errorf("embed: Input must not be an empty array")
+		}
+		strs := make([]string, 0, len(v))
+		for i, item := range v {
+			s, ok := item.(string)
+			if !ok {
+				return nil, fmt.Errorf("embed: Input[%d] is %T, want string", i, item)
+			}
+			strs = append(strs, s)
+		}
+		return strs, nil
+	case nil:
+		return nil, fmt.Errorf("embed: Input must not be nil")
+	default:
+		return nil, fmt.Errorf("embed: unsupported Input type %T; want string or []string", input)
+	}
+}

--- a/providers/gemini/gemini.go
+++ b/providers/gemini/gemini.go
@@ -31,6 +31,7 @@ var (
 	_ core.Provider          = (*Provider)(nil)
 	_ core.StreamProvider    = (*Provider)(nil)
 	_ core.EmbeddingProvider = (*Provider)(nil)
+	_ core.ImageProvider     = (*Provider)(nil)
 	_ core.ProxiableProvider = (*Provider)(nil)
 )
 
@@ -71,13 +72,16 @@ func (p *Provider) SupportedModels() []string {
 		"gemini-embedding-001",
 		"text-embedding-004",
 		"embedding-001",
+		"imagen-4.0-generate-001",
+		"imagen-4.0-ultra-generate-001",
+		"imagen-4.0-fast-generate-001",
 	}
 }
 
-// SupportsModel returns true if the model is a known Gemini chat or embedding model.
+// SupportsModel returns true if the model is a known Gemini chat, embedding, or image model.
 func (p *Provider) SupportsModel(model string) bool {
 	model = strings.TrimPrefix(model, "models/")
-	if strings.HasPrefix(model, "gemini-") {
+	if strings.HasPrefix(model, "gemini-") || strings.HasPrefix(model, "imagen-") {
 		return true
 	}
 	switch model {

--- a/providers/gemini/image.go
+++ b/providers/gemini/image.go
@@ -1,0 +1,125 @@
+package gemini
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/ferro-labs/ai-gateway/providers/core"
+)
+
+// imagenInstance is a single Imagen prediction input.
+type imagenInstance struct {
+	Prompt string `json:"prompt"`
+}
+
+// imagenParameters carries the optional Imagen generation knobs.
+type imagenParameters struct {
+	SampleCount *int   `json:"sampleCount,omitempty"`
+	AspectRatio string `json:"aspectRatio,omitempty"`
+}
+
+// imagenRequest is the Imagen :predict request envelope.
+type imagenRequest struct {
+	Instances  []imagenInstance  `json:"instances"`
+	Parameters *imagenParameters `json:"parameters,omitempty"`
+}
+
+// imagenPrediction is a single Imagen :predict result.
+type imagenPrediction struct {
+	BytesBase64Encoded string `json:"bytesBase64Encoded"`
+	MimeType           string `json:"mimeType"`
+	RAIFilteredReason  string `json:"raiFilteredReason"`
+}
+
+// imagenResponse is the Imagen :predict response envelope.
+type imagenResponse struct {
+	Predictions []imagenPrediction `json:"predictions"`
+}
+
+// buildImagenRequest maps a gateway ImageRequest onto the Imagen :predict shape.
+// req.Size ("WxH") is not directly mappable to Imagen and is ignored;
+// req.ResponseFormat is ignored (Imagen returns base64 only).
+func buildImagenRequest(req core.ImageRequest) imagenRequest {
+	out := imagenRequest{
+		Instances: []imagenInstance{{Prompt: req.Prompt}},
+	}
+	if req.N != nil {
+		params := imagenParameters{SampleCount: req.N}
+		out.Parameters = &params
+	}
+	return out
+}
+
+// mapImagenPredictions converts Imagen predictions to gateway images. It returns
+// an error when every prediction was rai-filtered or empty.
+func mapImagenPredictions(model string, predictions []imagenPrediction) ([]core.GeneratedImage, error) {
+	images := make([]core.GeneratedImage, 0, len(predictions))
+	for _, pred := range predictions {
+		if pred.BytesBase64Encoded == "" {
+			continue
+		}
+		images = append(images, core.GeneratedImage{B64JSON: pred.BytesBase64Encoded})
+	}
+	if len(images) == 0 {
+		return nil, fmt.Errorf("gemini image generation for %q returned no images (all predictions were filtered or empty)", model)
+	}
+	return images, nil
+}
+
+// GenerateImage sends an image generation request to Gemini's Imagen :predict endpoint.
+func (p *Provider) GenerateImage(ctx context.Context, req core.ImageRequest) (*core.ImageResponse, error) {
+	imagenReq := buildImagenRequest(req)
+
+	bodyReader, _, release, err := core.JSONBodyReader(imagenReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal image request: %w", err)
+	}
+	defer release()
+
+	model := strings.TrimPrefix(req.Model, "models/")
+	url := fmt.Sprintf("%s/v1beta/models/%s:predict?key=%s", p.baseURL, model, p.apiKey)
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bodyReader)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create image request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	httpResp, err := p.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("image request failed: %w", err)
+	}
+	defer func() { _ = httpResp.Body.Close() }()
+
+	respBody, err := io.ReadAll(httpResp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read image response: %w", err)
+	}
+
+	if httpResp.StatusCode != http.StatusOK {
+		var errResp geminiErrorResponse
+		if json.Unmarshal(respBody, &errResp) == nil && errResp.Error.Message != "" {
+			return nil, fmt.Errorf("gemini image API error (%d): %s", httpResp.StatusCode, errResp.Error.Message)
+		}
+		return nil, fmt.Errorf("gemini image API error (%d): %s", httpResp.StatusCode, string(respBody))
+	}
+
+	var imagenResp imagenResponse
+	if err := json.Unmarshal(respBody, &imagenResp); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal image response: %w", err)
+	}
+
+	images, err := mapImagenPredictions(req.Model, imagenResp.Predictions)
+	if err != nil {
+		return nil, err
+	}
+
+	return &core.ImageResponse{
+		Created: time.Now().Unix(),
+		Data:    images,
+	}, nil
+}

--- a/providers/gemini/image_test.go
+++ b/providers/gemini/image_test.go
@@ -1,0 +1,98 @@
+package gemini
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/ferro-labs/ai-gateway/providers/core"
+)
+
+func TestGeminiProvider_GenerateImage_Interface(_ *testing.T) {
+	p, _ := New("test-key", "")
+	var _ core.ImageProvider = p
+}
+
+func TestGeminiProvider_SupportsModel_Imagen(t *testing.T) {
+	p, _ := New("test-key", "")
+	if !p.SupportsModel("imagen-4.0-generate-001") {
+		t.Error("expected imagen-4.0-generate-001 to be supported")
+	}
+}
+
+func TestGeminiProvider_GenerateImage(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, ":predict") {
+			t.Errorf("request path = %q, want suffix :predict", r.URL.Path)
+		}
+		if !strings.Contains(r.URL.Path, "imagen-4.0-generate-001") {
+			t.Errorf("request path = %q, want it to contain the model id", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("key"); got != "test-key" {
+			t.Errorf("key query = %q, want test-key", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"predictions":[{"bytesBase64Encoded":"aGk=","mimeType":"image/png"}]}`))
+	}))
+	defer srv.Close()
+
+	p, err := New("test-key", srv.URL)
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	n := 1
+	resp, err := p.GenerateImage(context.Background(), core.ImageRequest{
+		Model:  "imagen-4.0-generate-001",
+		Prompt: "a red panda",
+		N:      &n,
+	})
+	if err != nil {
+		t.Fatalf("GenerateImage() error: %v", err)
+	}
+	if len(resp.Data) != 1 {
+		t.Fatalf("len(Data) = %d, want 1", len(resp.Data))
+	}
+	if resp.Data[0].B64JSON != "aGk=" {
+		t.Errorf("B64JSON = %q, want aGk=", resp.Data[0].B64JSON)
+	}
+	if resp.Created == 0 {
+		t.Error("Created should be set")
+	}
+}
+
+func TestGeminiProvider_GenerateImage_AllFiltered(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"predictions":[{"raiFilteredReason":"safety"}]}`))
+	}))
+	defer srv.Close()
+
+	p, _ := New("test-key", srv.URL)
+	_, err := p.GenerateImage(context.Background(), core.ImageRequest{
+		Model:  "imagen-4.0-generate-001",
+		Prompt: "blocked",
+	})
+	if err == nil {
+		t.Fatal("expected error when all predictions are filtered")
+	}
+}
+
+func TestGeminiProvider_GenerateImage_UpstreamError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":{"message":"bad image request"}}`))
+	}))
+	defer srv.Close()
+
+	p, _ := New("test-key", srv.URL)
+	_, err := p.GenerateImage(context.Background(), core.ImageRequest{
+		Model:  "imagen-4.0-generate-001",
+		Prompt: "x",
+	})
+	if err == nil || !strings.Contains(err.Error(), "bad image request") {
+		t.Fatalf("GenerateImage() error = %v, want upstream error", err)
+	}
+}

--- a/providers/groq/groq.go
+++ b/providers/groq/groq.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/ferro-labs/ai-gateway/internal/discovery"
 	providerhttp "github.com/ferro-labs/ai-gateway/internal/httpclient"
 	"github.com/ferro-labs/ai-gateway/internal/openaicompat"
 	"github.com/ferro-labs/ai-gateway/providers/core"
@@ -33,6 +34,7 @@ var (
 	_ core.Provider          = (*Provider)(nil)
 	_ core.StreamProvider    = (*Provider)(nil)
 	_ core.ProxiableProvider = (*Provider)(nil)
+	_ core.DiscoveryProvider = (*Provider)(nil)
 )
 
 // New creates a new Groq provider.
@@ -82,6 +84,11 @@ func (p *Provider) SupportsModel(_ string) bool {
 // Models returns structured model metadata.
 func (p *Provider) Models() []core.ModelInfo {
 	return core.ModelsFromList(p.name, p.SupportedModels())
+}
+
+// DiscoverModels fetches the live model list from the Groq /v1/models endpoint.
+func (p *Provider) DiscoverModels(ctx context.Context) ([]core.ModelInfo, error) {
+	return discovery.DiscoverOpenAICompatibleModels(ctx, p.httpClient, p.baseURL+"/v1/models", p.apiKey, p.name)
 }
 
 // Complete sends a chat completion request to Groq.

--- a/providers/groq/groq_test.go
+++ b/providers/groq/groq_test.go
@@ -127,3 +127,36 @@ func TestGroqProvider_Complete_Integration(t *testing.T) {
 }
 
 func intPtr(i int) *int { return &i }
+
+func TestGroqProvider_DiscoverModels(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("method = %q, want GET", r.Method)
+		}
+		if r.URL.Path != "/v1/models" {
+			t.Errorf("path = %q, want /v1/models", r.URL.Path)
+		}
+		if r.Header.Get("Authorization") != "Bearer test-key" {
+			t.Errorf("Authorization = %q, want Bearer test-key", r.Header.Get("Authorization"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"object":"list","data":[{"id":"llama-3.3-70b-versatile","object":"model","created":1700000000,"owned_by":"Groq"},{"id":"gemma2-9b-it","object":"model"}]}`))
+	}))
+	defer srv.Close()
+
+	p, _ := New("test-key", srv.URL)
+	models, err := p.DiscoverModels(context.Background())
+	if err != nil {
+		t.Fatalf("DiscoverModels() error: %v", err)
+	}
+	if len(models) != 2 {
+		t.Fatalf("expected 2 models, got %d", len(models))
+	}
+	if models[0].ID != "llama-3.3-70b-versatile" || models[0].OwnedBy != "Groq" {
+		t.Errorf("unexpected model[0]: %+v", models[0])
+	}
+	if models[1].ID != "gemma2-9b-it" || models[1].OwnedBy != "groq" {
+		t.Errorf("model[1] owned_by fallback = %q, want groq", models[1].OwnedBy)
+	}
+}

--- a/providers/mistral/mistral.go
+++ b/providers/mistral/mistral.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/ferro-labs/ai-gateway/internal/discovery"
 	providerhttp "github.com/ferro-labs/ai-gateway/internal/httpclient"
 	"github.com/ferro-labs/ai-gateway/internal/openaicompat"
 	"github.com/ferro-labs/ai-gateway/providers/core"
@@ -32,6 +33,7 @@ var (
 	_ core.StreamProvider    = (*Provider)(nil)
 	_ core.EmbeddingProvider = (*Provider)(nil)
 	_ core.ProxiableProvider = (*Provider)(nil)
+	_ core.DiscoveryProvider = (*Provider)(nil)
 )
 
 // New creates a new Mistral provider.
@@ -85,6 +87,11 @@ func (p *Provider) SupportsModel(model string) bool {
 // Models returns structured model metadata.
 func (p *Provider) Models() []core.ModelInfo {
 	return core.ModelsFromList(p.name, p.SupportedModels())
+}
+
+// DiscoverModels fetches the live model list from the Mistral /v1/models endpoint.
+func (p *Provider) DiscoverModels(ctx context.Context) ([]core.ModelInfo, error) {
+	return discovery.DiscoverOpenAICompatibleModels(ctx, p.httpClient, p.baseURL+"/v1/models", p.apiKey, p.name)
 }
 
 // ------------------------------------------------------------------ types ---

--- a/providers/mistral/mistral_test.go
+++ b/providers/mistral/mistral_test.go
@@ -15,6 +15,39 @@ import (
 
 const testEmbeddingModel = "mistral-embed"
 
+func TestMistralProvider_DiscoverModels(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("method = %q, want GET", r.Method)
+		}
+		if r.URL.Path != "/v1/models" {
+			t.Errorf("path = %q, want /v1/models", r.URL.Path)
+		}
+		if r.Header.Get("Authorization") != "Bearer test-key" {
+			t.Errorf("Authorization = %q, want Bearer test-key", r.Header.Get("Authorization"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"object":"list","data":[{"id":"mistral-large-latest","object":"model","created":1700000000,"owned_by":"mistralai"},{"id":"codestral-latest","object":"model"}]}`))
+	}))
+	defer srv.Close()
+
+	p, _ := New("test-key", srv.URL)
+	models, err := p.DiscoverModels(context.Background())
+	if err != nil {
+		t.Fatalf("DiscoverModels() error: %v", err)
+	}
+	if len(models) != 2 {
+		t.Fatalf("expected 2 models, got %d", len(models))
+	}
+	if models[0].ID != "mistral-large-latest" || models[0].OwnedBy != "mistralai" {
+		t.Errorf("unexpected model[0]: %+v", models[0])
+	}
+	if models[1].ID != "codestral-latest" || models[1].OwnedBy != "mistral" {
+		t.Errorf("model[1] owned_by fallback = %q, want mistral", models[1].OwnedBy)
+	}
+}
+
 func TestNewMistral(t *testing.T) {
 	p, err := New("test-key", "")
 	if err != nil {

--- a/providers/nvidia_nim/embedding.go
+++ b/providers/nvidia_nim/embedding.go
@@ -1,0 +1,132 @@
+package nvidianim
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/ferro-labs/ai-gateway/providers/core"
+)
+
+type embeddingRequest struct {
+	Model          string      `json:"model"`
+	Input          interface{} `json:"input"`
+	EncodingFormat string      `json:"encoding_format,omitempty"`
+	Dimensions     *int        `json:"dimensions,omitempty"`
+	User           string      `json:"user,omitempty"`
+	// InputType distinguishes embedding intent for NeMo retriever models
+	// (e.g. "query" / "passage"). Required by some models or they return 400.
+	InputType string `json:"input_type,omitempty"`
+	// Truncate controls truncation behaviour ("NONE", "START", "END").
+	Truncate string `json:"truncate,omitempty"`
+}
+
+type embeddingResponse struct {
+	Object string              `json:"object"`
+	Data   []core.Embedding    `json:"data"`
+	Model  string              `json:"model"`
+	Usage  core.EmbeddingUsage `json:"usage"`
+}
+
+type embeddingErrorDetail struct {
+	Message string `json:"message"`
+	Type    string `json:"type"`
+}
+
+type embeddingErrorResponse struct {
+	Error embeddingErrorDetail `json:"error"`
+}
+
+// Embed sends an OpenAI-compatible embedding request to NVIDIA NIM.
+// req.InputType is passed through verbatim with no default injection; NeMo
+// retriever models require it or respond with HTTP 400.
+func (p *Provider) Embed(ctx context.Context, req core.EmbeddingRequest) (*core.EmbeddingResponse, error) {
+	input, err := normalizeEmbeddingInput(req.Input)
+	if err != nil {
+		return nil, err
+	}
+	if req.EncodingFormat != "" && req.EncodingFormat != "float" {
+		return nil, fmt.Errorf("embed: unsupported encoding_format %q; valid value is \"float\"", req.EncodingFormat)
+	}
+
+	pReq := embeddingRequest{
+		Model:          req.Model,
+		Input:          input,
+		EncodingFormat: req.EncodingFormat,
+		Dimensions:     req.Dimensions,
+		User:           req.User,
+		InputType:      req.InputType,
+	}
+	bodyReader, _, release, err := core.JSONBodyReader(pReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal embedding request: %w", err)
+	}
+	defer release()
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, p.baseURL+"/embeddings", bodyReader) //nolint:gosec // baseURL validated in New()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	httpReq.Header.Set("Authorization", "Bearer "+p.apiKey)
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	httpResp, err := p.httpClient.Do(httpReq) //nolint:gosec // baseURL validated in New()
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer func() { _ = httpResp.Body.Close() }()
+
+	respBody, err := io.ReadAll(httpResp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+	if httpResp.StatusCode < http.StatusOK || httpResp.StatusCode >= http.StatusMultipleChoices {
+		var errResp embeddingErrorResponse
+		if json.Unmarshal(respBody, &errResp) == nil && errResp.Error.Message != "" {
+			return nil, fmt.Errorf("nvidia nim API error (%d): %s", httpResp.StatusCode, errResp.Error.Message)
+		}
+		return nil, fmt.Errorf("nvidia nim API error (%d): %s", httpResp.StatusCode, string(respBody))
+	}
+
+	var pResp embeddingResponse
+	if err := json.Unmarshal(respBody, &pResp); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal embedding response: %w", err)
+	}
+	return &core.EmbeddingResponse{
+		Object: pResp.Object,
+		Data:   pResp.Data,
+		Model:  pResp.Model,
+		Usage:  pResp.Usage,
+	}, nil
+}
+
+func normalizeEmbeddingInput(input interface{}) (interface{}, error) {
+	switch v := input.(type) {
+	case string:
+		return v, nil
+	case []string:
+		if len(v) == 0 {
+			return nil, fmt.Errorf("embed: Input must not be an empty array")
+		}
+		return v, nil
+	case []interface{}:
+		if len(v) == 0 {
+			return nil, fmt.Errorf("embed: Input must not be an empty array")
+		}
+		strs := make([]string, 0, len(v))
+		for i, item := range v {
+			s, ok := item.(string)
+			if !ok {
+				return nil, fmt.Errorf("embed: Input[%d] is %T, want string", i, item)
+			}
+			strs = append(strs, s)
+		}
+		return strs, nil
+	case nil:
+		return nil, fmt.Errorf("embed: Input must not be nil")
+	default:
+		return nil, fmt.Errorf("embed: unsupported Input type %T; want string or []string", input)
+	}
+}

--- a/providers/nvidia_nim/nvidia_nim.go
+++ b/providers/nvidia_nim/nvidia_nim.go
@@ -31,6 +31,7 @@ var (
 	_ core.Provider          = (*Provider)(nil)
 	_ core.StreamProvider    = (*Provider)(nil)
 	_ core.ProxiableProvider = (*Provider)(nil)
+	_ core.EmbeddingProvider = (*Provider)(nil)
 )
 
 // New creates a new NVIDIA NIM provider.

--- a/providers/nvidia_nim/nvidia_nim_test.go
+++ b/providers/nvidia_nim/nvidia_nim_test.go
@@ -2,14 +2,18 @@ package nvidianim
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"testing"
 
 	"github.com/ferro-labs/ai-gateway/providers/core"
 )
 
 const testBearerAPIKey = "Bearer test-key"
+
+const testEmbeddingModel = "nvidia/nv-embedqa-e5-v5"
 
 func TestNewNVIDIANIM(t *testing.T) {
 	p, err := New("test-key", "")
@@ -133,5 +137,78 @@ func TestNVIDIANIMProvider_Complete_MockHTTP(t *testing.T) {
 	}
 	if len(resp.Choices) == 0 {
 		t.Error("expected at least one choice")
+	}
+}
+
+func TestNVIDIANIMProvider_Embed_Interface(_ *testing.T) {
+	p, _ := New("test-key", "")
+	var _ core.EmbeddingProvider = p
+}
+
+func TestNVIDIANIMProvider_Embed_MockHTTP(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+		if r.URL.Path != "/embeddings" {
+			t.Errorf("path = %q, want /embeddings", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != testBearerAPIKey {
+			t.Errorf("Authorization = %q, want %s", got, testBearerAPIKey)
+		}
+		var body map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		if body["model"] != testEmbeddingModel {
+			t.Errorf("model = %v, want %s", body["model"], testEmbeddingModel)
+		}
+		if body["input_type"] != "query" {
+			t.Errorf("input_type = %v, want query", body["input_type"])
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"object":"list","data":[{"object":"embedding","embedding":[0.5,0.6],"index":0}],"model":"` + testEmbeddingModel + `","usage":{"prompt_tokens":2,"total_tokens":2}}`))
+	}))
+	defer srv.Close()
+
+	p, _ := New("test-key", srv.URL)
+	resp, err := p.Embed(context.Background(), core.EmbeddingRequest{
+		Model:     testEmbeddingModel,
+		Input:     "hello world",
+		InputType: "query",
+	})
+	if err != nil {
+		t.Fatalf("Embed() error: %v", err)
+	}
+	if resp.Object != "list" || resp.Model != testEmbeddingModel {
+		t.Errorf("resp = %+v, want list/%s", resp, testEmbeddingModel)
+	}
+	if len(resp.Data) != 1 || !reflect.DeepEqual(resp.Data[0].Embedding, []float64{0.5, 0.6}) {
+		t.Errorf("Data = %+v, want one embedding", resp.Data)
+	}
+	if resp.Usage.PromptTokens != 2 || resp.Usage.TotalTokens != 2 {
+		t.Errorf("Usage = %+v, want prompt=2 total=2", resp.Usage)
+	}
+}
+
+func TestNVIDIANIMProvider_Embed_NoInputTypeDefaultInjection(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		if _, present := body["input_type"]; present {
+			t.Errorf("input_type present = %v, want omitted when req.InputType is empty", body["input_type"])
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"object":"list","data":[{"object":"embedding","embedding":[0.1],"index":0}],"model":"` + testEmbeddingModel + `","usage":{"prompt_tokens":1,"total_tokens":1}}`))
+	}))
+	defer srv.Close()
+
+	p, _ := New("test-key", srv.URL)
+	if _, err := p.Embed(context.Background(), core.EmbeddingRequest{Model: testEmbeddingModel, Input: "hi"}); err != nil {
+		t.Fatalf("Embed() error: %v", err)
 	}
 }

--- a/providers/ollama/embedding.go
+++ b/providers/ollama/embedding.go
@@ -1,0 +1,124 @@
+package ollama
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/ferro-labs/ai-gateway/providers/core"
+)
+
+// ollamaEmbedRequest is the native Ollama /api/embed request schema.
+type ollamaEmbedRequest struct {
+	Model string      `json:"model"`
+	Input interface{} `json:"input"` // string or []string
+}
+
+// ollamaEmbedResponse is the native Ollama /api/embed response schema.
+type ollamaEmbedResponse struct {
+	Model           string      `json:"model"`
+	Embeddings      [][]float64 `json:"embeddings"`
+	PromptEvalCount int         `json:"prompt_eval_count"`
+}
+
+// Embed sends a request to the native Ollama /api/embed endpoint and adapts
+// the response to the OpenAI-compatible core.EmbeddingResponse shape.
+func (p *Provider) Embed(ctx context.Context, req core.EmbeddingRequest) (*core.EmbeddingResponse, error) {
+	input, err := normalizeEmbeddingInput(req.Input)
+	if err != nil {
+		return nil, err
+	}
+	if req.EncodingFormat != "" && req.EncodingFormat != "float" {
+		return nil, fmt.Errorf("embed: unsupported encoding_format %q; valid value is \"float\"", req.EncodingFormat)
+	}
+	// Ollama's native API does not support output dimension control; ignore req.Dimensions.
+
+	pReq := ollamaEmbedRequest{
+		Model: req.Model,
+		Input: input,
+	}
+	bodyReader, _, release, err := core.JSONBodyReader(pReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal embedding request: %w", err)
+	}
+	defer release()
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, p.baseURL+"/api/embed", bodyReader)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	httpResp, err := p.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer func() { _ = httpResp.Body.Close() }()
+
+	respBody, err := io.ReadAll(httpResp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+	if httpResp.StatusCode != http.StatusOK {
+		var errResp ollamaErrorResponse
+		if json.Unmarshal(respBody, &errResp) == nil && errResp.Error.Message != "" {
+			return nil, fmt.Errorf("ollama API error (%d): %s", httpResp.StatusCode, errResp.Error.Message)
+		}
+		return nil, fmt.Errorf("ollama API error (%d): %s", httpResp.StatusCode, string(respBody))
+	}
+
+	var oResp ollamaEmbedResponse
+	if err := json.Unmarshal(respBody, &oResp); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal embedding response: %w", err)
+	}
+
+	data := make([]core.Embedding, 0, len(oResp.Embeddings))
+	for i, row := range oResp.Embeddings {
+		data = append(data, core.Embedding{
+			Object:    "embedding",
+			Embedding: row,
+			Index:     i,
+		})
+	}
+
+	return &core.EmbeddingResponse{
+		Object: "list",
+		Data:   data,
+		Model:  oResp.Model,
+		Usage: core.EmbeddingUsage{
+			PromptTokens: oResp.PromptEvalCount,
+			TotalTokens:  oResp.PromptEvalCount,
+		},
+	}, nil
+}
+
+func normalizeEmbeddingInput(input interface{}) (interface{}, error) {
+	switch v := input.(type) {
+	case string:
+		return v, nil
+	case []string:
+		if len(v) == 0 {
+			return nil, fmt.Errorf("embed: Input must not be an empty array")
+		}
+		return v, nil
+	case []interface{}:
+		if len(v) == 0 {
+			return nil, fmt.Errorf("embed: Input must not be an empty array")
+		}
+		strs := make([]string, 0, len(v))
+		for i, item := range v {
+			s, ok := item.(string)
+			if !ok {
+				return nil, fmt.Errorf("embed: Input[%d] is %T, want string", i, item)
+			}
+			strs = append(strs, s)
+		}
+		return strs, nil
+	case nil:
+		return nil, fmt.Errorf("embed: Input must not be nil")
+	default:
+		return nil, fmt.Errorf("embed: unsupported Input type %T; want string or []string", input)
+	}
+}

--- a/providers/ollama/ollama.go
+++ b/providers/ollama/ollama.go
@@ -32,6 +32,7 @@ var (
 	_ core.Provider          = (*Provider)(nil)
 	_ core.StreamProvider    = (*Provider)(nil)
 	_ core.ProxiableProvider = (*Provider)(nil)
+	_ core.EmbeddingProvider = (*Provider)(nil)
 )
 
 // New creates a new Ollama provider.

--- a/providers/ollama/ollama_test.go
+++ b/providers/ollama/ollama_test.go
@@ -2,8 +2,10 @@ package ollama
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"testing"
 
 	"github.com/ferro-labs/ai-gateway/providers/core"
@@ -99,5 +101,78 @@ func TestOllamaProvider_CompleteStream_MockSSE(t *testing.T) {
 	}
 	if chunks[2].Choices[0].Delta.Content != " there" {
 		t.Errorf("delta content = %q, want ' there'", chunks[2].Choices[0].Delta.Content)
+	}
+}
+
+func TestOllamaProvider_Embed_Interface(_ *testing.T) {
+	p, _ := New("", nil)
+	var _ core.EmbeddingProvider = p
+}
+
+func TestOllamaProvider_Embed_MockHTTP(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+		if r.URL.Path != "/api/embed" {
+			t.Errorf("path = %q, want /api/embed", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "" {
+			t.Errorf("Authorization = %q, want empty (no auth)", got)
+		}
+		var body map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		if body["model"] != "nomic-embed-text" {
+			t.Errorf("model = %v, want nomic-embed-text", body["model"])
+		}
+		arr, ok := body["input"].([]interface{})
+		if !ok || len(arr) != 2 || arr[0] != "hello" || arr[1] != "world" {
+			t.Errorf("input = %v, want [hello world]", body["input"])
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"model":"nomic-embed-text","embeddings":[[0.1,0.2],[0.3,0.4]],"prompt_eval_count":6}`))
+	}))
+	defer srv.Close()
+
+	p, _ := New(srv.URL, []string{"nomic-embed-text"})
+	resp, err := p.Embed(context.Background(), core.EmbeddingRequest{
+		Model: "nomic-embed-text",
+		Input: []string{"hello", "world"},
+	})
+	if err != nil {
+		t.Fatalf("Embed() error: %v", err)
+	}
+	if resp.Object != "list" {
+		t.Errorf("Object = %q, want list", resp.Object)
+	}
+	if resp.Model != "nomic-embed-text" {
+		t.Errorf("Model = %q, want nomic-embed-text", resp.Model)
+	}
+	if len(resp.Data) != 2 {
+		t.Fatalf("Data length = %d, want 2", len(resp.Data))
+	}
+	if resp.Data[0].Object != "embedding" || resp.Data[0].Index != 0 || !reflect.DeepEqual(resp.Data[0].Embedding, []float64{0.1, 0.2}) {
+		t.Errorf("Data[0] = %+v, want embedding at index 0", resp.Data[0])
+	}
+	if resp.Data[1].Index != 1 || !reflect.DeepEqual(resp.Data[1].Embedding, []float64{0.3, 0.4}) {
+		t.Errorf("Data[1] = %+v, want embedding at index 1", resp.Data[1])
+	}
+	if resp.Usage.PromptTokens != 6 || resp.Usage.TotalTokens != 6 {
+		t.Errorf("Usage = %+v, want prompt=6 total=6", resp.Usage)
+	}
+}
+
+func TestOllamaProvider_Embed_RejectsNonFloatEncoding(t *testing.T) {
+	p, _ := New("http://127.0.0.1:0", []string{"nomic-embed-text"})
+	_, err := p.Embed(context.Background(), core.EmbeddingRequest{
+		Model:          "nomic-embed-text",
+		Input:          "hi",
+		EncodingFormat: "base64",
+	})
+	if err == nil {
+		t.Fatal("Embed() error = nil, want unsupported encoding_format error")
 	}
 }

--- a/providers/providers_list.go
+++ b/providers/providers_list.go
@@ -53,7 +53,7 @@ var allProviders = []ProviderEntry{
 	},
 	{
 		ID:           NameAnthropic,
-		Capabilities: []string{CapabilityChat, CapabilityStream, CapabilityProxy},
+		Capabilities: []string{CapabilityChat, CapabilityStream, CapabilityDiscovery, CapabilityProxy},
 		EnvMappings: []EnvMapping{
 			{CfgKeyAPIKey, "ANTHROPIC_API_KEY", true},
 			{CfgKeyBaseURL, "ANTHROPIC_BASE_URL", false},
@@ -79,7 +79,7 @@ var allProviders = []ProviderEntry{
 	},
 	{
 		ID:           NameAzureOpenAI,
-		Capabilities: []string{CapabilityChat, CapabilityStream, CapabilityProxy},
+		Capabilities: []string{CapabilityChat, CapabilityStream, CapabilityEmbed, CapabilityImage, CapabilityProxy},
 		EnvMappings: []EnvMapping{
 			{CfgKeyAPIKey, "AZURE_OPENAI_API_KEY", true},
 			{CfgKeyBaseURL, "AZURE_OPENAI_ENDPOINT", true},
@@ -98,7 +98,7 @@ var allProviders = []ProviderEntry{
 	},
 	{
 		ID:           NameBedrock,
-		Capabilities: []string{CapabilityChat, CapabilityStream, CapabilityEmbed, CapabilityProxy},
+		Capabilities: []string{CapabilityChat, CapabilityStream, CapabilityEmbed, CapabilityImage, CapabilityProxy},
 		// All Bedrock env mappings are optional because the provider can be
 		// configured in two different ways:
 		//   1. Instance-role / credential-chain auth: only AWS_REGION is set.
@@ -172,7 +172,7 @@ var allProviders = []ProviderEntry{
 	},
 	{
 		ID:           NameDeepInfra,
-		Capabilities: []string{CapabilityChat, CapabilityStream, CapabilityProxy},
+		Capabilities: []string{CapabilityChat, CapabilityStream, CapabilityEmbed, CapabilityProxy},
 		EnvMappings: []EnvMapping{
 			{CfgKeyAPIKey, "DEEPINFRA_API_KEY", true},
 			{CfgKeyBaseURL, "DEEPINFRA_BASE_URL", false},
@@ -205,7 +205,7 @@ var allProviders = []ProviderEntry{
 	},
 	{
 		ID:           NameGemini,
-		Capabilities: []string{CapabilityChat, CapabilityStream, CapabilityEmbed, CapabilityProxy},
+		Capabilities: []string{CapabilityChat, CapabilityStream, CapabilityEmbed, CapabilityImage, CapabilityProxy},
 		EnvMappings: []EnvMapping{
 			{CfgKeyAPIKey, "GEMINI_API_KEY", true},
 			{CfgKeyBaseURL, "GEMINI_BASE_URL", false},
@@ -216,7 +216,7 @@ var allProviders = []ProviderEntry{
 	},
 	{
 		ID:           NameGroq,
-		Capabilities: []string{CapabilityChat, CapabilityStream, CapabilityProxy},
+		Capabilities: []string{CapabilityChat, CapabilityStream, CapabilityDiscovery, CapabilityProxy},
 		EnvMappings: []EnvMapping{
 			{CfgKeyAPIKey, "GROQ_API_KEY", true},
 			{CfgKeyBaseURL, "GROQ_BASE_URL", false},
@@ -238,7 +238,7 @@ var allProviders = []ProviderEntry{
 	},
 	{
 		ID:           NameMistral,
-		Capabilities: []string{CapabilityChat, CapabilityStream, CapabilityEmbed, CapabilityProxy},
+		Capabilities: []string{CapabilityChat, CapabilityStream, CapabilityEmbed, CapabilityDiscovery, CapabilityProxy},
 		EnvMappings: []EnvMapping{
 			{CfgKeyAPIKey, "MISTRAL_API_KEY", true},
 			{CfgKeyBaseURL, "MISTRAL_BASE_URL", false},
@@ -271,7 +271,7 @@ var allProviders = []ProviderEntry{
 	},
 	{
 		ID:           NameNVIDIANIM,
-		Capabilities: []string{CapabilityChat, CapabilityStream, CapabilityProxy},
+		Capabilities: []string{CapabilityChat, CapabilityStream, CapabilityEmbed, CapabilityProxy},
 		EnvMappings: []EnvMapping{
 			{CfgKeyAPIKey, "NVIDIA_NIM_API_KEY", true},
 			{CfgKeyBaseURL, "NVIDIA_NIM_BASE_URL", false},
@@ -282,7 +282,7 @@ var allProviders = []ProviderEntry{
 	},
 	{
 		ID:           NameOllama,
-		Capabilities: []string{CapabilityChat, CapabilityStream, CapabilityProxy},
+		Capabilities: []string{CapabilityChat, CapabilityStream, CapabilityEmbed, CapabilityProxy},
 		// Ollama has no API key; CfgKeyHost acts as the "configured?" gate.
 		EnvMappings: []EnvMapping{
 			{CfgKeyHost, "OLLAMA_HOST", true},
@@ -347,7 +347,7 @@ var allProviders = []ProviderEntry{
 	},
 	{
 		ID:           NameQwen,
-		Capabilities: []string{CapabilityChat, CapabilityStream, CapabilityProxy},
+		Capabilities: []string{CapabilityChat, CapabilityStream, CapabilityEmbed, CapabilityProxy},
 		EnvMappings: []EnvMapping{
 			{CfgKeyAPIKey, "QWEN_API_KEY", true},
 			{CfgKeyBaseURL, "QWEN_BASE_URL", false},
@@ -390,7 +390,7 @@ var allProviders = []ProviderEntry{
 	},
 	{
 		ID:           NameTogether,
-		Capabilities: []string{CapabilityChat, CapabilityStream, CapabilityEmbed, CapabilityProxy},
+		Capabilities: []string{CapabilityChat, CapabilityStream, CapabilityEmbed, CapabilityDiscovery, CapabilityProxy},
 		EnvMappings: []EnvMapping{
 			{CfgKeyAPIKey, "TOGETHER_API_KEY", true},
 			{CfgKeyBaseURL, "TOGETHER_BASE_URL", false},
@@ -401,7 +401,7 @@ var allProviders = []ProviderEntry{
 	},
 	{
 		ID:           NameVertexAI,
-		Capabilities: []string{CapabilityChat, CapabilityStream, CapabilityEmbed, CapabilityProxy},
+		Capabilities: []string{CapabilityChat, CapabilityStream, CapabilityEmbed, CapabilityImage, CapabilityProxy},
 		// project_id is the gate: if unset, skip silently.
 		// region plus one of api_key / service_account_json are required once
 		// project_id is present.
@@ -428,7 +428,7 @@ var allProviders = []ProviderEntry{
 	},
 	{
 		ID:           NameXAI,
-		Capabilities: []string{CapabilityChat, CapabilityStream, CapabilityDiscovery, CapabilityProxy},
+		Capabilities: []string{CapabilityChat, CapabilityStream, CapabilityDiscovery, CapabilityImage, CapabilityProxy},
 		EnvMappings: []EnvMapping{
 			{CfgKeyAPIKey, "XAI_API_KEY", true},
 			{CfgKeyBaseURL, "XAI_BASE_URL", false},

--- a/providers/qwen/embedding.go
+++ b/providers/qwen/embedding.go
@@ -1,0 +1,124 @@
+package qwen
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/ferro-labs/ai-gateway/providers/core"
+)
+
+type embeddingRequest struct {
+	Model          string      `json:"model"`
+	Input          interface{} `json:"input"`
+	EncodingFormat string      `json:"encoding_format,omitempty"`
+	Dimensions     *int        `json:"dimensions,omitempty"`
+	User           string      `json:"user,omitempty"`
+}
+
+type embeddingResponse struct {
+	Object string              `json:"object"`
+	Data   []core.Embedding    `json:"data"`
+	Model  string              `json:"model"`
+	Usage  core.EmbeddingUsage `json:"usage"`
+}
+
+type embeddingErrorDetail struct {
+	Message string `json:"message"`
+	Type    string `json:"type"`
+}
+
+type embeddingErrorResponse struct {
+	Error embeddingErrorDetail `json:"error"`
+}
+
+// Embed sends an OpenAI-compatible embedding request to Qwen (DashScope compatible mode).
+func (p *Provider) Embed(ctx context.Context, req core.EmbeddingRequest) (*core.EmbeddingResponse, error) {
+	input, err := normalizeEmbeddingInput(req.Input)
+	if err != nil {
+		return nil, err
+	}
+	if req.EncodingFormat != "" && req.EncodingFormat != "float" {
+		return nil, fmt.Errorf("embed: unsupported encoding_format %q; valid value is \"float\"", req.EncodingFormat)
+	}
+
+	pReq := embeddingRequest{
+		Model:          req.Model,
+		Input:          input,
+		EncodingFormat: req.EncodingFormat,
+		Dimensions:     req.Dimensions,
+		User:           req.User,
+	}
+	bodyReader, _, release, err := core.JSONBodyReader(pReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal embedding request: %w", err)
+	}
+	defer release()
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, p.baseURL+"/embeddings", bodyReader) //nolint:gosec // baseURL validated in New()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	httpReq.Header.Set("Authorization", "Bearer "+p.apiKey)
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	httpResp, err := p.httpClient.Do(httpReq) //nolint:gosec // baseURL validated in New()
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer func() { _ = httpResp.Body.Close() }()
+
+	respBody, err := io.ReadAll(httpResp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+	if httpResp.StatusCode < http.StatusOK || httpResp.StatusCode >= http.StatusMultipleChoices {
+		var errResp embeddingErrorResponse
+		if json.Unmarshal(respBody, &errResp) == nil && errResp.Error.Message != "" {
+			return nil, fmt.Errorf("qwen API error (%d): %s", httpResp.StatusCode, errResp.Error.Message)
+		}
+		return nil, fmt.Errorf("qwen API error (%d): %s", httpResp.StatusCode, string(respBody))
+	}
+
+	var pResp embeddingResponse
+	if err := json.Unmarshal(respBody, &pResp); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal embedding response: %w", err)
+	}
+	return &core.EmbeddingResponse{
+		Object: pResp.Object,
+		Data:   pResp.Data,
+		Model:  pResp.Model,
+		Usage:  pResp.Usage,
+	}, nil
+}
+
+func normalizeEmbeddingInput(input interface{}) (interface{}, error) {
+	switch v := input.(type) {
+	case string:
+		return v, nil
+	case []string:
+		if len(v) == 0 {
+			return nil, fmt.Errorf("embed: Input must not be an empty array")
+		}
+		return v, nil
+	case []interface{}:
+		if len(v) == 0 {
+			return nil, fmt.Errorf("embed: Input must not be an empty array")
+		}
+		strs := make([]string, 0, len(v))
+		for i, item := range v {
+			s, ok := item.(string)
+			if !ok {
+				return nil, fmt.Errorf("embed: Input[%d] is %T, want string", i, item)
+			}
+			strs = append(strs, s)
+		}
+		return strs, nil
+	case nil:
+		return nil, fmt.Errorf("embed: Input must not be nil")
+	default:
+		return nil, fmt.Errorf("embed: unsupported Input type %T; want string or []string", input)
+	}
+}

--- a/providers/qwen/qwen.go
+++ b/providers/qwen/qwen.go
@@ -30,6 +30,7 @@ var (
 	_ core.Provider          = (*Provider)(nil)
 	_ core.StreamProvider    = (*Provider)(nil)
 	_ core.ProxiableProvider = (*Provider)(nil)
+	_ core.EmbeddingProvider = (*Provider)(nil)
 )
 
 // New creates a new Qwen provider.

--- a/providers/qwen/qwen_test.go
+++ b/providers/qwen/qwen_test.go
@@ -2,14 +2,18 @@ package qwen
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"testing"
 
 	"github.com/ferro-labs/ai-gateway/providers/core"
 )
 
 const testBearerAPIKey = "Bearer test-key"
+
+const testEmbeddingModel = "text-embedding-v3"
 
 func TestNewQwen(t *testing.T) {
 	p, err := New("test-key", "")
@@ -136,5 +140,66 @@ func TestQwenProvider_Complete_MockHTTP(t *testing.T) {
 	}
 	if len(resp.Choices) == 0 {
 		t.Error("expected at least one choice")
+	}
+}
+
+func TestQwenProvider_Embed_Interface(_ *testing.T) {
+	p, _ := New("test-key", "")
+	var _ core.EmbeddingProvider = p
+}
+
+func TestQwenProvider_Embed_MockHTTP(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+		if r.URL.Path != "/embeddings" {
+			t.Errorf("path = %q, want /embeddings", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != testBearerAPIKey {
+			t.Errorf("Authorization = %q, want %s", got, testBearerAPIKey)
+		}
+		var body map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		if body["model"] != testEmbeddingModel {
+			t.Errorf("model = %v, want %s", body["model"], testEmbeddingModel)
+		}
+		arr, ok := body["input"].([]interface{})
+		if !ok || len(arr) != 2 || arr[0] != "hello" || arr[1] != "world" {
+			t.Errorf("input = %v, want [hello world]", body["input"])
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"object":"list","data":[{"object":"embedding","embedding":[0.1,0.2],"index":0},{"object":"embedding","embedding":[0.3,0.4],"index":1}],"model":"` + testEmbeddingModel + `","usage":{"prompt_tokens":4,"total_tokens":4}}`))
+	}))
+	defer srv.Close()
+
+	p, _ := New("test-key", srv.URL)
+	resp, err := p.Embed(context.Background(), core.EmbeddingRequest{Model: testEmbeddingModel, Input: []string{"hello", "world"}})
+	if err != nil {
+		t.Fatalf("Embed() error: %v", err)
+	}
+	if resp.Object != "list" || resp.Model != testEmbeddingModel {
+		t.Errorf("resp = %+v, want list/%s", resp, testEmbeddingModel)
+	}
+	if len(resp.Data) != 2 || resp.Data[1].Index != 1 || !reflect.DeepEqual(resp.Data[1].Embedding, []float64{0.3, 0.4}) {
+		t.Errorf("Data = %+v, want two embeddings", resp.Data)
+	}
+	if resp.Usage.PromptTokens != 4 || resp.Usage.TotalTokens != 4 {
+		t.Errorf("Usage = %+v, want prompt=4 total=4", resp.Usage)
+	}
+}
+
+func TestQwenProvider_Embed_InvalidEncodingFormat(t *testing.T) {
+	p, _ := New("test-key", "http://127.0.0.1:0")
+	_, err := p.Embed(context.Background(), core.EmbeddingRequest{
+		Model:          testEmbeddingModel,
+		Input:          "hi",
+		EncodingFormat: "base64",
+	})
+	if err == nil {
+		t.Fatal("Embed() error = nil, want unsupported encoding_format error")
 	}
 }

--- a/providers/together/together.go
+++ b/providers/together/together.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/ferro-labs/ai-gateway/internal/discovery"
 	providerhttp "github.com/ferro-labs/ai-gateway/internal/httpclient"
 	"github.com/ferro-labs/ai-gateway/internal/openaicompat"
 	"github.com/ferro-labs/ai-gateway/providers/core"
@@ -34,6 +35,7 @@ var (
 	_ core.StreamProvider    = (*Provider)(nil)
 	_ core.EmbeddingProvider = (*Provider)(nil)
 	_ core.ProxiableProvider = (*Provider)(nil)
+	_ core.DiscoveryProvider = (*Provider)(nil)
 )
 
 // New creates a new Together AI provider.
@@ -87,6 +89,13 @@ func (p *Provider) SupportsModel(_ string) bool {
 // Models returns structured model metadata.
 func (p *Provider) Models() []core.ModelInfo {
 	return core.ModelsFromList(p.name, p.SupportedModels())
+}
+
+// DiscoverModels fetches the live model list from the Together AI /v1/models
+// endpoint. Together returns a bare JSON array whose items omit owned_by, so the
+// shared helper's dual-shape parser applies and owned_by falls back to "together".
+func (p *Provider) DiscoverModels(ctx context.Context) ([]core.ModelInfo, error) {
+	return discovery.DiscoverOpenAICompatibleModels(ctx, p.httpClient, p.baseURL+"/v1/models", p.apiKey, p.name)
 }
 
 // ------------------------------------------------------------------ types ---

--- a/providers/together/together_test.go
+++ b/providers/together/together_test.go
@@ -17,6 +17,41 @@ import (
 
 const testEmbeddingModel = "BAAI/bge-base-en-v1.5"
 
+func TestTogetherProvider_DiscoverModels(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("method = %q, want GET", r.Method)
+		}
+		if r.URL.Path != "/v1/models" {
+			t.Errorf("path = %q, want /v1/models", r.URL.Path)
+		}
+		if r.Header.Get("Authorization") != "Bearer test-key" {
+			t.Errorf("Authorization = %q, want Bearer test-key", r.Header.Get("Authorization"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		// Together AI returns a BARE JSON ARRAY whose items omit owned_by.
+		// This is a regression guard for the dual-shape parser + fallback.
+		_, _ = w.Write([]byte(`[{"id":"meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo","object":"model","created":1700000000},{"id":"Qwen/Qwen2.5-72B-Instruct-Turbo","object":"model"}]`))
+	}))
+	defer srv.Close()
+
+	p, _ := New("test-key", srv.URL)
+	models, err := p.DiscoverModels(context.Background())
+	if err != nil {
+		t.Fatalf("DiscoverModels() error: %v", err)
+	}
+	if len(models) != 2 {
+		t.Fatalf("expected 2 models, got %d", len(models))
+	}
+	if models[0].ID != "meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo" || models[0].OwnedBy != "together" {
+		t.Errorf("unexpected model[0] (bare-array fallback): %+v", models[0])
+	}
+	if models[1].ID != "Qwen/Qwen2.5-72B-Instruct-Turbo" || models[1].OwnedBy != "together" {
+		t.Errorf("unexpected model[1] (bare-array fallback): %+v", models[1])
+	}
+}
+
 func TestNewTogether(t *testing.T) {
 	p, err := New("test-key", "")
 	if err != nil {

--- a/providers/vertex_ai/image.go
+++ b/providers/vertex_ai/image.go
@@ -1,0 +1,141 @@
+package vertexai
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/ferro-labs/ai-gateway/providers/core"
+)
+
+// imagenInstance is a single Imagen prediction input.
+type imagenInstance struct {
+	Prompt string `json:"prompt"`
+}
+
+// imagenParameters carries the optional Imagen generation knobs.
+type imagenParameters struct {
+	SampleCount *int   `json:"sampleCount,omitempty"`
+	AspectRatio string `json:"aspectRatio,omitempty"`
+}
+
+// imagenRequest is the Imagen :predict request envelope.
+type imagenRequest struct {
+	Instances  []imagenInstance  `json:"instances"`
+	Parameters *imagenParameters `json:"parameters,omitempty"`
+}
+
+// imagenPrediction is a single Imagen :predict result.
+type imagenPrediction struct {
+	BytesBase64Encoded string `json:"bytesBase64Encoded"`
+	MimeType           string `json:"mimeType"`
+	RAIFilteredReason  string `json:"raiFilteredReason"`
+}
+
+// imagenResponse is the Imagen :predict response envelope.
+type imagenResponse struct {
+	Predictions []imagenPrediction `json:"predictions"`
+}
+
+// isVertexAIUltraImageModel reports whether the model is an Imagen "ultra"
+// variant, which supports only a single generated image per request.
+func isVertexAIUltraImageModel(model string) bool {
+	model = vertexAIModelID(model)
+	return strings.HasPrefix(model, "imagen-") && strings.Contains(model, "-ultra")
+}
+
+// buildImagenRequest maps a gateway ImageRequest onto the Imagen :predict shape.
+// req.Size ("WxH") is not directly mappable to Imagen and is ignored;
+// req.ResponseFormat is ignored (Imagen returns base64 only). For ultra models,
+// sampleCount is clamped to 1.
+func buildImagenRequest(req core.ImageRequest) imagenRequest {
+	out := imagenRequest{
+		Instances: []imagenInstance{{Prompt: req.Prompt}},
+	}
+	if req.N != nil {
+		count := *req.N
+		if isVertexAIUltraImageModel(req.Model) && count > 1 {
+			count = 1
+		}
+		out.Parameters = &imagenParameters{SampleCount: &count}
+	} else if isVertexAIUltraImageModel(req.Model) {
+		one := 1
+		out.Parameters = &imagenParameters{SampleCount: &one}
+	}
+	return out
+}
+
+// mapImagenPredictions converts Imagen predictions to gateway images. It returns
+// an error when every prediction was rai-filtered or empty.
+func mapImagenPredictions(model string, predictions []imagenPrediction) ([]core.GeneratedImage, error) {
+	images := make([]core.GeneratedImage, 0, len(predictions))
+	for _, pred := range predictions {
+		if pred.BytesBase64Encoded == "" {
+			continue
+		}
+		images = append(images, core.GeneratedImage{B64JSON: pred.BytesBase64Encoded})
+	}
+	if len(images) == 0 {
+		return nil, fmt.Errorf("vertex ai image generation for %q returned no images (all predictions were filtered or empty)", model)
+	}
+	return images, nil
+}
+
+// GenerateImage sends an image generation request to Vertex AI's Imagen
+// publisher :predict endpoint.
+func (p *Provider) GenerateImage(ctx context.Context, req core.ImageRequest) (*core.ImageResponse, error) {
+	imagenReq := buildImagenRequest(req)
+
+	bodyReader, _, release, err := core.JSONBodyReader(imagenReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal image request: %w", err)
+	}
+	defer release()
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, p.predictionEndpoint(req.Model), bodyReader)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create image request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	if err := p.authorizeRequest(httpReq); err != nil {
+		return nil, err
+	}
+
+	httpResp, err := p.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("image request failed: %w", err)
+	}
+	defer func() { _ = httpResp.Body.Close() }()
+
+	respBody, err := io.ReadAll(httpResp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read image response: %w", err)
+	}
+
+	if httpResp.StatusCode != http.StatusOK {
+		var errResp vertexAIError
+		if json.Unmarshal(respBody, &errResp) == nil && errResp.Error.Message != "" {
+			return nil, fmt.Errorf("vertex ai image API error (%d): %s", httpResp.StatusCode, errResp.Error.Message)
+		}
+		return nil, fmt.Errorf("vertex ai image API error (%d): %s", httpResp.StatusCode, string(respBody))
+	}
+
+	var imagenResp imagenResponse
+	if err := json.Unmarshal(respBody, &imagenResp); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal image response: %w", err)
+	}
+
+	images, err := mapImagenPredictions(req.Model, imagenResp.Predictions)
+	if err != nil {
+		return nil, err
+	}
+
+	return &core.ImageResponse{
+		Created: time.Now().Unix(),
+		Data:    images,
+	}, nil
+}

--- a/providers/vertex_ai/image_test.go
+++ b/providers/vertex_ai/image_test.go
@@ -1,0 +1,135 @@
+package vertexai
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/ferro-labs/ai-gateway/providers/core"
+)
+
+func TestVertexAIProvider_GenerateImage_Interface(_ *testing.T) {
+	p, _ := New(Options{ProjectID: "demo-project", Region: "us-central1", APIKey: testAPIKey})
+	var _ core.ImageProvider = p
+}
+
+func TestVertexAIProvider_SupportsModel_Imagen(t *testing.T) {
+	p, _ := New(Options{ProjectID: "demo-project", Region: "us-central1", APIKey: testAPIKey})
+	if !p.SupportsModel("imagen-4.0-generate-001") {
+		t.Error("expected imagen-4.0-generate-001 to be supported")
+	}
+	if !p.SupportsModel("imagen-3.0-generate-002") {
+		t.Error("expected imagen-3.0-generate-002 to be supported")
+	}
+}
+
+func TestVertexAIProvider_GenerateImage(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "/publishers/google/models/imagen-4.0-generate-001:predict") {
+			t.Errorf("request path = %q, want it to contain /publishers/google/models/imagen-4.0-generate-001:predict", r.URL.Path)
+		}
+		if r.Header.Get("x-goog-api-key") != testAPIKey {
+			t.Errorf("x-goog-api-key = %q, want %s", r.Header.Get("x-goog-api-key"), testAPIKey)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"predictions":[{"bytesBase64Encoded":"aGk=","mimeType":"image/png"}]}`))
+	}))
+	defer srv.Close()
+
+	p, _ := New(Options{ProjectID: "demo-project", Region: "us-central1", APIKey: testAPIKey})
+	p.SetBaseURL(srv.URL)
+
+	n := 2
+	resp, err := p.GenerateImage(context.Background(), core.ImageRequest{
+		Model:  "imagen-4.0-generate-001",
+		Prompt: "a red panda",
+		N:      &n,
+	})
+	if err != nil {
+		t.Fatalf("GenerateImage() error: %v", err)
+	}
+	if len(resp.Data) != 1 {
+		t.Fatalf("len(Data) = %d, want 1", len(resp.Data))
+	}
+	if resp.Data[0].B64JSON != "aGk=" {
+		t.Errorf("B64JSON = %q, want aGk=", resp.Data[0].B64JSON)
+	}
+	if resp.Created == 0 {
+		t.Error("Created should be set")
+	}
+}
+
+func TestVertexAIProvider_GenerateImage_UltraClampsSampleCount(t *testing.T) {
+	var gotSampleCount *int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var req struct {
+			Parameters struct {
+				SampleCount *int `json:"sampleCount"`
+			} `json:"parameters"`
+		}
+		_ = json.Unmarshal(body, &req)
+		gotSampleCount = req.Parameters.SampleCount
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"predictions":[{"bytesBase64Encoded":"aGk=","mimeType":"image/png"}]}`))
+	}))
+	defer srv.Close()
+
+	p, _ := New(Options{ProjectID: "demo-project", Region: "us-central1", APIKey: testAPIKey})
+	p.SetBaseURL(srv.URL)
+
+	n := 4
+	_, err := p.GenerateImage(context.Background(), core.ImageRequest{
+		Model:  "imagen-4.0-ultra-generate-001",
+		Prompt: "x",
+		N:      &n,
+	})
+	if err != nil {
+		t.Fatalf("GenerateImage() error: %v", err)
+	}
+	if gotSampleCount == nil || *gotSampleCount != 1 {
+		t.Errorf("ultra sampleCount = %v, want 1", gotSampleCount)
+	}
+}
+
+func TestVertexAIProvider_GenerateImage_AllFiltered(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"predictions":[{"raiFilteredReason":"safety"}]}`))
+	}))
+	defer srv.Close()
+
+	p, _ := New(Options{ProjectID: "demo-project", Region: "us-central1", APIKey: testAPIKey})
+	p.SetBaseURL(srv.URL)
+
+	_, err := p.GenerateImage(context.Background(), core.ImageRequest{
+		Model:  "imagen-4.0-generate-001",
+		Prompt: "blocked",
+	})
+	if err == nil {
+		t.Fatal("expected error when all predictions are filtered")
+	}
+}
+
+func TestVertexAIProvider_GenerateImage_UpstreamError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":{"message":"bad image request"}}`))
+	}))
+	defer srv.Close()
+
+	p, _ := New(Options{ProjectID: "demo-project", Region: "us-central1", APIKey: testAPIKey})
+	p.SetBaseURL(srv.URL)
+
+	_, err := p.GenerateImage(context.Background(), core.ImageRequest{
+		Model:  "imagen-4.0-generate-001",
+		Prompt: "x",
+	})
+	if err == nil || !strings.Contains(err.Error(), "bad image request") {
+		t.Fatalf("GenerateImage() error = %v, want upstream error", err)
+	}
+}

--- a/providers/vertex_ai/vertex_ai.go
+++ b/providers/vertex_ai/vertex_ai.go
@@ -42,6 +42,7 @@ var (
 	_ core.Provider          = (*Provider)(nil)
 	_ core.StreamProvider    = (*Provider)(nil)
 	_ core.EmbeddingProvider = (*Provider)(nil)
+	_ core.ImageProvider     = (*Provider)(nil)
 	_ core.ProxiableProvider = (*Provider)(nil)
 )
 
@@ -118,16 +119,21 @@ func (p *Provider) SupportedModels() []string {
 		"text-multilingual-embedding-002",
 		"textembedding-gecko@003",
 		"textembedding-gecko-multilingual@001",
+		"imagen-4.0-generate-001",
+		"imagen-4.0-ultra-generate-001",
+		"imagen-4.0-fast-generate-001",
+		"imagen-3.0-generate-002",
 	}
 }
 
-// SupportsModel returns true for known Vertex AI chat and text embedding model families.
+// SupportsModel returns true for known Vertex AI chat, text embedding, and image model families.
 func (p *Provider) SupportsModel(model string) bool {
 	model = vertexAIModelID(model)
 	return strings.HasPrefix(model, "gemini-") ||
 		strings.HasPrefix(model, "text-embedding-") ||
 		strings.HasPrefix(model, "textembedding-gecko") ||
-		strings.HasPrefix(model, "text-multilingual-embedding-")
+		strings.HasPrefix(model, "text-multilingual-embedding-") ||
+		strings.HasPrefix(model, "imagen-")
 }
 
 // Models returns structured model metadata.

--- a/providers/xai/image.go
+++ b/providers/xai/image.go
@@ -1,0 +1,101 @@
+package xai
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/ferro-labs/ai-gateway/providers/core"
+)
+
+// xaiImageRequest is the OpenAI-compatible request body for xAI image
+// generation. grok-2-image rejects size/quality/style, so those fields are
+// intentionally omitted.
+type xaiImageRequest struct {
+	Model          string `json:"model"`
+	Prompt         string `json:"prompt"`
+	N              *int   `json:"n,omitempty"`
+	ResponseFormat string `json:"response_format,omitempty"`
+}
+
+// xaiImageResponse is the OpenAI-compatible response body for xAI image
+// generation.
+type xaiImageResponse struct {
+	Data []struct {
+		URL           string `json:"url"`
+		B64JSON       string `json:"b64_json"`
+		RevisedPrompt string `json:"revised_prompt"`
+	} `json:"data"`
+}
+
+// xaiImageErrorResponse mirrors the OpenAI-compatible error envelope.
+type xaiImageErrorResponse struct {
+	Error struct {
+		Message string `json:"message"`
+	} `json:"error"`
+}
+
+// GenerateImage sends an image generation request to xAI (Grok image models).
+// It is OpenAI-compatible against the /images/generations endpoint.
+func (p *Provider) GenerateImage(ctx context.Context, req core.ImageRequest) (*core.ImageResponse, error) {
+	payload := xaiImageRequest{
+		Model:          req.Model,
+		Prompt:         req.Prompt,
+		N:              req.N,
+		ResponseFormat: req.ResponseFormat,
+	}
+
+	body, contentLen, release, err := core.JSONBodyReader(payload)
+	if err != nil {
+		return nil, fmt.Errorf("xai: failed to marshal image request: %w", err)
+	}
+	defer release()
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, p.baseURL+"/images/generations", body)
+	if err != nil {
+		return nil, fmt.Errorf("xai: failed to create image request: %w", err)
+	}
+	httpReq.ContentLength = int64(contentLen)
+	httpReq.Header.Set("Authorization", "Bearer "+p.apiKey)
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	httpResp, err := p.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("xai: image request failed: %w", err)
+	}
+	defer func() { _ = httpResp.Body.Close() }()
+
+	if httpResp.StatusCode != http.StatusOK {
+		respBody, readErr := io.ReadAll(httpResp.Body)
+		if readErr != nil {
+			return nil, fmt.Errorf("xai: failed to read error response: %w", readErr)
+		}
+		var errResp xaiImageErrorResponse
+		if json.Unmarshal(respBody, &errResp) == nil && errResp.Error.Message != "" {
+			return nil, fmt.Errorf("xai API error (%d): %s", httpResp.StatusCode, errResp.Error.Message)
+		}
+		return nil, fmt.Errorf("xai API error (%d): %s", httpResp.StatusCode, string(respBody))
+	}
+
+	var decoded xaiImageResponse
+	if err := json.NewDecoder(httpResp.Body).Decode(&decoded); err != nil {
+		return nil, fmt.Errorf("xai: failed to decode image response: %w", err)
+	}
+
+	images := make([]core.GeneratedImage, len(decoded.Data))
+	for i, d := range decoded.Data {
+		images[i] = core.GeneratedImage{
+			URL:           d.URL,
+			B64JSON:       d.B64JSON,
+			RevisedPrompt: d.RevisedPrompt,
+		}
+	}
+
+	return &core.ImageResponse{
+		Created: time.Now().Unix(),
+		Data:    images,
+	}, nil
+}

--- a/providers/xai/xai.go
+++ b/providers/xai/xai.go
@@ -33,6 +33,7 @@ var (
 	_ core.StreamProvider    = (*Provider)(nil)
 	_ core.DiscoveryProvider = (*Provider)(nil)
 	_ core.ProxiableProvider = (*Provider)(nil)
+	_ core.ImageProvider     = (*Provider)(nil)
 )
 
 // New creates a new xAI provider.
@@ -66,6 +67,9 @@ func (p *Provider) SupportedModels() []string {
 		"grok-2-latest",
 		"grok-2-vision-latest",
 		"grok-beta",
+		"grok-2-image",
+		"grok-2-image-1212",
+		"grok-2-image-latest",
 	}
 }
 

--- a/providers/xai/xai_test.go
+++ b/providers/xai/xai_test.go
@@ -83,6 +83,46 @@ func TestXAIProvider_Complete_MockHTTP(t *testing.T) {
 	}
 }
 
+func TestXAIProvider_GenerateImage_Interface(_ *testing.T) {
+	p, _ := New("test-key", "")
+	var _ core.ImageProvider = p
+}
+
+func TestXAIProvider_GenerateImage_MockHTTP(t *testing.T) {
+	respBody := `{"data":[{"b64_json":"aGVsbG8=","revised_prompt":"x"}]}`
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/images/generations" {
+			t.Errorf("request path = %q, want /images/generations", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-key" {
+			t.Errorf("Authorization = %q, want Bearer test-key", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(respBody))
+	}))
+	defer srv.Close()
+
+	p, _ := New("test-key", srv.URL)
+	resp, err := p.GenerateImage(context.Background(), core.ImageRequest{
+		Model:  "grok-2-image",
+		Prompt: "a red apple",
+	})
+	if err != nil {
+		t.Fatalf("GenerateImage() error: %v", err)
+	}
+	if len(resp.Data) == 0 {
+		t.Fatal("expected at least one image in response")
+	}
+	if resp.Data[0].B64JSON != "aGVsbG8=" {
+		t.Errorf("Data[0].B64JSON = %q, want aGVsbG8=", resp.Data[0].B64JSON)
+	}
+	if resp.Data[0].RevisedPrompt != "x" {
+		t.Errorf("Data[0].RevisedPrompt = %q, want x", resp.Data[0].RevisedPrompt)
+	}
+}
+
 func TestXAIProvider_CompleteStream_MockSSE(t *testing.T) {
 	sseData := "data: {\"id\":\"chatcmpl-1\",\"model\":\"grok-2-latest\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\"},\"finish_reason\":\"\"}]}\n\n" +
 		"data: {\"id\":\"chatcmpl-1\",\"model\":\"grok-2-latest\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"Hello\"},\"finish_reason\":\"\"}]}\n\n" +


### PR DESCRIPTION
Closes #148.

Implements the missing optional provider interfaces (umbrella issue). AI21 embeddings dropped — AI21 exposes no embeddings endpoint.

## Embeddings (EmbeddingProvider)
- deepinfra, qwen, nvidia-nim (OpenAI-compatible), ollama (native `/api/embed`).

## DiscoverModels (DiscoveryProvider)
- anthropic (`x-api-key`+`anthropic-version`), mistral, groq, together.
- Shared helper gains `DiscoverModelsWithHeaders` (custom auth headers) + tolerates wrapped **and** bare-array `/models` responses; existing 8 callers unchanged.

## Azure OpenAI
- `Embed` + `GenerateImage` via deployment-in-URL routing (deployment from `req.Model`, fallback to configured deployment). `Complete` stays pinned to the chat deployment (intentional).

## Image generation (ImageProvider)
- bedrock: Nova Canvas / Titan Image / Stability SDXL (InvokeModel).
- gemini + vertex-ai: Imagen `:predict`.
- xai: OpenAI-compatible grok image.

## Safety
Every capability registered in `providers_list.go` and enforced by the compile-time assertions + the 5 capability↔interface alignment tests in `stability_test.go`.

## Verification (local — CI only runs on PRs to main)
`gofmt -l` clean · `go build ./...` · `go vet ./...` · `golangci-lint run` (0 issues) · `go test -short -race ./...` all pass.

## Notes / follow-ups
- Imagen `:predict` (gemini/vertex) is deprecated (~Aug 2026); durable path is `gemini-2.5-flash-image` `:generateContent` — fast-follow.
- Image generation is unit-tested with stubbed transports (no live endpoint here).