### PR TITLE
feat(providers): add per-provider concurrency limiting via worker pool (#248)

### DIFF
--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ferro-labs/ai-gateway/internal/ratelimit"
 	"github.com/ferro-labs/ai-gateway/internal/version"
 	"github.com/ferro-labs/ai-gateway/providers"
+	"github.com/ferro-labs/ai-gateway/providers/concurrency"
 	bedrockpkg "github.com/ferro-labs/ai-gateway/providers/bedrock"
 )
 
@@ -234,6 +235,19 @@ func RegisterProviders() *providers.Registry {
 		if err != nil {
 			logging.Logger.Error("provider init failed", "provider", entry.ID, "error", err)
 			os.Exit(1)
+		}
+		if mc := cfg[providers.CfgKeyMaxConcurrency]; mc != "" {
+			workerCount, _ := strconv.Atoi(mc)
+			queueSize := 1000
+			if qs := cfg[providers.CfgKeyQueueSize]; qs != "" {
+				if n, err2 := strconv.Atoi(qs); err2 == nil && n > 0 {
+					queueSize = n
+				}
+			}
+			if workerCount > 0 {
+				p = concurrency.Wrap(p, workerCount, queueSize)
+				logging.Logger.Info("provider concurrency limit applied", "provider", entry.ID, "workers", workerCount, "queue", queueSize)
+			}
 		}
 		registry.Register(p)
 		logging.Logger.Info("provider registered", "provider", entry.ID)

--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -28,7 +28,7 @@ func Serve() {
 	logging.Setup(os.Getenv("LOG_LEVEL"), os.Getenv("LOG_FORMAT"))
 
 	cfg := LoadConfig()
-	registry := RegisterProviders()
+	registry, closeProviders := RegisterProviders()
 	masterKey := ResolveMasterKey()
 
 	if strings.EqualFold(strings.TrimSpace(os.Getenv("ALLOW_UNAUTHENTICATED_PROXY")), "true") {
@@ -136,6 +136,8 @@ func Serve() {
 	}
 	cancel()
 
+	closeProviders()
+
 	if err := httpserver.CloseResources(
 		httpserver.NamedResource{Name: "gateway", Value: gw},
 		httpserver.NamedResource{Name: "config manager", Value: cfgManager},
@@ -217,8 +219,11 @@ func LoadConfig() *aigateway.Config {
 }
 
 // RegisterProviders auto-registers all providers found via environment variables.
-func RegisterProviders() *providers.Registry {
+// It returns the registry and a cleanup function that closes any concurrency-
+// limited provider wrappers; call the cleanup function during graceful shutdown.
+func RegisterProviders() (*providers.Registry, func()) {
 	registry := providers.NewRegistry()
+	var limitedProviders []*concurrency.LimitedProvider
 
 	// Register all providers whose required environment variables are set.
 	for _, entry := range providers.AllProviders() {
@@ -237,15 +242,19 @@ func RegisterProviders() *providers.Registry {
 			os.Exit(1)
 		}
 		if mc := cfg[providers.CfgKeyMaxConcurrency]; mc != "" {
-			workerCount, _ := strconv.Atoi(mc)
-			queueSize := 1000
-			if qs := cfg[providers.CfgKeyQueueSize]; qs != "" {
-				if n, err2 := strconv.Atoi(qs); err2 == nil && n > 0 {
-					queueSize = n
+			workerCount, wcErr := strconv.Atoi(mc)
+			if wcErr != nil || workerCount <= 0 {
+				logging.Logger.Warn("invalid max_concurrency value, skipping concurrency limit", "provider", entry.ID, "value", mc)
+			} else {
+				queueSize := 1000
+				if qs := cfg[providers.CfgKeyQueueSize]; qs != "" {
+					if n, err2 := strconv.Atoi(qs); err2 == nil && n > 0 {
+						queueSize = n
+					}
 				}
-			}
-			if workerCount > 0 {
-				p = concurrency.Wrap(p, workerCount, queueSize)
+				lp := concurrency.Wrap(p, workerCount, queueSize)
+				limitedProviders = append(limitedProviders, lp)
+				p = lp
 				logging.Logger.Info("provider concurrency limit applied", "provider", entry.ID, "workers", workerCount, "queue", queueSize)
 			}
 		}
@@ -273,7 +282,12 @@ func RegisterProviders() *providers.Registry {
 		}
 	}
 
-	return registry
+	cleanup := func() {
+		for _, lp := range limitedProviders {
+			lp.Close()
+		}
+	}
+	return registry, cleanup
 }
 
 // BuildGateway constructs the Gateway, wires providers, and loads plugins.

--- a/providers/concurrency/limited.go
+++ b/providers/concurrency/limited.go
@@ -3,20 +3,22 @@
 //
 // Pattern mirrors Bifrost (github.com/maximhq/bifrost): N worker goroutines
 // drain a buffered channel of jobs. The channel buffer is the queue; the
-// goroutine count is the concurrency cap. No explicit semaphore is needed —
-// the bounded goroutine pool + bounded channel act as a two-level gate.
+// goroutine count is the concurrency cap per operation type. No explicit
+// semaphore is needed — the bounded goroutine pool + bounded channel act as a
+// two-level gate.
 package concurrency
 
 import (
 	"context"
 	"errors"
 	"sync"
+	"sync/atomic"
 
 	"github.com/ferro-labs/ai-gateway/providers/core"
 )
 
 // ErrQueueFull is returned when the provider queue is at capacity and the
-// request cannot be accepted without blocking indefinitely.
+// request cannot be accepted without blocking.
 var ErrQueueFull = errors.New("provider concurrency queue full")
 
 type completionResult struct {
@@ -53,8 +55,9 @@ type embedJob struct {
 }
 
 // LimitedProvider wraps a Provider and enforces per-provider concurrency limits.
-// It implements Provider (and optionally StreamProvider / EmbeddingProvider)
-// transparently — callers do not need to know a limit is in place.
+// It implements Provider (and optionally StreamProvider / EmbeddingProvider /
+// ProxiableProvider / DiscoveryProvider / ImageProvider) transparently —
+// callers do not need to know a limit is in place.
 type LimitedProvider struct {
 	inner core.Provider
 
@@ -62,14 +65,16 @@ type LimitedProvider struct {
 	streamQueue   chan streamJob
 	embedQueue    chan embedJob
 
-	done chan struct{}
-	once sync.Once
+	closing atomic.Bool
+	done    chan struct{}
+	once    sync.Once
 }
 
 // Wrap creates a LimitedProvider around inner with the given concurrency and
-// queue sizes. workerCount is the number of goroutines (= max simultaneous
-// upstream calls). queueSize is the channel buffer depth (= max waiting
-// requests). Call Close() to shut down workers cleanly.
+// queue sizes. workerCount is the number of worker goroutines per operation
+// type (complete / stream / embed each get their own pool of workerCount
+// goroutines). queueSize is the channel buffer depth per queue.
+// Call Close() to shut down workers cleanly.
 func Wrap(inner core.Provider, workerCount, queueSize int) *LimitedProvider {
 	lp := &LimitedProvider{
 		inner:         inner,
@@ -85,29 +90,40 @@ func Wrap(inner core.Provider, workerCount, queueSize int) *LimitedProvider {
 
 	for range workerCount {
 		go lp.completionWorker()
-		if lp.streamQueue != nil {
+	}
+	if lp.streamQueue != nil {
+		for range workerCount {
 			go lp.streamWorker()
 		}
-		if lp.embedQueue != nil {
+	}
+	if lp.embedQueue != nil {
+		for range workerCount {
 			go lp.embedWorker()
 		}
 	}
 	return lp
 }
 
-// Close signals all workers to stop after draining in-flight work.
+// Close signals all workers to stop. Jobs already enqueued are drained and
+// rejected with a shutdown error. New calls after Close() return immediately.
 func (lp *LimitedProvider) Close() {
-	lp.once.Do(func() { close(lp.done) })
+	lp.once.Do(func() {
+		lp.closing.Store(true)
+		close(lp.done)
+	})
 }
 
 // --- Provider interface ---
 
-func (lp *LimitedProvider) Name() string            { return lp.inner.Name() }
+func (lp *LimitedProvider) Name() string              { return lp.inner.Name() }
 func (lp *LimitedProvider) SupportedModels() []string { return lp.inner.SupportedModels() }
 func (lp *LimitedProvider) SupportsModel(m string) bool { return lp.inner.SupportsModel(m) }
-func (lp *LimitedProvider) Models() []core.ModelInfo   { return lp.inner.Models() }
+func (lp *LimitedProvider) Models() []core.ModelInfo  { return lp.inner.Models() }
 
 func (lp *LimitedProvider) Complete(ctx context.Context, req core.Request) (*core.Response, error) {
+	if lp.closing.Load() {
+		return nil, errors.New("provider shutting down")
+	}
 	job := completionJob{
 		ctx:      ctx,
 		req:      req,
@@ -120,14 +136,7 @@ func (lp *LimitedProvider) Complete(ctx context.Context, req core.Request) (*cor
 	case <-ctx.Done():
 		return nil, ctx.Err()
 	default:
-		// Queue full — non-blocking fast path.
-		select {
-		case lp.completeQueue <- job:
-		case <-lp.done:
-			return nil, errors.New("provider shutting down")
-		case <-ctx.Done():
-			return nil, ctx.Err()
-		}
+		return nil, ErrQueueFull
 	}
 	select {
 	case res := <-job.response:
@@ -143,6 +152,9 @@ func (lp *LimitedProvider) CompleteStream(ctx context.Context, req core.Request)
 	if lp.streamQueue == nil {
 		return nil, errors.New("inner provider does not support streaming")
 	}
+	if lp.closing.Load() {
+		return nil, errors.New("provider shutting down")
+	}
 	job := streamJob{
 		ctx:      ctx,
 		req:      req,
@@ -154,6 +166,8 @@ func (lp *LimitedProvider) CompleteStream(ctx context.Context, req core.Request)
 		return nil, errors.New("provider shutting down")
 	case <-ctx.Done():
 		return nil, ctx.Err()
+	default:
+		return nil, ErrQueueFull
 	}
 	select {
 	case res := <-job.response:
@@ -169,6 +183,9 @@ func (lp *LimitedProvider) Embed(ctx context.Context, req core.EmbeddingRequest)
 	if lp.embedQueue == nil {
 		return nil, errors.New("inner provider does not support embeddings")
 	}
+	if lp.closing.Load() {
+		return nil, errors.New("provider shutting down")
+	}
 	job := embedJob{
 		ctx:      ctx,
 		req:      req,
@@ -180,6 +197,8 @@ func (lp *LimitedProvider) Embed(ctx context.Context, req core.EmbeddingRequest)
 		return nil, errors.New("provider shutting down")
 	case <-ctx.Done():
 		return nil, ctx.Err()
+	default:
+		return nil, ErrQueueFull
 	}
 	select {
 	case res := <-job.response:
@@ -187,6 +206,40 @@ func (lp *LimitedProvider) Embed(ctx context.Context, req core.EmbeddingRequest)
 	case <-ctx.Done():
 		return nil, ctx.Err()
 	}
+}
+
+// --- ProxiableProvider (forwarded directly — not queue-gated) ---
+
+func (lp *LimitedProvider) BaseURL() string {
+	if pp, ok := lp.inner.(core.ProxiableProvider); ok {
+		return pp.BaseURL()
+	}
+	return ""
+}
+
+func (lp *LimitedProvider) AuthHeaders() map[string]string {
+	if pp, ok := lp.inner.(core.ProxiableProvider); ok {
+		return pp.AuthHeaders()
+	}
+	return nil
+}
+
+// --- DiscoveryProvider (forwarded directly — not queue-gated) ---
+
+func (lp *LimitedProvider) DiscoverModels(ctx context.Context) ([]core.ModelInfo, error) {
+	if dp, ok := lp.inner.(core.DiscoveryProvider); ok {
+		return dp.DiscoverModels(ctx)
+	}
+	return nil, errors.New("inner provider does not support model discovery")
+}
+
+// --- ImageProvider (forwarded directly — not queue-gated) ---
+
+func (lp *LimitedProvider) GenerateImage(ctx context.Context, req core.ImageRequest) (*core.ImageResponse, error) {
+	if ip, ok := lp.inner.(core.ImageProvider); ok {
+		return ip.GenerateImage(ctx, req)
+	}
+	return nil, errors.New("inner provider does not support image generation")
 }
 
 // --- Workers ---

--- a/providers/concurrency/limited.go
+++ b/providers/concurrency/limited.go
@@ -1,0 +1,251 @@
+// Package concurrency provides a transparent Provider wrapper that gates
+// concurrent upstream calls to a configurable worker pool + queue.
+//
+// Pattern mirrors Bifrost (github.com/maximhq/bifrost): N worker goroutines
+// drain a buffered channel of jobs. The channel buffer is the queue; the
+// goroutine count is the concurrency cap. No explicit semaphore is needed —
+// the bounded goroutine pool + bounded channel act as a two-level gate.
+package concurrency
+
+import (
+	"context"
+	"errors"
+	"sync"
+
+	"github.com/ferro-labs/ai-gateway/providers/core"
+)
+
+// ErrQueueFull is returned when the provider queue is at capacity and the
+// request cannot be accepted without blocking indefinitely.
+var ErrQueueFull = errors.New("provider concurrency queue full")
+
+type completionResult struct {
+	resp *core.Response
+	err  error
+}
+
+type completionJob struct {
+	ctx      context.Context
+	req      core.Request
+	response chan completionResult
+}
+
+type streamResult struct {
+	ch  <-chan core.StreamChunk
+	err error
+}
+
+type streamJob struct {
+	ctx      context.Context
+	req      core.Request
+	response chan streamResult
+}
+
+type embedResult struct {
+	resp *core.EmbeddingResponse
+	err  error
+}
+
+type embedJob struct {
+	ctx      context.Context
+	req      core.EmbeddingRequest
+	response chan embedResult
+}
+
+// LimitedProvider wraps a Provider and enforces per-provider concurrency limits.
+// It implements Provider (and optionally StreamProvider / EmbeddingProvider)
+// transparently — callers do not need to know a limit is in place.
+type LimitedProvider struct {
+	inner core.Provider
+
+	completeQueue chan completionJob
+	streamQueue   chan streamJob
+	embedQueue    chan embedJob
+
+	done chan struct{}
+	once sync.Once
+}
+
+// Wrap creates a LimitedProvider around inner with the given concurrency and
+// queue sizes. workerCount is the number of goroutines (= max simultaneous
+// upstream calls). queueSize is the channel buffer depth (= max waiting
+// requests). Call Close() to shut down workers cleanly.
+func Wrap(inner core.Provider, workerCount, queueSize int) *LimitedProvider {
+	lp := &LimitedProvider{
+		inner:         inner,
+		completeQueue: make(chan completionJob, queueSize),
+		done:          make(chan struct{}),
+	}
+	if _, ok := inner.(core.StreamProvider); ok {
+		lp.streamQueue = make(chan streamJob, queueSize)
+	}
+	if _, ok := inner.(core.EmbeddingProvider); ok {
+		lp.embedQueue = make(chan embedJob, queueSize)
+	}
+
+	for range workerCount {
+		go lp.completionWorker()
+		if lp.streamQueue != nil {
+			go lp.streamWorker()
+		}
+		if lp.embedQueue != nil {
+			go lp.embedWorker()
+		}
+	}
+	return lp
+}
+
+// Close signals all workers to stop after draining in-flight work.
+func (lp *LimitedProvider) Close() {
+	lp.once.Do(func() { close(lp.done) })
+}
+
+// --- Provider interface ---
+
+func (lp *LimitedProvider) Name() string            { return lp.inner.Name() }
+func (lp *LimitedProvider) SupportedModels() []string { return lp.inner.SupportedModels() }
+func (lp *LimitedProvider) SupportsModel(m string) bool { return lp.inner.SupportsModel(m) }
+func (lp *LimitedProvider) Models() []core.ModelInfo   { return lp.inner.Models() }
+
+func (lp *LimitedProvider) Complete(ctx context.Context, req core.Request) (*core.Response, error) {
+	job := completionJob{
+		ctx:      ctx,
+		req:      req,
+		response: make(chan completionResult, 1),
+	}
+	select {
+	case lp.completeQueue <- job:
+	case <-lp.done:
+		return nil, errors.New("provider shutting down")
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+		// Queue full — non-blocking fast path.
+		select {
+		case lp.completeQueue <- job:
+		case <-lp.done:
+			return nil, errors.New("provider shutting down")
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+	select {
+	case res := <-job.response:
+		return res.resp, res.err
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+// --- StreamProvider ---
+
+func (lp *LimitedProvider) CompleteStream(ctx context.Context, req core.Request) (<-chan core.StreamChunk, error) {
+	if lp.streamQueue == nil {
+		return nil, errors.New("inner provider does not support streaming")
+	}
+	job := streamJob{
+		ctx:      ctx,
+		req:      req,
+		response: make(chan streamResult, 1),
+	}
+	select {
+	case lp.streamQueue <- job:
+	case <-lp.done:
+		return nil, errors.New("provider shutting down")
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+	select {
+	case res := <-job.response:
+		return res.ch, res.err
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+// --- EmbeddingProvider ---
+
+func (lp *LimitedProvider) Embed(ctx context.Context, req core.EmbeddingRequest) (*core.EmbeddingResponse, error) {
+	if lp.embedQueue == nil {
+		return nil, errors.New("inner provider does not support embeddings")
+	}
+	job := embedJob{
+		ctx:      ctx,
+		req:      req,
+		response: make(chan embedResult, 1),
+	}
+	select {
+	case lp.embedQueue <- job:
+	case <-lp.done:
+		return nil, errors.New("provider shutting down")
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+	select {
+	case res := <-job.response:
+		return res.resp, res.err
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+// --- Workers ---
+
+func (lp *LimitedProvider) completionWorker() {
+	for {
+		select {
+		case job := <-lp.completeQueue:
+			resp, err := lp.inner.Complete(job.ctx, job.req)
+			job.response <- completionResult{resp: resp, err: err}
+		case <-lp.done:
+			for {
+				select {
+				case job := <-lp.completeQueue:
+					job.response <- completionResult{err: errors.New("provider shutting down")}
+				default:
+					return
+				}
+			}
+		}
+	}
+}
+
+func (lp *LimitedProvider) streamWorker() {
+	sp := lp.inner.(core.StreamProvider)
+	for {
+		select {
+		case job := <-lp.streamQueue:
+			ch, err := sp.CompleteStream(job.ctx, job.req)
+			job.response <- streamResult{ch: ch, err: err}
+		case <-lp.done:
+			for {
+				select {
+				case job := <-lp.streamQueue:
+					job.response <- streamResult{err: errors.New("provider shutting down")}
+				default:
+					return
+				}
+			}
+		}
+	}
+}
+
+func (lp *LimitedProvider) embedWorker() {
+	ep := lp.inner.(core.EmbeddingProvider)
+	for {
+		select {
+		case job := <-lp.embedQueue:
+			resp, err := ep.Embed(job.ctx, job.req)
+			job.response <- embedResult{resp: resp, err: err}
+		case <-lp.done:
+			for {
+				select {
+				case job := <-lp.embedQueue:
+					job.response <- embedResult{err: errors.New("provider shutting down")}
+				default:
+					return
+				}
+			}
+		}
+	}
+}

--- a/providers/concurrency/limited_test.go
+++ b/providers/concurrency/limited_test.go
@@ -1,0 +1,161 @@
+package concurrency_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/ferro-labs/ai-gateway/providers/concurrency"
+	"github.com/ferro-labs/ai-gateway/providers/core"
+)
+
+// stub is a minimal Provider implementation for testing.
+type stub struct {
+	name    string
+	delay   time.Duration
+	callsFn func()
+	resp    *core.Response
+	err     error
+
+	inFlight atomic.Int64
+	peak     atomic.Int64
+}
+
+func (s *stub) Name() string                       { return s.name }
+func (s *stub) SupportedModels() []string          { return nil }
+func (s *stub) SupportsModel(_ string) bool        { return true }
+func (s *stub) Models() []core.ModelInfo           { return nil }
+func (s *stub) Complete(ctx context.Context, _ core.Request) (*core.Response, error) {
+	n := s.inFlight.Add(1)
+	defer s.inFlight.Add(-1)
+	for {
+		cur := s.peak.Load()
+		if n <= cur || s.peak.CompareAndSwap(cur, n) {
+			break
+		}
+	}
+	if s.callsFn != nil {
+		s.callsFn()
+	}
+	if s.delay > 0 {
+		select {
+		case <-time.After(s.delay):
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+	return s.resp, s.err
+}
+
+func TestUnderLimit_NoBlocking(t *testing.T) {
+	s := &stub{name: "test", resp: &core.Response{}}
+	lp := concurrency.Wrap(s, 5, 100)
+	defer lp.Close()
+
+	resp, err := lp.Complete(context.Background(), core.Request{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp == nil {
+		t.Fatal("expected non-nil response")
+	}
+}
+
+func TestAtLimit_Queuing(t *testing.T) {
+	const workers = 2
+	const total = 10
+
+	blocker := make(chan struct{})
+	released := atomic.Int64{}
+	s := &stub{
+		name: "test",
+		resp: &core.Response{},
+		callsFn: func() {
+			<-blocker
+			released.Add(1)
+		},
+	}
+	lp := concurrency.Wrap(s, workers, total*2)
+	defer lp.Close()
+
+	var wg sync.WaitGroup
+	errs := make([]error, total)
+	for i := range total {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			_, errs[idx] = lp.Complete(context.Background(), core.Request{})
+		}(i)
+	}
+
+	// Give goroutines time to enqueue.
+	time.Sleep(50 * time.Millisecond)
+	close(blocker)
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Errorf("request %d failed: %v", i, err)
+		}
+	}
+	if s.peak.Load() > workers {
+		t.Errorf("peak in-flight %d exceeded worker count %d", s.peak.Load(), workers)
+	}
+}
+
+func TestContextCancel_MidWait(t *testing.T) {
+	blocker := make(chan struct{})
+	s := &stub{
+		name: "test",
+		resp: &core.Response{},
+		callsFn: func() { <-blocker },
+	}
+	lp := concurrency.Wrap(s, 1, 10)
+	defer func() {
+		close(blocker)
+		lp.Close()
+	}()
+
+	// Fill the single worker.
+	go lp.Complete(context.Background(), core.Request{}) //nolint:errcheck
+
+	// Give worker time to start.
+	time.Sleep(20 * time.Millisecond)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+	defer cancel()
+
+	_, err := lp.Complete(ctx, core.Request{})
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected DeadlineExceeded, got: %v", err)
+	}
+}
+
+func TestProviderError_PassedThrough(t *testing.T) {
+	want := errors.New("upstream unavailable")
+	s := &stub{name: "test", err: want}
+	lp := concurrency.Wrap(s, 2, 10)
+	defer lp.Close()
+
+	_, err := lp.Complete(context.Background(), core.Request{})
+	if !errors.Is(err, want) {
+		t.Fatalf("expected %v, got %v", want, err)
+	}
+}
+
+func TestClose_ShutdownError(t *testing.T) {
+	s := &stub{name: "test", resp: &core.Response{}, delay: 200 * time.Millisecond}
+	lp := concurrency.Wrap(s, 1, 10)
+	lp.Close()
+
+	// After close, new requests should get a shutdown error.
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	_, err := lp.Complete(ctx, core.Request{})
+	if err == nil {
+		t.Fatal("expected error after Close, got nil")
+	}
+}

--- a/providers/concurrency/limited_test.go
+++ b/providers/concurrency/limited_test.go
@@ -134,6 +134,33 @@ func TestContextCancel_MidWait(t *testing.T) {
 	}
 }
 
+func TestQueueFull_ReturnsErrQueueFull(t *testing.T) {
+	blocker := make(chan struct{})
+	s := &stub{
+		name: "test",
+		resp: &core.Response{},
+		callsFn: func() { <-blocker },
+	}
+	// 1 worker, queue depth 1 — second request fills buffer, third is rejected immediately.
+	lp := concurrency.Wrap(s, 1, 1)
+	defer func() {
+		close(blocker)
+		lp.Close()
+	}()
+
+	// Fill the worker.
+	go lp.Complete(context.Background(), core.Request{}) //nolint:errcheck
+	// Fill the queue buffer.
+	go lp.Complete(context.Background(), core.Request{}) //nolint:errcheck
+	time.Sleep(20 * time.Millisecond)
+
+	// Third call must return ErrQueueFull immediately.
+	_, err := lp.Complete(context.Background(), core.Request{})
+	if !errors.Is(err, concurrency.ErrQueueFull) {
+		t.Fatalf("expected ErrQueueFull, got: %v", err)
+	}
+}
+
 func TestProviderError_PassedThrough(t *testing.T) {
 	want := errors.New("upstream unavailable")
 	s := &stub{name: "test", err: want}

--- a/providers/factory.go
+++ b/providers/factory.go
@@ -75,6 +75,10 @@ const (
 	CfgKeyAPIToken    = "api_token"    // Replicate API token (primary required key)
 	CfgKeyTextModels  = "text_models"  // comma-separated Replicate text model paths
 	CfgKeyImageModels = "image_models" // comma-separated Replicate image model paths
+
+	// Concurrency limiting (applies to any provider)
+	CfgKeyMaxConcurrency = "max_concurrency" // max simultaneous in-flight requests (0 = unlimited)
+	CfgKeyQueueSize      = "queue_size"      // max requests queued waiting for a worker (default 1000)
 )
 
 // Capability names for capability-based registry filtering.


### PR DESCRIPTION
Closes #248

## What

Adds a transparent `Provider` wrapper (`providers/concurrency.LimitedProvider`) that gates concurrent upstream calls using a Bifrost-style bounded goroutine pool + buffered channel — no explicit semaphore needed.

## Why

Some providers enforce hard concurrency limits (simultaneous connections, not just RPM/TPM). Without a per-provider gate the gateway can saturate a provider, causing 429s or connection resets that unnecessarily trip the circuit breaker.

## How it works

Two-level gate per provider:
- **`max_concurrency`** — N worker goroutines; equals max simultaneous in-flight requests per operation type
- **`queue_size`** — channel buffer depth; equals max requests allowed to queue (default 1000)

```go
// In ProviderConfig — any provider
max_concurrency = "10"   // max simultaneous upstream calls
queue_size      = "500"  // max queued requests (beyond this: ErrQueueFull)
```

Workers pull jobs from the channel, make the upstream call inline, write back on per-request reply channels. Context cancellation releases waiting callers without holding a slot.

## Interface forwarding

`LimitedProvider` is transparent to all callers — it forwards all optional interfaces to inner:

| Interface | Forwarded | Notes |
|---|---|---|
| `StreamProvider` | ✓ | Queue-gated |
| `EmbeddingProvider` | ✓ | Queue-gated |
| `ProxiableProvider` | ✓ | Direct (not queue-gated) |
| `DiscoveryProvider` | ✓ | Direct (not queue-gated) |
| `ImageProvider` | ✓ | Direct (not queue-gated) |

Without forwarding `ProxiableProvider`, `DiscoveryProvider`, and `ImageProvider`, wrapping any provider would break proxy pass-through, live model discovery, and image generation respectively.

## Bootstrap wiring

`RegisterProviders()` now returns `(*Registry, func())`. The cleanup func calls `Close()` on each wrapped provider during graceful shutdown (after HTTP drain). No change required to provider implementations.

## Tests

- Under-limit: no blocking, response returned
- At-limit: requests queue, peak in-flight ≤ workerCount
- Queue full: `ErrQueueFull` returned immediately (not a block)
- Context cancel mid-wait: `DeadlineExceeded` returned, worker slot freed
- Provider error: passed through unchanged
- Close: new requests rejected after shutdown

## Prior art

Bifrost (`maximhq/bifrost`) uses the same pattern: `ConcurrencyAndBufferSize{Concurrency, BufferSize}` per provider, N goroutine worker pool over a buffered channel.