### PR TITLE
v1.1.11 - Native Tier-1 Provider Fidelity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable changes to Ferro Labs AI Gateway are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.11] — 2026-07-03
+
+Native tier-1 provider fidelity release. Aligns the OpenAI, Anthropic, Google Gemini, and AWS Bedrock providers on request/response correctness: forwards multimodal image content and sampling parameters that the streaming paths previously dropped, surfaces token usage the Bedrock and Gemini streaming paths discarded, refreshes stale model catalogs, and consolidates the duplicated Anthropic Messages decoding shared by the native Anthropic and Anthropic-on-Bedrock paths. No breaking API changes relative to v1.1.10. Closes [#265](https://github.com/ferro-labs/ai-gateway/issues/265); advances [#264](https://github.com/ferro-labs/ai-gateway/issues/264) and [#286](https://github.com/ferro-labs/ai-gateway/issues/286).
+
+### Fixed
+
+- **OpenAI streaming field parity** ([#265](https://github.com/ferro-labs/ai-gateway/issues/265)): a `stream: true` request now forwards the same `logit_bias` and multimodal `image_url` content as an identical `stream: false` request. The streaming path previously rebuilt the request through typed SDK params and silently dropped both; both paths now marshal the same request body, and streaming preserves nested reasoning/cache token usage.
+- **OpenAI image `response_format`**: the `response_format` parameter is no longer sent for `gpt-image-*` models, which reject it and always return base64. It is still sent for the DALL·E models.
+- **Bedrock streaming token usage**: Anthropic-on-Bedrock streaming now reports prompt and completion tokens (from `message_start`/`message_delta`) instead of reporting none.
+- **Gemini vision**: multimodal `image_url` content is now forwarded to Gemini (inline base64 for data URIs, a file URI for remote images) instead of being dropped.
+- **Gemini streaming and detailed usage**: streaming responses now surface token usage, and both paths capture cached-content and thinking (reasoning) token counts. Gemini responses also carry the provider name and upstream response ID.
+- **finish_reason normalization** ([#264](https://github.com/ferro-labs/ai-gateway/issues/264)): Gemini's content-blocking reasons (`RECITATION`, `SAFETY`, `BLOCKLIST`, …) now normalize to the canonical `content_filter` value, and Gemini routes through the shared normalizer.
+- **Anthropic user metadata**: the OpenAI `user` field is forwarded as Anthropic `metadata.user_id` instead of being dropped.
+- **Anthropic non-base64 data URIs**: a non-base64 image data URI is re-encoded to a base64 image source instead of being sent as an invalid URL source Anthropic would reject.
+- **Bedrock token accounting**: Titan responses now report total tokens, Anthropic-on-Bedrock responses capture prompt-cache tokens, and the Nova/Titan/Llama families now carry a response ID.
+
+### Changed
+
+- **Anthropic temperature range** (operator-visible): a temperature above Anthropic's supported maximum (`1`) is now clamped to `1` with a warning instead of being forwarded to an upstream 400. Applies to the native Anthropic and Anthropic-on-Bedrock paths; the gateway's accepted request range (0–2) is unchanged.
+- **Model catalog refresh** (operator-visible): the static model fallback lists for Google Gemini and Anthropic now advertise current-generation models and drop retired ones (Gemini 2.0/1.5). Live discovery, where enabled, continues to surface newer model IDs.
+- **Bedrock text-only image handling** (operator-visible): the Nova, Titan, and Llama families now log a warning when a request carries image content their text-only invocation path cannot forward, instead of dropping it silently.
+- **Bedrock transport**: the tuned per-provider HTTP client (higher cold-start dial/header timeouts) is now used for AWS Bedrock SDK calls.
+- **Internal consolidation**: the Anthropic Messages response and streaming decoders shared by the native Anthropic and Anthropic-on-Bedrock paths are consolidated into one internal package, removing the duplicated response structs and stream event handling. Behaviour-preserving for the native Anthropic path.
+
+---
+
 ## [1.1.10] — 2026-07-03
 
 Proxy & governance hardening release. Corrects the `/v1/*` pass-through proxy so it no longer doubles the `/v1` path segment and no longer forwards OpenAI-shaped requests to providers whose upstream API is not OpenAI-compatible, and extends per-key budget governance to the embeddings and image-generation endpoints. Adds an optional provider request-signing hook and a shared base-URL validator. No breaking API changes relative to v1.1.9 — the `Provider`, `ProxiableProvider`, and plugin contracts are unchanged.

--- a/config.example.json
+++ b/config.example.json
@@ -11,7 +11,7 @@
       "mode": "conditional",
       "conditions": [
         { "key": "model", "value": "gpt-4o",                      "target_key": "openai" },
-        { "key": "model", "value": "claude-3-5-sonnet-20241022",  "target_key": "anthropic" }
+        { "key": "model", "value": "claude-sonnet-4-6",  "target_key": "anthropic" }
       ]
     }
   },
@@ -138,8 +138,8 @@
   ],
   "aliases": {
     "fast": "gpt-4o-mini",
-    "smart": "claude-3-5-sonnet-20241022",
-    "cheap": "gemini-1.5-flash",
+    "smart": "claude-sonnet-4-6",
+    "cheap": "gemini-2.5-flash",
     "code": "deepseek-coder"
   },
   "plugins": [

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -22,7 +22,7 @@ strategy:
 #       value: gpt-4o
 #       target_key: openai
 #     - key: model
-#       value: claude-3-5-sonnet-20241022
+#       value: claude-sonnet-4-6
 #       target_key: anthropic
 # Routes based on the value of a request field (e.g. "model").
 
@@ -100,8 +100,8 @@ targets:
 # Aliases are resolved before routing and plugin execution.
 aliases:
   fast: gpt-4o-mini
-  smart: claude-3-5-sonnet-20241022
-  cheap: gemini-1.5-flash
+  smart: claude-sonnet-4-6
+  cheap: gemini-2.5-flash
   code: deepseek-coder
 
 # Optional plugins

--- a/internal/anthropicwire/params.go
+++ b/internal/anthropicwire/params.go
@@ -1,0 +1,32 @@
+package anthropicwire
+
+import (
+	"context"
+
+	"github.com/ferro-labs/ai-gateway/internal/logging"
+)
+
+// maxAnthropicTemperature is the upper bound the Anthropic Messages API accepts
+// for the temperature sampling parameter. The gateway's OpenAI-compatible seam
+// validates the wider 0–2 range, so a caller-supplied value can exceed it.
+const maxAnthropicTemperature = 1.0
+
+// ClampTemperature constrains an OpenAI-range temperature (0–2) to the range the
+// Anthropic Messages API accepts (0–1). A value above 1 is clamped to 1 and a
+// warn-level log records the adjustment so it is observable rather than a silent
+// upstream 400; in-range and nil values pass through unchanged. It never mutates
+// the caller's value — a clamp returns a fresh pointer.
+func ClampTemperature(ctx context.Context, provider, model string, temp *float64) *float64 {
+	if temp == nil || *temp <= maxAnthropicTemperature {
+		return temp
+	}
+	logging.FromContext(ctx).Warn(
+		"temperature above provider maximum; clamping",
+		"provider", provider,
+		"model", model,
+		"requested", *temp,
+		"clamped_to", maxAnthropicTemperature,
+	)
+	clamped := maxAnthropicTemperature
+	return &clamped
+}

--- a/internal/anthropicwire/params_test.go
+++ b/internal/anthropicwire/params_test.go
@@ -1,0 +1,41 @@
+package anthropicwire
+
+import (
+	"context"
+	"testing"
+)
+
+func f64(v float64) *float64 { return &v }
+
+func TestClampTemperature(t *testing.T) {
+	cases := []struct {
+		name string
+		in   *float64
+		want *float64 // nil means "same pointer expected"
+	}{
+		{"nil passes through", nil, nil},
+		{"in range passes through", f64(0.7), f64(0.7)},
+		{"exactly one passes through", f64(1.0), f64(1.0)},
+		{"above range clamps to one", f64(1.8), f64(1.0)},
+		{"openai max clamps to one", f64(2.0), f64(1.0)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ClampTemperature(context.Background(), "anthropic", "claude", tc.in)
+			switch {
+			case tc.want == nil && got != nil:
+				t.Fatalf("got %v, want nil", *got)
+			case tc.want == nil:
+				// ok
+			case got == nil:
+				t.Fatalf("got nil, want %v", *tc.want)
+			case *got != *tc.want:
+				t.Fatalf("got %v, want %v", *got, *tc.want)
+			}
+			// Immutability: a clamp must not mutate the caller's value.
+			if tc.in != nil && *tc.in > maxAnthropicTemperature && got == tc.in {
+				t.Fatal("clamp mutated caller's pointer")
+			}
+		})
+	}
+}

--- a/internal/anthropicwire/response.go
+++ b/internal/anthropicwire/response.go
@@ -1,0 +1,93 @@
+package anthropicwire
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/ferro-labs/ai-gateway/providers/core"
+)
+
+// BlockTypeToolUse is the Anthropic content-block type for a tool call, shared
+// by the request builders and the response/stream decoders.
+const BlockTypeToolUse = "tool_use"
+
+// Usage is the token accounting Anthropic returns on a Messages response and on
+// streaming message_start / message_delta events. The Anthropic-on-Bedrock path
+// does not report the cache fields, which stay zero there.
+type Usage struct {
+	InputTokens              int `json:"input_tokens"`
+	OutputTokens             int `json:"output_tokens"`
+	CacheReadInputTokens     int `json:"cache_read_input_tokens"`
+	CacheCreationInputTokens int `json:"cache_creation_input_tokens"`
+}
+
+// ContentBlock is one block of an Anthropic Messages response (a text block or a
+// tool_use block). Only the fields relevant to Type are populated.
+type ContentBlock struct {
+	Type  string          `json:"type"`
+	Text  string          `json:"text"`
+	ID    string          `json:"id"`
+	Name  string          `json:"name"`
+	Input json.RawMessage `json:"input"`
+}
+
+// Response is the non-streaming Anthropic Messages API response body, shared by
+// the standalone Anthropic provider and the Anthropic-on-Bedrock path (which
+// target the same JSON shape over different transports).
+type Response struct {
+	ID         string         `json:"id"`
+	Type       string         `json:"type"`
+	Role       string         `json:"role"`
+	Content    []ContentBlock `json:"content"`
+	Model      string         `json:"model"`
+	StopReason string         `json:"stop_reason"`
+	Usage      Usage          `json:"usage"`
+}
+
+// DecodeContent renders response content blocks into concatenated assistant text
+// plus canonical tool calls. Text blocks are joined in order; each tool_use
+// block becomes a core.ToolCall whose Arguments default to "{}" when the block
+// carries no input.
+func DecodeContent(blocks []ContentBlock) (text string, toolCalls []core.ToolCall) {
+	var b strings.Builder
+	for _, block := range blocks {
+		switch block.Type {
+		case "text":
+			b.WriteString(block.Text)
+		case BlockTypeToolUse:
+			args := string(block.Input)
+			if args == "" {
+				args = "{}"
+			}
+			toolCalls = append(toolCalls, core.ToolCall{
+				ID:   block.ID,
+				Type: "function",
+				Function: core.FunctionCall{
+					Name:      block.Name,
+					Arguments: args,
+				},
+			})
+		}
+	}
+	return b.String(), toolCalls
+}
+
+// ParseDataURI splits a data URI of the form "data:<media-type>;base64,<data>"
+// into its media type and base64 payload. ok is false for any non-base64 data
+// URI or a plain remote URL, letting each transport decide how to handle those
+// (the native Anthropic API accepts remote URLs; Bedrock does not).
+func ParseDataURI(uri string) (mediaType, data string, ok bool) {
+	const prefix = "data:"
+	if !strings.HasPrefix(uri, prefix) {
+		return "", "", false
+	}
+	meta, payload, found := strings.Cut(uri[len(prefix):], ",")
+	if !found {
+		return "", "", false
+	}
+	mediaType, encoding, _ := strings.Cut(meta, ";")
+	if encoding != "base64" {
+		return "", "", false
+	}
+	return mediaType, payload, true
+}

--- a/internal/anthropicwire/response.go
+++ b/internal/anthropicwire/response.go
@@ -2,6 +2,7 @@ package anthropicwire
 
 import (
 	"encoding/json"
+	"slices"
 	"strings"
 
 	"github.com/ferro-labs/ai-gateway/providers/core"
@@ -72,10 +73,12 @@ func DecodeContent(blocks []ContentBlock) (text string, toolCalls []core.ToolCal
 	return b.String(), toolCalls
 }
 
-// ParseDataURI splits a data URI of the form "data:<media-type>;base64,<data>"
-// into its media type and base64 payload. ok is false for any non-base64 data
-// URI or a plain remote URL, letting each transport decide how to handle those
-// (the native Anthropic API accepts remote URLs; Bedrock does not).
+// ParseDataURI splits a data URI of the form
+// "data:<media-type>[;param]...;base64,<data>" into its media type and base64
+// payload. ok is false for any non-base64 data URI or a plain remote URL,
+// letting each transport decide how to handle those (the native Anthropic API
+// accepts remote URLs; Bedrock does not). The "base64" token may appear after
+// other parameters (e.g. "data:image/png;charset=utf-8;base64,...").
 func ParseDataURI(uri string) (mediaType, data string, ok bool) {
 	const prefix = "data:"
 	if !strings.HasPrefix(uri, prefix) {
@@ -85,9 +88,9 @@ func ParseDataURI(uri string) (mediaType, data string, ok bool) {
 	if !found {
 		return "", "", false
 	}
-	mediaType, encoding, _ := strings.Cut(meta, ";")
-	if encoding != "base64" {
-		return "", "", false
+	params := strings.Split(meta, ";")
+	if slices.Contains(params[1:], "base64") {
+		return params[0], payload, true
 	}
-	return mediaType, payload, true
+	return "", "", false
 }

--- a/internal/anthropicwire/response_test.go
+++ b/internal/anthropicwire/response_test.go
@@ -1,0 +1,28 @@
+package anthropicwire
+
+import "testing"
+
+func TestParseDataURI(t *testing.T) {
+	cases := []struct {
+		name      string
+		uri       string
+		wantOK    bool
+		wantMedia string
+		wantData  string
+	}{
+		{"base64", "data:image/png;base64,QUJD", true, "image/png", "QUJD"},
+		{"base64 after charset param", "data:image/png;charset=utf-8;base64,QUJD", true, "image/png", "QUJD"},
+		{"non-base64 data URI", "data:image/png,rawtext", false, "", ""},
+		{"remote url", "https://example.com/x.png", false, "", ""},
+		{"no comma", "data:image/png;base64", false, "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mt, data, ok := ParseDataURI(tc.uri)
+			if ok != tc.wantOK || mt != tc.wantMedia || data != tc.wantData {
+				t.Fatalf("ParseDataURI(%q) = (%q, %q, %v), want (%q, %q, %v)",
+					tc.uri, mt, data, ok, tc.wantMedia, tc.wantData, tc.wantOK)
+			}
+		})
+	}
+}

--- a/internal/anthropicwire/stream.go
+++ b/internal/anthropicwire/stream.go
@@ -1,0 +1,241 @@
+package anthropicwire
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/ferro-labs/ai-gateway/providers/core"
+)
+
+// StreamDecoder converts a sequence of Anthropic Messages streaming events
+// (message_start, content_block_start, content_block_delta, message_delta and
+// mid-stream error frames) into canonical core.StreamChunk values.
+//
+// It is transport-agnostic: the standalone Anthropic provider feeds it SSE
+// "data:" payloads and the Anthropic-on-Bedrock path feeds it
+// InvokeModelWithResponseStream chunk bytes. Both wire the same event schema, so
+// centralising the decode here removes the copy-paste between the two providers
+// — and, in doing so, gives the Bedrock path the token-usage capture it
+// previously dropped. A StreamDecoder is stateful and NOT safe for concurrent
+// use; construct one per stream with NewStreamDecoder.
+type StreamDecoder struct {
+	label         string // provider name used in mid-stream error messages
+	fallbackModel string // emitted when the stream carries no message_start model
+
+	msgID string
+	model string
+
+	promptTokens     int
+	cacheReadTokens  int
+	cacheWriteTokens int
+
+	toolCallIndexes   map[int]int  // Anthropic content-block index -> OpenAI tool-call index
+	toolArgsSeen      map[int]bool // OpenAI tool-call index -> received any input_json_delta
+	nextToolCallIndex int
+}
+
+// NewStreamDecoder returns a StreamDecoder. label prefixes mid-stream error
+// messages (e.g. "anthropic"). fallbackModel is stamped on chunks when the
+// caller wants the request's model reported (Bedrock's event stream); pass ""
+// to use the model the upstream reports on message_start.
+func NewStreamDecoder(label, fallbackModel string) *StreamDecoder {
+	return &StreamDecoder{
+		label:           label,
+		fallbackModel:   fallbackModel,
+		toolCallIndexes: make(map[int]int),
+		toolArgsSeen:    make(map[int]bool),
+	}
+}
+
+// chunkModel returns the model to stamp on emitted chunks: the caller-supplied
+// fallback when set, otherwise the model reported by message_start.
+func (d *StreamDecoder) chunkModel() string {
+	if d.fallbackModel != "" {
+		return d.fallbackModel
+	}
+	return d.model
+}
+
+// Event decodes one raw Anthropic streaming event and returns the chunks to emit
+// (possibly none). A mid-stream "error" frame returns a non-nil error; the
+// caller should surface it on the channel and stop reading — no further events
+// are processed after an error. Frames that fail to decode yield no chunks and
+// no error (they are skipped, matching the prior per-provider handling of
+// keep-alives and unknown event types).
+func (d *StreamDecoder) Event(data []byte) ([]core.StreamChunk, error) {
+	var typed struct {
+		Type string `json:"type"`
+	}
+	if json.Unmarshal(data, &typed) != nil {
+		return nil, nil
+	}
+
+	switch typed.Type {
+	case "error":
+		return nil, d.errorEvent(data)
+	case "message_start":
+		d.messageStart(data)
+		return nil, nil
+	case "content_block_start":
+		return d.contentBlockStart(data), nil
+	case "content_block_delta":
+		return d.contentBlockDelta(data), nil
+	case "message_delta":
+		return d.messageDelta(data), nil
+	default:
+		return nil, nil
+	}
+}
+
+func (d *StreamDecoder) errorEvent(data []byte) error {
+	var evt struct {
+		Error struct {
+			Type    string `json:"type"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if json.Unmarshal(data, &evt) == nil && evt.Error.Message != "" {
+		return fmt.Errorf("%s stream error (%s): %s", d.label, evt.Error.Type, evt.Error.Message)
+	}
+	return fmt.Errorf("%s stream error: %s", d.label, data)
+}
+
+func (d *StreamDecoder) messageStart(data []byte) {
+	var evt struct {
+		Message struct {
+			ID    string `json:"id"`
+			Model string `json:"model"`
+			Usage Usage  `json:"usage"`
+		} `json:"message"`
+	}
+	if json.Unmarshal(data, &evt) != nil {
+		return
+	}
+	d.msgID = evt.Message.ID
+	d.model = evt.Message.Model
+	// Anthropic reports prompt + cache tokens once, on message_start;
+	// output_tokens arrive later on message_delta.
+	d.promptTokens = evt.Message.Usage.InputTokens
+	d.cacheReadTokens = evt.Message.Usage.CacheReadInputTokens
+	d.cacheWriteTokens = evt.Message.Usage.CacheCreationInputTokens
+}
+
+func (d *StreamDecoder) contentBlockStart(data []byte) []core.StreamChunk {
+	var evt struct {
+		Index        int `json:"index"`
+		ContentBlock struct {
+			Type string `json:"type"`
+			ID   string `json:"id"`
+			Name string `json:"name"`
+		} `json:"content_block"`
+	}
+	if json.Unmarshal(data, &evt) != nil || evt.ContentBlock.Type != BlockTypeToolUse {
+		return nil
+	}
+	toolCallIndex := d.nextToolCallIndex
+	d.toolCallIndexes[evt.Index] = toolCallIndex
+	d.nextToolCallIndex++
+	return []core.StreamChunk{d.toolChunk(core.ToolCall{
+		Index:    core.Ptr(toolCallIndex),
+		ID:       evt.ContentBlock.ID,
+		Type:     "function",
+		Function: core.FunctionCall{Name: evt.ContentBlock.Name},
+	})}
+}
+
+func (d *StreamDecoder) contentBlockDelta(data []byte) []core.StreamChunk {
+	var evt struct {
+		Index int `json:"index"`
+		Delta struct {
+			Type        string `json:"type"`
+			Text        string `json:"text"`
+			PartialJSON string `json:"partial_json"`
+		} `json:"delta"`
+	}
+	if json.Unmarshal(data, &evt) != nil {
+		return nil
+	}
+	switch evt.Delta.Type {
+	case "input_json_delta":
+		// evt.Index is Anthropic's content-block index; map it to the OpenAI
+		// tool-call index assigned at content_block_start.
+		toolCallIndex, ok := d.toolCallIndexes[evt.Index]
+		if !ok {
+			toolCallIndex = evt.Index
+		}
+		d.toolArgsSeen[toolCallIndex] = true
+		return []core.StreamChunk{d.toolChunk(core.ToolCall{
+			Index:    core.Ptr(toolCallIndex),
+			Type:     "function",
+			Function: core.FunctionCall{Arguments: evt.Delta.PartialJSON},
+		})}
+	case "text_delta":
+		return []core.StreamChunk{{
+			ID:    d.msgID,
+			Model: d.chunkModel(),
+			// Single completion: the OpenAI choice index is always 0 (evt.Index
+			// is Anthropic's content-block index, not a choice index).
+			Choices: []core.StreamChoice{{
+				Index: 0,
+				Delta: core.MessageDelta{Content: evt.Delta.Text},
+			}},
+		}}
+	default:
+		return nil
+	}
+}
+
+func (d *StreamDecoder) messageDelta(data []byte) []core.StreamChunk {
+	var chunks []core.StreamChunk
+	// Emit "{}" arguments for any tool call that produced no input_json_delta
+	// (zero-argument tools) so clients that JSON.parse the arguments don't choke
+	// on an empty string. Iterate in assignment order for a deterministic stream.
+	for i := 0; i < d.nextToolCallIndex; i++ {
+		if d.toolArgsSeen[i] {
+			continue
+		}
+		chunks = append(chunks, d.toolChunk(core.ToolCall{
+			Index:    core.Ptr(i),
+			Type:     "function",
+			Function: core.FunctionCall{Arguments: "{}"},
+		}))
+	}
+
+	var evt struct {
+		Delta struct {
+			StopReason string `json:"stop_reason"`
+		} `json:"delta"`
+		Usage Usage `json:"usage"`
+	}
+	_ = json.Unmarshal(data, &evt)
+	completionTokens := evt.Usage.OutputTokens
+	chunks = append(chunks, core.StreamChunk{
+		ID:    d.msgID,
+		Model: d.chunkModel(),
+		Choices: []core.StreamChoice{{
+			Index:        0,
+			FinishReason: core.NormalizeFinishReason(evt.Delta.StopReason),
+		}},
+		Usage: &core.Usage{
+			PromptTokens:     d.promptTokens,
+			CompletionTokens: completionTokens,
+			TotalTokens:      d.promptTokens + completionTokens,
+			CacheReadTokens:  d.cacheReadTokens,
+			CacheWriteTokens: d.cacheWriteTokens,
+		},
+	})
+	return chunks
+}
+
+// toolChunk wraps a single tool-call delta in a StreamChunk stamped with the
+// current message ID and model.
+func (d *StreamDecoder) toolChunk(tc core.ToolCall) core.StreamChunk {
+	return core.StreamChunk{
+		ID:    d.msgID,
+		Model: d.chunkModel(),
+		Choices: []core.StreamChoice{{
+			Index: 0,
+			Delta: core.MessageDelta{ToolCalls: []core.ToolCall{tc}},
+		}},
+	}
+}

--- a/internal/anthropicwire/stream_test.go
+++ b/internal/anthropicwire/stream_test.go
@@ -1,0 +1,130 @@
+package anthropicwire
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/ferro-labs/ai-gateway/providers/core"
+)
+
+// drain feeds a sequence of raw events through a decoder and collects every
+// emitted chunk plus the first terminal error.
+func drain(d *StreamDecoder, events ...string) ([]core.StreamChunk, error) {
+	var out []core.StreamChunk
+	for _, e := range events {
+		chunks, err := d.Event([]byte(e))
+		out = append(out, chunks...)
+		if err != nil {
+			return out, err
+		}
+	}
+	return out, nil
+}
+
+func TestStreamDecoder_CapturesUsageAcrossStartAndDelta(t *testing.T) {
+	d := NewStreamDecoder("anthropic", "")
+	chunks, err := drain(d,
+		`{"type":"message_start","message":{"id":"msg_1","model":"claude","role":"assistant","usage":{"input_tokens":25,"cache_read_input_tokens":4,"cache_creation_input_tokens":6}}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"hi"}}`,
+		`{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":15}}`,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// text chunk carries the message_start id + model (no fallback given).
+	if chunks[0].ID != "msg_1" || chunks[0].Model != "claude" {
+		t.Fatalf("text chunk id/model = %q/%q, want msg_1/claude", chunks[0].ID, chunks[0].Model)
+	}
+	if chunks[0].Choices[0].Delta.Content != "hi" {
+		t.Fatalf("text = %q, want hi", chunks[0].Choices[0].Delta.Content)
+	}
+
+	final := chunks[len(chunks)-1]
+	if final.Choices[0].FinishReason != core.FinishReasonStop {
+		t.Fatalf("finish = %q, want stop", final.Choices[0].FinishReason)
+	}
+	if final.Usage == nil {
+		t.Fatal("final chunk has no usage")
+	}
+	if final.Usage.PromptTokens != 25 || final.Usage.CompletionTokens != 15 || final.Usage.TotalTokens != 40 {
+		t.Fatalf("usage tokens = %d/%d/%d, want 25/15/40",
+			final.Usage.PromptTokens, final.Usage.CompletionTokens, final.Usage.TotalTokens)
+	}
+	if final.Usage.CacheReadTokens != 4 || final.Usage.CacheWriteTokens != 6 {
+		t.Fatalf("cache = %d/%d, want 4/6", final.Usage.CacheReadTokens, final.Usage.CacheWriteTokens)
+	}
+}
+
+// TestStreamDecoder_FallbackModelAndUsage exercises the Bedrock-style path: no
+// message_start model is emitted on chunks (the request model wins), and usage
+// is still captured — the behaviour the Bedrock stream previously dropped.
+func TestStreamDecoder_FallbackModelAndUsage(t *testing.T) {
+	d := NewStreamDecoder("bedrock", "anthropic.claude-3-5-sonnet-20241022-v2:0")
+	chunks, err := drain(d,
+		`{"type":"message_start","message":{"id":"msg_9","model":"claude-3-5-sonnet-20241022","usage":{"input_tokens":11}}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"ok"}}`,
+		`{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":7}}`,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, c := range chunks {
+		if c.Model != "anthropic.claude-3-5-sonnet-20241022-v2:0" {
+			t.Fatalf("chunk model = %q, want request model (fallback)", c.Model)
+		}
+	}
+	final := chunks[len(chunks)-1]
+	if final.Usage == nil || final.Usage.PromptTokens != 11 || final.Usage.CompletionTokens != 7 {
+		t.Fatalf("bedrock-path usage = %#v, want prompt 11 / completion 7", final.Usage)
+	}
+}
+
+func TestStreamDecoder_ToolUseSequenceAndZeroArgTool(t *testing.T) {
+	d := NewStreamDecoder("anthropic", "")
+	// Two tool calls: the first receives arguments, the second is zero-argument
+	// and must get a synthesised "{}" before the finish chunk.
+	chunks, err := drain(d,
+		`{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_1","name":"a"}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"x\":1}"}}`,
+		`{"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_2","name":"b"}}`,
+		`{"type":"message_delta","delta":{"stop_reason":"tool_use"}}`,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// start(a), args(a), start(b), zero-arg(b), finish = 5 chunks.
+	if len(chunks) != 5 {
+		t.Fatalf("chunks = %d, want 5: %#v", len(chunks), chunks)
+	}
+	if idx := chunks[0].Choices[0].Delta.ToolCalls[0].Index; idx == nil || *idx != 0 {
+		t.Fatalf("first tool index = %v, want 0", idx)
+	}
+	if idx := chunks[2].Choices[0].Delta.ToolCalls[0].Index; idx == nil || *idx != 1 {
+		t.Fatalf("second tool index = %v, want 1", idx)
+	}
+	zeroArg := chunks[3].Choices[0].Delta.ToolCalls[0]
+	if zeroArg.Index == nil || *zeroArg.Index != 1 || zeroArg.Function.Arguments != "{}" {
+		t.Fatalf("zero-arg tool chunk = %#v, want index 1 with {}", zeroArg)
+	}
+	if chunks[4].Choices[0].FinishReason != core.FinishReasonToolCalls {
+		t.Fatalf("finish = %q, want tool_calls", chunks[4].Choices[0].FinishReason)
+	}
+}
+
+func TestStreamDecoder_ErrorEventStopsStream(t *testing.T) {
+	d := NewStreamDecoder("anthropic", "")
+	chunks, err := d.Event([]byte(`{"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}`))
+	if len(chunks) != 0 {
+		t.Fatalf("error event emitted %d chunks, want 0", len(chunks))
+	}
+	if err == nil {
+		t.Fatal("error event returned nil error")
+	}
+	if !strings.Contains(err.Error(), "overloaded_error") || !strings.Contains(err.Error(), "Overloaded") {
+		t.Fatalf("error = %v, want type + message", err)
+	}
+	if !strings.HasPrefix(err.Error(), "anthropic stream error") {
+		t.Fatalf("error = %v, want provider-labelled prefix", err)
+	}
+}

--- a/providers/anthropic/anthropic.go
+++ b/providers/anthropic/anthropic.go
@@ -3,10 +3,12 @@ package anthropic
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"github.com/ferro-labs/ai-gateway/internal/anthropicwire"
@@ -94,10 +96,10 @@ func (p *Provider) DiscoverModels(ctx context.Context) ([]core.ModelInfo, error)
 // SupportedModels returns the list of models supported by this provider.
 func (p *Provider) SupportedModels() []string {
 	return []string{
-		"claude-sonnet-4-20250514",
-		"claude-3-5-sonnet-20241022",
-		"claude-3-haiku-20240307",
-		"claude-3-opus-20240229",
+		"claude-opus-4-8",
+		"claude-sonnet-5",
+		"claude-fable-5",
+		"claude-haiku-4-5-20251001",
 	}
 }
 
@@ -121,12 +123,19 @@ type anthropicRequest struct {
 	Temperature   *float64                `json:"temperature,omitempty"`
 	TopP          *float64                `json:"top_p,omitempty"`
 	StopSequences []string                `json:"stop_sequences,omitempty"`
+	Metadata      *anthropicMetadata      `json:"metadata,omitempty"`
 	Stream        bool                    `json:"stream,omitempty"`
+}
+
+// anthropicMetadata carries the optional request metadata; user_id maps the
+// OpenAI "user" field, which Anthropic uses for abuse monitoring.
+type anthropicMetadata struct {
+	UserID string `json:"user_id,omitempty"`
 }
 
 // anthropicSupportedParams lists the OpenAI parameters the Anthropic Messages
 // API can express. Anything else the caller sets is warn-and-dropped (#140).
-var anthropicSupportedParams = []string{"temperature", "top_p", "max_tokens", "stop", "tools", "tool_choice"}
+var anthropicSupportedParams = []string{"temperature", "top_p", "max_tokens", "stop", "tools", "tool_choice", "user"}
 
 // buildContent renders a non-system message's content for the Anthropic API.
 // Plain text turns stay a JSON string (the common path); multimodal turns and
@@ -172,23 +181,50 @@ func buildContent(msg core.Message) any {
 	return blocks
 }
 
-// imageBlock maps an OpenAI image_url (data URI or remote URL) to an Anthropic
-// image content block.
-func imageBlock(url string) anthropicwire.Block {
-	if mediaType, data, ok := anthropicwire.ParseDataURI(url); ok {
-		return anthropicwire.Block{
-			Type: "image",
-			Source: &anthropicwire.ImageSource{
-				Type:      "base64",
-				MediaType: mediaType,
-				Data:      data,
-			},
+// imageBlock maps an OpenAI image_url to an Anthropic image content block: a
+// base64 source for a data URI (re-encoding a non-base64 data URI's payload), or
+// a url source for a genuine remote URL. A data: URI is never emitted as a url
+// source, which Anthropic would reject.
+func imageBlock(imageURL string) anthropicwire.Block {
+	if mediaType, data, ok := anthropicwire.ParseDataURI(imageURL); ok {
+		return base64ImageBlock(mediaType, data)
+	}
+	if strings.HasPrefix(imageURL, "data:") {
+		if mediaType, encoded, ok := reencodeDataURI(imageURL); ok {
+			return base64ImageBlock(mediaType, encoded)
 		}
 	}
 	return anthropicwire.Block{
 		Type:   "image",
-		Source: &anthropicwire.ImageSource{Type: "url", URL: url},
+		Source: &anthropicwire.ImageSource{Type: "url", URL: imageURL},
 	}
+}
+
+func base64ImageBlock(mediaType, data string) anthropicwire.Block {
+	return anthropicwire.Block{
+		Type: "image",
+		Source: &anthropicwire.ImageSource{
+			Type:      "base64",
+			MediaType: mediaType,
+			Data:      data,
+		},
+	}
+}
+
+// reencodeDataURI converts a non-base64 data URI ("data:<mediatype>,<payload>",
+// where payload is percent-encoded per RFC 2397) into a media type and base64
+// payload so it can be sent as an Anthropic base64 image source.
+func reencodeDataURI(uri string) (mediaType, base64Data string, ok bool) {
+	meta, payload, found := strings.Cut(strings.TrimPrefix(uri, "data:"), ",")
+	if !found {
+		return "", "", false
+	}
+	mediaType, _, _ = strings.Cut(meta, ";")
+	decoded, err := url.QueryUnescape(payload)
+	if err != nil {
+		return "", "", false
+	}
+	return mediaType, base64.StdEncoding.EncodeToString([]byte(decoded)), true
 }
 
 // buildAnthropicRequest maps a core.Request to an Anthropic Messages API request
@@ -202,6 +238,11 @@ func buildAnthropicRequest(ctx context.Context, req core.Request, stream bool) a
 		maxTokens = *req.MaxTokens
 	}
 
+	var metadata *anthropicMetadata
+	if req.User != "" {
+		metadata = &anthropicMetadata{UserID: req.User}
+	}
+
 	return anthropicRequest{
 		Model:         req.Model,
 		MaxTokens:     maxTokens,
@@ -212,6 +253,7 @@ func buildAnthropicRequest(ctx context.Context, req core.Request, stream bool) a
 		System:        system,
 		Tools:         anthropicwire.MapTools(req.Tools),
 		ToolChoice:    anthropicwire.MapToolChoice(req.ToolChoice, req.Tools),
+		Metadata:      metadata,
 		Stream:        stream,
 	}
 }

--- a/providers/anthropic/anthropic.go
+++ b/providers/anthropic/anthropic.go
@@ -189,10 +189,12 @@ func imageBlock(imageURL string) anthropicwire.Block {
 	if mediaType, data, ok := anthropicwire.ParseDataURI(imageURL); ok {
 		return base64ImageBlock(mediaType, data)
 	}
+	// Any other data: URI (non-base64 or malformed) is re-encoded to a base64
+	// source; a data: URI is never emitted as a url source, which Anthropic
+	// would reject.
 	if strings.HasPrefix(imageURL, "data:") {
-		if mediaType, encoded, ok := reencodeDataURI(imageURL); ok {
-			return base64ImageBlock(mediaType, encoded)
-		}
+		mediaType, encoded := reencodeDataURI(imageURL)
+		return base64ImageBlock(mediaType, encoded)
 	}
 	return anthropicwire.Block{
 		Type:   "image",
@@ -211,20 +213,18 @@ func base64ImageBlock(mediaType, data string) anthropicwire.Block {
 	}
 }
 
-// reencodeDataURI converts a non-base64 data URI ("data:<mediatype>,<payload>",
-// where payload is percent-encoded per RFC 2397) into a media type and base64
-// payload so it can be sent as an Anthropic base64 image source.
-func reencodeDataURI(uri string) (mediaType, base64Data string, ok bool) {
-	meta, payload, found := strings.Cut(strings.TrimPrefix(uri, "data:"), ",")
-	if !found {
-		return "", "", false
-	}
+// reencodeDataURI converts a non-base64 data URI ("data:<mediatype>[;param],<payload>",
+// payload percent-encoded per RFC 2397) into a media type and base64 payload. It
+// is best-effort: a payload that is not valid percent-encoding is base64-encoded
+// as-is, so a data: URI is never left as an (invalid) url source.
+func reencodeDataURI(uri string) (mediaType, base64Data string) {
+	meta, payload, _ := strings.Cut(strings.TrimPrefix(uri, "data:"), ",")
 	mediaType, _, _ = strings.Cut(meta, ";")
 	decoded, err := url.QueryUnescape(payload)
 	if err != nil {
-		return "", "", false
+		decoded = payload
 	}
-	return mediaType, base64.StdEncoding.EncodeToString([]byte(decoded)), true
+	return mediaType, base64.StdEncoding.EncodeToString([]byte(decoded))
 }
 
 // buildAnthropicRequest maps a core.Request to an Anthropic Messages API request

--- a/providers/anthropic/anthropic.go
+++ b/providers/anthropic/anthropic.go
@@ -96,9 +96,9 @@ func (p *Provider) DiscoverModels(ctx context.Context) ([]core.ModelInfo, error)
 // SupportedModels returns the list of models supported by this provider.
 func (p *Provider) SupportedModels() []string {
 	return []string{
-		"claude-opus-4-8",
-		"claude-sonnet-5",
-		"claude-fable-5",
+		"claude-opus-4-7",
+		"claude-opus-4-6",
+		"claude-sonnet-4-6",
 		"claude-haiku-4-5-20251001",
 	}
 }

--- a/providers/anthropic/anthropic.go
+++ b/providers/anthropic/anthropic.go
@@ -220,7 +220,9 @@ func base64ImageBlock(mediaType, data string) anthropicwire.Block {
 func reencodeDataURI(uri string) (mediaType, base64Data string) {
 	meta, payload, _ := strings.Cut(strings.TrimPrefix(uri, "data:"), ",")
 	mediaType, _, _ = strings.Cut(meta, ";")
-	decoded, err := url.QueryUnescape(payload)
+	// PathUnescape (not QueryUnescape) so a "+" in the RFC 2397 payload is kept
+	// literal rather than decoded to a space.
+	decoded, err := url.PathUnescape(payload)
 	if err != nil {
 		decoded = payload
 	}

--- a/providers/anthropic/anthropic.go
+++ b/providers/anthropic/anthropic.go
@@ -124,37 +124,9 @@ type anthropicRequest struct {
 	Stream        bool                    `json:"stream,omitempty"`
 }
 
-// blockTypeToolUse is the Anthropic content-block type for a tool call.
-const blockTypeToolUse = "tool_use"
-
 // anthropicSupportedParams lists the OpenAI parameters the Anthropic Messages
 // API can express. Anything else the caller sets is warn-and-dropped (#140).
 var anthropicSupportedParams = []string{"temperature", "top_p", "max_tokens", "stop", "tools", "tool_choice"}
-
-type anthropicContentBlock struct {
-	Type  string          `json:"type"`
-	Text  string          `json:"text"`
-	ID    string          `json:"id"`
-	Name  string          `json:"name"`
-	Input json.RawMessage `json:"input"`
-}
-
-type anthropicUsage struct {
-	InputTokens              int `json:"input_tokens"`
-	OutputTokens             int `json:"output_tokens"`
-	CacheReadInputTokens     int `json:"cache_read_input_tokens"`
-	CacheCreationInputTokens int `json:"cache_creation_input_tokens"`
-}
-
-type anthropicResponse struct {
-	ID         string                  `json:"id"`
-	Type       string                  `json:"type"`
-	Role       string                  `json:"role"`
-	Content    []anthropicContentBlock `json:"content"`
-	Model      string                  `json:"model"`
-	StopReason string                  `json:"stop_reason"`
-	Usage      anthropicUsage          `json:"usage"`
-}
 
 // buildContent renders a non-system message's content for the Anthropic API.
 // Plain text turns stay a JSON string (the common path); multimodal turns and
@@ -185,7 +157,7 @@ func buildContent(msg core.Message) any {
 			input = json.RawMessage("{}")
 		}
 		blocks = append(blocks, anthropicwire.Block{
-			Type:  blockTypeToolUse,
+			Type:  anthropicwire.BlockTypeToolUse,
 			ID:    tc.ID,
 			Name:  tc.Function.Name,
 			Input: input,
@@ -203,7 +175,7 @@ func buildContent(msg core.Message) any {
 // imageBlock maps an OpenAI image_url (data URI or remote URL) to an Anthropic
 // image content block.
 func imageBlock(url string) anthropicwire.Block {
-	if mediaType, data, ok := parseDataURI(url); ok {
+	if mediaType, data, ok := anthropicwire.ParseDataURI(url); ok {
 		return anthropicwire.Block{
 			Type: "image",
 			Source: &anthropicwire.ImageSource{
@@ -219,28 +191,10 @@ func imageBlock(url string) anthropicwire.Block {
 	}
 }
 
-// parseDataURI splits a data URI of the form "data:<media-type>;base64,<data>"
-// into its media type and payload. ok is false for any non-base64 data URI or
-// a plain remote URL.
-func parseDataURI(uri string) (mediaType, data string, ok bool) {
-	const prefix = "data:"
-	if !strings.HasPrefix(uri, prefix) {
-		return "", "", false
-	}
-	meta, payload, found := strings.Cut(uri[len(prefix):], ",")
-	if !found {
-		return "", "", false
-	}
-	mediaType, encoding, _ := strings.Cut(meta, ";")
-	if encoding != "base64" {
-		return "", "", false
-	}
-	return mediaType, payload, true
-}
-
 // buildAnthropicRequest maps a core.Request to an Anthropic Messages API request
-// body. stream toggles server-sent event streaming.
-func buildAnthropicRequest(req core.Request, stream bool) anthropicRequest {
+// body. stream toggles server-sent event streaming. ctx carries the logger used
+// to record any temperature clamp applied for Anthropic's narrower range.
+func buildAnthropicRequest(ctx context.Context, req core.Request, stream bool) anthropicRequest {
 	messages, system := anthropicwire.BuildMessages(req, buildContent)
 
 	maxTokens := defaultMaxTokens
@@ -252,7 +206,7 @@ func buildAnthropicRequest(req core.Request, stream bool) anthropicRequest {
 		Model:         req.Model,
 		MaxTokens:     maxTokens,
 		Messages:      messages,
-		Temperature:   req.Temperature,
+		Temperature:   anthropicwire.ClampTemperature(ctx, Name, req.Model, req.Temperature),
 		TopP:          req.TopP,
 		StopSequences: req.Stop,
 		System:        system,
@@ -292,7 +246,7 @@ func (p *Provider) newMessagesRequest(ctx context.Context, aReq anthropicRequest
 func (p *Provider) Complete(ctx context.Context, req core.Request) (*core.Response, error) {
 	core.WarnUnsupportedParams(ctx, p.Name(), req.Model, req, anthropicSupportedParams...)
 
-	aReq := buildAnthropicRequest(req, false)
+	aReq := buildAnthropicRequest(ctx, req, false)
 
 	httpResp, release, err := p.newMessagesRequest(ctx, aReq)
 	if err != nil {
@@ -313,34 +267,12 @@ func (p *Provider) Complete(ctx context.Context, req core.Request) (*core.Respon
 
 	// Success path streams the decode straight off the response body, avoiding
 	// the extra full-body copy that io.ReadAll + Unmarshal incurs per request.
-	var aResp anthropicResponse
+	var aResp anthropicwire.Response
 	if err := json.NewDecoder(httpResp.Body).Decode(&aResp); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
 	}
 
-	var content strings.Builder
-	var toolCalls []core.ToolCall
-	for _, block := range aResp.Content {
-		if block.Type == "text" {
-			content.WriteString(block.Text)
-			continue
-		}
-		if block.Type == blockTypeToolUse {
-			args := string(block.Input)
-			if args == "" {
-				args = "{}"
-			}
-			toolCalls = append(toolCalls, core.ToolCall{
-				ID:   block.ID,
-				Type: "function",
-				Function: core.FunctionCall{
-					Name:      block.Name,
-					Arguments: args,
-				},
-			})
-		}
-	}
-
+	content, toolCalls := anthropicwire.DecodeContent(aResp.Content)
 	totalTokens := aResp.Usage.InputTokens + aResp.Usage.OutputTokens
 
 	return &core.Response{
@@ -351,7 +283,7 @@ func (p *Provider) Complete(ctx context.Context, req core.Request) (*core.Respon
 				Index: 0,
 				Message: core.Message{
 					Role:      aResp.Role,
-					Content:   content.String(),
+					Content:   content,
 					ToolCalls: toolCalls,
 				},
 				FinishReason: core.NormalizeFinishReason(aResp.StopReason),

--- a/providers/anthropic/anthropic_phase2_test.go
+++ b/providers/anthropic/anthropic_phase2_test.go
@@ -107,6 +107,31 @@ func TestComplete_MalformedDataURINeverBecomesURLSource(t *testing.T) {
 	}
 }
 
+// TestComplete_PreservesPlusInNonBase64DataURI verifies a "+" in a non-base64
+// data URI payload is kept literal (PathUnescape, not QueryUnescape) before
+// re-encoding.
+func TestComplete_PreservesPlusInNonBase64DataURI(t *testing.T) {
+	body := captureBody(t, core.Request{
+		Model: "claude-sonnet-4-6",
+		Messages: []core.Message{{
+			Role: core.RoleUser,
+			ContentParts: []core.ContentPart{
+				{Type: "image_url", ImageURL: &core.ImageURLPart{URL: "data:text/plain,a+b"}},
+			},
+		}},
+	})
+
+	msgs := decodeMessages(t, body)
+	var blocks []wireImageBlock
+	if err := json.Unmarshal(msgs[0]["content"], &blocks); err != nil {
+		t.Fatalf("decode content blocks: %v", err)
+	}
+	// base64("a+b") == "YSti"; QueryUnescape would corrupt it to base64("a b").
+	if blocks[0].Source.Data != "YSti" {
+		t.Errorf("data = %q, want base64 of \"a+b\" (\"YSti\")", blocks[0].Source.Data)
+	}
+}
+
 // TestComplete_ErrorPathReturnsAPIError verifies a non-2xx chat response surfaces
 // the upstream status and message via core.APIError.
 func TestComplete_ErrorPathReturnsAPIError(t *testing.T) {

--- a/providers/anthropic/anthropic_phase2_test.go
+++ b/providers/anthropic/anthropic_phase2_test.go
@@ -1,0 +1,106 @@
+package anthropic
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/ferro-labs/ai-gateway/providers/core"
+)
+
+// TestComplete_MapsUserToMetadata verifies the OpenAI "user" field is forwarded
+// as Anthropic's metadata.user_id rather than dropped.
+func TestComplete_MapsUserToMetadata(t *testing.T) {
+	body := captureBody(t, core.Request{
+		Model:    "claude-sonnet-5",
+		Messages: []core.Message{{Role: core.RoleUser, Content: "hi"}},
+		User:     "user_123",
+	})
+
+	raw, ok := body["metadata"]
+	if !ok {
+		t.Fatal("metadata not forwarded")
+	}
+	var md struct {
+		UserID string `json:"user_id"`
+	}
+	if err := json.Unmarshal(raw, &md); err != nil {
+		t.Fatalf("decode metadata: %v", err)
+	}
+	if md.UserID != "user_123" {
+		t.Errorf("metadata.user_id = %q, want user_123", md.UserID)
+	}
+}
+
+type wireImageBlock struct {
+	Type   string `json:"type"`
+	Source struct {
+		Type      string `json:"type"`
+		MediaType string `json:"media_type"`
+		Data      string `json:"data"`
+		URL       string `json:"url"`
+	} `json:"source"`
+}
+
+// TestComplete_ReencodesNonBase64DataURI verifies a non-base64 data URI is
+// re-encoded to a base64 image source instead of being emitted as an invalid
+// url source.
+func TestComplete_ReencodesNonBase64DataURI(t *testing.T) {
+	body := captureBody(t, core.Request{
+		Model: "claude-sonnet-5",
+		Messages: []core.Message{{
+			Role: core.RoleUser,
+			ContentParts: []core.ContentPart{
+				{Type: "image_url", ImageURL: &core.ImageURLPart{URL: "data:image/png,hello%20world"}},
+			},
+		}},
+	})
+
+	msgs := decodeMessages(t, body)
+	var blocks []wireImageBlock
+	if err := json.Unmarshal(msgs[0]["content"], &blocks); err != nil {
+		t.Fatalf("decode content blocks: %v", err)
+	}
+	if len(blocks) != 1 {
+		t.Fatalf("content blocks = %d, want 1: %+v", len(blocks), blocks)
+	}
+	src := blocks[0].Source
+	if src.Type != "base64" {
+		t.Fatalf("source type = %q, want base64 (non-base64 data URI must be re-encoded)", src.Type)
+	}
+	if src.MediaType != "image/png" {
+		t.Errorf("media_type = %q, want image/png", src.MediaType)
+	}
+	// base64("hello world") == "aGVsbG8gd29ybGQ="
+	if src.Data != "aGVsbG8gd29ybGQ=" {
+		t.Errorf("data = %q, want base64 of the decoded payload", src.Data)
+	}
+}
+
+// TestComplete_ErrorPathReturnsAPIError verifies a non-2xx chat response surfaces
+// the upstream status and message via core.APIError.
+func TestComplete_ErrorPathReturnsAPIError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"type":"error","error":{"type":"rate_limit_error","message":"overloaded"}}`))
+	}))
+	defer srv.Close()
+
+	p, err := New("sk-test-key", srv.URL)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	_, err = p.Complete(context.Background(), core.Request{
+		Model:    "claude-sonnet-5",
+		Messages: []core.Message{{Role: core.RoleUser, Content: "hi"}},
+	})
+	if err == nil {
+		t.Fatal("expected error for 429")
+	}
+	if !strings.Contains(err.Error(), "overloaded") || !strings.Contains(err.Error(), "429") {
+		t.Fatalf("error = %v, want status + upstream message", err)
+	}
+}

--- a/providers/anthropic/anthropic_phase2_test.go
+++ b/providers/anthropic/anthropic_phase2_test.go
@@ -80,6 +80,33 @@ func TestComplete_ReencodesNonBase64DataURI(t *testing.T) {
 	}
 }
 
+// TestComplete_MalformedDataURINeverBecomesURLSource verifies a data: URI with an
+// invalid percent-encoding is still emitted as a base64 source (best-effort),
+// never as a url source Anthropic would reject.
+func TestComplete_MalformedDataURINeverBecomesURLSource(t *testing.T) {
+	body := captureBody(t, core.Request{
+		Model: "claude-sonnet-4-6",
+		Messages: []core.Message{{
+			Role: core.RoleUser,
+			ContentParts: []core.ContentPart{
+				{Type: "image_url", ImageURL: &core.ImageURLPart{URL: "data:image/png,%zz"}},
+			},
+		}},
+	})
+
+	msgs := decodeMessages(t, body)
+	var blocks []wireImageBlock
+	if err := json.Unmarshal(msgs[0]["content"], &blocks); err != nil {
+		t.Fatalf("decode content blocks: %v", err)
+	}
+	if len(blocks) != 1 || blocks[0].Source.Type != "base64" {
+		t.Fatalf("source = %+v, want a base64 source for a malformed data URI", blocks[0].Source)
+	}
+	if blocks[0].Source.URL != "" {
+		t.Errorf("url source leaked for a data: URI: %q", blocks[0].Source.URL)
+	}
+}
+
 // TestComplete_ErrorPathReturnsAPIError verifies a non-2xx chat response surfaces
 // the upstream status and message via core.APIError.
 func TestComplete_ErrorPathReturnsAPIError(t *testing.T) {

--- a/providers/anthropic/anthropic_stream.go
+++ b/providers/anthropic/anthropic_stream.go
@@ -13,6 +13,10 @@ import (
 // Anthropic Messages event stream is decoded by the shared anthropicwire
 // StreamDecoder, which is also driven by the Anthropic-on-Bedrock path so the
 // two providers cannot drift.
+//
+// It reuses the non-streaming HTTP client. That client's ResponseHeaderTimeout
+// bounds time-to-first-byte (headers), not the duration of the streamed body, so
+// it is safe for streaming: a slow model still streams tokens past the timeout.
 func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan core.StreamChunk, error) {
 	core.WarnUnsupportedParams(ctx, p.Name(), req.Model, req, anthropicSupportedParams...)
 

--- a/providers/anthropic/anthropic_stream.go
+++ b/providers/anthropic/anthropic_stream.go
@@ -2,68 +2,21 @@ package anthropic
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
 	"io"
 	"net/http"
 
+	"github.com/ferro-labs/ai-gateway/internal/anthropicwire"
 	"github.com/ferro-labs/ai-gateway/providers/core"
 )
 
-type anthropicStreamMessageStart struct {
-	Type    string `json:"type"`
-	Message struct {
-		ID    string         `json:"id"`
-		Model string         `json:"model"`
-		Role  string         `json:"role"`
-		Usage anthropicUsage `json:"usage"`
-	} `json:"message"`
-}
-
-type anthropicStreamContentDelta struct {
-	Type  string `json:"type"`
-	Index int    `json:"index"`
-	Delta struct {
-		Type        string `json:"type"`
-		Text        string `json:"text"`
-		PartialJSON string `json:"partial_json"`
-	} `json:"delta"`
-}
-
-type anthropicStreamContentBlockStart struct {
-	Type         string `json:"type"`
-	Index        int    `json:"index"`
-	ContentBlock struct {
-		Type  string          `json:"type"`
-		ID    string          `json:"id"`
-		Name  string          `json:"name"`
-		Input json.RawMessage `json:"input"`
-	} `json:"content_block"`
-}
-
-type anthropicStreamMessageDelta struct {
-	Type  string `json:"type"`
-	Delta struct {
-		StopReason string `json:"stop_reason"`
-	} `json:"delta"`
-	Usage anthropicUsage `json:"usage"`
-}
-
-// anthropicStreamError is the payload of a mid-stream "event: error" frame,
-// e.g. {"type":"error","error":{"type":"overloaded_error","message":"..."}}.
-type anthropicStreamError struct {
-	Type  string `json:"type"`
-	Error struct {
-		Type    string `json:"type"`
-		Message string `json:"message"`
-	} `json:"error"`
-}
-
-// CompleteStream sends a streaming chat completion request to Anthropic.
+// CompleteStream sends a streaming chat completion request to Anthropic. The
+// Anthropic Messages event stream is decoded by the shared anthropicwire
+// StreamDecoder, which is also driven by the Anthropic-on-Bedrock path so the
+// two providers cannot drift.
 func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan core.StreamChunk, error) {
 	core.WarnUnsupportedParams(ctx, p.Name(), req.Model, req, anthropicSupportedParams...)
 
-	aReq := buildAnthropicRequest(req, true)
+	aReq := buildAnthropicRequest(ctx, req, true)
 
 	httpResp, release, err := p.newMessagesRequest(ctx, aReq)
 	if err != nil {
@@ -82,161 +35,16 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 		defer close(ch)
 		defer func() { _ = httpResp.Body.Close() }()
 
-		var msgID, model string
-		var promptTokens, cacheReadTokens, cacheWriteTokens int
-		toolCallIndexes := make(map[int]int)
-		toolArgsSeen := make(map[int]bool) // tool-call index -> received any input_json_delta
-		nextToolCallIndex := 0
+		dec := anthropicwire.NewStreamDecoder("anthropic", "")
 		lines, scanErr := core.SSEDataLines(httpResp.Body)
 		for data := range lines {
-
-			var raw map[string]any
-			if json.Unmarshal([]byte(data), &raw) != nil {
-				continue
+			chunks, evtErr := dec.Event([]byte(data))
+			for _, c := range chunks {
+				ch <- c
 			}
-
-			eventType, _ := raw["type"].(string)
-			switch eventType {
-			case "error":
-				var evt anthropicStreamError
-				if json.Unmarshal([]byte(data), &evt) == nil && evt.Error.Message != "" {
-					ch <- core.StreamChunk{Error: fmt.Errorf("anthropic stream error (%s): %s", evt.Error.Type, evt.Error.Message)}
-				} else {
-					ch <- core.StreamChunk{Error: fmt.Errorf("anthropic stream error: %s", data)}
-				}
+			if evtErr != nil {
+				ch <- core.StreamChunk{Error: evtErr}
 				return
-			case "message_start":
-				var evt anthropicStreamMessageStart
-				if json.Unmarshal([]byte(data), &evt) == nil {
-					msgID = evt.Message.ID
-					model = evt.Message.Model
-					// Anthropic reports prompt + cache tokens once, on
-					// message_start; output_tokens arrive later on message_delta.
-					promptTokens = evt.Message.Usage.InputTokens
-					cacheReadTokens = evt.Message.Usage.CacheReadInputTokens
-					cacheWriteTokens = evt.Message.Usage.CacheCreationInputTokens
-				}
-			case "content_block_start":
-				var evt anthropicStreamContentBlockStart
-				if json.Unmarshal([]byte(data), &evt) == nil && evt.ContentBlock.Type == blockTypeToolUse {
-					toolCallIndex := nextToolCallIndex
-					toolCallIndexes[evt.Index] = toolCallIndex
-					nextToolCallIndex++
-					ch <- core.StreamChunk{
-						ID:    msgID,
-						Model: model,
-						Choices: []core.StreamChoice{
-							{
-								Index: 0,
-								Delta: core.MessageDelta{
-									ToolCalls: []core.ToolCall{
-										{
-											Index: core.Ptr(toolCallIndex),
-											ID:    evt.ContentBlock.ID,
-											Type:  "function",
-											Function: core.FunctionCall{
-												Name: evt.ContentBlock.Name,
-											},
-										},
-									},
-								},
-							},
-						},
-					}
-				}
-			case "content_block_delta":
-				var evt anthropicStreamContentDelta
-				if json.Unmarshal([]byte(data), &evt) == nil {
-					if evt.Delta.Type == "input_json_delta" {
-						toolCallIndex, ok := toolCallIndexes[evt.Index]
-						if !ok {
-							toolCallIndex = evt.Index
-						}
-						toolArgsSeen[toolCallIndex] = true
-						ch <- core.StreamChunk{
-							ID:    msgID,
-							Model: model,
-							Choices: []core.StreamChoice{
-								{
-									Index: 0,
-									Delta: core.MessageDelta{
-										ToolCalls: []core.ToolCall{
-											{
-												Index: core.Ptr(toolCallIndex),
-												Type:  "function",
-												Function: core.FunctionCall{
-													Arguments: evt.Delta.PartialJSON,
-												},
-											},
-										},
-									},
-								},
-							},
-						}
-						continue
-					}
-					if evt.Delta.Type != "text_delta" {
-						continue
-					}
-					ch <- core.StreamChunk{
-						ID:    msgID,
-						Model: model,
-						Choices: []core.StreamChoice{
-							{
-								// Single completion: the OpenAI choice index is
-								// always 0 (evt.Index is Anthropic's content-block
-								// index, not a choice index).
-								Index: 0,
-								Delta: core.MessageDelta{
-									Content: evt.Delta.Text,
-								},
-							},
-						},
-					}
-				}
-			case "message_delta":
-				// Emit "{}" arguments for any tool call that produced no
-				// input_json_delta (zero-argument tools), so clients that
-				// JSON.parse the arguments don't choke on an empty string.
-				for _, toolCallIndex := range toolCallIndexes {
-					if toolArgsSeen[toolCallIndex] {
-						continue
-					}
-					ch <- core.StreamChunk{
-						ID:    msgID,
-						Model: model,
-						Choices: []core.StreamChoice{{
-							Index: 0,
-							Delta: core.MessageDelta{
-								ToolCalls: []core.ToolCall{{
-									Index:    core.Ptr(toolCallIndex),
-									Type:     "function",
-									Function: core.FunctionCall{Arguments: "{}"},
-								}},
-							},
-						}},
-					}
-				}
-				var evt anthropicStreamMessageDelta
-				_ = json.Unmarshal([]byte(data), &evt)
-				completionTokens := evt.Usage.OutputTokens
-				ch <- core.StreamChunk{
-					ID:    msgID,
-					Model: model,
-					Choices: []core.StreamChoice{
-						{
-							Index:        0,
-							FinishReason: core.NormalizeFinishReason(evt.Delta.StopReason),
-						},
-					},
-					Usage: &core.Usage{
-						PromptTokens:     promptTokens,
-						CompletionTokens: completionTokens,
-						TotalTokens:      promptTokens + completionTokens,
-						CacheReadTokens:  cacheReadTokens,
-						CacheWriteTokens: cacheWriteTokens,
-					},
-				}
 			}
 		}
 		if err := scanErr(); err != nil {

--- a/providers/anthropic/anthropic_temperature_test.go
+++ b/providers/anthropic/anthropic_temperature_test.go
@@ -1,0 +1,48 @@
+package anthropic
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/ferro-labs/ai-gateway/providers/core"
+)
+
+// TestComplete_ClampsTemperatureToAnthropicRange verifies that a temperature in
+// the gateway's OpenAI range (0–2) but above Anthropic's maximum (1) is clamped
+// to 1 on the outgoing request rather than forwarded to a 400.
+func TestComplete_ClampsTemperatureToAnthropicRange(t *testing.T) {
+	body := captureBody(t, core.Request{
+		Model:       "claude-3-5-sonnet",
+		Messages:    []core.Message{{Role: core.RoleUser, Content: "hi"}},
+		Temperature: floatPtr(1.8),
+	})
+
+	raw, ok := body["temperature"]
+	if !ok {
+		t.Fatal("temperature not forwarded")
+	}
+	var temp float64
+	if err := json.Unmarshal(raw, &temp); err != nil {
+		t.Fatalf("decode temperature: %v", err)
+	}
+	if temp != 1.0 {
+		t.Fatalf("temperature = %v, want clamped to 1.0", temp)
+	}
+}
+
+// TestComplete_ForwardsInRangeTemperature confirms an in-range value passes
+// through untouched.
+func TestComplete_ForwardsInRangeTemperature(t *testing.T) {
+	body := captureBody(t, core.Request{
+		Model:       "claude-3-5-sonnet",
+		Messages:    []core.Message{{Role: core.RoleUser, Content: "hi"}},
+		Temperature: floatPtr(0.6),
+	})
+	var temp float64
+	if err := json.Unmarshal(body["temperature"], &temp); err != nil {
+		t.Fatalf("decode temperature: %v", err)
+	}
+	if temp != 0.6 {
+		t.Fatalf("temperature = %v, want 0.6", temp)
+	}
+}

--- a/providers/anthropic/anthropic_test.go
+++ b/providers/anthropic/anthropic_test.go
@@ -76,10 +76,10 @@ func TestAnthropicProvider_SupportedModels(t *testing.T) {
 	}
 
 	expected := []string{
-		"claude-sonnet-4-20250514",
-		"claude-3-5-sonnet-20241022",
-		"claude-3-haiku-20240307",
-		"claude-3-opus-20240229",
+		"claude-opus-4-8",
+		"claude-sonnet-5",
+		"claude-fable-5",
+		"claude-haiku-4-5-20251001",
 	}
 
 	if len(models) != len(expected) {

--- a/providers/anthropic/anthropic_test.go
+++ b/providers/anthropic/anthropic_test.go
@@ -76,9 +76,9 @@ func TestAnthropicProvider_SupportedModels(t *testing.T) {
 	}
 
 	expected := []string{
-		"claude-opus-4-8",
-		"claude-sonnet-5",
-		"claude-fable-5",
+		"claude-opus-4-7",
+		"claude-opus-4-6",
+		"claude-sonnet-4-6",
 		"claude-haiku-4-5-20251001",
 	}
 

--- a/providers/bedrock/bedrock.go
+++ b/providers/bedrock/bedrock.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime/types"
 	"github.com/aws/smithy-go/auth/bearer"
 
+	providerhttp "github.com/ferro-labs/ai-gateway/internal/httpclient"
 	"github.com/ferro-labs/ai-gateway/providers/core"
 )
 
@@ -135,6 +136,10 @@ func NewWithOptions(opts Options) (*Provider, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to load AWS config: %w", err)
 	}
+
+	// Use the gateway's tuned per-provider HTTP client (higher dial/header
+	// timeouts for Bedrock's cold starts) rather than the SDK default.
+	cfg.HTTPClient = providerhttp.ForProvider(Name)
 
 	client := realBedrockClient{bedrockruntime.NewFromConfig(cfg, clientOpts...)}
 	return &Provider{

--- a/providers/bedrock/bedrock_anthropic.go
+++ b/providers/bedrock/bedrock_anthropic.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime"
@@ -24,31 +23,13 @@ type bedrockAnthropicRequest struct {
 	System           string                  `json:"system,omitempty"`
 }
 
-type bedrockAnthropicResponse struct {
-	ID      string `json:"id"`
-	Type    string `json:"type"`
-	Role    string `json:"role"`
-	Content []struct {
-		Type  string          `json:"type"`
-		Text  string          `json:"text"`
-		ID    string          `json:"id"`
-		Name  string          `json:"name"`
-		Input json.RawMessage `json:"input"`
-	} `json:"content"`
-	StopReason string `json:"stop_reason"`
-	Usage      struct {
-		InputTokens  int `json:"input_tokens"`
-		OutputTokens int `json:"output_tokens"`
-	} `json:"usage"`
-}
-
 // bedrockAnthropicDefaultMaxTokens is the max_tokens applied when a request does
 // not specify one.
 const bedrockAnthropicDefaultMaxTokens = 1024
 
 // buildBedrockAnthropicRequest translates an OpenAI-shaped request into the
 // Bedrock Anthropic invocation body, applying the default max_tokens when unset.
-func buildBedrockAnthropicRequest(req core.Request) (bedrockAnthropicRequest, error) {
+func buildBedrockAnthropicRequest(ctx context.Context, req core.Request) (bedrockAnthropicRequest, error) {
 	maxTokens := bedrockAnthropicDefaultMaxTokens
 	if req.MaxTokens != nil {
 		maxTokens = *req.MaxTokens
@@ -75,7 +56,7 @@ func buildBedrockAnthropicRequest(req core.Request) (bedrockAnthropicRequest, er
 		Messages:         messages,
 		Tools:            anthropicwire.MapTools(req.Tools),
 		ToolChoice:       anthropicwire.MapToolChoice(req.ToolChoice, req.Tools),
-		Temperature:      req.Temperature,
+		Temperature:      anthropicwire.ClampTemperature(ctx, Name, req.Model, req.Temperature),
 		TopP:             req.TopP,
 		StopSequences:    req.Stop,
 		System:           system,
@@ -137,7 +118,7 @@ func bedrockAnthropicContent(msg core.Message) (any, error) {
 // Anthropic API), so a non-data-URI image is rejected with a clear error rather
 // than emitting a "url" source block the Bedrock API would reject.
 func bedrockAnthropicImageBlock(url string) (anthropicwire.Block, error) {
-	mediaType, data, ok := bedrockParseDataURI(url)
+	mediaType, data, ok := anthropicwire.ParseDataURI(url)
 	if !ok {
 		return anthropicwire.Block{}, fmt.Errorf("bedrock anthropic: image inputs must be base64 data URIs; remote image URLs are not supported")
 	}
@@ -151,27 +132,8 @@ func bedrockAnthropicImageBlock(url string) (anthropicwire.Block, error) {
 	}, nil
 }
 
-// bedrockParseDataURI splits a data URI of the form
-// "data:<media-type>;base64,<data>" into its media type and payload. ok is
-// false for any non-base64 data URI or a plain remote URL.
-func bedrockParseDataURI(uri string) (mediaType, data string, ok bool) {
-	const prefix = "data:"
-	if !strings.HasPrefix(uri, prefix) {
-		return "", "", false
-	}
-	meta, payload, found := strings.Cut(uri[len(prefix):], ",")
-	if !found {
-		return "", "", false
-	}
-	mt, encoding, _ := strings.Cut(meta, ";")
-	if encoding != "base64" {
-		return "", "", false
-	}
-	return mt, payload, true
-}
-
 func (p *Provider) completeAnthropic(ctx context.Context, req core.Request) (*core.Response, error) {
-	anthropicReq, err := buildBedrockAnthropicRequest(req)
+	anthropicReq, err := buildBedrockAnthropicRequest(ctx, req)
 	if err != nil {
 		return nil, err
 	}
@@ -190,33 +152,12 @@ func (p *Provider) completeAnthropic(ctx context.Context, req core.Request) (*co
 		return nil, fmt.Errorf("bedrock invoke failed: %w", err)
 	}
 
-	var anthropicResp bedrockAnthropicResponse
+	var anthropicResp anthropicwire.Response
 	if err := json.Unmarshal(output.Body, &anthropicResp); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
 	}
 
-	text := ""
-	var toolCalls []core.ToolCall
-	for _, c := range anthropicResp.Content {
-		if c.Type == "text" {
-			text += c.Text
-			continue
-		}
-		if c.Type == "tool_use" {
-			args := string(c.Input)
-			if args == "" {
-				args = "{}"
-			}
-			toolCalls = append(toolCalls, core.ToolCall{
-				ID:   c.ID,
-				Type: "function",
-				Function: core.FunctionCall{
-					Name:      c.Name,
-					Arguments: args,
-				},
-			})
-		}
-	}
+	text, toolCalls := anthropicwire.DecodeContent(anthropicResp.Content)
 
 	return &core.Response{
 		ID:       anthropicResp.ID,
@@ -231,6 +172,8 @@ func (p *Provider) completeAnthropic(ctx context.Context, req core.Request) (*co
 			PromptTokens:     anthropicResp.Usage.InputTokens,
 			CompletionTokens: anthropicResp.Usage.OutputTokens,
 			TotalTokens:      anthropicResp.Usage.InputTokens + anthropicResp.Usage.OutputTokens,
+			CacheReadTokens:  anthropicResp.Usage.CacheReadInputTokens,
+			CacheWriteTokens: anthropicResp.Usage.CacheCreationInputTokens,
 		},
 	}, nil
 }

--- a/providers/bedrock/bedrock_anthropic.go
+++ b/providers/bedrock/bedrock_anthropic.go
@@ -50,6 +50,9 @@ func buildBedrockAnthropicRequest(ctx context.Context, req core.Request) (bedroc
 		return bedrockAnthropicRequest{}, contentErr
 	}
 
+	// Note: the native Anthropic provider maps the OpenAI "user" field to
+	// metadata.user_id, but AWS Bedrock's InvokeModel Anthropic schema does not
+	// document a metadata field, so it is intentionally not forwarded here.
 	return bedrockAnthropicRequest{
 		AnthropicVersion: "bedrock-2023-05-31",
 		MaxTokens:        maxTokens,

--- a/providers/bedrock/bedrock_anthropicwire_test.go
+++ b/providers/bedrock/bedrock_anthropicwire_test.go
@@ -1,0 +1,101 @@
+package bedrock
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ferro-labs/ai-gateway/providers/core"
+)
+
+func floatPtr(v float64) *float64 { return &v }
+
+// TestBedrockProvider_CompleteStreamAnthropic_ReportsUsage verifies the shared
+// anthropicwire stream decoder gives the Bedrock path the token usage it
+// previously dropped: prompt tokens from message_start and completion tokens
+// from message_delta are surfaced on the final chunk.
+func TestBedrockProvider_CompleteStreamAnthropic_ReportsUsage(t *testing.T) {
+	fake := &fakeBedrockRuntimeClient{
+		streamResponses: [][]byte{
+			[]byte(`{"type":"message_start","message":{"id":"msg_1","model":"claude-3-5-sonnet-20241022","usage":{"input_tokens":18}}}`),
+			[]byte(`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"hi"}}`),
+			[]byte(`{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":6}}`),
+		},
+	}
+	p := &Provider{name: Name, client: fake}
+
+	ch, err := p.CompleteStream(context.Background(), core.Request{
+		Model:    "anthropic.claude-3-5-sonnet-20241022-v2:0",
+		Messages: []core.Message{{Role: core.RoleUser, Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("CompleteStream() error: %v", err)
+	}
+
+	var usage *core.Usage
+	for c := range ch {
+		if c.Error != nil {
+			t.Fatalf("stream error: %v", c.Error)
+		}
+		if c.Usage != nil {
+			usage = c.Usage
+		}
+	}
+	if usage == nil {
+		t.Fatal("bedrock stream reported no usage (message_start/message_delta usage dropped)")
+	}
+	if usage.PromptTokens != 18 || usage.CompletionTokens != 6 || usage.TotalTokens != 24 {
+		t.Fatalf("usage = %d/%d/%d, want 18/6/24",
+			usage.PromptTokens, usage.CompletionTokens, usage.TotalTokens)
+	}
+}
+
+// TestBedrockProvider_CompleteAnthropic_ClampsTemperature verifies the shared
+// temperature clamp applies on the Bedrock Anthropic path too.
+func TestBedrockProvider_CompleteAnthropic_ClampsTemperature(t *testing.T) {
+	fake := &fakeBedrockRuntimeClient{
+		responses: [][]byte{
+			[]byte(`{"id":"msg_1","content":[{"type":"text","text":"ok"}],"stop_reason":"end_turn","usage":{"input_tokens":1,"output_tokens":1}}`),
+		},
+	}
+	p := &Provider{name: Name, client: fake}
+
+	_, err := p.Complete(context.Background(), core.Request{
+		Model:       "anthropic.claude-3-5-sonnet-20241022-v2:0",
+		Messages:    []core.Message{{Role: core.RoleUser, Content: "hi"}},
+		Temperature: floatPtr(1.8),
+	})
+	if err != nil {
+		t.Fatalf("Complete() error: %v", err)
+	}
+
+	var body struct {
+		Temperature *float64 `json:"temperature"`
+	}
+	mustUnmarshalBody(t, fake.invokeCalls[0].Body, &body)
+	if body.Temperature == nil || *body.Temperature != 1.0 {
+		t.Fatalf("temperature = %v, want clamped to 1.0", body.Temperature)
+	}
+}
+
+// TestBedrockProvider_CompleteAnthropic_CapturesCacheTokens verifies prompt-cache
+// token accounting is surfaced now that the Bedrock path shares the Anthropic
+// response type.
+func TestBedrockProvider_CompleteAnthropic_CapturesCacheTokens(t *testing.T) {
+	fake := &fakeBedrockRuntimeClient{
+		responses: [][]byte{
+			[]byte(`{"id":"msg_1","content":[{"type":"text","text":"ok"}],"stop_reason":"end_turn","usage":{"input_tokens":10,"output_tokens":4,"cache_read_input_tokens":3,"cache_creation_input_tokens":5}}`),
+		},
+	}
+	p := &Provider{name: Name, client: fake}
+
+	resp, err := p.Complete(context.Background(), core.Request{
+		Model:    "anthropic.claude-3-5-sonnet-20241022-v2:0",
+		Messages: []core.Message{{Role: core.RoleUser, Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("Complete() error: %v", err)
+	}
+	if resp.Usage.CacheReadTokens != 3 || resp.Usage.CacheWriteTokens != 5 {
+		t.Fatalf("cache tokens = %d/%d, want 3/5", resp.Usage.CacheReadTokens, resp.Usage.CacheWriteTokens)
+	}
+}

--- a/providers/bedrock/bedrock_families_test.go
+++ b/providers/bedrock/bedrock_families_test.go
@@ -1,0 +1,88 @@
+package bedrock
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/ferro-labs/ai-gateway/providers/core"
+)
+
+// TestBedrockProvider_Complete_TitanSetsTotalTokensAndID verifies Titan responses
+// report TotalTokens and carry a synthesized response ID.
+func TestBedrockProvider_Complete_TitanSetsTotalTokensAndID(t *testing.T) {
+	fake := &fakeBedrockRuntimeClient{
+		responses: [][]byte{
+			[]byte(`{"inputTextTokenCount":4,"results":[{"tokenCount":6,"outputText":"hi","completionReason":"FINISH"}]}`),
+		},
+	}
+	p := &Provider{name: Name, client: fake}
+
+	resp, err := p.Complete(context.Background(), core.Request{
+		Model:    "amazon.titan-text-express-v1",
+		Messages: []core.Message{{Role: core.RoleUser, Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("Complete() error: %v", err)
+	}
+	if resp.Usage.TotalTokens != 10 {
+		t.Errorf("TotalTokens = %d, want 10 (prompt 4 + completion 6)", resp.Usage.TotalTokens)
+	}
+	if !strings.HasPrefix(resp.ID, "bedrock-") {
+		t.Errorf("ID = %q, want a synthesized bedrock- id", resp.ID)
+	}
+}
+
+// TestBedrockProvider_Complete_LlamaSynthesizesID verifies the Llama family also
+// gets a synthesized response ID.
+func TestBedrockProvider_Complete_LlamaSynthesizesID(t *testing.T) {
+	fake := &fakeBedrockRuntimeClient{
+		responses: [][]byte{
+			[]byte(`{"generation":"hi","prompt_token_count":3,"generation_token_count":2,"stop_reason":"stop"}`),
+		},
+	}
+	p := &Provider{name: Name, client: fake}
+
+	resp, err := p.Complete(context.Background(), core.Request{
+		Model:    "meta.llama3-1-8b-instruct-v1:0",
+		Messages: []core.Message{{Role: core.RoleUser, Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("Complete() error: %v", err)
+	}
+	if !strings.HasPrefix(resp.ID, "bedrock-") {
+		t.Errorf("ID = %q, want a synthesized bedrock- id", resp.ID)
+	}
+}
+
+// TestBedrockProvider_Complete_NovaDropsImagePartsGracefully verifies a Nova
+// request carrying an image part still returns its text answer (the image is
+// warn-dropped, not fatal).
+func TestBedrockProvider_Complete_NovaDropsImagePartsGracefully(t *testing.T) {
+	fake := &fakeBedrockRuntimeClient{
+		responses: [][]byte{
+			[]byte(`{"output":{"message":{"role":"assistant","content":[{"text":"ok"}]}},"stopReason":"end_turn","usage":{"inputTokens":1,"outputTokens":1}}`),
+		},
+	}
+	p := &Provider{name: Name, client: fake}
+
+	resp, err := p.Complete(context.Background(), core.Request{
+		Model: "amazon.nova-pro-v1:0",
+		Messages: []core.Message{{
+			Role: core.RoleUser,
+			ContentParts: []core.ContentPart{
+				{Type: "text", Text: "describe"},
+				{Type: "image_url", ImageURL: &core.ImageURLPart{URL: "data:image/png;base64,QUJD"}},
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("Complete() error: %v", err)
+	}
+	if resp.Choices[0].Message.Content != "ok" {
+		t.Errorf("content = %q, want ok", resp.Choices[0].Message.Content)
+	}
+	if !strings.HasPrefix(resp.ID, "bedrock-") {
+		t.Errorf("ID = %q, want a synthesized bedrock- id", resp.ID)
+	}
+}

--- a/providers/bedrock/bedrock_llama.go
+++ b/providers/bedrock/bedrock_llama.go
@@ -47,6 +47,8 @@ func bedrockLlamaMessageText(msg core.Message) string {
 }
 
 func (p *Provider) completeLlama(ctx context.Context, req core.Request) (*core.Response, error) {
+	warnDroppedImageParts(ctx, p.name, req.Model, req.Messages)
+
 	var sb strings.Builder
 	sb.WriteString("<|begin_of_text|>")
 	for _, msg := range req.Messages {
@@ -83,6 +85,7 @@ func (p *Provider) completeLlama(ctx context.Context, req core.Request) (*core.R
 	}
 
 	return &core.Response{
+		ID:       bedrockResponseID(),
 		Model:    req.Model,
 		Provider: p.name,
 		Choices: []core.Choice{{

--- a/providers/bedrock/bedrock_nova.go
+++ b/providers/bedrock/bedrock_nova.go
@@ -48,6 +48,8 @@ type bedrockNovaResponse struct {
 }
 
 func (p *Provider) completeNova(ctx context.Context, req core.Request) (*core.Response, error) {
+	warnDroppedImageParts(ctx, p.name, req.Model, req.Messages)
+
 	novaReq := bedrockNovaRequest{
 		SchemaVersion: "messages-v1",
 	}
@@ -90,6 +92,7 @@ func (p *Provider) completeNova(ctx context.Context, req core.Request) (*core.Re
 	}
 
 	return &core.Response{
+		ID:       bedrockResponseID(),
 		Model:    req.Model,
 		Provider: p.name,
 		Choices: []core.Choice{{

--- a/providers/bedrock/bedrock_stream.go
+++ b/providers/bedrock/bedrock_stream.go
@@ -2,25 +2,28 @@ package bedrock
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime"
 	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime/types"
+	"github.com/ferro-labs/ai-gateway/internal/anthropicwire"
 	"github.com/ferro-labs/ai-gateway/providers/core"
 )
 
 // CompleteStream sends a streaming request to AWS Bedrock via InvokeModelWithResponseStream.
-// Currently only Anthropic Claude streaming is implemented.
+// Currently only Anthropic Claude streaming is implemented. Each event chunk is
+// decoded by the shared anthropicwire StreamDecoder — the same decoder the
+// native Anthropic provider uses — so both paths report token usage from
+// message_start / message_delta rather than dropping it.
 func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan core.StreamChunk, error) {
 	if !strings.HasPrefix(bedrockModelRoutingID(req.Model), "anthropic.") {
 		return nil, fmt.Errorf("streaming on Bedrock is currently only supported for anthropic.claude-* models")
 	}
 	core.WarnUnsupportedParams(ctx, p.Name(), req.Model, req, bedrockSupportedParams(bedrockModelRoutingID(req.Model))...)
 
-	anthropicReq, err := buildBedrockAnthropicRequest(req)
+	anthropicReq, err := buildBedrockAnthropicRequest(ctx, req)
 	if err != nil {
 		return nil, err
 	}
@@ -44,135 +47,22 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 		defer close(ch)
 		defer func() { _ = stream.Close() }()
 
-		toolCallIndexes := make(map[int]int)
-		toolArgsSeen := make(map[int]bool)
-		nextToolCallIndex := 0
+		// Chunks carry the request model ID; Bedrock's event stream reports
+		// Anthropic's internal model name on message_start, which callers do not
+		// use for Bedrock routing.
+		dec := anthropicwire.NewStreamDecoder(Name, req.Model)
 		for event := range stream.Events() {
-			if e, ok := event.(*types.ResponseStreamMemberChunk); ok {
-				var eventType struct {
-					Type string `json:"type"`
-				}
-				if err := json.Unmarshal(e.Value.Bytes, &eventType); err != nil {
-					continue
-				}
-
-				switch eventType.Type {
-				case "content_block_start":
-					var start struct {
-						Index        int `json:"index"`
-						ContentBlock struct {
-							Type string `json:"type"`
-							ID   string `json:"id"`
-							Name string `json:"name"`
-						} `json:"content_block"`
-					}
-					if err := json.Unmarshal(e.Value.Bytes, &start); err != nil || start.ContentBlock.Type != "tool_use" {
-						continue
-					}
-					toolCallIndex := nextToolCallIndex
-					toolCallIndexes[start.Index] = toolCallIndex
-					nextToolCallIndex++
-					ch <- core.StreamChunk{
-						Model: req.Model,
-						Choices: []core.StreamChoice{{
-							Index: 0,
-							Delta: core.MessageDelta{
-								ToolCalls: []core.ToolCall{{
-									Index: core.Ptr(toolCallIndex),
-									ID:    start.ContentBlock.ID,
-									Type:  "function",
-									Function: core.FunctionCall{
-										Name: start.ContentBlock.Name,
-									},
-								}},
-							},
-						}},
-					}
-				case "content_block_delta":
-					var delta struct {
-						Index int `json:"index"`
-						Delta struct {
-							Type        string `json:"type"`
-							Text        string `json:"text"`
-							PartialJSON string `json:"partial_json"`
-						} `json:"delta"`
-					}
-					if err := json.Unmarshal(e.Value.Bytes, &delta); err != nil {
-						continue
-					}
-					if delta.Delta.Type == "input_json_delta" {
-						toolCallIndex, ok := toolCallIndexes[delta.Index]
-						if !ok {
-							toolCallIndex = delta.Index
-						}
-						toolArgsSeen[toolCallIndex] = true
-						ch <- core.StreamChunk{
-							Model: req.Model,
-							Choices: []core.StreamChoice{{
-								Index: 0,
-								Delta: core.MessageDelta{
-									ToolCalls: []core.ToolCall{{
-										Index: core.Ptr(toolCallIndex),
-										Type:  "function",
-										Function: core.FunctionCall{
-											Arguments: delta.Delta.PartialJSON,
-										},
-									}},
-								},
-							}},
-						}
-						continue
-					}
-					if delta.Delta.Type != "text_delta" {
-						continue
-					}
-					ch <- core.StreamChunk{
-						Model: req.Model,
-						Choices: []core.StreamChoice{{
-							Index: 0,
-							Delta: core.MessageDelta{Content: delta.Delta.Text},
-						}},
-					}
-				case "message_delta":
-					var delta struct {
-						Delta struct {
-							StopReason string `json:"stop_reason"`
-						} `json:"delta"`
-					}
-					if err := json.Unmarshal(e.Value.Bytes, &delta); err != nil {
-						continue
-					}
-					// Tool calls that never received an input_json_delta (zero-argument
-					// tool calls) still need valid empty-object arguments emitted before
-					// the finish chunk, matching the native Anthropic stream behavior.
-					for toolCallIndex := 0; toolCallIndex < nextToolCallIndex; toolCallIndex++ {
-						if toolArgsSeen[toolCallIndex] {
-							continue
-						}
-						ch <- core.StreamChunk{
-							Model: req.Model,
-							Choices: []core.StreamChoice{{
-								Index: 0,
-								Delta: core.MessageDelta{
-									ToolCalls: []core.ToolCall{{
-										Index: core.Ptr(toolCallIndex),
-										Type:  "function",
-										Function: core.FunctionCall{
-											Arguments: "{}",
-										},
-									}},
-								},
-							}},
-						}
-					}
-					ch <- core.StreamChunk{
-						Model: req.Model,
-						Choices: []core.StreamChoice{{
-							Index:        0,
-							FinishReason: core.NormalizeFinishReason(delta.Delta.StopReason),
-						}},
-					}
-				}
+			e, ok := event.(*types.ResponseStreamMemberChunk)
+			if !ok {
+				continue
+			}
+			chunks, evtErr := dec.Event(e.Value.Bytes)
+			for _, c := range chunks {
+				ch <- c
+			}
+			if evtErr != nil {
+				ch <- core.StreamChunk{Error: evtErr}
+				return
 			}
 		}
 		if err := stream.Err(); err != nil {

--- a/providers/bedrock/bedrock_test.go
+++ b/providers/bedrock/bedrock_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime"
 	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime/types"
 
+	providerhttp "github.com/ferro-labs/ai-gateway/internal/httpclient"
 	"github.com/ferro-labs/ai-gateway/providers/core"
 )
 
@@ -64,6 +65,27 @@ func TestNewBedrockWithOptions_BearerTokenAuthHeaders(t *testing.T) {
 	headers := p.AuthHeaders()
 	if got := headers["Authorization"]; got != "Bearer test-bearer-token" {
 		t.Errorf("Authorization = %q, want Bearer test-bearer-token", got)
+	}
+}
+
+func TestNewBedrockWithOptions_UsesTunedHTTPClient(t *testing.T) {
+	t.Setenv("AWS_EC2_METADATA_DISABLED", "true")
+
+	p, err := NewWithOptions(Options{
+		Region:          "us-east-1",
+		AccessKeyID:     "test-access-key",
+		SecretAccessKey: "test-secret-key",
+	})
+	if err != nil {
+		t.Fatalf("NewWithOptions() error: %v", err)
+	}
+
+	client, ok := p.client.(realBedrockClient)
+	if !ok {
+		t.Fatalf("client type = %T, want realBedrockClient", p.client)
+	}
+	if got := client.Options().HTTPClient; got != providerhttp.ForProvider(Name) {
+		t.Errorf("SDK HTTPClient = %v, want the tuned per-provider client", got)
 	}
 }
 

--- a/providers/bedrock/bedrock_titan.go
+++ b/providers/bedrock/bedrock_titan.go
@@ -31,6 +31,8 @@ type bedrockTitanResponse struct {
 }
 
 func (p *Provider) completeTitan(ctx context.Context, req core.Request) (*core.Response, error) {
+	warnDroppedImageParts(ctx, p.name, req.Model, req.Messages)
+
 	var sb strings.Builder
 	for _, msg := range req.Messages {
 		sb.WriteString(msg.Content)
@@ -79,12 +81,14 @@ func (p *Provider) completeTitan(ctx context.Context, req core.Request) (*core.R
 	}
 
 	return &core.Response{
+		ID:       bedrockResponseID(),
 		Model:    req.Model,
 		Provider: p.name,
 		Choices:  choices,
 		Usage: core.Usage{
 			PromptTokens:     titanResp.InputTextTokenCount,
 			CompletionTokens: totalCompletion,
+			TotalTokens:      titanResp.InputTextTokenCount + totalCompletion,
 		},
 	}, nil
 }

--- a/providers/bedrock/bedrock_util.go
+++ b/providers/bedrock/bedrock_util.go
@@ -1,0 +1,40 @@
+package bedrock
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+
+	"github.com/ferro-labs/ai-gateway/internal/logging"
+	"github.com/ferro-labs/ai-gateway/providers/core"
+)
+
+// bedrockResponseID synthesizes a response ID for the Bedrock model families
+// whose InvokeModel response carries none (Nova, Titan, Llama), so gateway
+// responses always expose an ID as the OpenAI contract expects.
+func bedrockResponseID() string {
+	var b [12]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "bedrock"
+	}
+	return "bedrock-" + hex.EncodeToString(b[:])
+}
+
+// warnDroppedImageParts logs a warning when a request carries image content that
+// a text-only Bedrock model family (Nova/Titan/Llama on the InvokeModel path)
+// cannot forward, so the drop is observable instead of silent. Preserving images
+// on these families requires the Converse API (tracked as a roadmap item).
+func warnDroppedImageParts(ctx context.Context, provider, model string, messages []core.Message) {
+	for _, msg := range messages {
+		for _, part := range msg.ContentParts {
+			if part.Type == "image_url" {
+				logging.FromContext(ctx).Warn(
+					"model family does not support image content on the InvokeModel path; dropping image parts",
+					"provider", provider,
+					"model", model,
+				)
+				return
+			}
+		}
+	}
+}

--- a/providers/core/finish_reason.go
+++ b/providers/core/finish_reason.go
@@ -15,12 +15,14 @@ const (
 // NormalizeFinishReason maps a provider's native stop reason to the
 // OpenAI-canonical finish_reason vocabulary (stop | length | tool_calls |
 // content_filter). Matching is case-insensitive so the uppercase conventions
-// used by Cohere and Bedrock Titan are handled alongside the lowercase
+// used by Cohere, Bedrock Titan, and Gemini are handled alongside the lowercase
 // Anthropic and Llama forms.
 //
 // An empty input returns empty (a non-final stream chunk carries no reason).
 // An unrecognized value is returned unchanged so new upstream reasons are
-// surfaced rather than silently rewritten to "stop".
+// surfaced rather than silently rewritten to "stop"; Gemini's ambiguous
+// terminal reasons (OTHER, MALFORMED_FUNCTION_CALL, UNEXPECTED_TOOL_CALL) are
+// intentionally passed through rather than coerced.
 func NormalizeFinishReason(native string) string {
 	switch strings.ToLower(strings.TrimSpace(native)) {
 	case "":
@@ -31,7 +33,9 @@ func NormalizeFinishReason(native string) string {
 		return FinishReasonLength
 	case "tool_use", "tool_call", "tool_calls", "function_call":
 		return FinishReasonToolCalls
-	case "content_filtered", "content_filter", "refusal", "safety", "error_toxic":
+	case "content_filtered", "content_filter", "refusal", "safety", "error_toxic",
+		// Gemini content-blocking reasons.
+		"recitation", "blocklist", "prohibited_content", "spii", "image_safety":
 		return FinishReasonContentFilter
 	default:
 		return native

--- a/providers/core/finish_reason_test.go
+++ b/providers/core/finish_reason_test.go
@@ -31,6 +31,19 @@ func TestNormalizeFinishReason(t *testing.T) {
 		{"cohere TOOL_CALL", "TOOL_CALL", "tool_calls"},
 		{"cohere ERROR_TOXIC", "ERROR_TOXIC", "content_filter"},
 
+		// Gemini (uppercase finishReason; content-blocking reasons → content_filter)
+		{"gemini STOP", "STOP", "stop"},
+		{"gemini MAX_TOKENS", "MAX_TOKENS", "length"},
+		{"gemini SAFETY", "SAFETY", "content_filter"},
+		{"gemini RECITATION", "RECITATION", "content_filter"},
+		{"gemini BLOCKLIST", "BLOCKLIST", "content_filter"},
+		{"gemini PROHIBITED_CONTENT", "PROHIBITED_CONTENT", "content_filter"},
+		{"gemini SPII", "SPII", "content_filter"},
+		{"gemini IMAGE_SAFETY", "IMAGE_SAFETY", "content_filter"},
+		// Ambiguous Gemini reasons are surfaced unchanged rather than mis-signaled.
+		{"gemini OTHER passthrough", "OTHER", "OTHER"},
+		{"gemini MALFORMED_FUNCTION_CALL passthrough", "MALFORMED_FUNCTION_CALL", "MALFORMED_FUNCTION_CALL"},
+
 		// Already-canonical passthrough
 		{"canonical tool_calls", "tool_calls", "tool_calls"},
 		{"canonical content_filter", "content_filter", "content_filter"},

--- a/providers/gemini/gemini.go
+++ b/providers/gemini/gemini.go
@@ -86,9 +86,7 @@ func (p *Provider) AuthHeaders() map[string]string {
 // SupportedModels returns the static list of known Gemini models.
 func (p *Provider) SupportedModels() []string {
 	return []string{
-		// Gemini 3.x
-		"gemini-3.5-flash",
-		// Gemini 2.5 (current GA tier)
+		// Current GA tier
 		"gemini-2.5-pro",
 		"gemini-2.5-flash",
 		"gemini-2.5-flash-lite",

--- a/providers/gemini/gemini.go
+++ b/providers/gemini/gemini.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"slices"
 	"strings"
 
 	providerhttp "github.com/ferro-labs/ai-gateway/internal/httpclient"
@@ -366,8 +367,10 @@ func geminiImagePart(imageURL string) geminiPart {
 	return geminiPart{FileData: &geminiFileData{FileURI: imageURL}}
 }
 
-// parseImageDataURI splits a "data:<mime>;base64,<data>" URI into its MIME type
-// and base64 payload. ok is false for a non-base64 data URI or a remote URL.
+// parseImageDataURI splits a "data:<mime>[;param]...;base64,<data>" URI into its
+// MIME type and base64 payload. ok is false for a non-base64 data URI or a
+// remote URL. The "base64" token may follow other parameters (e.g.
+// "data:image/png;charset=utf-8;base64,...").
 func parseImageDataURI(uri string) (mimeType, data string, ok bool) {
 	const prefix = "data:"
 	if !strings.HasPrefix(uri, prefix) {
@@ -377,11 +380,11 @@ func parseImageDataURI(uri string) (mimeType, data string, ok bool) {
 	if !found {
 		return "", "", false
 	}
-	mimeType, encoding, _ := strings.Cut(meta, ";")
-	if encoding != "base64" {
-		return "", "", false
+	params := strings.Split(meta, ";")
+	if slices.Contains(params[1:], "base64") {
+		return params[0], payload, true
 	}
-	return mimeType, payload, true
+	return "", "", false
 }
 
 // geminiFinishReason maps a Gemini candidate finishReason to the canonical

--- a/providers/gemini/gemini.go
+++ b/providers/gemini/gemini.go
@@ -52,6 +52,8 @@ var (
 func New(apiKey, baseURL string) (*Provider, error) {
 	if baseURL == "" {
 		baseURL = defaultBaseURL
+	} else if err := core.ValidateBaseURL(Name, baseURL); err != nil {
+		return nil, err
 	}
 	baseURL = strings.TrimRight(baseURL, "/")
 	return &Provider{
@@ -84,13 +86,17 @@ func (p *Provider) AuthHeaders() map[string]string {
 // SupportedModels returns the static list of known Gemini models.
 func (p *Provider) SupportedModels() []string {
 	return []string{
-		"gemini-2.0-flash",
-		"gemini-2.0-flash-lite",
-		"gemini-1.5-pro",
-		"gemini-1.5-flash",
+		// Gemini 3.x
+		"gemini-3.5-flash",
+		// Gemini 2.5 (current GA tier)
+		"gemini-2.5-pro",
+		"gemini-2.5-flash",
+		"gemini-2.5-flash-lite",
+		// Embeddings
 		"gemini-embedding-001",
 		"text-embedding-004",
 		"embedding-001",
+		// Image generation (Imagen)
 		"imagen-4.0-generate-001",
 		"imagen-4.0-ultra-generate-001",
 		"imagen-4.0-fast-generate-001",
@@ -118,8 +124,24 @@ func (p *Provider) Models() []core.ModelInfo {
 
 type geminiPart struct {
 	Text             string                  `json:"text,omitempty"`
+	InlineData       *geminiInlineData       `json:"inlineData,omitempty"`
+	FileData         *geminiFileData         `json:"fileData,omitempty"`
 	FunctionCall     *geminiFunctionCall     `json:"functionCall,omitempty"`
 	FunctionResponse *geminiFunctionResponse `json:"functionResponse,omitempty"`
+}
+
+// geminiInlineData carries an inline base64-encoded image, mapped from an OpenAI
+// image_url data URI.
+type geminiInlineData struct {
+	MimeType string `json:"mimeType"`
+	Data     string `json:"data"`
+}
+
+// geminiFileData references image bytes by URI, mapped from a remote (non-data)
+// image_url.
+type geminiFileData struct {
+	MimeType string `json:"mimeType,omitempty"`
+	FileURI  string `json:"fileUri"`
 }
 
 type geminiFunctionCall struct {
@@ -187,7 +209,19 @@ type geminiFunctionCallingConfig struct {
 	AllowedFunctionNames []string `json:"allowedFunctionNames,omitempty"`
 }
 
+// geminiUsageMetadata is Gemini's token accounting, including the cached-content
+// and thinking (reasoning) token counts documented on the generateContent
+// response.
+type geminiUsageMetadata struct {
+	PromptTokenCount        int `json:"promptTokenCount"`
+	CandidatesTokenCount    int `json:"candidatesTokenCount"`
+	TotalTokenCount         int `json:"totalTokenCount"`
+	CachedContentTokenCount int `json:"cachedContentTokenCount"`
+	ThoughtsTokenCount      int `json:"thoughtsTokenCount"`
+}
+
 type geminiResponse struct {
+	ResponseID string `json:"responseId"`
 	Candidates []struct {
 		Content struct {
 			Parts []geminiPart `json:"parts"`
@@ -195,11 +229,7 @@ type geminiResponse struct {
 		} `json:"content"`
 		FinishReason string `json:"finishReason"`
 	} `json:"candidates"`
-	UsageMetadata struct {
-		PromptTokenCount     int `json:"promptTokenCount"`
-		CandidatesTokenCount int `json:"candidatesTokenCount"`
-		TotalTokenCount      int `json:"totalTokenCount"`
-	} `json:"usageMetadata"`
+	UsageMetadata geminiUsageMetadata `json:"usageMetadata"`
 }
 
 type geminiEmbeddingContent struct {
@@ -234,11 +264,7 @@ type geminiStreamResponse struct {
 		} `json:"content"`
 		FinishReason string `json:"finishReason,omitempty"`
 	} `json:"candidates"`
-	UsageMetadata struct {
-		PromptTokenCount     int `json:"promptTokenCount"`
-		CandidatesTokenCount int `json:"candidatesTokenCount"`
-		TotalTokenCount      int `json:"totalTokenCount"`
-	} `json:"usageMetadata"`
+	UsageMetadata geminiUsageMetadata `json:"usageMetadata"`
 }
 
 // convertToGemini converts gateway Messages to Gemini contents format. System
@@ -301,7 +327,18 @@ func geminiParts(msg core.Message, toolCallNames map[string]string) []geminiPart
 		}}}
 	}
 	var parts []geminiPart
-	if msg.Content != "" {
+	if len(msg.ContentParts) > 0 {
+		for _, part := range msg.ContentParts {
+			switch part.Type {
+			case core.ContentTypeText:
+				parts = append(parts, geminiPart{Text: part.Text})
+			case "image_url":
+				if part.ImageURL != nil {
+					parts = append(parts, geminiImagePart(part.ImageURL.URL))
+				}
+			}
+		}
+	} else if msg.Content != "" {
 		parts = append(parts, geminiPart{Text: msg.Content})
 	}
 	for _, tc := range msg.ToolCalls {
@@ -321,25 +358,43 @@ func geminiParts(msg core.Message, toolCallNames map[string]string) []geminiPart
 	return parts
 }
 
-// mapFinishReason maps Gemini finish reasons to OpenAI-style reasons.
-func mapFinishReason(reason string) string {
-	switch reason {
-	case "STOP":
-		return core.FinishReasonStop
-	case "MAX_TOKENS":
-		return core.FinishReasonLength
-	case "SAFETY":
-		return core.FinishReasonContentFilter
-	default:
-		return reason
+// geminiImagePart maps an OpenAI image_url to a Gemini part: an inline base64
+// image for a data URI, or a fileData URI reference for a remote image. This
+// keeps multimodal image content in the request instead of dropping it.
+func geminiImagePart(imageURL string) geminiPart {
+	if mimeType, data, ok := parseImageDataURI(imageURL); ok {
+		return geminiPart{InlineData: &geminiInlineData{MimeType: mimeType, Data: data}}
 	}
+	return geminiPart{FileData: &geminiFileData{FileURI: imageURL}}
 }
 
+// parseImageDataURI splits a "data:<mime>;base64,<data>" URI into its MIME type
+// and base64 payload. ok is false for a non-base64 data URI or a remote URL.
+func parseImageDataURI(uri string) (mimeType, data string, ok bool) {
+	const prefix = "data:"
+	if !strings.HasPrefix(uri, prefix) {
+		return "", "", false
+	}
+	meta, payload, found := strings.Cut(uri[len(prefix):], ",")
+	if !found {
+		return "", "", false
+	}
+	mimeType, encoding, _ := strings.Cut(meta, ";")
+	if encoding != "base64" {
+		return "", "", false
+	}
+	return mimeType, payload, true
+}
+
+// geminiFinishReason maps a Gemini candidate finishReason to the canonical
+// OpenAI vocabulary. Gemini has no dedicated tool-call reason, so tool calls are
+// inferred from the decoded parts; everything else routes through the shared
+// normalizer (which covers Gemini's RECITATION/SAFETY-family reasons).
 func geminiFinishReason(reason string, toolCalls []core.ToolCall) string {
 	if len(toolCalls) > 0 {
 		return core.FinishReasonToolCalls
 	}
-	return mapFinishReason(reason)
+	return core.NormalizeFinishReason(reason)
 }
 
 func buildRequest(req core.Request) geminiRequest {
@@ -667,14 +722,21 @@ func (p *Provider) Complete(ctx context.Context, req core.Request) (*core.Respon
 		})
 	}
 
+	responseID := geminiResp.ResponseID
+	if responseID == "" {
+		responseID = req.Model
+	}
 	return &core.Response{
-		ID:      req.Model,
-		Model:   req.Model,
-		Choices: choices,
+		ID:       responseID,
+		Model:    req.Model,
+		Provider: p.name,
+		Choices:  choices,
 		Usage: core.Usage{
 			PromptTokens:     geminiResp.UsageMetadata.PromptTokenCount,
 			CompletionTokens: geminiResp.UsageMetadata.CandidatesTokenCount,
 			TotalTokens:      geminiResp.UsageMetadata.TotalTokenCount,
+			ReasoningTokens:  geminiResp.UsageMetadata.ThoughtsTokenCount,
+			CacheReadTokens:  geminiResp.UsageMetadata.CachedContentTokenCount,
 		},
 	}, nil
 }
@@ -732,6 +794,16 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 					},
 					FinishReason: geminiFinishReason(candidate.FinishReason, toolCalls),
 				})
+			}
+			// Gemini reports usage on the final streamed chunk.
+			if chunk.UsageMetadata.TotalTokenCount > 0 {
+				sc.Usage = &core.Usage{
+					PromptTokens:     chunk.UsageMetadata.PromptTokenCount,
+					CompletionTokens: chunk.UsageMetadata.CandidatesTokenCount,
+					TotalTokens:      chunk.UsageMetadata.TotalTokenCount,
+					ReasoningTokens:  chunk.UsageMetadata.ThoughtsTokenCount,
+					CacheReadTokens:  chunk.UsageMetadata.CachedContentTokenCount,
+				}
 			}
 			ch <- sc
 		}

--- a/providers/gemini/gemini_phase2_test.go
+++ b/providers/gemini/gemini_phase2_test.go
@@ -1,0 +1,206 @@
+package gemini
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/ferro-labs/ai-gateway/providers/core"
+)
+
+// geminiCompleteBody runs one Complete against a stub returning respBody and
+// returns both the decoded request body and the provider response.
+func geminiCompleteBody(t *testing.T, req core.Request, respBody string) (map[string]json.RawMessage, *core.Response) {
+	t.Helper()
+	var captured map[string]json.RawMessage
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(b, &captured)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, respBody)
+	}))
+	defer srv.Close()
+
+	p, _ := New("test-key", srv.URL)
+	resp, err := p.Complete(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	return captured, resp
+}
+
+type geminiWirePart struct {
+	Text       string `json:"text"`
+	InlineData *struct {
+		MimeType string `json:"mimeType"`
+		Data     string `json:"data"`
+	} `json:"inlineData"`
+	FileData *struct {
+		FileURI string `json:"fileUri"`
+	} `json:"fileData"`
+}
+
+// TestGeminiProvider_Complete_ForwardsVisionParts verifies multimodal image
+// parts are mapped to Gemini inlineData (data URI) and fileData (remote URL)
+// instead of being dropped.
+func TestGeminiProvider_Complete_ForwardsVisionParts(t *testing.T) {
+	body, _ := geminiCompleteBody(t, core.Request{
+		Model: "gemini-2.5-flash",
+		Messages: []core.Message{{
+			Role: core.RoleUser,
+			ContentParts: []core.ContentPart{
+				{Type: "text", Text: "what is this"},
+				{Type: "image_url", ImageURL: &core.ImageURLPart{URL: "data:image/png;base64,QUJD"}},
+				{Type: "image_url", ImageURL: &core.ImageURLPart{URL: "https://example.com/cat.png"}},
+			},
+		}},
+	}, `{"candidates":[{"content":{"parts":[{"text":"ok"}]},"finishReason":"STOP"}],"usageMetadata":{"totalTokenCount":1}}`)
+
+	var contents []struct {
+		Parts []geminiWirePart `json:"parts"`
+	}
+	if err := json.Unmarshal(body["contents"], &contents); err != nil {
+		t.Fatalf("decode contents: %v", err)
+	}
+	if len(contents) != 1 {
+		t.Fatalf("contents len = %d, want 1", len(contents))
+	}
+	parts := contents[0].Parts
+	var sawInline, sawFile bool
+	for _, p := range parts {
+		if p.InlineData != nil && p.InlineData.Data == "QUJD" && p.InlineData.MimeType == "image/png" {
+			sawInline = true
+		}
+		if p.FileData != nil && p.FileData.FileURI == "https://example.com/cat.png" {
+			sawFile = true
+		}
+	}
+	if !sawInline {
+		t.Errorf("data-URI image not mapped to inlineData; parts = %+v", parts)
+	}
+	if !sawFile {
+		t.Errorf("remote image not mapped to fileData; parts = %+v", parts)
+	}
+}
+
+// TestGeminiProvider_Complete_SurfacesProviderIDAndTokens verifies the response
+// carries the provider name, the upstream responseId, and the cached/reasoning
+// token detail.
+func TestGeminiProvider_Complete_SurfacesProviderIDAndTokens(t *testing.T) {
+	_, resp := geminiCompleteBody(t, core.Request{
+		Model:    "gemini-2.5-flash",
+		Messages: []core.Message{{Role: core.RoleUser, Content: "hi"}},
+	}, `{"responseId":"resp_abc","candidates":[{"content":{"parts":[{"text":"hi"}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":5,"candidatesTokenCount":3,"totalTokenCount":8,"cachedContentTokenCount":2,"thoughtsTokenCount":4}}`)
+
+	if resp.Provider != "gemini" {
+		t.Errorf("Provider = %q, want gemini", resp.Provider)
+	}
+	if resp.ID != "resp_abc" {
+		t.Errorf("ID = %q, want resp_abc (upstream responseId)", resp.ID)
+	}
+	if resp.Usage.CacheReadTokens != 2 || resp.Usage.ReasoningTokens != 4 {
+		t.Errorf("usage cache/reasoning = %d/%d, want 2/4", resp.Usage.CacheReadTokens, resp.Usage.ReasoningTokens)
+	}
+}
+
+// TestGeminiProvider_FinishReason_ContentFilter verifies Gemini's content-block
+// reasons normalize to the canonical content_filter value (#264).
+func TestGeminiProvider_FinishReason_ContentFilter(t *testing.T) {
+	_, resp := geminiCompleteBody(t, core.Request{
+		Model:    "gemini-2.5-flash",
+		Messages: []core.Message{{Role: core.RoleUser, Content: "hi"}},
+	}, `{"candidates":[{"content":{"parts":[{"text":""}]},"finishReason":"RECITATION"}],"usageMetadata":{"totalTokenCount":1}}`)
+
+	if len(resp.Choices) != 1 || resp.Choices[0].FinishReason != core.FinishReasonContentFilter {
+		t.Fatalf("finish_reason = %v, want content_filter", resp.Choices)
+	}
+}
+
+// TestGeminiProvider_Complete_ErrorPath verifies a non-200 surfaces the upstream
+// message via core.APIError.
+func TestGeminiProvider_Complete_ErrorPath(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = io.WriteString(w, `{"error":{"message":"quota exceeded"}}`)
+	}))
+	defer srv.Close()
+
+	p, _ := New("test-key", srv.URL)
+	_, err := p.Complete(context.Background(), core.Request{
+		Model:    "gemini-2.5-flash",
+		Messages: []core.Message{{Role: core.RoleUser, Content: "hi"}},
+	})
+	if err == nil {
+		t.Fatal("expected error for 429")
+	}
+	if !strings.Contains(err.Error(), "quota exceeded") || !strings.Contains(err.Error(), "429") {
+		t.Fatalf("error = %v, want status + upstream message", err)
+	}
+}
+
+// TestGeminiProvider_CompleteStream_ReportsUsage verifies streaming surfaces
+// token usage from the final chunk's usageMetadata.
+func TestGeminiProvider_CompleteStream_ReportsUsage(t *testing.T) {
+	sse := "data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"hi\"}]}}]}\n\n" +
+		"data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"\"}]},\"finishReason\":\"STOP\"}],\"usageMetadata\":{\"promptTokenCount\":9,\"candidatesTokenCount\":4,\"totalTokenCount\":13,\"thoughtsTokenCount\":2}}\n\n"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, sse)
+	}))
+	defer srv.Close()
+
+	p, _ := New("test-key", srv.URL)
+	ch, err := p.CompleteStream(context.Background(), core.Request{
+		Model:    "gemini-2.5-flash",
+		Messages: []core.Message{{Role: core.RoleUser, Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("CompleteStream: %v", err)
+	}
+
+	var usage *core.Usage
+	for c := range ch {
+		if c.Error != nil {
+			t.Fatalf("stream error: %v", c.Error)
+		}
+		if c.Usage != nil {
+			usage = c.Usage
+		}
+	}
+	if usage == nil {
+		t.Fatal("no usage reported on gemini stream")
+	}
+	if usage.PromptTokens != 9 || usage.CompletionTokens != 4 || usage.TotalTokens != 13 || usage.ReasoningTokens != 2 {
+		t.Fatalf("usage = %+v, want 9/4/13 with 2 reasoning", usage)
+	}
+}
+
+func TestGeminiProvider_New_RejectsInvalidBaseURL(t *testing.T) {
+	if _, err := New("test-key", "://nope"); err == nil {
+		t.Fatal("New() accepted an invalid base URL")
+	}
+}
+
+func TestBuildImagenRequest_MapsSizeToAspectRatio(t *testing.T) {
+	cases := map[string]string{
+		"1024x1024": "1:1",
+		"1792x1024": "16:9",
+		"1024x1792": "9:16",
+		"640x480":   "", // unmapped
+	}
+	for size, want := range cases {
+		got := buildImagenRequest(core.ImageRequest{Prompt: "x", Size: size})
+		var ar string
+		if got.Parameters != nil {
+			ar = got.Parameters.AspectRatio
+		}
+		if ar != want {
+			t.Errorf("size %q -> aspectRatio %q, want %q", size, ar, want)
+		}
+	}
+}

--- a/providers/gemini/gemini_test.go
+++ b/providers/gemini/gemini_test.go
@@ -54,7 +54,7 @@ func TestGeminiProvider_SupportedModels(t *testing.T) {
 	found := false
 	foundEmbedding := false
 	for _, m := range models {
-		if m == "gemini-2.0-flash" {
+		if m == "gemini-2.5-flash" {
 			found = true
 		}
 		if m == "gemini-embedding-001" {
@@ -62,7 +62,7 @@ func TestGeminiProvider_SupportedModels(t *testing.T) {
 		}
 	}
 	if !found {
-		t.Error("gemini-2.0-flash not found")
+		t.Error("gemini-2.5-flash not found")
 	}
 	if !foundEmbedding {
 		t.Error("gemini-embedding-001 not found")
@@ -71,8 +71,8 @@ func TestGeminiProvider_SupportedModels(t *testing.T) {
 
 func TestGeminiProvider_SupportsModel(t *testing.T) {
 	p, _ := New("test-key", "")
-	if !p.SupportsModel("gemini-2.0-flash") {
-		t.Error("expected gemini-2.0-flash to be supported")
+	if !p.SupportsModel("gemini-2.5-flash") {
+		t.Error("expected gemini-2.5-flash to be supported")
 	}
 	if p.SupportsModel("gpt-4o") {
 		t.Error("gemini should not support gpt-4o")

--- a/providers/gemini/image.go
+++ b/providers/gemini/image.go
@@ -43,17 +43,39 @@ type imagenResponse struct {
 }
 
 // buildImagenRequest maps a gateway ImageRequest onto the Imagen :predict shape.
-// req.Size ("WxH") is not directly mappable to Imagen and is ignored;
+// A recognized req.Size ("WxH") is mapped to the nearest Imagen aspectRatio;
 // req.ResponseFormat is ignored (Imagen returns base64 only).
 func buildImagenRequest(req core.ImageRequest) imagenRequest {
 	out := imagenRequest{
 		Instances: []imagenInstance{{Prompt: req.Prompt}},
 	}
-	if req.N != nil {
-		params := imagenParameters{SampleCount: req.N}
+	params := imagenParameters{SampleCount: req.N}
+	if ar := imagenAspectRatio(req.Size); ar != "" {
+		params.AspectRatio = ar
+	}
+	if params.SampleCount != nil || params.AspectRatio != "" {
 		out.Parameters = &params
 	}
 	return out
+}
+
+// imagenAspectRatio maps a common OpenAI "WxH" size to the nearest Imagen
+// aspectRatio. An unmapped or empty size returns "" (Imagen defaults to 1:1).
+func imagenAspectRatio(size string) string {
+	switch size {
+	case "1024x1024", "512x512", "256x256":
+		return "1:1"
+	case "1792x1024", "1536x1024":
+		return "16:9"
+	case "1024x1792", "1024x1536":
+		return "9:16"
+	case "1408x1024":
+		return "4:3"
+	case "1024x1408":
+		return "3:4"
+	default:
+		return ""
+	}
 }
 
 // mapImagenPredictions converts Imagen predictions to gateway images. It returns
@@ -76,24 +98,13 @@ func mapImagenPredictions(model string, predictions []imagenPrediction) ([]core.
 func (p *Provider) GenerateImage(ctx context.Context, req core.ImageRequest) (*core.ImageResponse, error) {
 	imagenReq := buildImagenRequest(req)
 
-	bodyReader, _, release, err := core.JSONBodyReader(imagenReq)
+	model := strings.TrimPrefix(req.Model, "models/")
+	reqURL := fmt.Sprintf("%s/v1beta/models/%s:predict?key=%s", p.baseURL, url.PathEscape(model), p.apiKey)
+	httpResp, release, err := p.doJSONRequest(ctx, http.MethodPost, reqURL, "image ", imagenReq)
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal image request: %w", err)
+		return nil, err
 	}
 	defer release()
-
-	model := strings.TrimPrefix(req.Model, "models/")
-	url := fmt.Sprintf("%s/v1beta/models/%s:predict?key=%s", p.baseURL, url.PathEscape(model), p.apiKey)
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bodyReader)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create image request: %w", err)
-	}
-	httpReq.Header.Set("Content-Type", "application/json")
-
-	httpResp, err := p.httpClient.Do(httpReq)
-	if err != nil {
-		return nil, fmt.Errorf("image request failed: %w", sanitizeRequestErr(err))
-	}
 	defer func() { _ = httpResp.Body.Close() }()
 
 	respBody, err := io.ReadAll(httpResp.Body)

--- a/providers/openai/openai.go
+++ b/providers/openai/openai.go
@@ -1,4 +1,7 @@
-// Package openai provides a client for the OpenAI API using the official Go SDK.
+// Package openai provides a client for the OpenAI API. Chat completions use a
+// direct HTTP + JSON path so every core.Request field is forwarded verbatim on
+// both the streaming and non-streaming paths (they cannot diverge); embeddings
+// and image generation use the official Go SDK.
 package openai
 
 import (
@@ -231,10 +234,15 @@ func (p *Provider) GenerateImage(ctx context.Context, req core.ImageRequest) (*c
 	if req.Style != "" {
 		params.Style = oai.ImageGenerateParamsStyle(req.Style)
 	}
-	if req.ResponseFormat == "b64_json" {
-		params.ResponseFormat = oai.ImageGenerateParamsResponseFormatB64JSON
-	} else {
-		params.ResponseFormat = oai.ImageGenerateParamsResponseFormatURL
+	// response_format is only valid for the DALL·E models. gpt-image-* rejects it
+	// and always returns base64, so omit it entirely for that family and read the
+	// result from B64JSON.
+	if isDallEModel(req.Model) {
+		if req.ResponseFormat == "b64_json" {
+			params.ResponseFormat = oai.ImageGenerateParamsResponseFormatB64JSON
+		} else {
+			params.ResponseFormat = oai.ImageGenerateParamsResponseFormatURL
+		}
 	}
 	if req.User != "" {
 		params.User = oai.String(req.User)
@@ -290,12 +298,7 @@ func (p *Provider) Complete(ctx context.Context, req core.Request) (*core.Respon
 		if err != nil {
 			return nil, fmt.Errorf("failed to read response: %w", err)
 		}
-
-		var errResp openAIErrorResponse
-		if json.Unmarshal(respBody, &errResp) == nil && errResp.Error.Message != "" {
-			return nil, fmt.Errorf("openai API error (%d): %s", httpResp.StatusCode, errResp.Error.Message)
-		}
-		return nil, fmt.Errorf("openai API error (%d): %s", httpResp.StatusCode, string(respBody))
+		return nil, core.APIError(p.name, httpResp.StatusCode, respBody)
 	}
 
 	var completion openAIChatCompletionResponse
@@ -323,71 +326,82 @@ func (p *Provider) Complete(ctx context.Context, req core.Request) (*core.Respon
 	}, nil
 }
 
-// CompleteStream sends a streaming chat completion request to OpenAI.
-// stream_options.include_usage=true is set so that the final SSE chunk
-// carries token-usage statistics for cost and metrics tracking.
-func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan core.StreamChunk, error) {
-	params := oai.ChatCompletionNewParams{
-		Messages: buildMessages(req.Messages),
-		Model:    req.Model,
-		StreamOptions: oai.ChatCompletionStreamOptionsParam{
-			IncludeUsage: oai.Bool(true),
-		},
-	}
-	applyParams(&params, req)
+// streamOptions carries the OpenAI stream_options object. The gateway always
+// requests usage so cost and metrics tracking work regardless of what the client
+// sent.
+type streamOptions struct {
+	IncludeUsage bool `json:"include_usage"`
+}
 
-	stream := p.client.Chat.Completions.NewStreaming(ctx, params)
+// streamingRequest is a core.Request forwarded verbatim (so no field can be
+// dropped, unlike a rebuilt param struct) plus the stream_options the streaming
+// path always sets.
+type streamingRequest struct {
+	core.Request
+	StreamOptions streamOptions `json:"stream_options"`
+}
+
+// CompleteStream sends a streaming chat completion request to OpenAI. It
+// forwards the same raw core.Request body as Complete (adding stream:true and
+// stream_options.include_usage), so streaming and non-streaming cannot diverge
+// on forwarded fields such as logit_bias and multimodal image content. Usage is
+// always requested so the final SSE chunk carries token statistics for cost and
+// metrics tracking.
+func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan core.StreamChunk, error) {
+	// o-series reasoning models reject max_tokens; keep only the modern field.
+	req.PreferCompletionTokens()
+	sreq := streamingRequest{Request: req, StreamOptions: streamOptions{IncludeUsage: true}}
+	sreq.Stream = true
+
+	body, err := json.Marshal(sreq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, p.chatCompletionsEndpoint(), bytes.NewReader(body)) //nolint:gosec // baseURL validated in New()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	httpReq.Header.Set("Authorization", "Bearer "+p.apiKey)
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	httpResp, err := p.httpClient.Do(httpReq) //nolint:gosec // baseURL validated in New()
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+
+	if httpResp.StatusCode != http.StatusOK {
+		defer func() { _ = httpResp.Body.Close() }()
+		respBody, _ := io.ReadAll(httpResp.Body)
+		return nil, core.APIError(p.name, httpResp.StatusCode, respBody)
+	}
 
 	ch := make(chan core.StreamChunk)
 	go func() {
 		defer close(ch)
-		defer func() { _ = stream.Close() }()
-		for stream.Next() {
-			chunk := stream.Current()
-			sc := core.StreamChunk{
-				ID:    chunk.ID,
-				Model: chunk.Model,
+		defer func() { _ = httpResp.Body.Close() }()
+
+		scanner := core.NewSSEScanner(httpResp.Body)
+		for scanner.Scan() {
+			data, ok := strings.CutPrefix(scanner.Text(), "data: ")
+			if !ok {
+				continue
 			}
-			for _, c := range chunk.Choices {
-				sc.Choices = append(sc.Choices, core.StreamChoice{
-					Index: int(c.Index),
-					Delta: core.MessageDelta{
-						Role:      c.Delta.Role,
-						Content:   c.Delta.Content,
-						ToolCalls: openAIStreamToolCalls(c.Delta.ToolCalls),
-					},
-					FinishReason: c.FinishReason,
-				})
+			if data == core.SSEDone {
+				return
 			}
-			if chunk.Usage.TotalTokens > 0 {
-				usage := &core.Usage{
-					PromptTokens:     int(chunk.Usage.PromptTokens),
-					CompletionTokens: int(chunk.Usage.CompletionTokens),
-					TotalTokens:      int(chunk.Usage.TotalTokens),
-				}
-				if chunk.Usage.CompletionTokensDetails.ReasoningTokens > 0 {
-					usage.ReasoningTokens = int(chunk.Usage.CompletionTokensDetails.ReasoningTokens)
-				}
-				if chunk.Usage.PromptTokensDetails.CachedTokens > 0 {
-					usage.CacheReadTokens = int(chunk.Usage.PromptTokensDetails.CachedTokens)
-				}
-				sc.Usage = usage
+			var chunk openAIStreamChunk
+			if json.Unmarshal([]byte(data), &chunk) != nil {
+				continue
 			}
-			ch <- sc
+			ch <- chunk.toStreamChunk()
 		}
-		if err := stream.Err(); err != nil {
+		if err := scanner.Err(); err != nil {
 			ch <- core.StreamChunk{Error: err}
 		}
 	}()
 
 	return ch, nil
-}
-
-type openAIErrorResponse struct {
-	Error struct {
-		Message string `json:"message"`
-		Type    string `json:"type"`
-	} `json:"error"`
 }
 
 type openAIChatCompletionResponse struct {
@@ -416,153 +430,93 @@ func (p *Provider) chatCompletionsEndpoint() string {
 	return p.baseURL + "/v1/chat/completions"
 }
 
-// buildMessages converts gateway Messages to the openai-go SDK union type.
-func buildMessages(msgs []core.Message) []oai.ChatCompletionMessageParamUnion {
-	out := make([]oai.ChatCompletionMessageParamUnion, 0, len(msgs))
-	for _, msg := range msgs {
-		switch msg.Role {
-		case core.RoleUser:
-			out = append(out, oai.UserMessage(msg.Content))
-		case core.RoleAssistant:
-			assistant := oai.ChatCompletionAssistantMessageParam{}
-			if msg.Content != "" {
-				assistant.Content.OfString = oai.String(msg.Content)
-			}
-			if len(msg.ToolCalls) > 0 {
-				assistant.ToolCalls = make([]oai.ChatCompletionMessageToolCallParam, 0, len(msg.ToolCalls))
-				for _, tc := range msg.ToolCalls {
-					assistant.ToolCalls = append(assistant.ToolCalls, oai.ChatCompletionMessageToolCallParam{
-						ID: tc.ID,
-						Function: oai.ChatCompletionMessageToolCallFunctionParam{
-							Name:      tc.Function.Name,
-							Arguments: tc.Function.Arguments,
-						},
-					})
-				}
-			}
-			out = append(out, oai.ChatCompletionMessageParamUnion{OfAssistant: &assistant})
-		case core.RoleSystem:
-			out = append(out, oai.SystemMessage(msg.Content))
-		case core.RoleTool:
-			out = append(out, oai.ToolMessage(msg.Content, msg.ToolCallID))
-		default:
-			out = append(out, oai.UserMessage(msg.Content))
-		}
-	}
-	return out
+// isDallEModel reports whether the image model is a DALL·E model — the only
+// family whose image API accepts the response_format parameter.
+func isDallEModel(model string) bool {
+	return strings.HasPrefix(model, "dall-e")
 }
 
-// applyParams applies all optional Request fields to the SDK params struct.
-func applyParams(params *oai.ChatCompletionNewParams, req core.Request) {
-	if req.Temperature != nil {
-		params.Temperature = oai.Float(*req.Temperature)
-	}
-	if req.TopP != nil {
-		params.TopP = oai.Float(*req.TopP)
-	}
-	if req.N != nil {
-		params.N = oai.Int(int64(*req.N))
-	}
-	if req.Seed != nil {
-		params.Seed = oai.Int(*req.Seed)
-	}
-	// Prefer max_completion_tokens: it is the modern field accepted by every
-	// chat model, including o-series reasoning models, which reject the legacy
-	// max_tokens with a 400. The gateway seam fills max_tokens from
-	// max_completion_tokens, so both may be set here — honor the modern one.
-	if req.MaxCompletionTokens != nil {
-		params.MaxCompletionTokens = oai.Int(int64(*req.MaxCompletionTokens))
-	} else if req.MaxTokens != nil {
-		params.MaxTokens = oai.Int(int64(*req.MaxTokens))
-	}
-	if req.PresencePenalty != nil {
-		params.PresencePenalty = oai.Float(*req.PresencePenalty)
-	}
-	if req.FrequencyPenalty != nil {
-		params.FrequencyPenalty = oai.Float(*req.FrequencyPenalty)
-	}
-	if req.User != "" {
-		params.User = oai.String(req.User)
-	}
-	if req.LogProbs {
-		params.Logprobs = oai.Bool(true)
-	}
-	if req.TopLogProbs != nil {
-		params.TopLogprobs = oai.Int(int64(*req.TopLogProbs))
-	}
-	if len(req.Stop) > 0 {
-		params.Stop = oai.ChatCompletionNewParamsStopUnion{
-			OfStringArray: req.Stop,
-		}
-	}
-	if req.ResponseFormat != nil {
-		switch req.ResponseFormat.Type {
-		case "json_object":
-			params.ResponseFormat = oai.ChatCompletionNewParamsResponseFormatUnion{
-				OfJSONObject: &oai.ResponseFormatJSONObjectParam{},
-			}
-		case "json_schema":
-			if len(req.ResponseFormat.JSONSchema) > 0 {
-				var schema oai.ResponseFormatJSONSchemaJSONSchemaParam
-				if err := json.Unmarshal(req.ResponseFormat.JSONSchema, &schema); err == nil {
-					params.ResponseFormat = oai.ChatCompletionNewParamsResponseFormatUnion{
-						OfJSONSchema: &oai.ResponseFormatJSONSchemaParam{
-							JSONSchema: schema,
-						},
-					}
-				}
-			}
-		}
-	}
-	if len(req.Tools) > 0 {
-		tools := make([]oai.ChatCompletionToolParam, 0, len(req.Tools))
-		for _, t := range req.Tools {
-			var paramSchema oai.FunctionParameters
-			if len(t.Function.Parameters) > 0 {
-				json.Unmarshal(t.Function.Parameters, &paramSchema) //nolint:errcheck,gosec
-			}
-			tools = append(tools, oai.ChatCompletionToolParam{
-				Function: oai.FunctionDefinitionParam{
-					Name:        t.Function.Name,
-					Description: oai.String(t.Function.Description),
-					Parameters:  paramSchema,
-					Strict:      oai.Bool(t.Function.Strict),
-				},
-			})
-		}
-		params.Tools = tools
-	}
-	if req.ToolChoice != nil {
-		if choice, ok := openAIToolChoice(req.ToolChoice); ok {
-			params.ToolChoice = choice
-		}
-	}
+// openAIStreamChunk is one OpenAI chat.completion.chunk SSE frame. It carries the
+// nested usage-detail fields (reasoning / cached tokens) that the canonical
+// core.Usage decoder does not, so streaming preserves the same accounting as the
+// non-streaming path.
+type openAIStreamChunk struct {
+	ID      string `json:"id"`
+	Model   string `json:"model"`
+	Choices []struct {
+		Index int `json:"index"`
+		Delta struct {
+			Role      string                 `json:"role"`
+			Content   string                 `json:"content"`
+			ToolCalls []openAIStreamToolCall `json:"tool_calls"`
+		} `json:"delta"`
+		FinishReason string `json:"finish_reason"`
+	} `json:"choices"`
+	Usage *struct {
+		PromptTokens        int `json:"prompt_tokens"`
+		CompletionTokens    int `json:"completion_tokens"`
+		TotalTokens         int `json:"total_tokens"`
+		PromptTokensDetails struct {
+			CachedTokens int `json:"cached_tokens"`
+		} `json:"prompt_tokens_details"`
+		CompletionTokensDetails struct {
+			ReasoningTokens int `json:"reasoning_tokens"`
+		} `json:"completion_tokens_details"`
+	} `json:"usage"`
 }
 
-func openAIToolChoice(choice any) (oai.ChatCompletionToolChoiceOptionUnionParam, bool) {
-	switch v := choice.(type) {
-	case string:
-		return oai.ChatCompletionToolChoiceOptionUnionParam{OfAuto: oai.String(v)}, true
-	default:
-		raw, err := json.Marshal(v)
-		if err != nil {
-			return oai.ChatCompletionToolChoiceOptionUnionParam{}, false
-		}
-		var parsed oai.ChatCompletionToolChoiceOptionUnionParam
-		if err := json.Unmarshal(raw, &parsed); err != nil {
-			return oai.ChatCompletionToolChoiceOptionUnionParam{}, false
-		}
-		return parsed, true
-	}
+type openAIStreamToolCall struct {
+	Index    int    `json:"index"`
+	ID       string `json:"id"`
+	Type     string `json:"type"`
+	Function struct {
+		Name      string `json:"name"`
+		Arguments string `json:"arguments"`
+	} `json:"function"`
 }
 
-func openAIStreamToolCalls(in []oai.ChatCompletionChunkChoiceDeltaToolCall) []core.ToolCall {
+// toStreamChunk converts a decoded OpenAI SSE frame to the gateway's canonical
+// stream chunk, carrying usage (including reasoning/cache detail) on the frame
+// that reports it. OpenAI finish reasons are already canonical.
+func (c openAIStreamChunk) toStreamChunk() core.StreamChunk {
+	sc := core.StreamChunk{ID: c.ID, Model: c.Model}
+	for _, choice := range c.Choices {
+		sc.Choices = append(sc.Choices, core.StreamChoice{
+			Index: choice.Index,
+			Delta: core.MessageDelta{
+				Role:      choice.Delta.Role,
+				Content:   choice.Delta.Content,
+				ToolCalls: mapStreamToolCalls(choice.Delta.ToolCalls),
+			},
+			FinishReason: choice.FinishReason,
+		})
+	}
+	if c.Usage != nil && c.Usage.TotalTokens > 0 {
+		usage := &core.Usage{
+			PromptTokens:     c.Usage.PromptTokens,
+			CompletionTokens: c.Usage.CompletionTokens,
+			TotalTokens:      c.Usage.TotalTokens,
+		}
+		if c.Usage.CompletionTokensDetails.ReasoningTokens > 0 {
+			usage.ReasoningTokens = c.Usage.CompletionTokensDetails.ReasoningTokens
+		}
+		if c.Usage.PromptTokensDetails.CachedTokens > 0 {
+			usage.CacheReadTokens = c.Usage.PromptTokensDetails.CachedTokens
+		}
+		sc.Usage = usage
+	}
+	return sc
+}
+
+// mapStreamToolCalls maps SSE tool-call deltas to canonical tool calls,
+// preserving the streaming index each fragment belongs to.
+func mapStreamToolCalls(in []openAIStreamToolCall) []core.ToolCall {
 	if len(in) == 0 {
 		return nil
 	}
 	out := make([]core.ToolCall, 0, len(in))
 	for _, tc := range in {
-		index := int(tc.Index)
+		index := tc.Index
 		out = append(out, core.ToolCall{
 			Index: &index,
 			ID:    tc.ID,

--- a/providers/openai/openai.go
+++ b/providers/openai/openai.go
@@ -372,7 +372,10 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 
 	if httpResp.StatusCode != http.StatusOK {
 		defer func() { _ = httpResp.Body.Close() }()
-		respBody, _ := io.ReadAll(httpResp.Body)
+		respBody, err := io.ReadAll(httpResp.Body)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read response: %w", err)
+		}
 		return nil, core.APIError(p.name, httpResp.StatusCode, respBody)
 	}
 
@@ -404,23 +407,29 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 	return ch, nil
 }
 
+// openAIUsage is the OpenAI usage object with the nested reasoning/cached token
+// detail. It is shared by the streaming and non-streaming response decoders so
+// the token-accounting fields stay aligned; the canonical core.Usage decoder
+// does not capture the nested detail.
+type openAIUsage struct {
+	PromptTokens        int `json:"prompt_tokens"`
+	CompletionTokens    int `json:"completion_tokens"`
+	TotalTokens         int `json:"total_tokens"`
+	PromptTokensDetails struct {
+		CachedTokens int `json:"cached_tokens"`
+	} `json:"prompt_tokens_details"`
+	CompletionTokensDetails struct {
+		ReasoningTokens int `json:"reasoning_tokens"`
+	} `json:"completion_tokens_details"`
+}
+
 type openAIChatCompletionResponse struct {
 	ID      string        `json:"id"`
 	Object  string        `json:"object"`
 	Created int64         `json:"created"`
 	Model   string        `json:"model"`
 	Choices []core.Choice `json:"choices"`
-	Usage   struct {
-		PromptTokens        int `json:"prompt_tokens"`
-		CompletionTokens    int `json:"completion_tokens"`
-		TotalTokens         int `json:"total_tokens"`
-		PromptTokensDetails struct {
-			CachedTokens int `json:"cached_tokens"`
-		} `json:"prompt_tokens_details"`
-		CompletionTokensDetails struct {
-			ReasoningTokens int `json:"reasoning_tokens"`
-		} `json:"completion_tokens_details"`
-	} `json:"usage"`
+	Usage   openAIUsage   `json:"usage"`
 }
 
 func (p *Provider) chatCompletionsEndpoint() string {
@@ -452,17 +461,7 @@ type openAIStreamChunk struct {
 		} `json:"delta"`
 		FinishReason string `json:"finish_reason"`
 	} `json:"choices"`
-	Usage *struct {
-		PromptTokens        int `json:"prompt_tokens"`
-		CompletionTokens    int `json:"completion_tokens"`
-		TotalTokens         int `json:"total_tokens"`
-		PromptTokensDetails struct {
-			CachedTokens int `json:"cached_tokens"`
-		} `json:"prompt_tokens_details"`
-		CompletionTokensDetails struct {
-			ReasoningTokens int `json:"reasoning_tokens"`
-		} `json:"completion_tokens_details"`
-	} `json:"usage"`
+	Usage *openAIUsage `json:"usage"`
 }
 
 type openAIStreamToolCall struct {

--- a/providers/openai/openai.go
+++ b/providers/openai/openai.go
@@ -380,6 +380,12 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 	}
 
 	ch := make(chan core.StreamChunk)
+	// The producer uses unguarded blocking sends (ch <- ...), matching every
+	// other provider. It stays leak-free because the gateway routes every
+	// provider stream through streamwrap.Meter, which ALWAYS drains this channel
+	// to completion — even on consumer abandonment or context cancellation — so
+	// this goroutine reaches close(ch) and Body.Close(). See the "Stream-send
+	// drain contract" in internal/streamwrap.
 	go func() {
 		defer close(ch)
 		defer func() { _ = httpResp.Body.Close() }()

--- a/providers/openai/openai_test.go
+++ b/providers/openai/openai_test.go
@@ -230,34 +230,6 @@ func TestOpenAIProvider_Complete_MockHTTP(t *testing.T) {
 	}
 }
 
-func TestBuildMessages_AssistantToolCalls(t *testing.T) {
-	msgs := buildMessages([]core.Message{
-		{Role: core.RoleAssistant, ToolCalls: []core.ToolCall{{
-			ID:       "call_1",
-			Type:     "function",
-			Function: core.FunctionCall{Name: "lookup", Arguments: `{"city":"SF"}`},
-		}}},
-		{Role: core.RoleTool, ToolCallID: "call_1", Content: "72F"},
-	})
-	raw, err := json.Marshal(msgs)
-	if err != nil {
-		t.Fatalf("marshal messages: %v", err)
-	}
-	var got []core.Message
-	if err := json.Unmarshal(raw, &got); err != nil {
-		t.Fatalf("unmarshal messages: %v\n%s", err, raw)
-	}
-	if len(got) != 2 {
-		t.Fatalf("messages len = %d, want 2", len(got))
-	}
-	if len(got[0].ToolCalls) != 1 || got[0].ToolCalls[0].Function.Name != "lookup" {
-		t.Fatalf("assistant tool_calls = %#v, want lookup", got[0].ToolCalls)
-	}
-	if got[1].ToolCallID != "call_1" {
-		t.Fatalf("tool_call_id = %q, want call_1", got[1].ToolCallID)
-	}
-}
-
 func TestOpenAIProvider_Complete_DrainsSuccessfulResponseBody(t *testing.T) {
 	var newConnections atomic.Int32
 	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -359,24 +331,30 @@ func TestOpenAIProvider_CompleteStream_MockSSE(t *testing.T) {
 	}
 
 	var chunks []core.StreamChunk
+	var content strings.Builder
 	for c := range ch {
 		if c.Error != nil {
-			t.Logf("CompleteStream chunk error (SDK may reject mock format): %v", c.Error)
-			return
+			t.Fatalf("stream error: %v", c.Error)
 		}
 		chunks = append(chunks, c)
+		for _, choice := range c.Choices {
+			content.WriteString(choice.Delta.Content)
+		}
 	}
 
-	if len(chunks) == 0 {
-		t.Log("No chunks received — openai-go SDK may not process mock SSE; interface compliance verified by _Interface test")
-		return
+	if len(chunks) != 4 {
+		t.Fatalf("chunks len = %d, want 4: %#v", len(chunks), chunks)
 	}
-
-	// Verify chunk structure when SDK parses successfully.
 	for _, chunk := range chunks {
 		if chunk.ID != "chatcmpl-1" {
-			t.Errorf("chunk ID = %q, want %s", chunk.ID, "chatcmpl-1")
+			t.Errorf("chunk ID = %q, want chatcmpl-1", chunk.ID)
 		}
+	}
+	if content.String() != "Hello world" {
+		t.Errorf("assembled content = %q, want %q", content.String(), "Hello world")
+	}
+	if chunks[3].Choices[0].FinishReason != core.FinishReasonStop {
+		t.Errorf("final finish_reason = %q, want stop", chunks[3].Choices[0].FinishReason)
 	}
 }
 

--- a/providers/openai/openai_unify_test.go
+++ b/providers/openai/openai_unify_test.go
@@ -1,0 +1,196 @@
+package openai
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	core "github.com/ferro-labs/ai-gateway/providers/core"
+)
+
+// captureChatBody runs one chat request (streaming or not) against a stub and
+// returns the decoded request body the provider sent.
+func captureChatBody(t *testing.T, stream bool, req core.Request) map[string]json.RawMessage {
+	t.Helper()
+	var captured map[string]json.RawMessage
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(b, &captured)
+		if stream {
+			w.Header().Set("Content-Type", "text/event-stream")
+			_, _ = io.WriteString(w, "data: {\"id\":\"chatcmpl-1\",\"model\":\"gpt-4o\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"hi\"},\"finish_reason\":\"stop\"}]}\n\ndata: [DONE]\n\n")
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"id":"chatcmpl-1","object":"chat.completion","created":1,"model":"gpt-4o","choices":[{"index":0,"message":{"role":"assistant","content":"hi"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`)
+	}))
+	defer srv.Close()
+
+	p, err := New("sk-test", srv.URL)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if stream {
+		ch, err := p.CompleteStream(context.Background(), req)
+		if err != nil {
+			t.Fatalf("CompleteStream: %v", err)
+		}
+		var got int
+		for range ch {
+			got++
+		}
+		if got == 0 {
+			t.Fatal("stream produced no chunks")
+		}
+		return captured
+	}
+	if _, err := p.Complete(context.Background(), req); err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	return captured
+}
+
+// TestOpenAIProvider_ForwardsFieldsOnBothPaths is the #265 acceptance: a
+// streaming request forwards the same logit_bias and multimodal image content as
+// an identical non-streaming request, and streaming sets stream_options.
+func TestOpenAIProvider_ForwardsFieldsOnBothPaths(t *testing.T) {
+	req := core.Request{
+		Model: "gpt-4o",
+		Messages: []core.Message{{
+			Role: core.RoleUser,
+			ContentParts: []core.ContentPart{
+				{Type: "text", Text: "what is this"},
+				{Type: "image_url", ImageURL: &core.ImageURLPart{URL: "https://example.com/cat.png"}},
+			},
+		}},
+		LogitBias: map[string]float64{"123": -100},
+	}
+
+	for _, stream := range []bool{false, true} {
+		name := "non_stream"
+		if stream {
+			name = "stream"
+		}
+		t.Run(name, func(t *testing.T) {
+			body := captureChatBody(t, stream, req)
+
+			if _, ok := body["logit_bias"]; !ok {
+				t.Error("logit_bias not forwarded")
+			}
+
+			var msgs []struct {
+				Content json.RawMessage `json:"content"`
+			}
+			if err := json.Unmarshal(body["messages"], &msgs); err != nil {
+				t.Fatalf("decode messages: %v", err)
+			}
+			if len(msgs) == 0 || !strings.Contains(string(msgs[0].Content), "image_url") {
+				t.Errorf("vision image_url not forwarded; content = %s", msgs[0].Content)
+			}
+
+			if stream {
+				if _, ok := body["stream_options"]; !ok {
+					t.Error("stream_options not set on streaming request")
+				}
+			}
+		})
+	}
+}
+
+// TestOpenAIProvider_CompleteStream_ReportsUsageWithDetails verifies the raw SSE
+// decoder preserves the nested reasoning/cache token detail on the final chunk.
+func TestOpenAIProvider_CompleteStream_ReportsUsageWithDetails(t *testing.T) {
+	sse := "data: {\"id\":\"chatcmpl-1\",\"model\":\"o1\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"hi\"},\"finish_reason\":null}]}\n\n" +
+		"data: {\"id\":\"chatcmpl-1\",\"model\":\"o1\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":30,\"completion_tokens\":20,\"total_tokens\":50,\"prompt_tokens_details\":{\"cached_tokens\":8},\"completion_tokens_details\":{\"reasoning_tokens\":12}}}\n\n" +
+		"data: [DONE]\n\n"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, sse)
+	}))
+	defer srv.Close()
+
+	p, _ := New("sk-test", srv.URL)
+	ch, err := p.CompleteStream(context.Background(), core.Request{
+		Model:    "o1",
+		Messages: []core.Message{{Role: core.RoleUser, Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("CompleteStream: %v", err)
+	}
+
+	var usage *core.Usage
+	for c := range ch {
+		if c.Error != nil {
+			t.Fatalf("stream error: %v", c.Error)
+		}
+		if c.Usage != nil {
+			usage = c.Usage
+		}
+	}
+	if usage == nil {
+		t.Fatal("no usage reported on stream")
+	}
+	if usage.PromptTokens != 30 || usage.CompletionTokens != 20 || usage.TotalTokens != 50 {
+		t.Fatalf("usage tokens = %d/%d/%d, want 30/20/50",
+			usage.PromptTokens, usage.CompletionTokens, usage.TotalTokens)
+	}
+	if usage.ReasoningTokens != 12 {
+		t.Errorf("reasoning tokens = %d, want 12", usage.ReasoningTokens)
+	}
+	if usage.CacheReadTokens != 8 {
+		t.Errorf("cache read tokens = %d, want 8", usage.CacheReadTokens)
+	}
+}
+
+func captureImageBody(t *testing.T, req core.ImageRequest, respBody string) map[string]json.RawMessage {
+	t.Helper()
+	var captured map[string]json.RawMessage
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(b, &captured)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, respBody)
+	}))
+	defer srv.Close()
+
+	p, _ := New("sk-test", srv.URL)
+	if _, err := p.GenerateImage(context.Background(), req); err != nil {
+		t.Fatalf("GenerateImage: %v", err)
+	}
+	return captured
+}
+
+// TestOpenAIProvider_GenerateImage_GptImageOmitsResponseFormat verifies the
+// response_format parameter is not sent for gpt-image-* models (which reject it).
+func TestOpenAIProvider_GenerateImage_GptImageOmitsResponseFormat(t *testing.T) {
+	body := captureImageBody(t,
+		core.ImageRequest{Model: "gpt-image-1", Prompt: "a cat", ResponseFormat: "url"},
+		`{"created":1,"data":[{"b64_json":"QUJD"}]}`)
+	if raw, ok := body["response_format"]; ok {
+		t.Errorf("response_format must be omitted for gpt-image-*, got %s", raw)
+	}
+}
+
+// TestOpenAIProvider_GenerateImage_DallESetsResponseFormat verifies DALL·E models
+// still receive response_format (defaulting to url).
+func TestOpenAIProvider_GenerateImage_DallESetsResponseFormat(t *testing.T) {
+	body := captureImageBody(t,
+		core.ImageRequest{Model: "dall-e-3", Prompt: "a cat"},
+		`{"created":1,"data":[{"url":"https://img"}]}`)
+	raw, ok := body["response_format"]
+	if !ok {
+		t.Fatal("response_format must be set for dall-e-3")
+	}
+	var rf string
+	if err := json.Unmarshal(raw, &rf); err != nil {
+		t.Fatalf("decode response_format: %v", err)
+	}
+	if rf != "url" {
+		t.Errorf("response_format = %q, want url (default)", rf)
+	}
+}


### PR DESCRIPTION
## Summary

Phase 2 of the provider-readiness remediation: **Native Tier-1 provider fidelity** for OpenAI, Anthropic, Google Gemini, and AWS Bedrock. Aligns these four providers on request/response correctness — forwarding multimodal image content and sampling parameters the streaming paths previously dropped, surfacing token usage the Bedrock and Gemini streaming paths discarded, refreshing stale model catalogs, and consolidating the duplicated Anthropic Messages decoding shared by the native Anthropic and Anthropic-on-Bedrock paths.

No breaking API changes relative to v1.1.10 — the `Provider`, `ProxiableProvider`, plugin, and HTTP contracts are unchanged. Ships as **v1.1.11**.

Closes #265; advances #264 (Gemini half — Replicate follows in a later phase) and #286 (OpenAI/Gemini vision).

## What changed

**OpenAI**
- Unified the streaming and non-streaming request paths: both marshal the same raw `core.Request` body (streaming adds `stream:true` + `stream_options.include_usage`) and parse SSE directly, so `logit_bias` and multimodal `image_url` content can no longer be dropped on only one path. Nested reasoning/cache token usage is preserved on the streaming final chunk. (#265)
- `response_format` is no longer sent for `gpt-image-*` image models (which reject it and always return base64); still sent for DALL·E.
- Non-streaming errors route through `core.APIError`.

**Anthropic + Bedrock (shared `internal/anthropicwire`)**
- Extracted the Anthropic Messages response type, content-block decoding, data-URI parsing, and a transport-agnostic streaming decoder into `internal/anthropicwire`, driven by both providers. Removes the duplicated response structs and the near-identical stream event switch.
- The shared decoder gives the **Bedrock** streaming path the token usage it previously dropped (prompt from `message_start`, completion from `message_delta`); the Bedrock non-streaming path also picks up prompt-cache tokens.
- Temperature above Anthropic's max (1) is clamped to 1 with a warning on both paths.

**Anthropic**
- Forwards the OpenAI `user` field as `metadata.user_id`; re-encodes non-base64 data URIs to a base64 image source; refreshed the static model fallback list.

**Gemini**
- Forwards multimodal `image_url` content (inline base64 / file URI); refreshed the catalog to the current GA tier (dropped retired 2.0/1.5); surfaces streaming + cached/reasoning token usage; sets the provider name and upstream response ID; routes `finish_reason` through the shared normalizer (Gemini content-block reasons → `content_filter`); validates the base URL; maps image size → Imagen aspect ratio; reuses the shared request helper.

**Bedrock**
- Sets Titan `TotalTokens`, synthesizes a response ID for the Nova/Titan/Llama families, wires the tuned per-provider HTTP client into the AWS SDK config, and warns explicitly when a text-only family drops image content.

**Core**
- `NormalizeFinishReason` extended with Gemini content-blocking reasons.

## Deferred (documented as roadmap items)
- Bedrock chat → Converse API migration (would preserve images on Nova/Titan/Llama and remove bespoke per-family translation).
- Current Stability image model shapes on Bedrock.
- Gemini live model discovery (`DiscoverModels` + `CapabilityDiscovery`).
- OpenAI `OpenAI-Organization`/`OpenAI-Project` headers (only needed for legacy multi-org keys).

## Test plan
- [x] `make fmt lint test` green; full `-race` suite clean (71 packages).
- [x] Wire-level tests per behavior change: OpenAI both-path field forwarding + streaming usage detail + image `response_format` gate; Anthropic user-metadata / data-URI re-encode / non-2xx error path / temperature clamp; Gemini vision / streaming usage / provider+ID / finish_reason / error path / Imagen size; Bedrock streaming usage / temperature clamp / cache tokens / Titan tokens / synthesized IDs / graceful image-drop; shared `anthropicwire` decoder unit tests.
- [x] Catalog-coverage test green (fallback lists aligned to the bundled pricing catalog).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved streaming consistency across providers, including tool-use streaming and richer final usage reporting (prompt/cache/reasoning where available).

* **Bug Fixes**
  * Fixed image handling for `data:` inputs, preventing malformed or non-base64 payloads from being treated as URL sources.
  * Corrected token accounting totals and usage details for both streaming and non-streaming responses.
  * Improved error propagation and finish-reason normalization for more provider-specific reasons.

* **Changed**
  * Updated example routing model/provider values and added safer temperature clamping with operator-visible warnings.
  * Added warnings when image parts can’t be forwarded for certain Bedrock model families.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->