### PR TITLE
v1.1.10 - Proxy & Governance Hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to Ferro Labs AI Gateway are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.10] — 2026-07-03
+
+Proxy & governance hardening release. Corrects the `/v1/*` pass-through proxy so it no longer doubles the `/v1` path segment and no longer forwards OpenAI-shaped requests to providers whose upstream API is not OpenAI-compatible, and extends per-key budget governance to the embeddings and image-generation endpoints. Adds an optional provider request-signing hook and a shared base-URL validator. No breaking API changes relative to v1.1.9 — the `Provider`, `ProxiableProvider`, and plugin contracts are unchanged.
+
+### Fixed
+
+- **Pass-through proxy path doubling**: the `/v1/*` pass-through no longer duplicates the `/v1` segment for providers whose configured base URL already ends in `/v1` (e.g. `https://api.x.ai/v1`), which previously produced a `/v1/v1/...` upstream path and a 404. Both base-URL conventions now forward correctly.
+
+### Changed
+
+- **Pass-through proxy scope** (operator-visible): the `/v1/*` pass-through now returns HTTP 501 for providers whose upstream API is not OpenAI-wire-compatible — Anthropic, Google Gemini, AWS Bedrock, Cohere, Vertex AI, and Azure OpenAI/Foundry — instead of forwarding an OpenAI-shaped request their API cannot process (which failed upstream, and for AWS Bedrock under SigV4 was sent unauthenticated). These providers remain fully available through their translated `chat/completions`, `embeddings`, and `images/generations` endpoints.
+- **Per-key budget on embeddings and images** (operator-visible): per-key budget limits now apply to `/v1/embeddings` and `/v1/images/generations`, not only chat. Embedding requests are gated and their spend recorded; image generation is gated (it reports no token usage). Per-IP rate limiting, authentication, and the request body-size limit already applied to every endpoint.
+
+### Added
+
+- **Provider request-signing hook**: an optional `RequestSigner` provider interface lets a provider sign each outbound pass-through request (e.g. AWS SigV4); the proxy invokes it when a provider implements it. No in-tree provider signs yet — this is the seam for future signed pass-through.
+- **Shared base-URL validation**: a shared `core.ValidateBaseURL` helper validates that a provider base URL is an `http(s)` URL with a host, adopted by the Anthropic provider. Remaining providers migrate to it in subsequent releases.
+
+---
+
 ## [1.1.9] — 2026-07-02
 
 Quality & maintainability release. Scopes per-key rate-limit and budget enforcement to the authenticated key, hardens the budget soft cap against concurrent lost updates, fixes a set of gateway routing/observability and provider streaming correctness issues, and lands a large behaviour-preserving internal refactor plus CI supply-chain hardening. No public API breaks relative to v1.1.8. Closes [#261](https://github.com/ferro-labs/ai-gateway/issues/261).

--- a/gateway_discovery.go
+++ b/gateway_discovery.go
@@ -76,6 +76,9 @@ func (g *Gateway) runSurfaceGovernance(ctx context.Context, surface string, call
 	if usage != nil {
 		pctx.Metadata["usage"] = *usage
 	}
+	// Explicit after_request signal so stage detection does not depend on token
+	// usage — image responses carry none. See budget.requestCompleted.
+	pctx.Metadata["completed"] = true
 	return plugins.RunAfter(ctx, pctx)
 }
 

--- a/gateway_discovery.go
+++ b/gateway_discovery.go
@@ -6,7 +6,9 @@ import (
 	"log/slog"
 	"time"
 
+	"github.com/ferro-labs/ai-gateway/internal/authctx"
 	"github.com/ferro-labs/ai-gateway/internal/logging"
+	"github.com/ferro-labs/ai-gateway/plugin"
 	"github.com/ferro-labs/ai-gateway/providers"
 	"github.com/ferro-labs/ai-gateway/providers/core"
 )
@@ -31,8 +33,54 @@ func (g *Gateway) resolveAlias(req providers.Request) providers.Request {
 	return req
 }
 
+// runSurfaceGovernance runs the before/after/error plugin pipeline around a
+// non-chat surface (embeddings, images) so per-key governance plugins — budget,
+// rate-limit — apply uniformly across every OpenAI surface, not just chat.
+//
+// It reuses the frozen plugin.Manager/Context without inventing a new lifecycle
+// (plugins architecture §2): the Context carries no chat Request, so content
+// plugins that key off Request.Messages guard nil and no-op; surface identity
+// and, on success, normalized token usage flow through Metadata — the sanctioned
+// additive channel (plugins architecture D8). call performs the provider request
+// and returns the token usage to account for, or nil when the surface reports
+// none (e.g. image generation).
+func (g *Gateway) runSurfaceGovernance(ctx context.Context, surface string, call func(context.Context) (*providers.Usage, error)) error {
+	g.mu.RLock()
+	plugins := g.plugins
+	release := acquirePluginManager(plugins)
+	g.mu.RUnlock()
+	defer release()
+
+	if !plugins.HasPlugins() {
+		_, err := call(ctx)
+		return err
+	}
+
+	pctx := plugin.NewContext(nil)
+	defer plugin.PutContext(pctx)
+	pctx.Metadata["surface"] = surface
+	if keyID, ok := authctx.KeyID(ctx); ok {
+		pctx.Metadata["api_key"] = keyID
+	}
+
+	if err := plugins.RunBefore(ctx, pctx); err != nil {
+		return err
+	}
+
+	usage, err := call(ctx)
+	if err != nil {
+		pctx.Error = err
+		plugins.RunOnError(ctx, pctx)
+		return err
+	}
+	if usage != nil {
+		pctx.Metadata["usage"] = *usage
+	}
+	return plugins.RunAfter(ctx, pctx)
+}
+
 // Embed routes an embedding request to the first registered EmbeddingProvider
-// that supports the requested model.
+// that supports the requested model, under the shared governance pipeline.
 func (g *Gateway) Embed(ctx context.Context, req providers.EmbeddingRequest) (*providers.EmbeddingResponse, error) {
 	log := logging.FromContext(ctx)
 
@@ -47,7 +95,15 @@ func (g *Gateway) Embed(ctx context.Context, req providers.EmbeddingRequest) (*p
 		return nil, fmt.Errorf("%w: no embedding provider for %q", core.ErrNoCapableProvider, req.Model)
 	}
 
-	resp, err := ep.Embed(ctx, req)
+	var resp *providers.EmbeddingResponse
+	err := g.runSurfaceGovernance(ctx, "embeddings", func(ctx context.Context) (*providers.Usage, error) {
+		r, callErr := ep.Embed(ctx, req)
+		if callErr != nil {
+			return nil, callErr
+		}
+		resp = r
+		return &providers.Usage{PromptTokens: r.Usage.PromptTokens, TotalTokens: r.Usage.TotalTokens}, nil
+	})
 	if err != nil {
 		log.Error("embedding request failed", "model", req.Model, "error", err.Error())
 		return nil, err
@@ -58,7 +114,9 @@ func (g *Gateway) Embed(ctx context.Context, req providers.EmbeddingRequest) (*p
 }
 
 // GenerateImage routes an image generation request to the first registered
-// ImageProvider that supports the requested model.
+// ImageProvider that supports the requested model, under the shared governance
+// pipeline. Image responses carry no token usage, so budget gates but does not
+// cost these requests.
 func (g *Gateway) GenerateImage(ctx context.Context, req providers.ImageRequest) (*providers.ImageResponse, error) {
 	log := logging.FromContext(ctx)
 
@@ -73,7 +131,15 @@ func (g *Gateway) GenerateImage(ctx context.Context, req providers.ImageRequest)
 		return nil, fmt.Errorf("%w: no image generation provider for %q", core.ErrNoCapableProvider, req.Model)
 	}
 
-	resp, err := ip.GenerateImage(ctx, req)
+	var resp *providers.ImageResponse
+	err := g.runSurfaceGovernance(ctx, "images", func(ctx context.Context) (*providers.Usage, error) {
+		r, callErr := ip.GenerateImage(ctx, req)
+		if callErr != nil {
+			return nil, callErr
+		}
+		resp = r
+		return nil, nil // image responses carry no token usage
+	})
 	if err != nil {
 		log.Error("image generation request failed", "model", req.Model, "error", err.Error())
 		return nil, err

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -2889,6 +2889,77 @@ func (m *mockImageProvider) GenerateImage(_ context.Context, req providers.Image
 
 // ── alias resolution tests ────────────────────────────────────────────────────
 
+func TestGateway_Embed_BeforePluginRejects(t *testing.T) {
+	// Governance (before-request plugins) must apply to embeddings, not just chat:
+	// a rejecting before-plugin blocks the request before the provider is called.
+	ep := &mockEmbeddingProvider{
+		mockProvider: mockProvider{name: mockProviderName, models: []string{"text-embedding-3-small"}},
+	}
+	gw, _ := New(Config{
+		Strategy: StrategyConfig{Mode: ModeSingle},
+		Targets:  []Target{{VirtualKey: mockProviderName}},
+	})
+	gw.RegisterProvider(ep)
+
+	_ = gw.RegisterPlugin(plugin.StageBeforeRequest, &testPlugin{
+		name: "embed-blocker",
+		typ:  plugin.TypeGuardrail,
+		execFn: func(_ context.Context, pctx *plugin.Context) error {
+			pctx.Reject = true
+			pctx.Reason = "blocked"
+			return nil
+		},
+	})
+
+	if _, err := gw.Embed(context.Background(), providers.EmbeddingRequest{
+		Model: "text-embedding-3-small",
+		Input: "hello",
+	}); err == nil {
+		t.Fatal("expected before-plugin to reject the embedding request")
+	}
+	if ep.capturedModel != "" {
+		t.Error("embedding provider was called despite a before-plugin rejection")
+	}
+}
+
+func TestGateway_Embed_AfterPluginSeesSurfaceAndUsage(t *testing.T) {
+	// After-request plugins on the embedding surface receive the surface tag and
+	// normalized token usage via Metadata (the additive channel budget uses).
+	ep := &mockEmbeddingProvider{
+		mockProvider: mockProvider{name: mockProviderName, models: []string{"text-embedding-3-small"}},
+	}
+	gw, _ := New(Config{
+		Strategy: StrategyConfig{Mode: ModeSingle},
+		Targets:  []Target{{VirtualKey: mockProviderName}},
+	})
+	gw.RegisterProvider(ep)
+
+	var gotSurface any
+	var sawUsage bool
+	_ = gw.RegisterPlugin(plugin.StageAfterRequest, &testPlugin{
+		name: "embed-observer",
+		typ:  plugin.TypeLogging,
+		execFn: func(_ context.Context, pctx *plugin.Context) error {
+			gotSurface = pctx.Metadata["surface"]
+			_, sawUsage = pctx.Metadata["usage"].(providers.Usage)
+			return nil
+		},
+	})
+
+	if _, err := gw.Embed(context.Background(), providers.EmbeddingRequest{
+		Model: "text-embedding-3-small",
+		Input: "hello",
+	}); err != nil {
+		t.Fatalf("Embed() error: %v", err)
+	}
+	if gotSurface != "embeddings" {
+		t.Errorf("after-plugin saw surface %v, want %q", gotSurface, "embeddings")
+	}
+	if !sawUsage {
+		t.Error(`after-plugin did not receive normalized usage via Metadata["usage"]`)
+	}
+}
+
 func TestGateway_Embed_ResolvesAlias(t *testing.T) {
 	ep := &mockEmbeddingProvider{
 		mockProvider: mockProvider{

--- a/internal/plugins/budget/plugin.go
+++ b/internal/plugins/budget/plugin.go
@@ -60,6 +60,7 @@ import (
 
 	"github.com/ferro-labs/ai-gateway/internal/plugins/plugincfg"
 	"github.com/ferro-labs/ai-gateway/plugin"
+	"github.com/ferro-labs/ai-gateway/providers"
 )
 
 func init() {
@@ -244,14 +245,30 @@ func (p *Plugin) Execute(_ context.Context, pctx *plugin.Context) error {
 		return nil
 	}
 
-	if pctx.Response == nil {
+	if _, completed := completedUsage(pctx); !completed {
 		// before_request stage: check accumulated spend.
 		return p.checkBudget(pctx, key)
 	}
 
-	// after_request stage: record cost.
+	// after_request stage: record cost from the completed request's usage.
 	p.recordCost(pctx, key)
 	return nil
+}
+
+// completedUsage reports the token usage of a completed request and whether the
+// request has finished, letting budget distinguish the after_request stage from
+// before_request without depending on the surface. Chat carries usage on the
+// typed Response; non-chat surfaces (embeddings) pass it through
+// Metadata["usage"] — the sanctioned additive channel for the frozen plugin
+// seam. Image generation reports no token usage, so it is gated but not costed.
+func completedUsage(pctx *plugin.Context) (providers.Usage, bool) {
+	if pctx.Response != nil {
+		return pctx.Response.Usage, true
+	}
+	if u, ok := pctx.Metadata["usage"].(providers.Usage); ok {
+		return u, true
+	}
+	return providers.Usage{}, false
 }
 
 // Close releases plugin resources.
@@ -291,10 +308,10 @@ func (p *Plugin) checkBudget(pctx *plugin.Context, key string) error {
 // the store via a single atomic read-modify-write, so concurrent completions
 // for the same key never lose an increment.
 func (p *Plugin) recordCost(pctx *plugin.Context, key string) {
-	if pctx.Response == nil {
+	usage, ok := completedUsage(pctx)
+	if !ok {
 		return
 	}
-	usage := pctx.Response.Usage
 	actual := (float64(usage.PromptTokens)/1_000_000.0)*p.inputPerMTokens +
 		(float64(usage.CompletionTokens)/1_000_000.0)*p.outputPerMTokens
 	if actual > 0 {

--- a/internal/plugins/budget/plugin.go
+++ b/internal/plugins/budget/plugin.go
@@ -245,7 +245,7 @@ func (p *Plugin) Execute(_ context.Context, pctx *plugin.Context) error {
 		return nil
 	}
 
-	if _, completed := completedUsage(pctx); !completed {
+	if !requestCompleted(pctx) {
 		// before_request stage: check accumulated spend.
 		return p.checkBudget(pctx, key)
 	}
@@ -255,13 +255,25 @@ func (p *Plugin) Execute(_ context.Context, pctx *plugin.Context) error {
 	return nil
 }
 
-// completedUsage reports the token usage of a completed request and whether the
-// request has finished, letting budget distinguish the after_request stage from
-// before_request without depending on the surface. Chat carries usage on the
-// typed Response; non-chat surfaces (embeddings) pass it through
-// Metadata["usage"] — the sanctioned additive channel for the frozen plugin
-// seam. Image generation reports no token usage, so it is gated but not costed.
-func completedUsage(pctx *plugin.Context) (providers.Usage, bool) {
+// requestCompleted reports whether Execute is running in the after_request
+// stage. Chat sets the typed Response; non-chat surfaces (embeddings, images)
+// set Metadata["completed"]. The explicit marker is required because image
+// responses carry no token usage, so completion cannot be inferred from usage
+// presence — doing so would re-run the budget gate on a completed image and
+// could reject an already-billed response under concurrent spend.
+func requestCompleted(pctx *plugin.Context) bool {
+	if pctx.Response != nil {
+		return true
+	}
+	completed, _ := pctx.Metadata["completed"].(bool)
+	return completed
+}
+
+// usageFromContext returns the completed request's token usage — from the chat
+// Response or, for non-chat surfaces, Metadata["usage"] (the sanctioned additive
+// channel for the frozen plugin seam). Image generation reports no usage, so ok
+// is false and the request is gated but not costed.
+func usageFromContext(pctx *plugin.Context) (providers.Usage, bool) {
 	if pctx.Response != nil {
 		return pctx.Response.Usage, true
 	}
@@ -308,7 +320,7 @@ func (p *Plugin) checkBudget(pctx *plugin.Context, key string) error {
 // the store via a single atomic read-modify-write, so concurrent completions
 // for the same key never lose an increment.
 func (p *Plugin) recordCost(pctx *plugin.Context, key string) {
-	usage, ok := completedUsage(pctx)
+	usage, ok := usageFromContext(pctx)
 	if !ok {
 		return
 	}

--- a/internal/plugins/budget/plugin_test.go
+++ b/internal/plugins/budget/plugin_test.go
@@ -145,6 +145,7 @@ func TestBudget_RecordsUsageFromMetadata_NonChatSurface(t *testing.T) {
 	afterPctx := pctxWithKey(apiKey)
 	afterPctx.Request = nil // non-chat surface: no chat request
 	afterPctx.Metadata["usage"] = providers.Usage{PromptTokens: 400, TotalTokens: 400}
+	afterPctx.Metadata["completed"] = true // explicit after_request signal
 	if err := p.Execute(context.Background(), afterPctx); err != nil {
 		t.Fatalf("recording embedding usage should not error: %v", err)
 	}
@@ -156,6 +157,38 @@ func TestBudget_RecordsUsageFromMetadata_NonChatSurface(t *testing.T) {
 		t.Fatal("expected rejection after embedding spend exceeded the limit")
 	} else if !beforePctx.Reject {
 		t.Error("pctx.Reject should be true when budget exceeded via embedding usage")
+	}
+}
+
+func TestBudget_ImageSurface_CompletedNotReRejected(t *testing.T) {
+	// Image generation reports no token usage. After a completed image request,
+	// the after_request stage must NOT re-run the budget gate (which could reject
+	// an already-generated, already-billed response); it records nothing.
+	p := makePlugin(t, map[string]any{
+		"store_id":            "test-image-surface",
+		"spend_limit_usd":     0.001, // $0.001 limit
+		"input_per_m_tokens":  3.0,
+		"output_per_m_tokens": 15.0,
+	})
+	apiKey := "key-image"
+
+	// Push accumulated spend over the limit via a prior completed request.
+	over := pctxWithKey(apiKey)
+	over.Request = nil
+	over.Metadata["usage"] = providers.Usage{PromptTokens: 1000, TotalTokens: 1000} // 0.003 USD > limit
+	over.Metadata["completed"] = true
+	_ = p.Execute(context.Background(), over)
+
+	// A completed image request (no usage) in the after stage must not reject,
+	// even though spend is now over the limit.
+	afterImg := pctxWithKey(apiKey)
+	afterImg.Request = nil
+	afterImg.Metadata["completed"] = true // completed, but no usage
+	if err := p.Execute(context.Background(), afterImg); err != nil {
+		t.Fatalf("after_request for a completed image must not reject: %v", err)
+	}
+	if afterImg.Reject {
+		t.Error("image after_request re-ran the budget gate and rejected a completed response")
 	}
 }
 

--- a/internal/plugins/budget/plugin_test.go
+++ b/internal/plugins/budget/plugin_test.go
@@ -128,6 +128,37 @@ func TestBudget_RecordAndExceed(t *testing.T) {
 	}
 }
 
+func TestBudget_RecordsUsageFromMetadata_NonChatSurface(t *testing.T) {
+	// Non-chat surfaces (embeddings) carry no chat Response; token usage arrives
+	// through Metadata["usage"]. Budget must gate and record cost from it exactly
+	// as it does for chat, so spend control is uniform across surfaces.
+	p := makePlugin(t, map[string]any{
+		"store_id":            "test-metadata-usage",
+		"spend_limit_usd":     0.001, // $0.001 limit
+		"input_per_m_tokens":  3.0,
+		"output_per_m_tokens": 15.0,
+	})
+	apiKey := "key-embed"
+
+	// after_request for an embedding: 400 prompt tokens, no completion.
+	// cost = 400/1_000_000 * 3.0 = 0.0012 USD → over the $0.001 limit.
+	afterPctx := pctxWithKey(apiKey)
+	afterPctx.Request = nil // non-chat surface: no chat request
+	afterPctx.Metadata["usage"] = providers.Usage{PromptTokens: 400, TotalTokens: 400}
+	if err := p.Execute(context.Background(), afterPctx); err != nil {
+		t.Fatalf("recording embedding usage should not error: %v", err)
+	}
+
+	// The before_request check must now reject (spend > limit).
+	beforePctx := pctxWithKey(apiKey)
+	beforePctx.Request = nil
+	if err := p.Execute(context.Background(), beforePctx); err == nil {
+		t.Fatal("expected rejection after embedding spend exceeded the limit")
+	} else if !beforePctx.Reject {
+		t.Error("pctx.Reject should be true when budget exceeded via embedding usage")
+	}
+}
+
 func TestBudget_Unlimited_NeverRejects(t *testing.T) {
 	// spend_limit_usd = 0 means unlimited.
 	p := makePlugin(t, map[string]any{

--- a/internal/plugins/budget/plugin_test.go
+++ b/internal/plugins/budget/plugin_test.go
@@ -177,7 +177,12 @@ func TestBudget_ImageSurface_CompletedNotReRejected(t *testing.T) {
 	over.Request = nil
 	over.Metadata["usage"] = providers.Usage{PromptTokens: 1000, TotalTokens: 1000} // 0.003 USD > limit
 	over.Metadata["completed"] = true
-	_ = p.Execute(context.Background(), over)
+	if err := p.Execute(context.Background(), over); err != nil {
+		t.Fatalf("setup over-budget recording should not error: %v", err)
+	}
+	if spent := p.store.get(apiKey); spent < p.spendLimitUSD {
+		t.Fatalf("setup precondition not met: spent $%.4f, want >= limit $%.4f", spent, p.spendLimitUSD)
+	}
 
 	// A completed image request (no usage) in the after stage must not reject,
 	// even though spend is now over the limit.

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -6,6 +6,7 @@ import (
 	"bufio"
 	"bytes"
 	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
@@ -61,6 +62,20 @@ func Handler(registry *providers.Registry) http.HandlerFunc {
 			return
 		}
 
+		// Non-OpenAI-wire providers (Anthropic, Gemini, Bedrock, Cohere, Vertex,
+		// Azure) cannot serve a transparently-forwarded OpenAI-shaped request at
+		// their base URL. Refuse with 501 instead of forwarding a request their
+		// upstream cannot parse; they remain available via their native
+		// translated endpoints. See core.NonOpenAIWireProvider.
+		if _, nativeOnly := p.(providers.NonOpenAIWireProvider); nativeOnly {
+			apierror.WriteOpenAI(w, http.StatusNotImplemented,
+				"provider "+p.Name()+" is not available for OpenAI-compatible pass-through; use its native chat, embeddings, or images endpoints",
+				"invalid_request_error",
+				"proxy_not_supported",
+			)
+			return
+		}
+
 		providerName := p.Name()
 
 		target, err := url.Parse(pp.BaseURL())
@@ -81,14 +96,23 @@ func Handler(registry *providers.Registry) http.HandlerFunc {
 
 		authHeaders := pp.AuthHeaders()
 
+		// Use the raw SSE-tuned transport (no ResponseHeaderTimeout) so slow or
+		// streaming pass-through endpoints are not cut off at 30s while waiting
+		// for the upstream's first response header. The raw transport (not the
+		// otelhttp-wrapped client RoundTripper) keeps this a transparent proxy:
+		// no traceparent/tracestate injected into upstream requests and no extra
+		// OTel CLIENT span per proxied call.
+		//
+		// Providers requiring per-request signing (e.g. AWS SigV4) wrap that
+		// transport so the fully-formed outbound request is signed; a signing
+		// failure surfaces via ErrorHandler rather than as an unsigned forward.
+		var transport http.RoundTripper = httpclient.SharedStreamingTransport()
+		if signer, ok := p.(providers.RequestSigner); ok {
+			transport = signingRoundTripper{base: transport, signer: signer}
+		}
+
 		proxy := &httputil.ReverseProxy{
-			// Use the raw SSE-tuned transport (no ResponseHeaderTimeout) so slow
-			// or streaming pass-through endpoints are not cut off at 30s while
-			// waiting for the upstream's first response header. The raw
-			// transport (not the otelhttp-wrapped client RoundTripper) keeps
-			// this a transparent proxy: no traceparent/tracestate injected into
-			// upstream requests and no extra OTel CLIENT span per proxied call.
-			Transport:     httpclient.SharedStreamingTransport(),
+			Transport:     transport,
 			FlushInterval: proxyFlushInterval,
 			Rewrite: func(pr *httputil.ProxyRequest) {
 				pr.SetURL(target)
@@ -121,6 +145,22 @@ func Handler(registry *providers.Registry) http.HandlerFunc {
 
 		proxy.ServeHTTP(w, r)
 	}
+}
+
+// signingRoundTripper signs each outbound proxied request via a provider's
+// RequestSigner before delegating to the base transport. A signing failure is
+// returned to the reverse proxy (surfaced as a 502 by ErrorHandler) rather than
+// forwarding an unsigned request upstream.
+type signingRoundTripper struct {
+	base   http.RoundTripper
+	signer providers.RequestSigner
+}
+
+func (s signingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if err := s.signer.SignProxyRequest(req); err != nil {
+		return nil, fmt.Errorf("sign proxy request: %w", err)
+	}
+	return s.base.RoundTrip(req)
 }
 
 // ResolveProvider determines which provider should receive the request.

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -12,6 +12,7 @@ import (
 	"net/http/httputil"
 	"net/url"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/ferro-labs/ai-gateway/internal/apierror"
@@ -69,6 +70,14 @@ func Handler(registry *providers.Registry) http.HandlerFunc {
 			apierror.WriteOpenAI(w, http.StatusInternalServerError, "upstream provider is unavailable", "server_error", "internal_error")
 			return
 		}
+
+		// The proxy is mounted at /v1/*, so every inbound path already carries
+		// the OpenAI /v1 prefix. Strip a trailing /v1 from the provider base
+		// path so a base URL that itself ends in /v1 (e.g. https://api.x.ai/v1)
+		// does not double the segment (…/v1 + /v1/responses -> /v1/v1/responses)
+		// and 404 upstream.
+		target.Path = strings.TrimSuffix(strings.TrimSuffix(target.Path, "/v1/"), "/v1")
+		target.RawPath = ""
 
 		authHeaders := pp.AuthHeaders()
 

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -400,6 +401,7 @@ func TestProxyHandler_GatesNonOpenAIWireProvider(t *testing.T) {
 type stubSigningProvider struct {
 	baseURL string
 	signed  *bool
+	signErr error
 }
 
 func (stubSigningProvider) Name() string { return "stub-signer" }
@@ -412,9 +414,11 @@ func (stubSigningProvider) Models() []providers.ModelInfo  { return nil }
 func (s stubSigningProvider) BaseURL() string              { return s.baseURL }
 func (stubSigningProvider) AuthHeaders() map[string]string { return nil }
 func (s stubSigningProvider) SignProxyRequest(req *http.Request) error {
-	*s.signed = true
+	if s.signed != nil {
+		*s.signed = true
+	}
 	req.Header.Set("X-Signed", "1")
-	return nil
+	return s.signErr
 }
 
 // TestProxyHandler_InvokesRequestSigner verifies that when a provider implements
@@ -445,6 +449,36 @@ func TestProxyHandler_InvokesRequestSigner(t *testing.T) {
 	}
 	if seenSigned != "1" {
 		t.Errorf("upstream X-Signed = %q, want 1 (signer header not applied)", seenSigned)
+	}
+}
+
+// TestProxyHandler_RequestSignerFailure_Returns502 verifies that when signing
+// fails the proxy surfaces a 502 (via ErrorHandler) and never reaches upstream,
+// rather than forwarding an unsigned request.
+func TestProxyHandler_RequestSignerFailure_Returns502(t *testing.T) {
+	var reached bool
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		reached = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	reg := providers.NewRegistry()
+	reg.Register(stubSigningProvider{baseURL: upstream.URL, signErr: errors.New("sign failed")})
+	handler := Handler(reg)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{}`))
+	req.Header.Set("X-Provider", "stub-signer")
+	req.ContentLength = 2
+	w := httptest.NewRecorder()
+
+	handler(w, req)
+
+	if w.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502 when signing fails", w.Code)
+	}
+	if reached {
+		t.Error("upstream must not be reached when signing fails")
 	}
 }
 

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -307,6 +307,62 @@ func TestProxyHandler_NoProvider_Returns400(t *testing.T) {
 	}
 }
 
+// TestProxyHandler_DoesNotDoubleV1Prefix guards against the pass-through proxy
+// doubling the /v1 path segment for providers whose base URL already ends in
+// /v1 (e.g. xai, openrouter, cerebras). The proxy is mounted at /v1/*, so the
+// inbound path always carries /v1; the upstream must receive it exactly once.
+func TestProxyHandler_DoesNotDoubleV1Prefix(t *testing.T) {
+	var gotPath string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer upstream.Close()
+
+	// Provider whose base URL already ends in /v1.
+	reg := buildTestRegistry(upstream.URL + "/v1")
+	handler := Handler(reg)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{}`))
+	req.Header.Set("X-Provider", providerOpenAI)
+	req.ContentLength = 2
+	w := httptest.NewRecorder()
+
+	handler(w, req)
+
+	if gotPath != "/v1/responses" {
+		t.Errorf("upstream path = %q, want /v1/responses (proxy must not double the /v1 segment)", gotPath)
+	}
+}
+
+// TestProxyHandler_PreservesV1PrefixForRootBase verifies that a bare-host base
+// URL (no /v1 suffix) still forwards the inbound /v1 prefix intact — the fix
+// must not over-trim.
+func TestProxyHandler_PreservesV1PrefixForRootBase(t *testing.T) {
+	var gotPath string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer upstream.Close()
+
+	reg := buildTestRegistry(upstream.URL) // base has no /v1
+	handler := Handler(reg)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{}`))
+	req.Header.Set("X-Provider", providerOpenAI)
+	req.ContentLength = 2
+	w := httptest.NewRecorder()
+
+	handler(w, req)
+
+	if gotPath != "/v1/responses" {
+		t.Errorf("upstream path = %q, want /v1/responses", gotPath)
+	}
+}
+
 func BenchmarkExtractTopLevelModel(b *testing.B) {
 	body := []byte(`{
 		"messages":[

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -11,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/ferro-labs/ai-gateway/providers"
+	geminipkg "github.com/ferro-labs/ai-gateway/providers/gemini"
 	openaipkg "github.com/ferro-labs/ai-gateway/providers/openai"
 )
 
@@ -360,6 +362,89 @@ func TestProxyHandler_PreservesV1PrefixForRootBase(t *testing.T) {
 
 	if gotPath != "/v1/responses" {
 		t.Errorf("upstream path = %q, want /v1/responses", gotPath)
+	}
+}
+
+// TestProxyHandler_GatesNonOpenAIWireProvider verifies a non-OpenAI-wire
+// provider (Gemini) is refused with 501 rather than transparently forwarded —
+// its upstream is not OpenAI-shaped, so an OpenAI-wire pass-through would fail.
+func TestProxyHandler_GatesNonOpenAIWireProvider(t *testing.T) {
+	g, err := geminipkg.New("test-key", "")
+	if err != nil {
+		t.Fatalf("gemini.New: %v", err)
+	}
+	reg := providers.NewRegistry()
+	reg.Register(g)
+	handler := Handler(reg)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{}`))
+	req.Header.Set("X-Provider", g.Name())
+	req.ContentLength = 2
+	w := httptest.NewRecorder()
+
+	handler(w, req)
+
+	if w.Code != http.StatusNotImplemented {
+		t.Fatalf("status = %d, want 501 for non-OpenAI-wire provider", w.Code)
+	}
+	var body map[string]any
+	_ = json.NewDecoder(w.Body).Decode(&body)
+	if _, ok := body["error"]; !ok {
+		t.Error("expected error envelope for gated provider")
+	}
+}
+
+// stubSigningProvider is a minimal OpenAI-wire ProxiableProvider that also
+// implements providers.RequestSigner, used to verify the proxy signs outbound
+// requests before forwarding them.
+type stubSigningProvider struct {
+	baseURL string
+	signed  *bool
+}
+
+func (stubSigningProvider) Name() string { return "stub-signer" }
+func (stubSigningProvider) Complete(context.Context, providers.Request) (*providers.Response, error) {
+	return nil, nil
+}
+func (stubSigningProvider) SupportedModels() []string      { return nil }
+func (stubSigningProvider) SupportsModel(string) bool      { return true }
+func (stubSigningProvider) Models() []providers.ModelInfo  { return nil }
+func (s stubSigningProvider) BaseURL() string              { return s.baseURL }
+func (stubSigningProvider) AuthHeaders() map[string]string { return nil }
+func (s stubSigningProvider) SignProxyRequest(req *http.Request) error {
+	*s.signed = true
+	req.Header.Set("X-Signed", "1")
+	return nil
+}
+
+// TestProxyHandler_InvokesRequestSigner verifies that when a provider implements
+// RequestSigner, the proxy signs the outbound request before forwarding it.
+func TestProxyHandler_InvokesRequestSigner(t *testing.T) {
+	var seenSigned string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenSigned = r.Header.Get("X-Signed")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer upstream.Close()
+
+	signed := false
+	reg := providers.NewRegistry()
+	reg.Register(stubSigningProvider{baseURL: upstream.URL, signed: &signed})
+	handler := Handler(reg)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{}`))
+	req.Header.Set("X-Provider", "stub-signer")
+	req.ContentLength = 2
+	w := httptest.NewRecorder()
+
+	handler(w, req)
+
+	if !signed {
+		t.Fatal("RequestSigner.SignProxyRequest was not called")
+	}
+	if seenSigned != "1" {
+		t.Errorf("upstream X-Signed = %q, want 1 (signer header not applied)", seenSigned)
 	}
 }
 

--- a/providers/anthropic/anthropic.go
+++ b/providers/anthropic/anthropic.go
@@ -37,10 +37,11 @@ type Provider struct {
 
 // Compile-time interface assertions.
 var (
-	_ core.Provider          = (*Provider)(nil)
-	_ core.StreamProvider    = (*Provider)(nil)
-	_ core.ProxiableProvider = (*Provider)(nil)
-	_ core.DiscoveryProvider = (*Provider)(nil)
+	_ core.Provider              = (*Provider)(nil)
+	_ core.StreamProvider        = (*Provider)(nil)
+	_ core.ProxiableProvider     = (*Provider)(nil)
+	_ core.NonOpenAIWireProvider = (*Provider)(nil)
+	_ core.DiscoveryProvider     = (*Provider)(nil)
 )
 
 // New creates a new Anthropic provider.

--- a/providers/anthropic/anthropic.go
+++ b/providers/anthropic/anthropic.go
@@ -75,6 +75,12 @@ func (p *Provider) Name() string { return p.name }
 // BaseURL implements core.ProxiableProvider.
 func (p *Provider) BaseURL() string { return p.baseURL }
 
+// NonOpenAIWire marks Anthropic as ineligible for transparent OpenAI-wire proxy
+// pass-through: its upstream is the Anthropic Messages API, not OpenAI-shaped.
+// It remains fully usable via its native translated endpoints. See
+// core.NonOpenAIWireProvider.
+func (*Provider) NonOpenAIWire() {}
+
 // AuthHeaders implements core.ProxiableProvider.
 func (p *Provider) AuthHeaders() map[string]string {
 	return map[string]string{

--- a/providers/anthropic/anthropic.go
+++ b/providers/anthropic/anthropic.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
 	"strings"
 
 	"github.com/ferro-labs/ai-gateway/internal/anthropicwire"
@@ -15,14 +14,6 @@ import (
 	providerhttp "github.com/ferro-labs/ai-gateway/internal/httpclient"
 	"github.com/ferro-labs/ai-gateway/providers/core"
 )
-
-func validateBaseURL(name, rawURL string) error {
-	u, err := url.Parse(rawURL)
-	if err != nil || (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
-		return fmt.Errorf("%s: invalid base URL %q: must be http or https with a host", name, rawURL)
-	}
-	return nil
-}
 
 // Name is the canonical provider identifier.
 const Name = "anthropic"
@@ -58,7 +49,7 @@ func New(apiKey, baseURL string) (*Provider, error) {
 		baseURL = defaultBaseURL
 	}
 	baseURL = strings.TrimRight(baseURL, "/")
-	if err := validateBaseURL(Name, baseURL); err != nil {
+	if err := core.ValidateBaseURL(Name, baseURL); err != nil {
 		return nil, err
 	}
 	return &Provider{

--- a/providers/azure_foundry/azure_foundry.go
+++ b/providers/azure_foundry/azure_foundry.go
@@ -28,9 +28,10 @@ type Provider struct {
 
 // Compile-time interface assertions.
 var (
-	_ core.Provider          = (*Provider)(nil)
-	_ core.StreamProvider    = (*Provider)(nil)
-	_ core.ProxiableProvider = (*Provider)(nil)
+	_ core.Provider              = (*Provider)(nil)
+	_ core.StreamProvider        = (*Provider)(nil)
+	_ core.ProxiableProvider     = (*Provider)(nil)
+	_ core.NonOpenAIWireProvider = (*Provider)(nil)
 )
 
 // New creates a new Azure AI Foundry provider.

--- a/providers/azure_foundry/azure_foundry.go
+++ b/providers/azure_foundry/azure_foundry.go
@@ -60,6 +60,13 @@ func (p *Provider) BaseURL() string { return p.baseURL }
 // APIVersion returns the configured Azure API version.
 func (p *Provider) APIVersion() string { return p.apiVersion }
 
+// NonOpenAIWire marks Azure AI Foundry as ineligible for transparent
+// OpenAI-wire proxy pass-through: its upstream uses Azure AI Foundry routing
+// paths and an api-version parameter, so an OpenAI-shaped request is not
+// directly forwardable. It remains fully usable via its native translated
+// endpoints. See core.NonOpenAIWireProvider.
+func (*Provider) NonOpenAIWire() {}
+
 // AuthHeaders implements core.ProxiableProvider.
 func (p *Provider) AuthHeaders() map[string]string {
 	return map[string]string{"api-key": p.apiKey}

--- a/providers/azure_openai/azure_openai.go
+++ b/providers/azure_openai/azure_openai.go
@@ -64,6 +64,13 @@ func (p *Provider) BaseURL() string { return p.baseURL }
 // APIVersion returns the configured Azure API version.
 func (p *Provider) APIVersion() string { return p.apiVersion }
 
+// NonOpenAIWire marks Azure OpenAI as ineligible for transparent OpenAI-wire
+// proxy pass-through: its upstream uses Azure deployment paths and an
+// api-version query parameter, so an OpenAI-shaped request is not directly
+// forwardable. It remains fully usable via its native translated endpoints. See
+// core.NonOpenAIWireProvider.
+func (*Provider) NonOpenAIWire() {}
+
 // AuthHeaders implements core.ProxiableProvider.
 func (p *Provider) AuthHeaders() map[string]string {
 	return map[string]string{"api-key": p.apiKey}

--- a/providers/azure_openai/azure_openai.go
+++ b/providers/azure_openai/azure_openai.go
@@ -32,11 +32,12 @@ type Provider struct {
 
 // Compile-time interface assertions.
 var (
-	_ core.Provider          = (*Provider)(nil)
-	_ core.StreamProvider    = (*Provider)(nil)
-	_ core.ProxiableProvider = (*Provider)(nil)
-	_ core.EmbeddingProvider = (*Provider)(nil)
-	_ core.ImageProvider     = (*Provider)(nil)
+	_ core.Provider              = (*Provider)(nil)
+	_ core.StreamProvider        = (*Provider)(nil)
+	_ core.ProxiableProvider     = (*Provider)(nil)
+	_ core.NonOpenAIWireProvider = (*Provider)(nil)
+	_ core.EmbeddingProvider     = (*Provider)(nil)
+	_ core.ImageProvider         = (*Provider)(nil)
 )
 
 // New creates a new Azure OpenAI provider.

--- a/providers/bedrock/bedrock.go
+++ b/providers/bedrock/bedrock.go
@@ -70,11 +70,12 @@ type Provider struct {
 
 // Compile-time interface assertions.
 var (
-	_ core.Provider          = (*Provider)(nil)
-	_ core.StreamProvider    = (*Provider)(nil)
-	_ core.EmbeddingProvider = (*Provider)(nil)
-	_ core.ImageProvider     = (*Provider)(nil)
-	_ core.ProxiableProvider = (*Provider)(nil)
+	_ core.Provider              = (*Provider)(nil)
+	_ core.StreamProvider        = (*Provider)(nil)
+	_ core.EmbeddingProvider     = (*Provider)(nil)
+	_ core.ImageProvider         = (*Provider)(nil)
+	_ core.ProxiableProvider     = (*Provider)(nil)
+	_ core.NonOpenAIWireProvider = (*Provider)(nil)
 )
 
 // New creates a new AWS Bedrock provider.

--- a/providers/bedrock/bedrock.go
+++ b/providers/bedrock/bedrock.go
@@ -155,6 +155,13 @@ func (p *Provider) BaseURL() string {
 	return fmt.Sprintf("https://bedrock-runtime.%s.amazonaws.com", p.region)
 }
 
+// NonOpenAIWire marks Bedrock as ineligible for transparent OpenAI-wire proxy
+// pass-through: its upstream is the AWS Bedrock API (SigV4-signed and not
+// OpenAI-shaped). It remains fully usable via its native translated endpoints,
+// and can graduate to signed pass-through by implementing RequestSigner. See
+// core.NonOpenAIWireProvider.
+func (*Provider) NonOpenAIWire() {}
+
 // AuthHeaders satisfies ProxiableProvider.
 func (p *Provider) AuthHeaders() map[string]string {
 	if p.bearerToken == "" {

--- a/providers/cohere/cohere.go
+++ b/providers/cohere/cohere.go
@@ -54,6 +54,12 @@ func (p *Provider) Name() string { return p.name }
 // BaseURL implements core.ProxiableProvider.
 func (p *Provider) BaseURL() string { return p.baseURL }
 
+// NonOpenAIWire marks Cohere as ineligible for transparent OpenAI-wire proxy
+// pass-through: its upstream is the Cohere v2 API, not OpenAI-shaped. It remains
+// fully usable via its native translated endpoints. See
+// core.NonOpenAIWireProvider.
+func (*Provider) NonOpenAIWire() {}
+
 // AuthHeaders implements core.ProxiableProvider.
 func (p *Provider) AuthHeaders() map[string]string {
 	return map[string]string{"Authorization": "Bearer " + p.apiKey}

--- a/providers/cohere/cohere.go
+++ b/providers/cohere/cohere.go
@@ -28,10 +28,11 @@ type Provider struct {
 
 // Compile-time interface assertions.
 var (
-	_ core.Provider          = (*Provider)(nil)
-	_ core.StreamProvider    = (*Provider)(nil)
-	_ core.ProxiableProvider = (*Provider)(nil)
-	_ core.EmbeddingProvider = (*Provider)(nil)
+	_ core.Provider              = (*Provider)(nil)
+	_ core.StreamProvider        = (*Provider)(nil)
+	_ core.ProxiableProvider     = (*Provider)(nil)
+	_ core.NonOpenAIWireProvider = (*Provider)(nil)
+	_ core.EmbeddingProvider     = (*Provider)(nil)
 )
 
 // New creates a new Cohere provider.

--- a/providers/core/contracts.go
+++ b/providers/core/contracts.go
@@ -10,7 +10,10 @@
 // to compile without changes.
 package core
 
-import "context"
+import (
+	"context"
+	"net/http"
+)
 
 // Provider defines the interface that all LLM providers must implement.
 type Provider interface {
@@ -37,6 +40,35 @@ type ProxiableProvider interface {
 	// AuthHeaders returns the HTTP headers required to authenticate with the
 	// provider (e.g. {"Authorization": "Bearer sk-..."}).
 	AuthHeaders() map[string]string
+}
+
+// NonOpenAIWireProvider is an optional marker for a ProxiableProvider whose
+// upstream cannot serve a transparently-forwarded OpenAI-shaped request at its
+// base URL — either because its request/response shape is not OpenAI-compatible
+// (Anthropic Messages, Google Gemini, AWS Bedrock, Cohere) or because it needs
+// non-standard path/auth rewriting (Azure OpenAI/Foundry deployment paths,
+// Vertex AI publisher-prefixed models).
+//
+// The transparent /v1/* pass-through proxy refuses these providers with 501
+// rather than forwarding a request their upstream cannot parse; they remain
+// fully usable through their native translated chat/embeddings/images
+// endpoints. A provider graduates to pass-through additively: via a separate
+// OpenAI-compatible provider entry, by implementing RequestSigner, or via a
+// future request-rewriter seam.
+type NonOpenAIWireProvider interface {
+	Provider
+	// NonOpenAIWire is a compile-time marker with no behavior.
+	NonOpenAIWire()
+}
+
+// RequestSigner is an optional interface for a ProxiableProvider whose upstream
+// requires per-request signing that cannot be expressed as static AuthHeaders
+// (e.g. AWS SigV4). When a provider implements it, the pass-through proxy signs
+// each outbound request before sending it upstream; a signing failure is
+// surfaced as an upstream error rather than forwarding an unsigned request.
+type RequestSigner interface {
+	// SignProxyRequest signs the fully-formed outbound proxy request in place.
+	SignProxyRequest(req *http.Request) error
 }
 
 // EmbeddingProvider is an optional interface for providers that support

--- a/providers/core/contracts.go
+++ b/providers/core/contracts.go
@@ -68,6 +68,10 @@ type NonOpenAIWireProvider interface {
 // surfaced as an upstream error rather than forwarding an unsigned request.
 type RequestSigner interface {
 	// SignProxyRequest signs the fully-formed outbound proxy request in place.
+	// An implementation that reads req.Body to compute the signature (e.g. AWS
+	// SigV4 body hashing) must restore it before returning — replace req.Body
+	// with a fresh io.NopCloser over the buffered bytes — so the base transport
+	// forwards the request with an intact body.
 	SignProxyRequest(req *http.Request) error
 }
 

--- a/providers/core/urlvalidate.go
+++ b/providers/core/urlvalidate.go
@@ -1,0 +1,19 @@
+package core
+
+import (
+	"fmt"
+	"net/url"
+)
+
+// ValidateBaseURL reports an error when rawURL is not a valid absolute HTTP(S)
+// URL with a host. Providers call it from their constructors so a misconfigured
+// base URL fails fast at startup instead of producing malformed upstream
+// requests. name is the provider identifier, included in the error for
+// diagnostics.
+func ValidateBaseURL(name, rawURL string) error {
+	u, err := url.Parse(rawURL)
+	if err != nil || (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
+		return fmt.Errorf("%s: invalid base URL %q: must be http or https with a host", name, rawURL)
+	}
+	return nil
+}

--- a/providers/core/urlvalidate_test.go
+++ b/providers/core/urlvalidate_test.go
@@ -1,0 +1,28 @@
+package core
+
+import "testing"
+
+func TestValidateBaseURL(t *testing.T) {
+	cases := []struct {
+		name    string
+		rawURL  string
+		wantErr bool
+	}{
+		{"https", "https://api.example.com", false},
+		{"https with path", "https://api.example.com/v1", false},
+		{"http", "http://localhost:8080", false},
+		{"empty", "", true},
+		{"no scheme", "api.example.com", true},
+		{"unsupported scheme", "ftp://api.example.com", true},
+		{"scheme without host", "https://", true},
+		{"unparseable", "http://[::1", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateBaseURL("prov", tc.rawURL)
+			if (err != nil) != tc.wantErr {
+				t.Errorf("ValidateBaseURL(%q) error = %v, wantErr = %v", tc.rawURL, err, tc.wantErr)
+			}
+		})
+	}
+}

--- a/providers/facade_aliases.go
+++ b/providers/facade_aliases.go
@@ -18,6 +18,12 @@ type StreamProvider = core.StreamProvider
 // ProxiableProvider is an alias for core.ProxiableProvider.
 type ProxiableProvider = core.ProxiableProvider
 
+// NonOpenAIWireProvider is an alias for core.NonOpenAIWireProvider.
+type NonOpenAIWireProvider = core.NonOpenAIWireProvider
+
+// RequestSigner is an alias for core.RequestSigner.
+type RequestSigner = core.RequestSigner
+
 // EmbeddingProvider is an alias for core.EmbeddingProvider.
 type EmbeddingProvider = core.EmbeddingProvider
 

--- a/providers/gemini/gemini.go
+++ b/providers/gemini/gemini.go
@@ -40,11 +40,12 @@ type Provider struct {
 
 // Compile-time interface assertions.
 var (
-	_ core.Provider          = (*Provider)(nil)
-	_ core.StreamProvider    = (*Provider)(nil)
-	_ core.EmbeddingProvider = (*Provider)(nil)
-	_ core.ImageProvider     = (*Provider)(nil)
-	_ core.ProxiableProvider = (*Provider)(nil)
+	_ core.Provider              = (*Provider)(nil)
+	_ core.StreamProvider        = (*Provider)(nil)
+	_ core.EmbeddingProvider     = (*Provider)(nil)
+	_ core.ImageProvider         = (*Provider)(nil)
+	_ core.ProxiableProvider     = (*Provider)(nil)
+	_ core.NonOpenAIWireProvider = (*Provider)(nil)
 )
 
 // New creates a new Google Gemini provider.

--- a/providers/gemini/gemini.go
+++ b/providers/gemini/gemini.go
@@ -67,6 +67,12 @@ func (p *Provider) Name() string { return p.name }
 // BaseURL implements core.ProxiableProvider.
 func (p *Provider) BaseURL() string { return p.baseURL }
 
+// NonOpenAIWire marks Gemini as ineligible for transparent OpenAI-wire proxy
+// pass-through: its upstream is the Gemini generateContent API, not
+// OpenAI-shaped. It remains fully usable via its native translated endpoints.
+// See core.NonOpenAIWireProvider.
+func (*Provider) NonOpenAIWire() {}
+
 // AuthHeaders implements core.ProxiableProvider.
 // Gemini authenticates via the ?key= query parameter (added by the proxy
 // director), so no Authorization header is required here.

--- a/providers/stability_test.go
+++ b/providers/stability_test.go
@@ -552,6 +552,33 @@ func TestProviderProxyCapabilityMatchesInterface(t *testing.T) {
 	}
 }
 
+// TestProviderNonOpenAIWireSet pins the exact set of providers gated from
+// transparent OpenAI-wire proxy pass-through via core.NonOpenAIWireProvider.
+// OpenAI-wire is the ecosystem default, so a new OpenAI-compatible provider must
+// NOT be added here; only a genuinely native / non-directly-forwardable provider
+// both implements the marker AND appears in this set. If this test fails,
+// reconcile the provider's marker with this list — do not blindly edit one side.
+func TestProviderNonOpenAIWireSet(t *testing.T) {
+	nativeOnly := map[string]bool{
+		NameAnthropic:    true,
+		NameGemini:       true,
+		NameBedrock:      true,
+		NameCohere:       true,
+		NameVertexAI:     true,
+		NameAzureOpenAI:  true,
+		NameAzureFoundry: true,
+	}
+	for _, tc := range providerNameStabilityCases() {
+		t.Run(tc.wantName, func(t *testing.T) {
+			p := tc.build(t)
+			_, marked := p.(NonOpenAIWireProvider)
+			if marked != nativeOnly[tc.wantName] {
+				t.Errorf("provider %q implements NonOpenAIWireProvider = %v, want %v (reconcile the provider marker with the gated set)", tc.wantName, marked, nativeOnly[tc.wantName])
+			}
+		})
+	}
+}
+
 // TestProviderEnvMappingsHaveRequiredKey verifies that each provider entry has
 // a configured? gate: either at least one EnvMapping with Required=true, or a
 // ConfiguredFn (used for providers whose gate is an OR across multiple env vars,

--- a/providers/vertex_ai/vertex_ai.go
+++ b/providers/vertex_ai/vertex_ai.go
@@ -98,6 +98,13 @@ func (p *Provider) BaseURL() string { return p.baseURL }
 // SetBaseURL overrides the base URL (used in tests to point to a mock server).
 func (p *Provider) SetBaseURL(url string) { p.baseURL = url }
 
+// NonOpenAIWire marks Vertex AI as ineligible for transparent OpenAI-wire proxy
+// pass-through: its upstream uses Vertex-native paths and auth (publisher-
+// prefixed models, project/location-scoped endpoints), not directly forwardable.
+// It remains fully usable via its native translated endpoints. See
+// core.NonOpenAIWireProvider.
+func (*Provider) NonOpenAIWire() {}
+
 // AuthHeaders implements core.ProxiableProvider.
 func (p *Provider) AuthHeaders() map[string]string {
 	if p.apiKey != "" {

--- a/providers/vertex_ai/vertex_ai.go
+++ b/providers/vertex_ai/vertex_ai.go
@@ -40,11 +40,12 @@ type Provider struct {
 
 // Compile-time interface assertions.
 var (
-	_ core.Provider          = (*Provider)(nil)
-	_ core.StreamProvider    = (*Provider)(nil)
-	_ core.EmbeddingProvider = (*Provider)(nil)
-	_ core.ImageProvider     = (*Provider)(nil)
-	_ core.ProxiableProvider = (*Provider)(nil)
+	_ core.Provider              = (*Provider)(nil)
+	_ core.StreamProvider        = (*Provider)(nil)
+	_ core.EmbeddingProvider     = (*Provider)(nil)
+	_ core.ImageProvider         = (*Provider)(nil)
+	_ core.ProxiableProvider     = (*Provider)(nil)
+	_ core.NonOpenAIWireProvider = (*Provider)(nil)
 )
 
 // New creates a new Vertex AI provider.


### PR DESCRIPTION
## Summary

Proxy & governance hardening. Corrects the `/v1/*` pass-through proxy and extends per-key budget governance beyond chat, plus two additive provider-contract seams. No breaking API changes relative to v1.1.9 — the `Provider`, `ProxiableProvider`, and plugin contracts are unchanged.

## Fixed

- **Pass-through proxy path doubling** — the `/v1/*` proxy no longer duplicates the `/v1` segment for providers whose configured base URL already ends in `/v1` (e.g. `https://api.x.ai/v1`), which previously produced a `/v1/v1/...` upstream path and a 404.

## Changed (operator-visible)

- **Pass-through proxy scope** — the `/v1/*` proxy now returns `501` for providers whose upstream API is not OpenAI-wire-compatible (Anthropic, Google Gemini, AWS Bedrock, Cohere, Vertex AI, Azure OpenAI/Foundry) instead of forwarding an OpenAI-shaped request their API cannot process — including the previously-unauthenticated AWS Bedrock SigV4 case. These providers remain fully available through their translated `chat/completions`, `embeddings`, and `images/generations` endpoints.
- **Per-key budget on embeddings and images** — per-key budget limits now apply to `/v1/embeddings` and `/v1/images/generations`, not only chat (embedding requests are gated and costed; image generation is gated, as it reports no token usage). Per-IP rate limiting, authentication, and the request body-size limit already applied to every endpoint.

## Added

- **`RequestSigner`** — an optional provider interface that lets a provider sign each outbound pass-through request (e.g. AWS SigV4); the proxy invokes it when present. No in-tree provider signs yet — this is the seam for future signed pass-through.
- **`core.ValidateBaseURL`** — a shared base-URL validator (`http(s)` with a host), adopted by the Anthropic provider; remaining providers migrate to it in subsequent releases.

## Compatibility

Additive only. No config, CLI, or HTTP request/response schema changes. The one operator-visible behavior change is non-OpenAI-compatible providers moving from a broken/unauthenticated pass-through to a clear `501` (documented in `CHANGELOG.md`).

## Test plan

- `make test` (unit, `-race`) — green across the tree.
- `make lint`, `make vet`, `gofmt` — clean.
- New coverage: proxy `/v1` de-duplication and non-wire `501` gate; `RequestSigner` invocation; budget gate/record via non-chat usage; embeddings governance pipeline (before-plugin reject, after-plugin surface/usage propagation); `core.ValidateBaseURL` table test.

## Commits

- `cba079c` fix: strip trailing `/v1` from provider base path in pass-through proxy
- `9931ee9` feat: gate non-OpenAI-wire providers from pass-through; add `RequestSigner` seam
- `d96498a` feat: apply per-key governance (budget) to embeddings and images
- `1566640` refactor: extract `core.ValidateBaseURL` as the shared base-URL validator
- `50c32b1` docs: add v1.1.10 changelog


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-request proxy signing for upstreams that require it.
  * Expanded per-key budget governance to enforce embeddings and image generation, with clearer surface/usage attribution for non-chat requests.
* **Bug Fixes**
  * Fixed `/v1` pass-through path handling to prevent double-prefixing.
  * Improved pass-through gating by returning **501** for incompatible non–OpenAI-wire upstreams.
  * Strengthened upstream base URL validation.
* **Tests**
  * Added coverage for embeddings/image governance, gateway plugin behavior, proxy `/v1` rules, non–OpenAI-wire gating, and request signing (including signing failure).
* **Documentation**
  * Added v1.1.10 “Proxy & governance hardening” release notes to the changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->