### PR TITLE
fix(otel): give shutdown stages independent deadlines

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,7 +375,7 @@ observability:
     service_name: ferrogw
     sample_ratio: 1.0
     privacy_level: metadata    # none | metadata | full  (see below)
-    shutdown_grace: 10s        # max time to drain OTel exports on shutdown
+    shutdown_grace: 10s        # per OTel shutdown stage; total can take up to 2x this value
     # headers:                        # OTLP export headers for authenticated backends
     #   dd-api-key: "${DATADOG_API_KEY}"  # values support ${ENV_VAR} interpolation
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -365,7 +365,7 @@ observability:
     service_name: ferrogw
     sample_ratio: 1.0
     privacy_level: metadata    # none | metadata | full（见下文）
-    shutdown_grace: 10s        # 关闭时排空 OTel 导出的最长等待时间
+    shutdown_grace: 10s        # 每个 OTel 关闭阶段的等待时间；总耗时最多可达该值的 2 倍
     # headers:                          # 认证后端所需的 OTLP 导出请求头
     #   dd-api-key: "${DATADOG_API_KEY}"  # 值支持 ${ENV_VAR} 环境变量插值
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -216,7 +216,7 @@ observability:
     service_name: ferrogw
     sample_ratio: 1.0
     privacy_level: metadata  # none | metadata | full
-    shutdown_grace: 10s      # max time to drain in-flight OTel exports on shutdown
+    shutdown_grace: 10s      # per OTel shutdown stage; total can take up to 2x this value
     # headers:                       # OTLP export headers (e.g. vendor API keys)
     #   dd-api-key: "${DATADOG_API_KEY}"   # values support ${ENV} interpolation
 

--- a/config.go
+++ b/config.go
@@ -95,10 +95,11 @@ type TracingConfig struct {
 	// PrivacyLevel controls whether prompt/response content is exported.
 	// One of: "none", "metadata" (default), "full".
 	PrivacyLevel string `json:"privacy_level,omitempty" yaml:"privacy_level,omitempty"`
-	// ShutdownGrace is the maximum time the gateway waits for in-flight
-	// OTel exports to drain during graceful shutdown. Accepts any Go
-	// duration string, e.g. "10s", "500ms". Defaults to 10s when empty
-	// or unparseable.
+	// ShutdownGrace is the maximum time each OTel shutdown stage waits.
+	// Exporter shutdown and TracerProvider shutdown each receive this
+	// budget, so total telemetry shutdown may take up to twice this value.
+	// Accepts any Go duration string, e.g. "10s", "500ms". Defaults to 10s
+	// when empty or unparseable.
 	ShutdownGrace string `json:"shutdown_grace,omitempty" yaml:"shutdown_grace,omitempty"`
 	// Headers are additional HTTP/gRPC metadata headers sent with every OTLP
 	// export request. Use this to authenticate with managed backends such as

--- a/internal/otel/config.go
+++ b/internal/otel/config.go
@@ -33,7 +33,9 @@ type Config struct {
 	PrivacyLevel string `yaml:"privacy_level" json:"privacy_level"`
 
 	// ShutdownGrace is the maximum time each shutdown stage will block waiting
-	// for in-flight exports to drain.
+	// for in-flight exports to drain. Exporter shutdown and TracerProvider
+	// shutdown each receive this budget, so total shutdown may take up to twice
+	// this value.
 	ShutdownGrace time.Duration `yaml:"shutdown_grace" json:"shutdown_grace"`
 
 	// Exporters is the list of plugin exporter configurations.  Each

--- a/internal/otel/config.go
+++ b/internal/otel/config.go
@@ -32,8 +32,8 @@ type Config struct {
 	// One of: "none", "metadata" (default), "full".
 	PrivacyLevel string `yaml:"privacy_level" json:"privacy_level"`
 
-	// ShutdownGrace is the maximum time Shutdown will block waiting for
-	// in-flight exports to drain.
+	// ShutdownGrace is the maximum time each shutdown stage will block waiting
+	// for in-flight exports to drain.
 	ShutdownGrace time.Duration `yaml:"shutdown_grace" json:"shutdown_grace"`
 
 	// Exporters is the list of plugin exporter configurations.  Each

--- a/internal/otel/otel.go
+++ b/internal/otel/otel.go
@@ -2,6 +2,7 @@ package otel
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -123,26 +124,42 @@ func Init(ctx context.Context, cfg Config) (observability.Provider, ShutdownFunc
 		shutdownGrace = 10 * time.Second
 	}
 	shutdown := func(ctx context.Context) error {
-		// Apply an internal deadline so callers can pass context.Background()
-		// and the closure still drains within ShutdownGrace.
-		innerCtx, cancel := context.WithTimeout(ctx, shutdownGrace)
-		defer cancel()
 		// Drain plugin exporters first, then the OTel pipeline.
-		exporterErr := prov.Shutdown(innerCtx)
-		tpErr := tpShutdown(innerCtx)
+		err := shutdownWithIndependentDeadlines(ctx, shutdownGrace, prov.Shutdown, tpShutdown)
 		// Restore the global TracerProvider to a no-op so any late
 		// otel.Tracer(...) calls after shutdown don't hit the drained
 		// pipeline, and so re-initialisation (tests, embedders) starts clean.
 		if globalTPSet {
 			otel.SetTracerProvider(noop.NewTracerProvider())
 		}
-		if tpErr != nil {
-			return tpErr
-		}
-		return exporterErr
+		return err
 	}
 
 	return prov, shutdown, nil
+}
+
+func shutdownWithIndependentDeadlines(
+	ctx context.Context,
+	shutdownGrace time.Duration,
+	exporterShutdown func(context.Context) error,
+	tpShutdown func(context.Context) error,
+) error {
+	if shutdownGrace <= 0 {
+		shutdownGrace = 10 * time.Second
+	}
+
+	// Give each shutdown stage its own grace window. A slow plugin exporter
+	// may use its full deadline, but that must not hand the TracerProvider an
+	// already-expired context and silently drop buffered spans.
+	exporterCtx, exporterCancel := context.WithTimeout(ctx, shutdownGrace)
+	exporterErr := exporterShutdown(exporterCtx)
+	exporterCancel()
+
+	tpCtx, tpCancel := context.WithTimeout(ctx, shutdownGrace)
+	tpErr := tpShutdown(tpCtx)
+	tpCancel()
+
+	return errors.Join(exporterErr, tpErr)
 }
 
 // resolveExporters instantiates and initialises each enabled exporter.

--- a/internal/otel/otel_test.go
+++ b/internal/otel/otel_test.go
@@ -134,6 +134,63 @@ func TestInitRegistersGlobalTracerProvider(t *testing.T) {
 	span2.End()
 }
 
+func TestShutdownUsesIndependentDeadlinesForExporterAndTracerProvider(t *testing.T) {
+	grace := 25 * time.Millisecond
+	exporterDone := make(chan struct{})
+	tpCtxErr := make(chan error, 1)
+
+	err := shutdownWithIndependentDeadlines(
+		context.Background(),
+		grace,
+		func(ctx context.Context) error {
+			<-ctx.Done()
+			close(exporterDone)
+			return ctx.Err()
+		},
+		func(ctx context.Context) error {
+			select {
+			case <-exporterDone:
+			case <-time.After(time.Second):
+				t.Fatal("tracer provider shutdown was not called after exporter shutdown")
+			}
+
+			select {
+			case <-ctx.Done():
+				tpCtxErr <- ctx.Err()
+			default:
+				tpCtxErr <- nil
+			}
+			return nil
+		},
+	)
+
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("shutdown error = %v, want context deadline exceeded", err)
+	}
+	if err := <-tpCtxErr; err != nil {
+		t.Fatalf("tracer provider received expired context: %v", err)
+	}
+}
+
+func TestShutdownJoinsExporterAndTracerProviderErrors(t *testing.T) {
+	exporterErr := errors.New("exporter shutdown failed")
+	tpErr := errors.New("tracer provider shutdown failed")
+
+	err := shutdownWithIndependentDeadlines(
+		context.Background(),
+		time.Second,
+		func(context.Context) error { return exporterErr },
+		func(context.Context) error { return tpErr },
+	)
+
+	if !errors.Is(err, exporterErr) {
+		t.Fatalf("shutdown error %v does not include exporter error", err)
+	}
+	if !errors.Is(err, tpErr) {
+		t.Fatalf("shutdown error %v does not include tracer provider error", err)
+	}
+}
+
 func TestEffectiveEndpointEnvWins(t *testing.T) {
 	// OTEL_EXPORTER_OTLP_ENDPOINT takes precedence over a configured endpoint
 	// so container deployments can redirect telemetry by env var.


### PR DESCRIPTION
## Summary

Splits OpenTelemetry exporter shutdown and TracerProvider shutdown into independent timeout windows so a slow exporter cannot consume the whole graceful-shutdown deadline and drop spans.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] New provider
- [ ] New plugin
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Performance improvement
- [x] Refactor / code quality
- [ ] Documentation / comments only
- [ ] CI / tooling

## Related issues

Fixes #151

## Changes

- Give exporter shutdown and TracerProvider shutdown separate `ShutdownGrace`-bounded contexts.
- Join exporter and TracerProvider shutdown errors with `errors.Join`.
- Add regression tests for expired shared-context span loss and dropped shutdown errors.
- Clarify `ShutdownGrace` behavior in the OTel config comment.

## Testing

- [x] Existing tests pass (`go test ./...`)
- [x] New unit tests added (if applicable)
- [ ] Manually tested against a live provider (if provider change)

Commands run:

- `go test ./internal/otel -run 'TestShutdownUsesIndependentDeadlinesForExporterAndTracerProvider|TestShutdownJoinsExporterAndTracerProviderErrors' -count=1`
- `go test ./internal/otel -count=1`
- `go test -v -short -race -timeout 30s ./internal/otel -count=1`
- `FERRO_MODEL_CATALOG_URL=http://127.0.0.1:1/catalog go test -short -race -timeout 120s ./...`

## Provider checklist (fill in only for new/updated providers)

- [ ] Provider file at `providers/<id>/<id>.go`
- [ ] Test file at `providers/<id>/<id>_test.go`
- [ ] `ProviderEntry` added to `providers/providers_list.go`
- [ ] Name constant added to `providers/names.go`
- [ ] Models added to `ferro-labs/model-catalog` when catalog coverage changes
- [ ] `AllowedTools`, `MaxCallDepth` and streaming tested

## Plugin checklist (fill in only for new/updated plugins)

- [ ] Plugin file at `internal/plugins/<name>/`
- [ ] `Stage` (before/after request) correctly set
- [ ] Test coverage added
- [ ] Example config documented

## Breaking change notes

None.

## Screenshots / output (optional)

The full short/race suite passed with a deterministic model-catalog URL override.
