### PR TITLE
feat(providers): add NanoGPT and ZAI providers

### DIFF
--- a/providers/names.go
+++ b/providers/names.go
@@ -18,6 +18,7 @@ import (
 	huggingfacepkg "github.com/ferro-labs/ai-gateway/providers/hugging_face"
 	mistralpkg "github.com/ferro-labs/ai-gateway/providers/mistral"
 	moonshotpkg "github.com/ferro-labs/ai-gateway/providers/moonshot"
+	nanogptpkg "github.com/ferro-labs/ai-gateway/providers/nanogpt"
 	novitapkg "github.com/ferro-labs/ai-gateway/providers/novita"
 	nvidianimpkg "github.com/ferro-labs/ai-gateway/providers/nvidia_nim"
 	ollamapkg "github.com/ferro-labs/ai-gateway/providers/ollama"
@@ -31,6 +32,7 @@ import (
 	togetherpkg "github.com/ferro-labs/ai-gateway/providers/together"
 	vertexaipkg "github.com/ferro-labs/ai-gateway/providers/vertex_ai"
 	xaipkg "github.com/ferro-labs/ai-gateway/providers/xai"
+	zaipkg "github.com/ferro-labs/ai-gateway/providers/zai"
 )
 
 // Canonical provider name constants.
@@ -124,6 +126,9 @@ const (
 	// NameMoonshot is the canonical name for the Moonshot AI provider.
 	NameMoonshot = moonshotpkg.Name
 
+	// NameNanoGPT is the canonical name for the NanoGPT provider.
+	NameNanoGPT = nanogptpkg.Name
+
 	// NameNVIDIANIM is the canonical name for the NVIDIA NIM provider.
 	NameNVIDIANIM = nvidianimpkg.Name
 
@@ -138,6 +143,9 @@ const (
 
 	// NameOpenRouter is the canonical name for the OpenRouter provider.
 	NameOpenRouter = openrouterpkg.Name
+
+	// NameZAI is the canonical name for the Z.ai (Zhipu AI) provider.
+	NameZAI = zaipkg.Name
 )
 
 // AllProviderNames returns every registered canonical provider name in a
@@ -162,6 +170,7 @@ func AllProviderNames() []string {
 		NameHuggingFace,
 		NameMistral,
 		NameMoonshot,
+		NameNanoGPT,
 		NameNovita,
 		NameNVIDIANIM,
 		NameOllama,
@@ -175,5 +184,6 @@ func AllProviderNames() []string {
 		NameTogether,
 		NameVertexAI,
 		NameXAI,
+		NameZAI,
 	}
 }

--- a/providers/nanogpt/nanogpt.go
+++ b/providers/nanogpt/nanogpt.go
@@ -1,0 +1,124 @@
+// Package nanogpt provides a client for the NanoGPT API.
+package nanogpt
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	discov "github.com/ferro-labs/ai-gateway/internal/discovery"
+	providerhttp "github.com/ferro-labs/ai-gateway/internal/httpclient"
+	"github.com/ferro-labs/ai-gateway/internal/openaicompat"
+	"github.com/ferro-labs/ai-gateway/providers/core"
+)
+
+const (
+	// Name is the canonical identifier for the NanoGPT provider.
+	// Re-exported as providers.NameNanoGPT in providers/names.go.
+	Name           = "nanogpt"
+	defaultBaseURL = "https://nano-gpt.com/api/v1"
+)
+
+// Provider implements the core.Provider interface for NanoGPT.
+type Provider struct {
+	name       string
+	apiKey     string
+	baseURL    string
+	httpClient *http.Client
+}
+
+// Compile-time interface assertions.
+var (
+	_ core.Provider          = (*Provider)(nil)
+	_ core.StreamProvider    = (*Provider)(nil)
+	_ core.ProxiableProvider = (*Provider)(nil)
+	_ core.DiscoveryProvider = (*Provider)(nil)
+)
+
+// New creates a new NanoGPT provider.
+func New(apiKey, baseURL string) (*Provider, error) {
+	if baseURL == "" {
+		baseURL = defaultBaseURL
+	}
+	baseURL = strings.TrimRight(baseURL, "/")
+	return &Provider{
+		name:       Name,
+		apiKey:     apiKey,
+		baseURL:    baseURL,
+		httpClient: providerhttp.ForProvider(Name),
+	}, nil
+}
+
+// Name implements core.Provider.
+func (p *Provider) Name() string { return p.name }
+
+// BaseURL implements core.ProxiableProvider.
+func (p *Provider) BaseURL() string { return p.baseURL }
+
+// AuthHeaders implements core.ProxiableProvider.
+func (p *Provider) AuthHeaders() map[string]string {
+	return map[string]string{"Authorization": "Bearer " + p.apiKey}
+}
+
+// SupportedModels returns a static list of known NanoGPT models.
+func (p *Provider) SupportedModels() []string {
+	return []string{
+		"anthropic/claude-opus-4.7",
+		"anthropic/claude-opus-latest",
+		"anthropic/claude-sonnet-latest",
+		"anthropic/claude-haiku-latest",
+		"anthropic/claude-opus-4.6",
+		"anthropic/claude-sonnet-4.6",
+		"openai/gpt-5.5",
+		"openai/gpt-chat-latest",
+		"openai/gpt-latest",
+		"x-ai/grok-4.20",
+		"x-ai/grok-4.3",
+		"x-ai/grok-latest",
+		"deepseek/deepseek-v4-pro",
+		"deepseek/deepseek-v4-flash",
+		"deepseek/deepseek-latest",
+		"moonshotai/kimi-k2.6",
+		"moonshotai/kimi-latest",
+		"google/gemini-flash-latest",
+		"google/gemini-pro-latest",
+		"google/gemini-3.5-flash",
+		"google/gemini-3-flash-preview",
+		"mistral/mistral-medium-3.5",
+	}
+}
+
+// SupportsModel returns true for any NanoGPT model name.
+func (p *Provider) SupportsModel(_ string) bool { return true }
+
+// Models returns structured model metadata.
+func (p *Provider) Models() []core.ModelInfo {
+	return core.ModelsFromList(p.name, p.SupportedModels())
+}
+
+// DiscoverModels fetches the live model list from the NanoGPT /models endpoint.
+func (p *Provider) DiscoverModels(ctx context.Context) ([]core.ModelInfo, error) {
+	return discov.DiscoverOpenAICompatibleModels(ctx, p.httpClient, p.baseURL+"/models", p.apiKey, p.name)
+}
+
+// Complete sends a chat completion request to NanoGPT.
+func (p *Provider) Complete(ctx context.Context, req core.Request) (*core.Response, error) {
+	return openaicompat.PostChat(ctx, openaicompat.ChatParams{
+		HTTPClient: p.httpClient,
+		URL:        p.baseURL + "/chat/completions",
+		Provider:   p.name,
+		Label:      "nanogpt",
+		Headers:    map[string]string{"Authorization": "Bearer " + p.apiKey, "Content-Type": "application/json"},
+	}, req)
+}
+
+// CompleteStream sends a streaming chat completion request to NanoGPT.
+func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan core.StreamChunk, error) {
+	return openaicompat.PostStream(ctx, openaicompat.ChatParams{
+		HTTPClient: p.httpClient,
+		URL:        p.baseURL + "/chat/completions",
+		Provider:   p.name,
+		Label:      "nanogpt",
+		Headers:    map[string]string{"Authorization": "Bearer " + p.apiKey, "Content-Type": "application/json"},
+	}, req)
+}

--- a/providers/nanogpt/nanogpt_test.go
+++ b/providers/nanogpt/nanogpt_test.go
@@ -1,0 +1,137 @@
+package nanogpt
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/ferro-labs/ai-gateway/providers/core"
+)
+
+const testBearerAPIKey = "Bearer test-key"
+
+func TestNewNanoGPT(t *testing.T) {
+	p, err := New("test-key", "")
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+	if p.Name() != "nanogpt" {
+		t.Errorf("Name() = %q, want nanogpt", p.Name())
+	}
+}
+
+func TestNanoGPTProvider_SupportedModels(t *testing.T) {
+	p, _ := New("test-key", "")
+	models := p.SupportedModels()
+	if len(models) == 0 {
+		t.Error("SupportedModels() returned empty")
+	}
+	found := false
+	for _, m := range models {
+		if m == "deepseek/deepseek-v4-pro" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("deepseek/deepseek-v4-pro not found in SupportedModels")
+	}
+}
+
+func TestNanoGPTProvider_SupportsModel(t *testing.T) {
+	p, _ := New("test-key", "")
+	if !p.SupportsModel("anthropic/claude-sonnet-latest") {
+		t.Error("expected anthropic/claude-sonnet-latest to be supported")
+	}
+	if !p.SupportsModel("custom-model") {
+		t.Error("passthrough: expected all models to return true")
+	}
+}
+
+func TestNanoGPTProvider_Models(t *testing.T) {
+	p, _ := New("test-key", "")
+	models := p.Models()
+	for _, m := range models {
+		if m.OwnedBy != "nanogpt" {
+			t.Errorf("ModelInfo.OwnedBy = %q, want nanogpt", m.OwnedBy)
+		}
+	}
+}
+
+func TestNanoGPTProvider_CompleteStream_Interface(_ *testing.T) {
+	p, _ := New("test-key", "")
+	var _ core.StreamProvider = p
+}
+
+func TestNanoGPTProvider_AuthHeaders(t *testing.T) {
+	p, _ := New("test-key", "")
+	headers := p.AuthHeaders()
+	if headers["Authorization"] != testBearerAPIKey {
+		t.Errorf("AuthHeaders Authorization = %q, want %s", headers["Authorization"], testBearerAPIKey)
+	}
+}
+
+func TestNanoGPTProvider_CompleteStream_MockSSE(t *testing.T) {
+	sseData := "data: {\"id\":\"cmpl-1\",\"model\":\"deepseek/deepseek-v4-pro\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\"},\"finish_reason\":\"\"}]}\n\n" +
+		"data: {\"id\":\"cmpl-1\",\"model\":\"deepseek/deepseek-v4-pro\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"Hello\"},\"finish_reason\":\"\"}]}\n\n" +
+		"data: {\"id\":\"cmpl-1\",\"model\":\"deepseek/deepseek-v4-pro\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\" there\"},\"finish_reason\":\"\"}]}\n\n" +
+		"data: {\"id\":\"cmpl-1\",\"model\":\"deepseek/deepseek-v4-pro\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n" +
+		"data: [DONE]\n\n"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(sseData))
+	}))
+	defer srv.Close()
+
+	p, _ := New("test-key", srv.URL)
+	ch, err := p.CompleteStream(context.Background(), core.Request{
+		Model:    "deepseek/deepseek-v4-pro",
+		Messages: []core.Message{{Role: "user", Content: "Hi"}},
+	})
+	if err != nil {
+		t.Fatalf("CompleteStream() error: %v", err)
+	}
+
+	var chunks []core.StreamChunk
+	for c := range ch {
+		chunks = append(chunks, c)
+	}
+
+	if len(chunks) < 3 {
+		t.Fatalf("expected at least 3 chunks, got %d", len(chunks))
+	}
+	if chunks[1].Choices[0].Delta.Content != "Hello" {
+		t.Errorf("delta content = %q, want Hello", chunks[1].Choices[0].Delta.Content)
+	}
+	if chunks[2].Choices[0].Delta.Content != " there" {
+		t.Errorf("delta content = %q, want ' there'", chunks[2].Choices[0].Delta.Content)
+	}
+}
+
+func TestNanoGPTProvider_Complete_MockHTTP(t *testing.T) {
+	respBody := `{"id":"cmpl-1","model":"deepseek/deepseek-v4-pro","choices":[{"index":0,"message":{"role":"assistant","content":"Hello!"},"finish_reason":"stop"}],"usage":{"prompt_tokens":5,"completion_tokens":2,"total_tokens":7}}`
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(respBody))
+	}))
+	defer srv.Close()
+
+	p, _ := New("test-key", srv.URL)
+	resp, err := p.Complete(context.Background(), core.Request{
+		Model:    "deepseek/deepseek-v4-pro",
+		Messages: []core.Message{{Role: "user", Content: "Hi"}},
+	})
+	if err != nil {
+		t.Fatalf("Complete() error: %v", err)
+	}
+	if resp.ID != "cmpl-1" {
+		t.Errorf("Response.ID = %q, want cmpl-1", resp.ID)
+	}
+	if len(resp.Choices) == 0 {
+		t.Error("expected at least one choice")
+	}
+}

--- a/providers/providers_list.go
+++ b/providers/providers_list.go
@@ -21,6 +21,7 @@ import (
 	huggingfacepkg "github.com/ferro-labs/ai-gateway/providers/hugging_face"
 	mistralpkg "github.com/ferro-labs/ai-gateway/providers/mistral"
 	moonshotpkg "github.com/ferro-labs/ai-gateway/providers/moonshot"
+	nanogptpkg "github.com/ferro-labs/ai-gateway/providers/nanogpt"
 	novitapkg "github.com/ferro-labs/ai-gateway/providers/novita"
 	nvidianimpkg "github.com/ferro-labs/ai-gateway/providers/nvidia_nim"
 	ollamapkg "github.com/ferro-labs/ai-gateway/providers/ollama"
@@ -34,6 +35,7 @@ import (
 	togetherpkg "github.com/ferro-labs/ai-gateway/providers/together"
 	vertexaipkg "github.com/ferro-labs/ai-gateway/providers/vertex_ai"
 	xaipkg "github.com/ferro-labs/ai-gateway/providers/xai"
+	zaipkg "github.com/ferro-labs/ai-gateway/providers/zai"
 )
 
 // allProviders is the canonical ordered registry of all built-in providers.
@@ -259,6 +261,17 @@ var allProviders = []ProviderEntry{
 		},
 	},
 	{
+		ID:           NameNanoGPT,
+		Capabilities: []string{CapabilityChat, CapabilityStream, CapabilityDiscovery, CapabilityProxy},
+		EnvMappings: []EnvMapping{
+			{CfgKeyAPIKey, "NANOGPT_API_KEY", true},
+			{CfgKeyBaseURL, "NANOGPT_BASE_URL", false},
+		},
+		Build: func(cfg ProviderConfig) (Provider, error) {
+			return nanogptpkg.New(cfg[CfgKeyAPIKey], cfg[CfgKeyBaseURL])
+		},
+	},
+	{
 		ID:           NameNovita,
 		Capabilities: []string{CapabilityChat, CapabilityStream, CapabilityEmbed, CapabilityDiscovery, CapabilityProxy},
 		EnvMappings: []EnvMapping{
@@ -435,6 +448,17 @@ var allProviders = []ProviderEntry{
 		},
 		Build: func(cfg ProviderConfig) (Provider, error) {
 			return xaipkg.New(cfg[CfgKeyAPIKey], cfg[CfgKeyBaseURL])
+		},
+	},
+	{
+		ID:           NameZAI,
+		Capabilities: []string{CapabilityChat, CapabilityStream, CapabilityDiscovery, CapabilityProxy},
+		EnvMappings: []EnvMapping{
+			{CfgKeyAPIKey, "ZAI_API_KEY", true},
+			{CfgKeyBaseURL, "ZAI_BASE_URL", false},
+		},
+		Build: func(cfg ProviderConfig) (Provider, error) {
+			return zaipkg.New(cfg[CfgKeyAPIKey], cfg[CfgKeyBaseURL])
 		},
 	},
 }

--- a/providers/stability_test.go
+++ b/providers/stability_test.go
@@ -18,6 +18,7 @@ import (
 	huggingfacepkg "github.com/ferro-labs/ai-gateway/providers/hugging_face"
 	mistralpkg "github.com/ferro-labs/ai-gateway/providers/mistral"
 	moonshotpkg "github.com/ferro-labs/ai-gateway/providers/moonshot"
+	nanogptpkg "github.com/ferro-labs/ai-gateway/providers/nanogpt"
 	novitapkg "github.com/ferro-labs/ai-gateway/providers/novita"
 	nvidianimpkg "github.com/ferro-labs/ai-gateway/providers/nvidia_nim"
 	ollamapkg "github.com/ferro-labs/ai-gateway/providers/ollama"
@@ -31,6 +32,7 @@ import (
 	togetherpkg "github.com/ferro-labs/ai-gateway/providers/together"
 	vertexaipkg "github.com/ferro-labs/ai-gateway/providers/vertex_ai"
 	xaipkg "github.com/ferro-labs/ai-gateway/providers/xai"
+	zaipkg "github.com/ferro-labs/ai-gateway/providers/zai"
 	"slices"
 	"testing"
 )
@@ -251,6 +253,17 @@ func providerNameStabilityExtensionCases() []providerNameStabilityCase {
 			},
 		},
 		{
+			wantName: NameNanoGPT,
+			build: func(t *testing.T) Provider {
+				t.Helper()
+				p, err := nanogptpkg.New(testAPIKey, "")
+				if err != nil {
+					t.Fatalf("NewNanoGPT: %v", err)
+				}
+				return p
+			},
+		},
+		{
 			wantName: NameNovita,
 			build: func(t *testing.T) Provider {
 				t.Helper()
@@ -393,6 +406,17 @@ func providerNameStabilityExtensionCases() []providerNameStabilityCase {
 				p, err := xaipkg.New(testAPIKey, "")
 				if err != nil {
 					t.Fatalf("NewXAI: %v", err)
+				}
+				return p
+			},
+		},
+		{
+			wantName: NameZAI,
+			build: func(t *testing.T) Provider {
+				t.Helper()
+				p, err := zaipkg.New(testAPIKey, "")
+				if err != nil {
+					t.Fatalf("NewZAI: %v", err)
 				}
 				return p
 			},

--- a/providers/zai/zai.go
+++ b/providers/zai/zai.go
@@ -1,0 +1,109 @@
+// Package zai provides a client for the Z.ai (Zhipu AI) API.
+package zai
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	discov "github.com/ferro-labs/ai-gateway/internal/discovery"
+	providerhttp "github.com/ferro-labs/ai-gateway/internal/httpclient"
+	"github.com/ferro-labs/ai-gateway/internal/openaicompat"
+	"github.com/ferro-labs/ai-gateway/providers/core"
+)
+
+const (
+	// Name is the canonical identifier for the Z.ai provider.
+	// Re-exported as providers.NameZAI in providers/names.go.
+	Name           = "zai"
+	defaultBaseURL = "https://api.z.ai/api/paas/v4"
+)
+
+// Provider implements the core.Provider interface for Z.ai.
+type Provider struct {
+	name       string
+	apiKey     string
+	baseURL    string
+	httpClient *http.Client
+}
+
+// Compile-time interface assertions.
+var (
+	_ core.Provider          = (*Provider)(nil)
+	_ core.StreamProvider    = (*Provider)(nil)
+	_ core.ProxiableProvider = (*Provider)(nil)
+	_ core.DiscoveryProvider = (*Provider)(nil)
+)
+
+// New creates a new Z.ai provider.
+func New(apiKey, baseURL string) (*Provider, error) {
+	if baseURL == "" {
+		baseURL = defaultBaseURL
+	}
+	baseURL = strings.TrimRight(baseURL, "/")
+	return &Provider{
+		name:       Name,
+		apiKey:     apiKey,
+		baseURL:    baseURL,
+		httpClient: providerhttp.ForProvider(Name),
+	}, nil
+}
+
+// Name implements core.Provider.
+func (p *Provider) Name() string { return p.name }
+
+// BaseURL implements core.ProxiableProvider.
+func (p *Provider) BaseURL() string { return p.baseURL }
+
+// AuthHeaders implements core.ProxiableProvider.
+func (p *Provider) AuthHeaders() map[string]string {
+	return map[string]string{"Authorization": "Bearer " + p.apiKey}
+}
+
+// SupportedModels returns a static list of known Z.ai models.
+func (p *Provider) SupportedModels() []string {
+	return []string{
+		"glm-5.1",
+		"glm-5-turbo",
+		"glm-5",
+		"glm-4.7",
+		"glm-4.6",
+		"glm-4.5",
+		"glm-4.5-air",
+	}
+}
+
+// SupportsModel returns true for any Z.ai model name.
+func (p *Provider) SupportsModel(_ string) bool { return true }
+
+// Models returns structured model metadata.
+func (p *Provider) Models() []core.ModelInfo {
+	return core.ModelsFromList(p.name, p.SupportedModels())
+}
+
+// DiscoverModels fetches the live model list from the Z.ai /models endpoint.
+func (p *Provider) DiscoverModels(ctx context.Context) ([]core.ModelInfo, error) {
+	return discov.DiscoverOpenAICompatibleModels(ctx, p.httpClient, p.baseURL+"/models", p.apiKey, p.name)
+}
+
+// Complete sends a chat completion request to Z.ai.
+func (p *Provider) Complete(ctx context.Context, req core.Request) (*core.Response, error) {
+	return openaicompat.PostChat(ctx, openaicompat.ChatParams{
+		HTTPClient: p.httpClient,
+		URL:        p.baseURL + "/chat/completions",
+		Provider:   p.name,
+		Label:      "zai",
+		Headers:    map[string]string{"Authorization": "Bearer " + p.apiKey, "Content-Type": "application/json"},
+	}, req)
+}
+
+// CompleteStream sends a streaming chat completion request to Z.ai.
+func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan core.StreamChunk, error) {
+	return openaicompat.PostStream(ctx, openaicompat.ChatParams{
+		HTTPClient: p.httpClient,
+		URL:        p.baseURL + "/chat/completions",
+		Provider:   p.name,
+		Label:      "zai",
+		Headers:    map[string]string{"Authorization": "Bearer " + p.apiKey, "Content-Type": "application/json"},
+	}, req)
+}

--- a/providers/zai/zai_test.go
+++ b/providers/zai/zai_test.go
@@ -1,0 +1,137 @@
+package zai
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/ferro-labs/ai-gateway/providers/core"
+)
+
+const testBearerAPIKey = "Bearer test-key"
+
+func TestNewZAI(t *testing.T) {
+	p, err := New("test-key", "")
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+	if p.Name() != "zai" {
+		t.Errorf("Name() = %q, want zai", p.Name())
+	}
+}
+
+func TestZAIProvider_SupportedModels(t *testing.T) {
+	p, _ := New("test-key", "")
+	models := p.SupportedModels()
+	if len(models) == 0 {
+		t.Error("SupportedModels() returned empty")
+	}
+	found := false
+	for _, m := range models {
+		if m == "glm-5.1" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("glm-5.1 not found in SupportedModels")
+	}
+}
+
+func TestZAIProvider_SupportsModel(t *testing.T) {
+	p, _ := New("test-key", "")
+	if !p.SupportsModel("glm-5.1") {
+		t.Error("expected glm-5.1 to be supported")
+	}
+	if !p.SupportsModel("custom-model") {
+		t.Error("passthrough: expected all models to return true")
+	}
+}
+
+func TestZAIProvider_Models(t *testing.T) {
+	p, _ := New("test-key", "")
+	models := p.Models()
+	for _, m := range models {
+		if m.OwnedBy != "zai" {
+			t.Errorf("ModelInfo.OwnedBy = %q, want zai", m.OwnedBy)
+		}
+	}
+}
+
+func TestZAIProvider_CompleteStream_Interface(_ *testing.T) {
+	p, _ := New("test-key", "")
+	var _ core.StreamProvider = p
+}
+
+func TestZAIProvider_AuthHeaders(t *testing.T) {
+	p, _ := New("test-key", "")
+	headers := p.AuthHeaders()
+	if headers["Authorization"] != testBearerAPIKey {
+		t.Errorf("AuthHeaders Authorization = %q, want %s", headers["Authorization"], testBearerAPIKey)
+	}
+}
+
+func TestZAIProvider_CompleteStream_MockSSE(t *testing.T) {
+	sseData := "data: {\"id\":\"cmpl-1\",\"model\":\"glm-5.1\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\"},\"finish_reason\":\"\"}]}\n\n" +
+		"data: {\"id\":\"cmpl-1\",\"model\":\"glm-5.1\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"Hello\"},\"finish_reason\":\"\"}]}\n\n" +
+		"data: {\"id\":\"cmpl-1\",\"model\":\"glm-5.1\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\" there\"},\"finish_reason\":\"\"}]}\n\n" +
+		"data: {\"id\":\"cmpl-1\",\"model\":\"glm-5.1\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n" +
+		"data: [DONE]\n\n"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(sseData))
+	}))
+	defer srv.Close()
+
+	p, _ := New("test-key", srv.URL)
+	ch, err := p.CompleteStream(context.Background(), core.Request{
+		Model:    "glm-5.1",
+		Messages: []core.Message{{Role: "user", Content: "Hi"}},
+	})
+	if err != nil {
+		t.Fatalf("CompleteStream() error: %v", err)
+	}
+
+	var chunks []core.StreamChunk
+	for c := range ch {
+		chunks = append(chunks, c)
+	}
+
+	if len(chunks) < 3 {
+		t.Fatalf("expected at least 3 chunks, got %d", len(chunks))
+	}
+	if chunks[1].Choices[0].Delta.Content != "Hello" {
+		t.Errorf("delta content = %q, want Hello", chunks[1].Choices[0].Delta.Content)
+	}
+	if chunks[2].Choices[0].Delta.Content != " there" {
+		t.Errorf("delta content = %q, want ' there'", chunks[2].Choices[0].Delta.Content)
+	}
+}
+
+func TestZAIProvider_Complete_MockHTTP(t *testing.T) {
+	respBody := `{"id":"cmpl-1","model":"glm-5.1","choices":[{"index":0,"message":{"role":"assistant","content":"Hello!"},"finish_reason":"stop"}],"usage":{"prompt_tokens":5,"completion_tokens":2,"total_tokens":7}}`
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(respBody))
+	}))
+	defer srv.Close()
+
+	p, _ := New("test-key", srv.URL)
+	resp, err := p.Complete(context.Background(), core.Request{
+		Model:    "glm-5.1",
+		Messages: []core.Message{{Role: "user", Content: "Hi"}},
+	})
+	if err != nil {
+		t.Fatalf("Complete() error: %v", err)
+	}
+	if resp.ID != "cmpl-1" {
+		t.Errorf("Response.ID = %q, want cmpl-1", resp.ID)
+	}
+	if len(resp.Choices) == 0 {
+		t.Error("expected at least one choice")
+	}
+}


### PR DESCRIPTION
## Summary

Adds two new provider packages, completing the intent of #168, rewritten to use upstream's `internal/openaicompat` helpers (shipped in v1.1.4) instead of the now-removed `internal/compat` package.

- **NanoGPT** (`providers/nanogpt/`) — aggregator at nano-gpt.com proxying Anthropic, OpenAI, xAI, DeepSeek, Moonshot, Google, Mistral models
- **ZAI** (`providers/zai/`) — Z.ai (Zhipu AI) at api.z.ai, GLM model family

Both implement `core.Provider`, `core.StreamProvider`, `core.ProxiableProvider`, and `core.DiscoveryProvider` using `openaicompat.PostChat`/`PostStream` — the same pattern as OpenRouter, Together, etc.

## Changes

- `providers/nanogpt/nanogpt.go` + `nanogpt_test.go`
- `providers/zai/zai.go` + `zai_test.go`
- `providers/names.go` — `NameNanoGPT`, `NameZAI` constants
- `providers/providers_list.go` — `ProviderEntry` registrations (`NANOGPT_API_KEY`, `ZAI_API_KEY`)
- `providers/stability_test.go` — name-stability cases for both new providers

## Test plan

- [x] `go build ./...` passes
- [x] `go test -short -race ./providers/...` passes (34 packages including stability/name-drift tests)
- [ ] Manual: curl a chat completion through each provider with a real API key

Replaces #168.

🤖 Generated with [Claude Code](https://claude.com/claude-code)