### PR TITLE
fix: point pplx DiscoverModels at /v1/models

### DIFF
--- a/providers/perplexity/perplexity.go
+++ b/providers/perplexity/perplexity.go
@@ -83,7 +83,7 @@ func (p *Provider) Models() []core.ModelInfo {
 
 // DiscoverModels fetches the live model list from the Perplexity /models endpoint.
 func (p *Provider) DiscoverModels(ctx context.Context) ([]core.ModelInfo, error) {
-	return discov.DiscoverOpenAICompatibleModels(ctx, p.httpClient, p.baseURL+"/models", p.apiKey, p.name)
+	return discov.DiscoverOpenAICompatibleModels(ctx, p.httpClient, p.baseURL+"/v1/models", p.apiKey, p.name)
 }
 
 // Complete sends a chat completion request to Perplexity.

--- a/providers/perplexity/perplexity_test.go
+++ b/providers/perplexity/perplexity_test.go
@@ -25,6 +25,39 @@ func TestNewPerplexity(t *testing.T) {
 	}
 }
 
+func TestPerplexityProvider_DiscoverModels(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("method = %q, want GET", r.Method)
+		}
+		if r.URL.Path != "/v1/models" {
+			t.Errorf("path = %q, want /v1/models", r.URL.Path)
+		}
+		if r.Header.Get("Authorization") != testBearerAPIKey {
+			t.Errorf("Authorization = %q, want %q", r.Header.Get("Authorization"), testBearerAPIKey)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"object":"list","data":[{"id":"sonar","object":"model","owned_by":"perplexity"},{"id":"sonar-pro","object":"model"}]}`))
+	}))
+	defer srv.Close()
+
+	p, _ := New(testAPIKey, srv.URL)
+	models, err := p.DiscoverModels(context.Background())
+	if err != nil {
+		t.Fatalf("DiscoverModels() error: %v", err)
+	}
+	if len(models) != 2 {
+		t.Fatalf("expected 2 models, got %d", len(models))
+	}
+	if models[0].ID != "sonar" || models[0].OwnedBy != "perplexity" {
+		t.Errorf("unexpected model[0]: %+v", models[0])
+	}
+	if models[1].ID != "sonar-pro" || models[1].OwnedBy != "perplexity" {
+		t.Errorf("model[1] owned_by fallback = %q, want perplexity", models[1].OwnedBy)
+	}
+}
+
 func TestPerplexityProvider_SupportedModels(t *testing.T) {
 	p, _ := New("test-key", "")
 	models := p.SupportedModels()


### PR DESCRIPTION
## Summary

Fix Perplexity model discovery by pointing DiscoverModels at /v1/models instead of the /models endpoint.

## Type of change

<!-- Check all that apply. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] New provider
- [ ] New plugin
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Performance improvement
- [ ] Refactor / code quality
- [ ] Documentation / comments only
- [ ] CI / tooling

## Related issues

Closes #296 .

## Changes

<!-- Bullet-point list of the notable changes in this PR. -->

- Changed DiscoverModels request path from /models to /v1/models in providers/perplexity/perplexity.go
- Added TestPerplexityProvider_DiscoverModels regression test with httptest server asserting GET method, /v1/models path, bearer auth, and OpenAI-compatible response parsing.

## Testing

<!-- Describe how you tested this change. -->

- [x] Existing tests pass (`go test ./...`)
- [ ] New unit tests added (if applicable)
- [ ] Manually tested against a live provider (if provider change)

## Provider checklist (fill in only for new/updated providers)

- [ ] Provider file at `providers/<id>/<id>.go`
- [ ] Test file at `providers/<id>/<id>_test.go`
- [ ] `ProviderEntry` added to `providers/providers_list.go`
- [ ] Name constant added to `providers/names.go`
- [ ] Models added to `ferro-labs/model-catalog` when catalog coverage changes
- [ ] `AllowedTools`, `MaxCallDepth` and streaming tested

## Plugin checklist (fill in only for new/updated plugins)

- [ ] Plugin file at `internal/plugins/<name>/`
- [ ] `Stage` (before/after request) correctly set
- [ ] Test coverage added
- [ ] Example config documented

## Breaking change notes

<!-- If this is a breaking change, describe what callers need to update. -->

## Screenshots / output (optional)

<!-- Paste relevant terminal output, benchmark results, or screenshots. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated model discovery to use the correct live Perplexity API endpoint, improving compatibility and ensuring available models load properly.
* **Tests**
  * Added coverage for model discovery to verify the request path, authentication header, and returned model details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->