### PR TITLE
feat(providers): add ZAI provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,16 @@ bin/
 # Superpowers brainstorm sessions and internal planning docs
 .superpowers/
 docs/superpowers/
+.env.*
+!.env.example
+.DS_Store
+node_modules/
+.venv/
+venv/
+.cache/
+dist/
+build/
+
+# Local dev-tooling scaffold (superset-dev-watch-development daemon)
+.superset/
+CODEX.md

--- a/providers/names.go
+++ b/providers/names.go
@@ -31,6 +31,7 @@ import (
 	togetherpkg "github.com/ferro-labs/ai-gateway/providers/together"
 	vertexaipkg "github.com/ferro-labs/ai-gateway/providers/vertex_ai"
 	xaipkg "github.com/ferro-labs/ai-gateway/providers/xai"
+	zaipkg "github.com/ferro-labs/ai-gateway/providers/zai"
 )
 
 // Canonical provider name constants.
@@ -138,6 +139,9 @@ const (
 
 	// NameOpenRouter is the canonical name for the OpenRouter provider.
 	NameOpenRouter = openrouterpkg.Name
+
+	// NameZAI is the canonical name for the Z.ai (Zhipu AI) provider.
+	NameZAI = zaipkg.Name
 )
 
 // AllProviderNames returns every registered canonical provider name in a
@@ -175,5 +179,6 @@ func AllProviderNames() []string {
 		NameTogether,
 		NameVertexAI,
 		NameXAI,
+		NameZAI,
 	}
 }

--- a/providers/providers_list.go
+++ b/providers/providers_list.go
@@ -34,6 +34,7 @@ import (
 	togetherpkg "github.com/ferro-labs/ai-gateway/providers/together"
 	vertexaipkg "github.com/ferro-labs/ai-gateway/providers/vertex_ai"
 	xaipkg "github.com/ferro-labs/ai-gateway/providers/xai"
+	zaipkg "github.com/ferro-labs/ai-gateway/providers/zai"
 )
 
 // allProviders is the canonical ordered registry of all built-in providers.
@@ -435,6 +436,17 @@ var allProviders = []ProviderEntry{
 		},
 		Build: func(cfg ProviderConfig) (Provider, error) {
 			return xaipkg.New(cfg[CfgKeyAPIKey], cfg[CfgKeyBaseURL])
+		},
+	},
+	{
+		ID:           NameZAI,
+		Capabilities: []string{CapabilityChat, CapabilityStream, CapabilityDiscovery, CapabilityProxy},
+		EnvMappings: []EnvMapping{
+			{CfgKeyAPIKey, "ZAI_API_KEY", true},
+			{CfgKeyBaseURL, "ZAI_BASE_URL", false},
+		},
+		Build: func(cfg ProviderConfig) (Provider, error) {
+			return zaipkg.New(cfg[CfgKeyAPIKey], cfg[CfgKeyBaseURL])
 		},
 	},
 }

--- a/providers/stability_test.go
+++ b/providers/stability_test.go
@@ -31,6 +31,7 @@ import (
 	togetherpkg "github.com/ferro-labs/ai-gateway/providers/together"
 	vertexaipkg "github.com/ferro-labs/ai-gateway/providers/vertex_ai"
 	xaipkg "github.com/ferro-labs/ai-gateway/providers/xai"
+	zaipkg "github.com/ferro-labs/ai-gateway/providers/zai"
 	"slices"
 	"testing"
 )
@@ -393,6 +394,17 @@ func providerNameStabilityExtensionCases() []providerNameStabilityCase {
 				p, err := xaipkg.New(testAPIKey, "")
 				if err != nil {
 					t.Fatalf("NewXAI: %v", err)
+				}
+				return p
+			},
+		},
+		{
+			wantName: NameZAI,
+			build: func(t *testing.T) Provider {
+				t.Helper()
+				p, err := zaipkg.New(testAPIKey, "")
+				if err != nil {
+					t.Fatalf("NewZAI: %v", err)
 				}
 				return p
 			},

--- a/providers/zai/zai.go
+++ b/providers/zai/zai.go
@@ -1,0 +1,109 @@
+// Package zai provides a client for the Z.ai (Zhipu AI) API.
+package zai
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	discov "github.com/ferro-labs/ai-gateway/internal/discovery"
+	providerhttp "github.com/ferro-labs/ai-gateway/internal/httpclient"
+	"github.com/ferro-labs/ai-gateway/internal/openaicompat"
+	"github.com/ferro-labs/ai-gateway/providers/core"
+)
+
+const (
+	// Name is the canonical identifier for the Z.ai provider.
+	// Re-exported as providers.NameZAI in providers/names.go.
+	Name           = "zai"
+	defaultBaseURL = "https://api.z.ai/api/paas/v4"
+)
+
+// Provider implements the core.Provider interface for Z.ai.
+type Provider struct {
+	name       string
+	apiKey     string
+	baseURL    string
+	httpClient *http.Client
+}
+
+// Compile-time interface assertions.
+var (
+	_ core.Provider          = (*Provider)(nil)
+	_ core.StreamProvider    = (*Provider)(nil)
+	_ core.ProxiableProvider = (*Provider)(nil)
+	_ core.DiscoveryProvider = (*Provider)(nil)
+)
+
+// New creates a new Z.ai provider.
+func New(apiKey, baseURL string) (*Provider, error) {
+	if baseURL == "" {
+		baseURL = defaultBaseURL
+	}
+	baseURL = strings.TrimRight(baseURL, "/")
+	return &Provider{
+		name:       Name,
+		apiKey:     apiKey,
+		baseURL:    baseURL,
+		httpClient: providerhttp.ForProvider(Name),
+	}, nil
+}
+
+// Name implements core.Provider.
+func (p *Provider) Name() string { return p.name }
+
+// BaseURL implements core.ProxiableProvider.
+func (p *Provider) BaseURL() string { return p.baseURL }
+
+// AuthHeaders implements core.ProxiableProvider.
+func (p *Provider) AuthHeaders() map[string]string {
+	return map[string]string{"Authorization": "Bearer " + p.apiKey}
+}
+
+// SupportedModels returns a static list of known Z.ai models.
+func (p *Provider) SupportedModels() []string {
+	return []string{
+		"glm-5.1",
+		"glm-5-turbo",
+		"glm-5",
+		"glm-4.7",
+		"glm-4.6",
+		"glm-4.5",
+		"glm-4.5-air",
+	}
+}
+
+// SupportsModel returns true for any Z.ai model name.
+func (p *Provider) SupportsModel(_ string) bool { return true }
+
+// Models returns structured model metadata.
+func (p *Provider) Models() []core.ModelInfo {
+	return core.ModelsFromList(p.name, p.SupportedModels())
+}
+
+// DiscoverModels fetches the live model list from the Z.ai /models endpoint.
+func (p *Provider) DiscoverModels(ctx context.Context) ([]core.ModelInfo, error) {
+	return discov.DiscoverOpenAICompatibleModels(ctx, p.httpClient, p.baseURL+"/models", p.apiKey, p.name)
+}
+
+// Complete sends a chat completion request to Z.ai.
+func (p *Provider) Complete(ctx context.Context, req core.Request) (*core.Response, error) {
+	return openaicompat.PostChat(ctx, openaicompat.ChatParams{
+		HTTPClient: p.httpClient,
+		URL:        p.baseURL + "/chat/completions",
+		Provider:   p.name,
+		Label:      "zai",
+		Headers:    map[string]string{"Authorization": "Bearer " + p.apiKey, "Content-Type": "application/json"},
+	}, req)
+}
+
+// CompleteStream sends a streaming chat completion request to Z.ai.
+func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan core.StreamChunk, error) {
+	return openaicompat.PostStream(ctx, openaicompat.ChatParams{
+		HTTPClient: p.httpClient,
+		URL:        p.baseURL + "/chat/completions",
+		Provider:   p.name,
+		Label:      "zai",
+		Headers:    map[string]string{"Authorization": "Bearer " + p.apiKey, "Content-Type": "application/json"},
+	}, req)
+}

--- a/providers/zai/zai_test.go
+++ b/providers/zai/zai_test.go
@@ -1,0 +1,137 @@
+package zai
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/ferro-labs/ai-gateway/providers/core"
+)
+
+const testBearerAPIKey = "Bearer test-key"
+
+func TestNewZAI(t *testing.T) {
+	p, err := New("test-key", "")
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+	if p.Name() != "zai" {
+		t.Errorf("Name() = %q, want zai", p.Name())
+	}
+}
+
+func TestZAIProvider_SupportedModels(t *testing.T) {
+	p, _ := New("test-key", "")
+	models := p.SupportedModels()
+	if len(models) == 0 {
+		t.Error("SupportedModels() returned empty")
+	}
+	found := false
+	for _, m := range models {
+		if m == "glm-5.1" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("glm-5.1 not found in SupportedModels")
+	}
+}
+
+func TestZAIProvider_SupportsModel(t *testing.T) {
+	p, _ := New("test-key", "")
+	if !p.SupportsModel("glm-5.1") {
+		t.Error("expected glm-5.1 to be supported")
+	}
+	if !p.SupportsModel("custom-model") {
+		t.Error("passthrough: expected all models to return true")
+	}
+}
+
+func TestZAIProvider_Models(t *testing.T) {
+	p, _ := New("test-key", "")
+	models := p.Models()
+	for _, m := range models {
+		if m.OwnedBy != "zai" {
+			t.Errorf("ModelInfo.OwnedBy = %q, want zai", m.OwnedBy)
+		}
+	}
+}
+
+func TestZAIProvider_CompleteStream_Interface(_ *testing.T) {
+	p, _ := New("test-key", "")
+	var _ core.StreamProvider = p
+}
+
+func TestZAIProvider_AuthHeaders(t *testing.T) {
+	p, _ := New("test-key", "")
+	headers := p.AuthHeaders()
+	if headers["Authorization"] != testBearerAPIKey {
+		t.Errorf("AuthHeaders Authorization = %q, want %s", headers["Authorization"], testBearerAPIKey)
+	}
+}
+
+func TestZAIProvider_CompleteStream_MockSSE(t *testing.T) {
+	sseData := "data: {\"id\":\"cmpl-1\",\"model\":\"glm-5.1\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\"},\"finish_reason\":\"\"}]}\n\n" +
+		"data: {\"id\":\"cmpl-1\",\"model\":\"glm-5.1\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"Hello\"},\"finish_reason\":\"\"}]}\n\n" +
+		"data: {\"id\":\"cmpl-1\",\"model\":\"glm-5.1\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\" there\"},\"finish_reason\":\"\"}]}\n\n" +
+		"data: {\"id\":\"cmpl-1\",\"model\":\"glm-5.1\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n" +
+		"data: [DONE]\n\n"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(sseData))
+	}))
+	defer srv.Close()
+
+	p, _ := New("test-key", srv.URL)
+	ch, err := p.CompleteStream(context.Background(), core.Request{
+		Model:    "glm-5.1",
+		Messages: []core.Message{{Role: "user", Content: "Hi"}},
+	})
+	if err != nil {
+		t.Fatalf("CompleteStream() error: %v", err)
+	}
+
+	var chunks []core.StreamChunk
+	for c := range ch {
+		chunks = append(chunks, c)
+	}
+
+	if len(chunks) < 3 {
+		t.Fatalf("expected at least 3 chunks, got %d", len(chunks))
+	}
+	if chunks[1].Choices[0].Delta.Content != "Hello" {
+		t.Errorf("delta content = %q, want Hello", chunks[1].Choices[0].Delta.Content)
+	}
+	if chunks[2].Choices[0].Delta.Content != " there" {
+		t.Errorf("delta content = %q, want ' there'", chunks[2].Choices[0].Delta.Content)
+	}
+}
+
+func TestZAIProvider_Complete_MockHTTP(t *testing.T) {
+	respBody := `{"id":"cmpl-1","model":"glm-5.1","choices":[{"index":0,"message":{"role":"assistant","content":"Hello!"},"finish_reason":"stop"}],"usage":{"prompt_tokens":5,"completion_tokens":2,"total_tokens":7}}`
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(respBody))
+	}))
+	defer srv.Close()
+
+	p, _ := New("test-key", srv.URL)
+	resp, err := p.Complete(context.Background(), core.Request{
+		Model:    "glm-5.1",
+		Messages: []core.Message{{Role: "user", Content: "Hi"}},
+	})
+	if err != nil {
+		t.Fatalf("Complete() error: %v", err)
+	}
+	if resp.ID != "cmpl-1" {
+		t.Errorf("Response.ID = %q, want cmpl-1", resp.ID)
+	}
+	if len(resp.Choices) == 0 {
+		t.Error("expected at least one choice")
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `providers/zai` — a direct single-vendor integration with **Z.ai** (`api.z.ai`), serving the Zhipu AI **GLM** model family
- Implements `core.Provider`, `core.StreamProvider`, `core.ProxiableProvider`, and `core.DiscoveryProvider` via the existing `internal/openaicompat` helpers (same pattern as xAI, Moonshot, etc.)
- Models: `glm-5.1`, `glm-5-turbo`, `glm-5`, `glm-4.7`, `glm-4.6`, `glm-4.5`, `glm-4.5-air` — sourced from live `/models` endpoint verification
- Env var: `ZAI_API_KEY` (+ optional `ZAI_BASE_URL`)

This is a **direct single-vendor** provider (not an aggregator), so it avoids any aggregator-design concerns raised in the broader review of #226.

Splits the ZAI portion of #230 into its own PR as requested by @MitulShah1.

## Test plan

- [x] `go build ./...` passes
- [x] Unit tests in `providers/zai/zai_test.go` cover `New`, `SupportedModels`, `SupportsModel`, `Models`, `AuthHeaders`, mock SSE streaming, and mock HTTP non-streaming
- [x] `providers/stability_test.go` extended with `NameZAI` stability case

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the Z.ai (Zhipu AI) provider with chat, streaming, model discovery, and proxy support.
  * Z.ai is now selectable in the built-in provider list; configure via `ZAI_API_KEY` (required) and `ZAI_BASE_URL` (optional).
* **Bug Fixes**
  * Ensured Z.ai provider naming matches its canonical provider name.
  * Expanded automated tests for authentication, model listing, non-streaming responses, and streaming output.
* **Chores**
  * Updated ignore rules for common local and generated artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->