### PR TITLE
fix(plugin): harden plugin pipeline lifecycle

### DIFF
--- a/gateway.go
+++ b/gateway.go
@@ -379,15 +379,19 @@ func (g *Gateway) MCPInitDone() <-chan struct{} {
 // when a plugin (e.g. response-cache) sets Skip=true. It also propagates any
 // request mutations the plugins made. RunAfter is called before returning the
 // early response so logging/metrics plugins still fire.
-func (g *Gateway) runBeforePlugins(ctx context.Context, pctx *plugin.Context, req *providers.Request) (*providers.Response, error) {
-	if err := g.plugins.RunBefore(ctx, pctx); err != nil {
+func (g *Gateway) runBeforePlugins(ctx context.Context, plugins *plugin.Manager, pctx *plugin.Context, req *providers.Request) (*providers.Response, error) {
+	if err := plugins.RunBefore(ctx, pctx); err != nil {
 		return nil, err
 	}
 	if pctx.Request != nil {
 		*req = *pctx.Request
 	}
 	if pctx.Skip && pctx.Response != nil {
-		_ = g.plugins.RunAfter(ctx, pctx)
+		if err := plugins.RunAfter(ctx, pctx); err != nil {
+			pctx.Error = err
+			plugins.RunOnError(ctx, pctx)
+			return nil, err
+		}
 		return pctx.Response, nil
 	}
 	return nil, nil
@@ -410,6 +414,7 @@ func (g *Gateway) Route(ctx context.Context, req providers.Request) (*providers.
 	obsEventsActive := g.obsEventsActive
 	mcpRegistrySnapshot := g.mcpRegistry
 	mcpExecutorSnapshot := g.mcpExecutor
+	plugins := g.plugins
 	g.mu.RUnlock()
 	ctx, span := obs.StartRequestSpan(ctx, observability.RequestAttrs{
 		Operation:       "chat",
@@ -432,12 +437,12 @@ func (g *Gateway) Route(ctx context.Context, req providers.Request) (*providers.
 
 	// Run before-request plugins (guardrails, transforms, rate-limit).
 	var pctx *plugin.Context
-	if g.plugins.HasPlugins() {
+	if plugins.HasPlugins() {
 		pctx = plugin.NewContext(&req)
 		defer plugin.PutContext(pctx)
 		var early *providers.Response
 		trace.WithRegion(ctx, "gateway.route.plugins.before", func() {
-			early, err = g.runBeforePlugins(ctx, pctx, &req)
+			early, err = g.runBeforePlugins(ctx, plugins, pctx, &req)
 		})
 		if err != nil {
 			metrics.ForRequest("", req.Model).Rejected.Inc()
@@ -496,7 +501,7 @@ func (g *Gateway) Route(ctx context.Context, req providers.Request) (*providers.
 	if err != nil {
 		if pctx != nil {
 			pctx.Error = err
-			g.plugins.RunOnError(ctx, pctx)
+			plugins.RunOnError(ctx, pctx)
 		}
 
 		provider := ""
@@ -581,10 +586,12 @@ func (g *Gateway) Route(ctx context.Context, req providers.Request) (*providers.
 	if pctx != nil {
 		pctx.Response = resp
 		trace.WithRegion(ctx, "gateway.route.plugins.after", func() {
-			err = g.plugins.RunAfter(ctx, pctx)
+			err = plugins.RunAfter(ctx, pctx)
 		})
 		if err != nil {
 			metrics.ForRequest(resp.Provider, resp.Model).Rejected.Inc()
+			pctx.Error = err
+			plugins.RunOnError(ctx, pctx)
 			return nil, err
 		}
 		if pctx.Response != nil {
@@ -832,10 +839,25 @@ func (g *Gateway) ReloadConfig(cfg Config) error {
 	if err != nil {
 		return fmt.Errorf("invalid config: %w", err)
 	}
+	plugins, err := buildPluginManager(cfg.Plugins)
+	if err != nil {
+		return err
+	}
+	pluginsInstalled := false
+	defer func() {
+		if pluginsInstalled {
+			return
+		}
+		if closeErr := closePluginManager(plugins); closeErr != nil {
+			slog.Warn("plugin close failed after config reload error", "error", closeErr)
+		}
+	}()
 	g.mu.Lock()
-	defer g.mu.Unlock()
+	oldPlugins := g.plugins
 	g.config = cfg
 	g.streamingContent = streamingContent
+	g.plugins = plugins
+	pluginsInstalled = true
 	g.strategy = nil // force rebuild on next request
 	g.circuitBreakers = make(map[string]*circuitbreaker.CircuitBreaker)
 	g.ensureCircuitBreakersLocked()
@@ -876,6 +898,10 @@ func (g *Gateway) ReloadConfig(cfg Config) error {
 		g.mcpInitDone = nil
 	}
 
+	g.mu.Unlock()
+	if err := closePluginManager(oldPlugins); err != nil {
+		slog.Warn("plugin close failed during config reload", "error", err)
+	}
 	return nil
 }
 
@@ -1131,24 +1157,56 @@ func isRateLimitError(err error) bool {
 
 // LoadPlugins initializes and registers plugins from the gateway configuration.
 func (g *Gateway) LoadPlugins() error {
-	for _, pc := range g.config.Plugins {
+	g.mu.RLock()
+	configs := append([]PluginConfig(nil), g.config.Plugins...)
+	g.mu.RUnlock()
+	plugins, err := buildPluginManager(configs)
+	if err != nil {
+		return err
+	}
+
+	g.mu.Lock()
+	oldPlugins := g.plugins
+	g.plugins = plugins
+	g.mu.Unlock()
+	if err := closePluginManager(oldPlugins); err != nil {
+		return err
+	}
+	return nil
+}
+
+func buildPluginManager(configs []PluginConfig) (*plugin.Manager, error) {
+	plugins := plugin.NewManager()
+	for _, pc := range configs {
 		if !pc.Enabled {
 			continue
 		}
 		factory, ok := plugin.GetFactory(pc.Name)
 		if !ok {
-			return fmt.Errorf("unknown plugin: %s", pc.Name)
+			_ = plugins.Close()
+			return nil, fmt.Errorf("unknown plugin: %s", pc.Name)
 		}
 		p := factory()
 		if err := p.Init(pc.Config); err != nil {
-			return fmt.Errorf("plugin %s init failed: %w", pc.Name, err)
+			_ = plugins.Close()
+			_ = p.Close()
+			return nil, fmt.Errorf("plugin %s init failed: %w", pc.Name, err)
 		}
 		stage := plugin.Stage(pc.Stage)
-		if err := g.RegisterPlugin(stage, p); err != nil {
-			return fmt.Errorf("plugin %s register failed: %w", pc.Name, err)
+		if err := plugins.Register(stage, p); err != nil {
+			_ = plugins.Close()
+			_ = p.Close()
+			return nil, fmt.Errorf("plugin %s register failed: %w", pc.Name, err)
 		}
 	}
-	return nil
+	return plugins, nil
+}
+
+func closePluginManager(plugins *plugin.Manager) error {
+	if plugins == nil {
+		return nil
+	}
+	return plugins.Close()
 }
 
 // RouteStream runs before-request plugins then returns a metered streaming
@@ -1179,6 +1237,7 @@ func (g *Gateway) RouteStream(ctx context.Context, req providers.Request) (<-cha
 	obs := g.obs
 	obsEventsActive := g.obsEventsActive
 	mcpRegistrySnapshot := g.mcpRegistry
+	plugins := g.plugins
 	g.mu.RUnlock()
 	ctx, span := obs.StartRequestSpan(ctx, observability.RequestAttrs{
 		Operation:       "chat",
@@ -1217,11 +1276,11 @@ func (g *Gateway) RouteStream(ctx context.Context, req providers.Request) (<-cha
 
 	// Run before-request plugins (word-filter, max-token, rate-limit, etc.).
 	var pctx *plugin.Context
-	if g.plugins.HasPlugins() {
+	if plugins.HasPlugins() {
 		pctx = plugin.NewContext(&req)
 		var early *providers.Response
 		trace.WithRegion(ctx, "gateway.route_stream.plugins.before", func() {
-			early, err = g.runBeforePlugins(ctx, pctx, &req)
+			early, err = g.runBeforePlugins(ctx, plugins, pctx, &req)
 		})
 		if err != nil {
 			plugin.PutContext(pctx)
@@ -1249,7 +1308,7 @@ func (g *Gateway) RouteStream(ctx context.Context, req providers.Request) (<-cha
 		span.SetError(err)
 		if pctx != nil {
 			pctx.Error = err
-			g.plugins.RunOnError(ctx, pctx)
+			plugins.RunOnError(ctx, pctx)
 			plugin.PutContext(pctx)
 		}
 		return nil, err
@@ -1260,7 +1319,7 @@ func (g *Gateway) RouteStream(ctx context.Context, req providers.Request) (<-cha
 		span.SetError(err)
 		if pctx != nil {
 			pctx.Error = err
-			g.plugins.RunOnError(ctx, pctx)
+			plugins.RunOnError(ctx, pctx)
 			plugin.PutContext(pctx)
 		}
 		return nil, err
@@ -1287,7 +1346,7 @@ func (g *Gateway) RouteStream(ctx context.Context, req providers.Request) (<-cha
 		}
 		if pctx != nil {
 			pctx.Error = err
-			g.plugins.RunOnError(ctx, pctx)
+			plugins.RunOnError(ctx, pctx)
 			plugin.PutContext(pctx)
 		}
 		metrics.ForRequest(providerName, req.Model).Error.Inc()
@@ -1333,13 +1392,13 @@ func (g *Gateway) RouteStream(ctx context.Context, req providers.Request) (<-cha
 	if pctx != nil {
 		meta.CompletionFn = func(ctx context.Context, resp *providers.Response) error {
 			pctx.Response = resp
-			err := g.plugins.RunAfter(ctx, pctx)
+			err := plugins.RunAfter(ctx, pctx)
 			if pctx.Response != nil {
 				*resp = *pctx.Response
 			}
 			if err != nil {
 				pctx.Error = err
-				g.plugins.RunOnError(ctx, pctx)
+				plugins.RunOnError(ctx, pctx)
 			}
 			plugin.PutContext(pctx)
 			pctx = nil
@@ -1350,7 +1409,7 @@ func (g *Gateway) RouteStream(ctx context.Context, req providers.Request) (<-cha
 				return
 			}
 			pctx.Error = err
-			g.plugins.RunOnError(ctx, pctx)
+			plugins.RunOnError(ctx, pctx)
 			plugin.PutContext(pctx)
 			pctx = nil
 		}
@@ -2056,6 +2115,12 @@ func (g *Gateway) FindStreamingByModel(model string) (providers.StreamProvider, 
 func (g *Gateway) Close() error {
 	g.closeOnce.Do(func() {
 		g.shutdownCancel()
+		g.mu.RLock()
+		plugins := g.plugins
+		g.mu.RUnlock()
+		if err := closePluginManager(plugins); err != nil {
+			slog.Warn("plugin close failed during gateway shutdown", "error", err)
+		}
 		done := make(chan struct{})
 		go func() {
 			g.hookWorkersDone.Wait()

--- a/gateway.go
+++ b/gateway.go
@@ -415,7 +415,9 @@ func (g *Gateway) Route(ctx context.Context, req providers.Request) (*providers.
 	mcpRegistrySnapshot := g.mcpRegistry
 	mcpExecutorSnapshot := g.mcpExecutor
 	plugins := g.plugins
+	releasePlugins := acquirePluginManager(plugins)
 	g.mu.RUnlock()
+	defer releasePlugins()
 	ctx, span := obs.StartRequestSpan(ctx, observability.RequestAttrs{
 		Operation:       "chat",
 		RequestModel:    req.Model,
@@ -1209,6 +1211,13 @@ func closePluginManager(plugins *plugin.Manager) error {
 	return plugins.Close()
 }
 
+func acquirePluginManager(plugins *plugin.Manager) func() {
+	if plugins == nil || !plugins.HasPlugins() {
+		return func() {}
+	}
+	return plugins.Acquire()
+}
+
 // RouteStream runs before-request plugins then returns a metered streaming
 // response channel. Provider resolution follows the configured strategy mode,
 // then falls back to any registered provider that supports the requested model
@@ -1238,7 +1247,12 @@ func (g *Gateway) RouteStream(ctx context.Context, req providers.Request) (<-cha
 	obsEventsActive := g.obsEventsActive
 	mcpRegistrySnapshot := g.mcpRegistry
 	plugins := g.plugins
+	releasePlugins := acquirePluginManager(plugins)
 	g.mu.RUnlock()
+	var releasePluginsOnce sync.Once
+	releasePluginManager := func() {
+		releasePluginsOnce.Do(releasePlugins)
+	}
 	ctx, span := obs.StartRequestSpan(ctx, observability.RequestAttrs{
 		Operation:       "chat",
 		RequestModel:    req.Model,
@@ -1263,6 +1277,7 @@ func (g *Gateway) RouteStream(ctx context.Context, req providers.Request) (<-cha
 	// entirely; we wrap its non-streaming result into a channel here.
 	hasMCP := mcpRegistrySnapshot != nil && mcpRegistrySnapshot.HasServers()
 	if hasMCP {
+		releasePluginManager()
 		// Do not force req.Stream = false here: let Route() capture the
 		// original stream flag via its own originalStream variable so that
 		// emitted events correctly reflect stream: true for RouteStream callers.
@@ -1285,14 +1300,18 @@ func (g *Gateway) RouteStream(ctx context.Context, req providers.Request) (<-cha
 		if err != nil {
 			plugin.PutContext(pctx)
 			pctx = nil
+			releasePluginManager()
 			metrics.ForRequest("", req.Model).Rejected.Inc()
 			return nil, err
 		}
 		if early != nil {
 			plugin.PutContext(pctx)
 			pctx = nil
+			releasePluginManager()
 			return responseStream(early), nil
 		}
+	} else {
+		releasePluginManager()
 	}
 
 	// Resolve provider according to strategy mode.
@@ -1310,6 +1329,7 @@ func (g *Gateway) RouteStream(ctx context.Context, req providers.Request) (<-cha
 			pctx.Error = err
 			plugins.RunOnError(ctx, pctx)
 			plugin.PutContext(pctx)
+			releasePluginManager()
 		}
 		return nil, err
 	}
@@ -1321,6 +1341,7 @@ func (g *Gateway) RouteStream(ctx context.Context, req providers.Request) (<-cha
 			pctx.Error = err
 			plugins.RunOnError(ctx, pctx)
 			plugin.PutContext(pctx)
+			releasePluginManager()
 		}
 		return nil, err
 	}
@@ -1348,6 +1369,7 @@ func (g *Gateway) RouteStream(ctx context.Context, req providers.Request) (<-cha
 			pctx.Error = err
 			plugins.RunOnError(ctx, pctx)
 			plugin.PutContext(pctx)
+			releasePluginManager()
 		}
 		metrics.ForRequest(providerName, req.Model).Error.Inc()
 		metrics.ForProviderError(providerName, errType).Inc()
@@ -1402,6 +1424,7 @@ func (g *Gateway) RouteStream(ctx context.Context, req providers.Request) (<-cha
 			}
 			plugin.PutContext(pctx)
 			pctx = nil
+			releasePluginManager()
 			return err
 		}
 		meta.ErrorFn = func(ctx context.Context, err error) {
@@ -1412,6 +1435,7 @@ func (g *Gateway) RouteStream(ctx context.Context, req providers.Request) (<-cha
 			plugins.RunOnError(ctx, pctx)
 			plugin.PutContext(pctx)
 			pctx = nil
+			releasePluginManager()
 		}
 	}
 
@@ -2115,9 +2139,10 @@ func (g *Gateway) FindStreamingByModel(model string) (providers.StreamProvider, 
 func (g *Gateway) Close() error {
 	g.closeOnce.Do(func() {
 		g.shutdownCancel()
-		g.mu.RLock()
+		g.mu.Lock()
 		plugins := g.plugins
-		g.mu.RUnlock()
+		g.plugins = plugin.NewManager()
+		g.mu.Unlock()
 		if err := closePluginManager(plugins); err != nil {
 			slog.Warn("plugin close failed during gateway shutdown", "error", err)
 		}

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -1676,6 +1676,52 @@ func TestGateway_RouteStream_AfterPluginRejectRunsOnError(t *testing.T) {
 	}
 }
 
+func TestGateway_Route_AfterPluginRejectRunsOnError(t *testing.T) {
+	gw, _ := New(Config{
+		Strategy: StrategyConfig{Mode: ModeSingle},
+		Targets:  []Target{{VirtualKey: mockProviderName}},
+	})
+	gw.RegisterProvider(&mockProvider{
+		name:   mockProviderName,
+		models: []string{"gpt-4o"},
+		resp:   &providers.Response{ID: "r1", Model: "gpt-4o", Provider: mockProviderName},
+	})
+
+	var onErrorCalls int
+	_ = gw.RegisterPlugin(plugin.StageAfterRequest, &testPlugin{
+		name: "after",
+		typ:  plugin.TypeLogging,
+		execFn: func(_ context.Context, pctx *plugin.Context) error {
+			pctx.Reject = true
+			pctx.Reason = "after plugin rejected"
+			return nil
+		},
+	})
+	_ = gw.RegisterPlugin(plugin.StageOnError, &testPlugin{
+		name: "on-error",
+		typ:  plugin.TypeLogging,
+		execFn: func(_ context.Context, pctx *plugin.Context) error {
+			onErrorCalls++
+			var rejection *plugin.RejectionError
+			if !errors.As(pctx.Error, &rejection) {
+				t.Fatalf("on-error plugin error = %T(%v), want *plugin.RejectionError", pctx.Error, pctx.Error)
+			}
+			return nil
+		},
+	})
+
+	_, err := gw.Route(context.Background(), providers.Request{
+		Model:    "gpt-4o",
+		Messages: []providers.Message{{Role: "user", Content: "hi"}},
+	})
+	if err == nil {
+		t.Fatal("expected after plugin rejection")
+	}
+	if onErrorCalls != 1 {
+		t.Fatalf("on-error plugin calls = %d, want 1", onErrorCalls)
+	}
+}
+
 func TestGateway_RouteStream_ResponseCacheHitSkipsProvider(t *testing.T) {
 	gw, _ := New(Config{
 		Strategy: StrategyConfig{Mode: ModeSingle},
@@ -2453,9 +2499,10 @@ func TestGateway_PublishEvent_IncrementsDropMetricWhenQueueFull(t *testing.T) {
 
 // testPlugin is a mock plugin for gateway tests.
 type testPlugin struct {
-	name   string
-	typ    plugin.PluginType
-	execFn func(ctx context.Context, pctx *plugin.Context) error
+	name    string
+	typ     plugin.PluginType
+	execFn  func(ctx context.Context, pctx *plugin.Context) error
+	closeFn func() error
 }
 
 func (p *testPlugin) Name() string              { return p.name }
@@ -2464,6 +2511,12 @@ func (p *testPlugin) Init(map[string]any) error { return nil }
 func (p *testPlugin) Execute(ctx context.Context, pctx *plugin.Context) error {
 	if p.execFn != nil {
 		return p.execFn(ctx, pctx)
+	}
+	return nil
+}
+func (p *testPlugin) Close() error {
+	if p.closeFn != nil {
+		return p.closeFn()
 	}
 	return nil
 }
@@ -2586,6 +2639,50 @@ func TestGateway_LoadPlugins_UnknownPlugin(t *testing.T) {
 	}
 	if got := err.Error(); got != "unknown plugin: does-not-exist" {
 		t.Errorf("got error %q, want %q", got, "unknown plugin: does-not-exist")
+	}
+}
+
+func TestGateway_ReloadConfig_ClosesOldPlugins(t *testing.T) {
+	var oldClosed atomic.Int32
+	plugin.RegisterFactory("test-close-plugin", func() plugin.Plugin {
+		return &testPlugin{
+			name: "test-close-plugin",
+			typ:  plugin.TypeLogging,
+			closeFn: func() error {
+				oldClosed.Add(1)
+				return nil
+			},
+		}
+	})
+
+	gw, _ := New(Config{
+		Strategy: StrategyConfig{Mode: ModeSingle},
+		Targets:  []Target{{VirtualKey: mockProviderName}},
+		Plugins: []PluginConfig{
+			{
+				Name:    "test-close-plugin",
+				Type:    "logging",
+				Stage:   "after_request",
+				Enabled: true,
+				Config:  map[string]any{},
+			},
+		},
+	})
+	if err := gw.LoadPlugins(); err != nil {
+		t.Fatalf("LoadPlugins failed: %v", err)
+	}
+
+	if err := gw.ReloadConfig(Config{
+		Strategy: StrategyConfig{Mode: ModeSingle},
+		Targets:  []Target{{VirtualKey: mockProviderName}},
+	}); err != nil {
+		t.Fatalf("ReloadConfig failed: %v", err)
+	}
+	if got := oldClosed.Load(); got != 1 {
+		t.Fatalf("old plugin closes = %d, want 1", got)
+	}
+	if gw.plugins.HasPlugins() {
+		t.Fatal("expected reload without plugin configs to clear registered plugins")
 	}
 }
 

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -2686,6 +2686,91 @@ func TestGateway_ReloadConfig_ClosesOldPlugins(t *testing.T) {
 	}
 }
 
+func TestGateway_ReloadConfig_WaitsForInFlightRoutePlugins(t *testing.T) {
+	provider := newGateMockProvider(&providers.Response{ID: "ok", Model: "gpt-4o"}, nil)
+	gw, err := New(Config{
+		Strategy: StrategyConfig{Mode: ModeSingle},
+		Targets:  []Target{{VirtualKey: provider.Name()}},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { _ = gw.Close() })
+	gw.RegisterProvider(provider)
+
+	oldClosed := make(chan struct{})
+	var closeOnce sync.Once
+	afterRan := make(chan struct{})
+	var afterOnce sync.Once
+	if err := gw.RegisterPlugin(plugin.StageAfterRequest, &testPlugin{
+		name: "in-flight-after",
+		typ:  plugin.TypeLogging,
+		execFn: func(context.Context, *plugin.Context) error {
+			afterOnce.Do(func() { close(afterRan) })
+			return nil
+		},
+		closeFn: func() error {
+			closeOnce.Do(func() { close(oldClosed) })
+			return nil
+		},
+	}); err != nil {
+		t.Fatalf("RegisterPlugin: %v", err)
+	}
+
+	routeDone := make(chan error, 1)
+	go func() {
+		_, routeErr := gw.Route(context.Background(), providers.Request{
+			Model:    "gpt-4o",
+			Messages: []providers.Message{{Role: "user", Content: "hi"}},
+		})
+		routeDone <- routeErr
+	}()
+
+	provider.waitActive(t, 1)
+	reloadDone := make(chan error, 1)
+	go func() {
+		reloadDone <- gw.ReloadConfig(Config{
+			Strategy: StrategyConfig{Mode: ModeSingle},
+			Targets:  []Target{{VirtualKey: provider.Name()}},
+		})
+	}()
+
+	select {
+	case <-oldClosed:
+		t.Fatal("old plugin manager closed while an in-flight route could still run after/error plugins")
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	provider.releaseAll()
+
+	select {
+	case err := <-routeDone:
+		if err != nil {
+			t.Fatalf("Route: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for route")
+	}
+	select {
+	case <-afterRan:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for after plugin")
+	}
+	select {
+	case err := <-reloadDone:
+		if err != nil {
+			t.Fatalf("ReloadConfig: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for reload")
+	}
+	select {
+	case <-oldClosed:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for old plugin close")
+	}
+}
+
 // ── mockEmbeddingProvider ─────────────────────────────────────────────────────
 
 type mockEmbeddingProvider struct {

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -2686,7 +2686,7 @@ func TestGateway_ReloadConfig_ClosesOldPlugins(t *testing.T) {
 	}
 }
 
-func TestGateway_ReloadConfig_WaitsForInFlightRoutePlugins(t *testing.T) {
+func TestGateway_ReloadConfig_DefersOldPluginCloseUntilInFlightRouteFinishes(t *testing.T) {
 	provider := newGateMockProvider(&providers.Response{ID: "ok", Model: "gpt-4o"}, nil)
 	gw, err := New(Config{
 		Strategy: StrategyConfig{Mode: ModeSingle},
@@ -2736,9 +2736,17 @@ func TestGateway_ReloadConfig_WaitsForInFlightRoutePlugins(t *testing.T) {
 	}()
 
 	select {
+	case err := <-reloadDone:
+		if err != nil {
+			t.Fatalf("ReloadConfig: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("reload blocked behind in-flight route")
+	}
+	select {
 	case <-oldClosed:
 		t.Fatal("old plugin manager closed while an in-flight route could still run after/error plugins")
-	case <-time.After(200 * time.Millisecond):
+	default:
 	}
 
 	provider.releaseAll()
@@ -2755,14 +2763,6 @@ func TestGateway_ReloadConfig_WaitsForInFlightRoutePlugins(t *testing.T) {
 	case <-afterRan:
 	case <-time.After(5 * time.Second):
 		t.Fatal("timed out waiting for after plugin")
-	}
-	select {
-	case err := <-reloadDone:
-		if err != nil {
-			t.Fatalf("ReloadConfig: %v", err)
-		}
-	case <-time.After(5 * time.Second):
-		t.Fatal("timed out waiting for reload")
 	}
 	select {
 	case <-oldClosed:

--- a/internal/plugins/budget/plugin.go
+++ b/internal/plugins/budget/plugin.go
@@ -235,6 +235,9 @@ func (p *Plugin) Execute(_ context.Context, pctx *plugin.Context) error {
 	return nil
 }
 
+// Close releases plugin resources.
+func (p *Plugin) Close() error { return nil }
+
 func (p *Plugin) checkBudget(pctx *plugin.Context, key string) error {
 	if p.spendLimitUSD <= 0 {
 		return nil // unlimited

--- a/internal/plugins/cache/cache.go
+++ b/internal/plugins/cache/cache.go
@@ -128,6 +128,9 @@ func (c *ResponseCache) Execute(_ context.Context, pctx *plugin.Context) error {
 	return nil
 }
 
+// Close releases plugin resources.
+func (c *ResponseCache) Close() error { return nil }
+
 func cacheKey(req *providers.Request) string {
 	h := sha256.New()
 	writeCacheKeyString(h, req.Model)

--- a/internal/plugins/logger/logger.go
+++ b/internal/plugins/logger/logger.go
@@ -141,3 +141,12 @@ func (l *RequestLogger) Execute(ctx context.Context, pctx *plugin.Context) error
 
 	return nil
 }
+
+// Close releases the persistent request-log writer, when one is configured.
+func (l *RequestLogger) Close() error {
+	closer, ok := l.writer.(interface{ Close() error })
+	if !ok {
+		return nil
+	}
+	return closer.Close()
+}

--- a/internal/plugins/maxtoken/maxtoken.go
+++ b/internal/plugins/maxtoken/maxtoken.go
@@ -98,3 +98,6 @@ func (m *MaxToken) Execute(_ context.Context, pctx *plugin.Context) error {
 
 	return nil
 }
+
+// Close releases plugin resources.
+func (m *MaxToken) Close() error { return nil }

--- a/internal/plugins/ratelimit/plugin.go
+++ b/internal/plugins/ratelimit/plugin.go
@@ -134,6 +134,9 @@ func (p *Plugin) Execute(_ context.Context, pctx *plugin.Context) error {
 	return nil
 }
 
+// Close releases plugin resources.
+func (p *Plugin) Close() error { return nil }
+
 // toFloat64 converts an interface{} value to float64, accepting float64 or int.
 func toFloat64(v interface{}) (float64, error) {
 	switch val := v.(type) {

--- a/internal/plugins/wordfilter/wordfilter.go
+++ b/internal/plugins/wordfilter/wordfilter.go
@@ -75,3 +75,6 @@ func (w *WordFilter) Execute(_ context.Context, pctx *plugin.Context) error {
 	}
 	return nil
 }
+
+// Close releases plugin resources.
+func (w *WordFilter) Close() error { return nil }

--- a/plugin/manager.go
+++ b/plugin/manager.go
@@ -2,6 +2,7 @@ package plugin
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 
@@ -142,14 +143,21 @@ func (m *Manager) RunOnError(ctx context.Context, pctx *Context) {
 // global TracerProvider is installed the span is a no-op and adds
 // effectively zero overhead. The span records the rejection outcome
 // via ferro.plugin.outcome / ferro.plugin.reason attributes.
-func (m *Manager) executePlugin(ctx context.Context, p Plugin, pctx *Context, stage string) error {
+func (m *Manager) executePlugin(ctx context.Context, p Plugin, pctx *Context, stage string) (err error) {
 	spanName := "plugin." + stage + "." + p.Name()
 	ctx, span := pluginTracer().Start(ctx, spanName, trace.WithAttributes(
 		pluginAttrs(p.Name(), string(p.Type()), stage)...,
 	))
-	defer span.End()
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			err = fmt.Errorf("plugin %s panicked at %s: %v", p.Name(), stage, recovered)
+			span.SetAttributes(attribute.String(observability.AttrFerroPluginOutcome, "error"))
+			span.SetStatus(codes.Error, err.Error())
+		}
+		span.End()
+	}()
 
-	err := p.Execute(ctx, pctx)
+	err = p.Execute(ctx, pctx)
 
 	switch {
 	case pctx.Reject:
@@ -162,6 +170,30 @@ func (m *Manager) executePlugin(ctx context.Context, p Plugin, pctx *Context, st
 		span.SetStatus(codes.Error, err.Error())
 	default:
 		span.SetAttributes(attribute.String(observability.AttrFerroPluginOutcome, "ok"))
+	}
+	return err
+}
+
+// Close releases resources for all currently registered plugin registrations
+// and clears the manager. A plugin instance registered in multiple stages will
+// receive one Close call per registration; Plugin implementations must make
+// Close idempotent.
+func (m *Manager) Close() error {
+	m.mu.Lock()
+	plugins := make([]Plugin, 0, len(m.before)+len(m.after)+len(m.onErr))
+	plugins = append(plugins, m.before...)
+	plugins = append(plugins, m.after...)
+	plugins = append(plugins, m.onErr...)
+	m.before = nil
+	m.after = nil
+	m.onErr = nil
+	m.mu.Unlock()
+
+	var err error
+	for _, p := range plugins {
+		if closeErr := p.Close(); closeErr != nil {
+			err = errors.Join(err, fmt.Errorf("plugin %s close failed: %w", p.Name(), closeErr))
+		}
 	}
 	return err
 }

--- a/plugin/manager.go
+++ b/plugin/manager.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"reflect"
+	"runtime/debug"
 	"sync"
 
 	"github.com/ferro-labs/ai-gateway/internal/logging"
@@ -37,15 +39,46 @@ func pluginAttrs(name, kind, stage string) []attribute.KeyValue {
 
 // Manager manages plugin lifecycle and execution.
 type Manager struct {
-	before []Plugin
-	after  []Plugin
-	onErr  []Plugin
-	mu     sync.RWMutex
+	before      []Plugin
+	after       []Plugin
+	onErr       []Plugin
+	mu          sync.RWMutex
+	lifecycleMu sync.Mutex
+	lifecycle   *sync.Cond
+	active      int
+	closed      bool
 }
 
 // NewManager creates a new plugin manager.
 func NewManager() *Manager {
-	return &Manager{}
+	m := &Manager{}
+	m.lifecycle = sync.NewCond(&m.lifecycleMu)
+	return m
+}
+
+// Acquire marks the manager as in use until the returned release function is
+// called. Close waits for active users before releasing plugin resources.
+func (m *Manager) Acquire() func() {
+	m.lifecycleMu.Lock()
+	m.ensureLifecycleLocked()
+	if m.closed {
+		m.lifecycleMu.Unlock()
+		return func() {}
+	}
+	m.active++
+	m.lifecycleMu.Unlock()
+
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			m.lifecycleMu.Lock()
+			m.active--
+			if m.active == 0 {
+				m.lifecycle.Broadcast()
+			}
+			m.lifecycleMu.Unlock()
+		})
+	}
 }
 
 // Register registers a plugin at the given stage.
@@ -150,7 +183,7 @@ func (m *Manager) executePlugin(ctx context.Context, p Plugin, pctx *Context, st
 	))
 	defer func() {
 		if recovered := recover(); recovered != nil {
-			err = fmt.Errorf("plugin %s panicked at %s: %v", p.Name(), stage, recovered)
+			err = fmt.Errorf("plugin %s panicked at %s: %v\n%s", p.Name(), stage, recovered, debug.Stack())
 			span.SetAttributes(attribute.String(observability.AttrFerroPluginOutcome, "error"))
 			span.SetStatus(codes.Error, err.Error())
 		}
@@ -174,11 +207,21 @@ func (m *Manager) executePlugin(ctx context.Context, p Plugin, pctx *Context, st
 	return err
 }
 
-// Close releases resources for all currently registered plugin registrations
-// and clears the manager. A plugin instance registered in multiple stages will
-// receive one Close call per registration; Plugin implementations must make
-// Close idempotent.
+// Close waits for active users, releases each registered plugin instance once,
+// and clears the manager.
 func (m *Manager) Close() error {
+	m.lifecycleMu.Lock()
+	m.ensureLifecycleLocked()
+	for m.active > 0 {
+		m.lifecycle.Wait()
+	}
+	if m.closed {
+		m.lifecycleMu.Unlock()
+		return nil
+	}
+	m.closed = true
+	m.lifecycleMu.Unlock()
+
 	m.mu.Lock()
 	plugins := make([]Plugin, 0, len(m.before)+len(m.after)+len(m.onErr))
 	plugins = append(plugins, m.before...)
@@ -190,12 +233,42 @@ func (m *Manager) Close() error {
 	m.mu.Unlock()
 
 	var err error
-	for _, p := range plugins {
+	for _, p := range uniquePluginInstances(plugins) {
 		if closeErr := p.Close(); closeErr != nil {
 			err = errors.Join(err, fmt.Errorf("plugin %s close failed: %w", p.Name(), closeErr))
 		}
 	}
 	return err
+}
+
+func (m *Manager) ensureLifecycleLocked() {
+	if m.lifecycle == nil {
+		m.lifecycle = sync.NewCond(&m.lifecycleMu)
+	}
+}
+
+func uniquePluginInstances(plugins []Plugin) []Plugin {
+	unique := make([]Plugin, 0, len(plugins))
+	seen := make(map[pluginInstanceKey]struct{}, len(plugins))
+	for _, p := range plugins {
+		v := reflect.ValueOf(p)
+		if v.Kind() != reflect.Pointer || v.IsNil() {
+			unique = append(unique, p)
+			continue
+		}
+		key := pluginInstanceKey{typ: v.Type(), ptr: v.Pointer()}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		unique = append(unique, p)
+	}
+	return unique
+}
+
+type pluginInstanceKey struct {
+	typ reflect.Type
+	ptr uintptr
 }
 
 // HasPlugins returns true if any plugins are registered.

--- a/plugin/manager.go
+++ b/plugin/manager.go
@@ -183,7 +183,14 @@ func (m *Manager) executePlugin(ctx context.Context, p Plugin, pctx *Context, st
 	))
 	defer func() {
 		if recovered := recover(); recovered != nil {
-			err = fmt.Errorf("plugin %s panicked at %s: %v\n%s", p.Name(), stage, recovered, debug.Stack())
+			stack := debug.Stack()
+			err = fmt.Errorf("plugin %s panicked at %s", p.Name(), stage)
+			logging.Logger.Error("plugin panicked",
+				"plugin", p.Name(),
+				"stage", stage,
+				"panic", recovered,
+				"stack", string(stack),
+			)
 			span.SetAttributes(attribute.String(observability.AttrFerroPluginOutcome, "error"))
 			span.SetStatus(codes.Error, err.Error())
 		}
@@ -207,21 +214,41 @@ func (m *Manager) executePlugin(ctx context.Context, p Plugin, pctx *Context, st
 	return err
 }
 
-// Close waits for active users, releases each registered plugin instance once,
-// and clears the manager.
+// Close starts closing the manager, releases each registered plugin instance
+// once, and clears the manager. If requests are still using this manager, Close
+// returns immediately and cleanup runs after the active users drain.
 func (m *Manager) Close() error {
 	m.lifecycleMu.Lock()
 	m.ensureLifecycleLocked()
-	for m.active > 0 {
-		m.lifecycle.Wait()
-	}
 	if m.closed {
 		m.lifecycleMu.Unlock()
 		return nil
 	}
 	m.closed = true
+	if m.active > 0 {
+		m.lifecycleMu.Unlock()
+		go m.closeWhenDrained()
+		return nil
+	}
 	m.lifecycleMu.Unlock()
 
+	return m.closePlugins()
+}
+
+func (m *Manager) closeWhenDrained() {
+	m.lifecycleMu.Lock()
+	m.ensureLifecycleLocked()
+	for m.active > 0 {
+		m.lifecycle.Wait()
+	}
+	m.lifecycleMu.Unlock()
+
+	if err := m.closePlugins(); err != nil {
+		logging.Logger.Warn("deferred plugin close failed", "error", err)
+	}
+}
+
+func (m *Manager) closePlugins() error {
 	m.mu.Lock()
 	plugins := make([]Plugin, 0, len(m.before)+len(m.after)+len(m.onErr))
 	plugins = append(plugins, m.before...)

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -22,6 +22,10 @@ type Plugin interface {
 	Type() PluginType
 	Init(config map[string]interface{}) error
 	Execute(ctx context.Context, pctx *Context) error
+	// Close releases resources owned by the plugin. Implementations should be
+	// safe to close more than once because a single plugin instance may be
+	// registered for multiple lifecycle stages.
+	Close() error
 }
 
 // PluginType categorizes plugins.

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -23,8 +23,7 @@ type Plugin interface {
 	Init(config map[string]interface{}) error
 	Execute(ctx context.Context, pctx *Context) error
 	// Close releases resources owned by the plugin. Implementations should be
-	// safe to close more than once because a single plugin instance may be
-	// registered for multiple lifecycle stages.
+	// safe to close more than once across reload and shutdown paths.
 	Close() error
 }
 

--- a/plugin/plugin_test.go
+++ b/plugin/plugin_test.go
@@ -181,6 +181,9 @@ func TestManager_RunBefore_PanicReturnsError(t *testing.T) {
 	if !strings.Contains(err.Error(), "plugin panic-guard panicked") {
 		t.Fatalf("error = %q, want plugin panic context", err.Error())
 	}
+	if !strings.Contains(err.Error(), "runtime/debug.Stack") {
+		t.Fatalf("error = %q, want panic stack", err.Error())
+	}
 }
 
 func TestManager_RunAfter(t *testing.T) {
@@ -259,15 +262,20 @@ func TestManager_RunAfter_RejectWithErrorAndEmptyReason_UsesErrorMessage(t *test
 
 func TestManager_RunOnError_PanicDoesNotPropagate(t *testing.T) {
 	m := NewManager()
+	called := false
 	_ = m.Register(StageOnError, &mockPlugin{
 		name: "panic-reporter",
 		typ:  TypeLogging,
 		execFn: func(context.Context, *Context) error {
+			called = true
 			panic("reporter failed")
 		},
 	})
 
 	m.RunOnError(context.Background(), NewContext(&providers.Request{Model: "gpt-4o"}))
+	if !called {
+		t.Fatal("expected on-error plugin to run")
+	}
 }
 
 func TestManager_CloseClosesRegisteredPlugins(t *testing.T) {
@@ -290,7 +298,7 @@ func TestManager_CloseClosesRegisteredPlugins(t *testing.T) {
 	}
 }
 
-func TestManager_CloseCallsClosePerRegistration(t *testing.T) {
+func TestManager_CloseCallsCloseOncePerInstance(t *testing.T) {
 	m := NewManager()
 	var closed int
 	p := &mockPlugin{
@@ -307,8 +315,30 @@ func TestManager_CloseCallsClosePerRegistration(t *testing.T) {
 	if err := m.Close(); err != nil {
 		t.Fatalf("Close() error: %v", err)
 	}
+	if closed != 1 {
+		t.Fatalf("closed = %d, want 1 because Close is deduplicated per plugin instance", closed)
+	}
+}
+
+func TestManager_CloseClosesDistinctInstances(t *testing.T) {
+	m := NewManager()
+	var closed int
+	for _, name := range []string{"first", "second"} {
+		_ = m.Register(StageBeforeRequest, &mockPlugin{
+			name: name,
+			typ:  TypeLogging,
+			closeFn: func() error {
+				closed++
+				return nil
+			},
+		})
+	}
+
+	if err := m.Close(); err != nil {
+		t.Fatalf("Close() error: %v", err)
+	}
 	if closed != 2 {
-		t.Fatalf("closed = %d, want 2 because Close is called once per registration", closed)
+		t.Fatalf("closed = %d, want 2 distinct instances closed", closed)
 	}
 }
 

--- a/plugin/plugin_test.go
+++ b/plugin/plugin_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"testing"
 
@@ -14,6 +15,7 @@ type mockPlugin struct {
 	name    string
 	typ     PluginType
 	execFn  func(ctx context.Context, pctx *Context) error
+	closeFn func() error
 	initErr error
 }
 
@@ -23,6 +25,12 @@ func (m *mockPlugin) Init(_ map[string]interface{}) error { return m.initErr }
 func (m *mockPlugin) Execute(ctx context.Context, pctx *Context) error {
 	if m.execFn != nil {
 		return m.execFn(ctx, pctx)
+	}
+	return nil
+}
+func (m *mockPlugin) Close() error {
+	if m.closeFn != nil {
+		return m.closeFn()
 	}
 	return nil
 }
@@ -155,6 +163,26 @@ func TestManager_RunBefore_RejectWithError_FallsBackToErrorMessage(t *testing.T)
 	}
 }
 
+func TestManager_RunBefore_PanicReturnsError(t *testing.T) {
+	m := NewManager()
+	_ = m.Register(StageBeforeRequest, &mockPlugin{
+		name: "panic-guard",
+		typ:  TypeGuardrail,
+		execFn: func(context.Context, *Context) error {
+			panic("boom")
+		},
+	})
+
+	pctx := NewContext(&providers.Request{Model: "gpt-4o"})
+	err := m.RunBefore(context.Background(), pctx)
+	if err == nil {
+		t.Fatal("expected panic to be converted to an error")
+	}
+	if !strings.Contains(err.Error(), "plugin panic-guard panicked") {
+		t.Fatalf("error = %q, want plugin panic context", err.Error())
+	}
+}
+
 func TestManager_RunAfter(t *testing.T) {
 	m := NewManager()
 	called := false
@@ -226,6 +254,61 @@ func TestManager_RunAfter_RejectWithErrorAndEmptyReason_UsesErrorMessage(t *test
 	}
 	if rejection.Reason != "schema mismatch" {
 		t.Fatalf("reason = %q, want %q", rejection.Reason, "schema mismatch")
+	}
+}
+
+func TestManager_RunOnError_PanicDoesNotPropagate(t *testing.T) {
+	m := NewManager()
+	_ = m.Register(StageOnError, &mockPlugin{
+		name: "panic-reporter",
+		typ:  TypeLogging,
+		execFn: func(context.Context, *Context) error {
+			panic("reporter failed")
+		},
+	})
+
+	m.RunOnError(context.Background(), NewContext(&providers.Request{Model: "gpt-4o"}))
+}
+
+func TestManager_CloseClosesRegisteredPlugins(t *testing.T) {
+	m := NewManager()
+	var closed int
+	_ = m.Register(StageBeforeRequest, &mockPlugin{
+		name: "closer",
+		typ:  TypeLogging,
+		closeFn: func() error {
+			closed++
+			return nil
+		},
+	})
+
+	if err := m.Close(); err != nil {
+		t.Fatalf("Close() error: %v", err)
+	}
+	if closed != 1 {
+		t.Fatalf("closed = %d, want 1", closed)
+	}
+}
+
+func TestManager_CloseCallsClosePerRegistration(t *testing.T) {
+	m := NewManager()
+	var closed int
+	p := &mockPlugin{
+		name: "multi-stage",
+		typ:  TypeLogging,
+		closeFn: func() error {
+			closed++
+			return nil
+		},
+	}
+	_ = m.Register(StageBeforeRequest, p)
+	_ = m.Register(StageAfterRequest, p)
+
+	if err := m.Close(); err != nil {
+		t.Fatalf("Close() error: %v", err)
+	}
+	if closed != 2 {
+		t.Fatalf("closed = %d, want 2 because Close is called once per registration", closed)
 	}
 }
 

--- a/plugin/plugin_test.go
+++ b/plugin/plugin_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/ferro-labs/ai-gateway/providers"
 )
@@ -181,8 +182,8 @@ func TestManager_RunBefore_PanicReturnsError(t *testing.T) {
 	if !strings.Contains(err.Error(), "plugin panic-guard panicked") {
 		t.Fatalf("error = %q, want plugin panic context", err.Error())
 	}
-	if !strings.Contains(err.Error(), "runtime/debug.Stack") {
-		t.Fatalf("error = %q, want panic stack", err.Error())
+	if strings.Contains(err.Error(), "runtime/debug.Stack") {
+		t.Fatalf("error = %q, should not expose panic stack", err.Error())
 	}
 }
 
@@ -339,6 +340,48 @@ func TestManager_CloseClosesDistinctInstances(t *testing.T) {
 	}
 	if closed != 2 {
 		t.Fatalf("closed = %d, want 2 distinct instances closed", closed)
+	}
+}
+
+func TestManager_CloseReturnsWhileActiveAndClosesAfterRelease(t *testing.T) {
+	m := NewManager()
+	closed := make(chan struct{})
+	var closeOnce sync.Once
+	_ = m.Register(StageAfterRequest, &mockPlugin{
+		name: "deferred-close",
+		typ:  TypeLogging,
+		closeFn: func() error {
+			closeOnce.Do(func() { close(closed) })
+			return nil
+		},
+	})
+	release := m.Acquire()
+
+	closeReturned := make(chan error, 1)
+	go func() {
+		closeReturned <- m.Close()
+	}()
+
+	select {
+	case err := <-closeReturned:
+		if err != nil {
+			t.Fatalf("Close() error: %v", err)
+		}
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("Close blocked while manager was active")
+	}
+	select {
+	case <-closed:
+		t.Fatal("plugin closed before active manager user released")
+	default:
+	}
+
+	release()
+
+	select {
+	case <-closed:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for deferred plugin close")
 	}
 }
 

--- a/plugin/registry_test.go
+++ b/plugin/registry_test.go
@@ -16,6 +16,7 @@ func (m *registryMockPlugin) Name() string                                { retu
 func (m *registryMockPlugin) Type() PluginType                            { return m.typ }
 func (m *registryMockPlugin) Init(_ map[string]interface{}) error         { return nil }
 func (m *registryMockPlugin) Execute(_ context.Context, _ *Context) error { return nil }
+func (m *registryMockPlugin) Close() error                                { return nil }
 
 func TestRegisterFactory(t *testing.T) {
 	// Clean up after test.


### PR DESCRIPTION
## Summary

Hardens the plugin pipeline so panicking plugins return errors, after-request rejections trigger `RunOnError`, and plugin resources are closed during reload/shutdown.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] New provider
- [ ] New plugin
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Performance improvement
- [x] Refactor / code quality
- [ ] Documentation / comments only
- [ ] CI / tooling

## Related issues

Fixes #150

## Changes

- Add `Plugin.Close() error` and close plugin managers on config reload and gateway shutdown.
- Recover panics inside plugin execution and return them as plugin errors.
- Run `RunOnError` when after-request plugins reject non-streaming responses.
- Snapshot the plugin manager pointer for request execution to avoid reload/request races.
- Add regression coverage for panic recovery, after-stage rejection handling, reload cleanup, and duplicate-stage close behavior.

## Testing

- [x] Existing tests pass (`go test ./...`)
- [x] New unit tests added (if applicable)
- [ ] Manually tested against a live provider (if provider change)

Commands run:

- `go test ./plugin -run 'TestManager_RunBefore_PanicReturnsError|TestManager_RunOnError_PanicDoesNotPropagate|TestManager_CloseClosesRegisteredPlugins|TestManager_CloseCallsClosePerRegistration'`
- `go test . -run 'TestGateway_Route_AfterPluginRejectRunsOnError|TestGateway_ReloadConfig_ClosesOldPlugins'`
- `go test -race ./plugin`
- `go test -race .`
- `go test ./...`
- `FERRO_MODEL_CATALOG_URL=http://127.0.0.1:1/catalog.json make test`

## Provider checklist (fill in only for new/updated providers)

- [ ] Provider file at `providers/<id>/<id>.go`
- [ ] Test file at `providers/<id>/<id>_test.go`
- [ ] `ProviderEntry` added to `providers/providers_list.go`
- [ ] Name constant added to `providers/names.go`
- [ ] Models added to `ferro-labs/model-catalog` when catalog coverage changes
- [ ] `AllowedTools`, `MaxCallDepth` and streaming tested

## Plugin checklist (fill in only for new/updated plugins)

- [x] Plugin file at `internal/plugins/<name>/`
- [x] `Stage` (before/after request) correctly set
- [x] Test coverage added
- [ ] Example config documented

## Breaking change notes

`plugin.Plugin` now requires `Close() error`. External plugin implementations need to add an idempotent `Close` method.

## Screenshots / output (optional)

The full short/race suite passed with `FERRO_MODEL_CATALOG_URL=http://127.0.0.1:1/catalog.json make test`.
