### PR TITLE
v1.1.12 - Enterprise Endpoints & Cohere

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to Ferro Labs AI Gateway are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.12] — 2026-07-04
+
+Enterprise-endpoint & Cohere fidelity release. The third provider-readiness remediation phase aligns the Vertex AI, Azure OpenAI, Azure AI Foundry, Databricks, and Cohere providers on request/response correctness and consolidates their hand-rolled HTTP onto the shared OpenAI-compatible helpers. No breaking API changes relative to v1.1.11.
+
+### Fixed
+
+- **Vertex AI model publisher prefix**: chat and streaming requests now send first-party models with the required `google/` publisher prefix (an existing publisher prefix — e.g. a Model Garden `meta/` model — is left intact), fixing requests the OpenAI-compatible endpoint rejected.
+- **Cohere vision**: multimodal `image_url` content is now forwarded to Cohere as content blocks instead of being silently dropped.
+- **Cohere streaming usage**: the message-end token counts are now surfaced on a stream chunk (previously parsed and discarded).
+- **Azure OpenAI response provider**: chat responses now carry the provider name, which the hand-rolled decoder dropped.
+- **Databricks retired model**: `databricks-claude-3-7-sonnet` is removed from the advertised model list (Databricks retired it).
+
+### Changed
+
+- **Azure AI Foundry endpoint** (operator-visible): the provider now targets the GA `{endpoint}/openai/v1/chat/completions` route (OpenAI-shaped, no `api-version`) instead of the Model Inference `/models` route the vendor is retiring, and sends `extra-parameters: drop` so a non-schema field is ignored rather than rejected.
+- **Vertex AI credentials** (operator-visible): when neither an API key nor service-account JSON is configured, the provider now falls back to Application Default Credentials (`GOOGLE_APPLICATION_CREDENTIALS`, `gcloud`, workload identity, or the GCE/GKE metadata server), so managed environments authenticate without an explicit key.
+- **Shared OpenAI-compatible request path**: Vertex AI, Azure OpenAI, Azure AI Foundry, and Databricks now route chat/embeddings through the shared `openaicompat` helpers, so their error handling (via `core.APIError`) and request/response shape stay consistent. Base-URL validation is enforced at construction for all five providers, and a tuned HTTP transport preset was added for Databricks serving-endpoint cold starts.
+- **Model catalog refresh**: the Vertex AI static fallback drops the retired `gemini-2.0-flash`; a recognized image size now maps to the Imagen aspect ratio.
+
+---
+
 ## [1.1.11] — 2026-07-03
 
 Native tier-1 provider fidelity release. Aligns the OpenAI, Anthropic, Google Gemini, and AWS Bedrock providers on request/response correctness: forwards multimodal image content and sampling parameters that the streaming paths previously dropped, surfaces token usage the Bedrock and Gemini streaming paths discarded, refreshes stale model catalogs, and consolidates the duplicated Anthropic Messages decoding shared by the native Anthropic and Anthropic-on-Bedrock paths. No breaking API changes relative to v1.1.10. Closes [#265](https://github.com/ferro-labs/ai-gateway/issues/265); advances [#264](https://github.com/ferro-labs/ai-gateway/issues/264) and [#286](https://github.com/ferro-labs/ai-gateway/issues/286).

--- a/internal/transport/provider.go
+++ b/internal/transport/provider.go
@@ -67,6 +67,11 @@ func KnownProviderPresets() map[string]ProviderPreset {
 			ResponseHeaderTimeout: 120 * time.Second,
 			DialTimeout:           15 * time.Second,
 		},
+		"databricks": {
+			MaxIdleConnsPerHost:   100,
+			ResponseHeaderTimeout: 120 * time.Second,
+			DialTimeout:           15 * time.Second,
+		},
 		"groq": {
 			MaxIdleConnsPerHost:   100,
 			ResponseHeaderTimeout: 15 * time.Second,

--- a/providers/azure_foundry/azure_foundry.go
+++ b/providers/azure_foundry/azure_foundry.go
@@ -66,8 +66,8 @@ func (p *Provider) BaseURL() string { return p.baseURL }
 func (p *Provider) APIVersion() string { return p.apiVersion }
 
 // NonOpenAIWire marks Azure AI Foundry as ineligible for transparent
-// OpenAI-wire proxy pass-through: its upstream uses Azure AI Foundry routing
-// paths and an api-version parameter, so an OpenAI-shaped request is not
+// OpenAI-wire proxy pass-through: its upstream uses Azure AI Foundry
+// deployment/routing paths and api-key auth, so an OpenAI-shaped request is not
 // directly forwardable. It remains fully usable via its native translated
 // endpoints. See core.NonOpenAIWireProvider.
 func (*Provider) NonOpenAIWire() {}

--- a/providers/azure_foundry/azure_foundry.go
+++ b/providers/azure_foundry/azure_foundry.go
@@ -3,9 +3,7 @@ package azurefoundry
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"strings"
 
@@ -40,6 +38,12 @@ func New(apiKey, baseURL, apiVersion string) (*Provider, error) {
 	if baseURL == "" {
 		return nil, fmt.Errorf("baseURL is required for azure-foundry provider")
 	}
+	if err := core.ValidateBaseURL(Name, baseURL); err != nil {
+		return nil, err
+	}
+	// apiVersion is retained for the APIVersion() accessor and backward
+	// compatibility; the GA /openai/v1 route this provider targets does not take
+	// an api-version query parameter.
 	if apiVersion == "" {
 		apiVersion = "2024-05-01-preview"
 	}
@@ -90,101 +94,37 @@ func (p *Provider) Models() []core.ModelInfo {
 	return core.ModelsFromList(p.name, p.SupportedModels())
 }
 
+// endpoint targets the GA OpenAI v1-compatible route. The older Model Inference
+// "/models" route (with an api-version query parameter) is retired by the
+// vendor; the v1 route is OpenAI-shaped, takes no api-version, and still routes
+// cross-provider Foundry models via the request "model" field.
 func (p *Provider) endpoint() string {
-	return fmt.Sprintf("%s/chat/completions?api-version=%s", p.baseURL, p.apiVersion)
+	return p.baseURL + "/openai/v1/chat/completions"
 }
 
-type azureFoundryResponse struct {
-	ID      string        `json:"id"`
-	Model   string        `json:"model"`
-	Choices []core.Choice `json:"choices"`
-	Usage   core.Usage    `json:"usage"`
-}
-
-type azureFoundryErrorResponse struct {
-	Error struct {
-		Message string `json:"message"`
-		Type    string `json:"type"`
-	} `json:"error"`
+// chatParams builds the shared OpenAI-compatible request parameters.
+// "extra-parameters: drop" asks Foundry to ignore any non-schema field the
+// gateway forwards rather than reject the request (the default is "error").
+func (p *Provider) chatParams() openaicompat.ChatParams {
+	return openaicompat.ChatParams{
+		HTTPClient: p.httpClient,
+		URL:        p.endpoint(),
+		Provider:   p.name,
+		Label:      "azure foundry",
+		Headers: map[string]string{
+			"api-key":          p.apiKey,
+			"Content-Type":     "application/json",
+			"extra-parameters": "drop",
+		},
+	}
 }
 
 // Complete sends a chat completion request to Azure AI Foundry.
 func (p *Provider) Complete(ctx context.Context, req core.Request) (*core.Response, error) {
-	bodyReader, _, release, err := openaicompat.BuildBody(req, false)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal request: %w", err)
-	}
-	defer release()
-
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, p.endpoint(), bodyReader)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
-	}
-	httpReq.Header.Set("api-key", p.apiKey)
-	httpReq.Header.Set("Content-Type", "application/json")
-
-	httpResp, err := p.httpClient.Do(httpReq)
-	if err != nil {
-		return nil, fmt.Errorf("request failed: %w", err)
-	}
-	defer func() { _ = httpResp.Body.Close() }()
-
-	respBody, err := io.ReadAll(httpResp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read response: %w", err)
-	}
-
-	if httpResp.StatusCode != http.StatusOK {
-		var errResp azureFoundryErrorResponse
-		if json.Unmarshal(respBody, &errResp) == nil && errResp.Error.Message != "" {
-			return nil, fmt.Errorf("azure foundry API error (%d): %s", httpResp.StatusCode, errResp.Error.Message)
-		}
-		return nil, fmt.Errorf("azure foundry API error (%d): %s", httpResp.StatusCode, string(respBody))
-	}
-
-	var foundryResp azureFoundryResponse
-	if err := json.Unmarshal(respBody, &foundryResp); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
-	}
-
-	return &core.Response{
-		ID:       foundryResp.ID,
-		Model:    foundryResp.Model,
-		Provider: p.name,
-		Choices:  foundryResp.Choices,
-		Usage:    foundryResp.Usage,
-	}, nil
+	return openaicompat.PostChat(ctx, p.chatParams(), req)
 }
 
 // CompleteStream sends a streaming chat completion request to Azure AI Foundry.
 func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan core.StreamChunk, error) {
-	bodyReader, _, release, err := openaicompat.BuildBody(req, true)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal request: %w", err)
-	}
-	defer release()
-
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, p.endpoint(), bodyReader)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
-	}
-	httpReq.Header.Set("api-key", p.apiKey)
-	httpReq.Header.Set("Content-Type", "application/json")
-
-	httpResp, err := p.httpClient.Do(httpReq)
-	if err != nil {
-		return nil, fmt.Errorf("request failed: %w", err)
-	}
-
-	if httpResp.StatusCode != http.StatusOK {
-		defer func() { _ = httpResp.Body.Close() }()
-		respBody, _ := io.ReadAll(httpResp.Body)
-		var errResp azureFoundryErrorResponse
-		if json.Unmarshal(respBody, &errResp) == nil && errResp.Error.Message != "" {
-			return nil, fmt.Errorf("azure foundry API error (%d): %s", httpResp.StatusCode, errResp.Error.Message)
-		}
-		return nil, fmt.Errorf("azure foundry API error (%d): %s", httpResp.StatusCode, string(respBody))
-	}
-
-	return openaicompat.StreamSSE(httpResp.Body), nil
+	return openaicompat.PostStream(ctx, p.chatParams(), req)
 }

--- a/providers/azure_foundry/azure_foundry_phase3_test.go
+++ b/providers/azure_foundry/azure_foundry_phase3_test.go
@@ -1,0 +1,74 @@
+package azurefoundry
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/ferro-labs/ai-gateway/providers/core"
+)
+
+// TestComplete_SetsExtraParametersAndDecodes verifies the request carries the
+// "extra-parameters: drop" header and the response is decoded (content + usage).
+func TestComplete_SetsExtraParametersAndDecodes(t *testing.T) {
+	var extraParams string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		extraParams = r.Header.Get("extra-parameters")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"id":"chatcmpl-1","model":"gpt-4o","choices":[{"index":0,"message":{"role":"assistant","content":"hello"},"finish_reason":"stop"}],"usage":{"prompt_tokens":5,"completion_tokens":2,"total_tokens":7}}`)
+	}))
+	defer srv.Close()
+
+	p, err := New(testAPIKey, srv.URL, "")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	resp, err := p.Complete(context.Background(), core.Request{
+		Model:    "gpt-4o",
+		Messages: []core.Message{{Role: core.RoleUser, Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	if extraParams != "drop" {
+		t.Errorf("extra-parameters header = %q, want drop", extraParams)
+	}
+	if len(resp.Choices) != 1 || resp.Choices[0].Message.Content != "hello" {
+		t.Errorf("decoded choices = %+v", resp.Choices)
+	}
+	if resp.Usage.TotalTokens != 7 {
+		t.Errorf("usage = %+v, want total 7", resp.Usage)
+	}
+}
+
+func TestComplete_ErrorPathReturnsAPIError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = io.WriteString(w, `{"error":{"message":"bad model"}}`)
+	}))
+	defer srv.Close()
+
+	p, err := New(testAPIKey, srv.URL, "")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	_, err = p.Complete(context.Background(), core.Request{
+		Model:    "gpt-4o",
+		Messages: []core.Message{{Role: core.RoleUser, Content: "hi"}},
+	})
+	if err == nil {
+		t.Fatal("expected error for 400")
+	}
+	if !strings.Contains(err.Error(), "bad model") || !strings.Contains(err.Error(), "400") {
+		t.Fatalf("error = %v, want status + message", err)
+	}
+}
+
+func TestNew_RejectsInvalidBaseURL(t *testing.T) {
+	if _, err := New(testAPIKey, "://bad", ""); err == nil {
+		t.Fatal("New accepted an invalid base URL")
+	}
+}

--- a/providers/azure_foundry/azure_foundry_test.go
+++ b/providers/azure_foundry/azure_foundry_test.go
@@ -12,7 +12,7 @@ import (
 const (
 	testAPIKey                    = "test-key"
 	testBearerAPIKey              = "Bearer test-key"
-	testChatCompletionsPath       = "/chat/completions"
+	testChatCompletionsPath       = "/openai/v1/chat/completions"
 	azureFoundryDefaultAPIVersion = "2024-05-01-preview"
 )
 
@@ -56,8 +56,8 @@ func TestAzureFoundryProvider_Complete_MockHTTP(t *testing.T) {
 		if r.URL.Path != testChatCompletionsPath {
 			t.Errorf("request path = %q, want %s", r.URL.Path, testChatCompletionsPath)
 		}
-		if r.URL.Query().Get("api-version") != azureFoundryDefaultAPIVersion {
-			t.Errorf("api-version = %q, want %s", r.URL.Query().Get("api-version"), azureFoundryDefaultAPIVersion)
+		if v := r.URL.Query().Get("api-version"); v != "" {
+			t.Errorf("api-version = %q, want none (GA v1 route takes no api-version)", v)
 		}
 		if got := r.Header.Get("api-key"); got != testAPIKey {
 			t.Errorf("api-key = %q, want %s", got, testAPIKey)

--- a/providers/azure_openai/azure_openai.go
+++ b/providers/azure_openai/azure_openai.go
@@ -40,6 +40,7 @@ var (
 
 // New creates a new Azure OpenAI provider.
 func New(apiKey, baseURL, deploymentName, apiVersion string) (*Provider, error) {
+	baseURL = strings.TrimSpace(baseURL)
 	if err := core.ValidateBaseURL(Name, baseURL); err != nil {
 		return nil, err
 	}

--- a/providers/azure_openai/azure_openai.go
+++ b/providers/azure_openai/azure_openai.go
@@ -3,9 +3,7 @@ package azureopenai
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -42,6 +40,9 @@ var (
 
 // New creates a new Azure OpenAI provider.
 func New(apiKey, baseURL, deploymentName, apiVersion string) (*Provider, error) {
+	if err := core.ValidateBaseURL(Name, baseURL); err != nil {
+		return nil, err
+	}
 	baseURL = strings.TrimRight(baseURL, "/")
 	if apiVersion == "" {
 		apiVersion = defaultAPIVersion
@@ -124,20 +125,16 @@ func (p *Provider) deploymentFor(model string) string {
 	return p.deploymentName
 }
 
-type azureOpenAIResponse struct {
-	ID      string        `json:"id"`
-	Model   string        `json:"model"`
-	Choices []core.Choice `json:"choices"`
-	Usage   core.Usage    `json:"usage"`
-}
-
-type azureOpenAIErrorDetail struct {
-	Message string `json:"message"`
-	Type    string `json:"type"`
-}
-
-type azureOpenAIErrorResponse struct {
-	Error azureOpenAIErrorDetail `json:"error"`
+// chatParams builds the shared OpenAI-compatible request parameters for the
+// configured chat deployment.
+func (p *Provider) chatParams() openaicompat.ChatParams {
+	return openaicompat.ChatParams{
+		HTTPClient: p.httpClient,
+		URL:        p.endpoint(),
+		Headers:    map[string]string{"api-key": p.apiKey, "Content-Type": "application/json"},
+		Provider:   p.name,
+		Label:      "azure openai",
+	}
 }
 
 // Complete sends a chat completion request to Azure OpenAI.
@@ -145,81 +142,11 @@ func (p *Provider) Complete(ctx context.Context, req core.Request) (*core.Respon
 	// Azure o-series reasoning deployments reject max_tokens; keep only the
 	// modern field (the gateway seam leaves both populated).
 	req.PreferCompletionTokens()
-	bodyReader, _, release, err := openaicompat.BuildBody(req, false)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal request: %w", err)
-	}
-	defer release()
-
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, p.endpoint(), bodyReader)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
-	}
-	httpReq.Header.Set("api-key", p.apiKey)
-	httpReq.Header.Set("Content-Type", "application/json")
-
-	httpResp, err := p.httpClient.Do(httpReq)
-	if err != nil {
-		return nil, fmt.Errorf("request failed: %w", err)
-	}
-	defer func() { _ = httpResp.Body.Close() }()
-
-	respBody, err := io.ReadAll(httpResp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read response: %w", err)
-	}
-
-	if httpResp.StatusCode != http.StatusOK {
-		var errResp azureOpenAIErrorResponse
-		if json.Unmarshal(respBody, &errResp) == nil && errResp.Error.Message != "" {
-			return nil, fmt.Errorf("azure openai API error (%d): %s", httpResp.StatusCode, errResp.Error.Message)
-		}
-		return nil, fmt.Errorf("azure openai API error (%d): %s", httpResp.StatusCode, string(respBody))
-	}
-
-	var azureResp azureOpenAIResponse
-	if err := json.Unmarshal(respBody, &azureResp); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
-	}
-
-	return &core.Response{
-		ID:      azureResp.ID,
-		Model:   azureResp.Model,
-		Choices: azureResp.Choices,
-		Usage:   azureResp.Usage,
-	}, nil
+	return openaicompat.PostChat(ctx, p.chatParams(), req)
 }
 
 // CompleteStream sends a streaming chat completion request to Azure OpenAI.
 func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan core.StreamChunk, error) {
 	req.PreferCompletionTokens()
-	bodyReader, _, release, err := openaicompat.BuildBody(req, true)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal request: %w", err)
-	}
-	defer release()
-
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, p.endpoint(), bodyReader)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
-	}
-	httpReq.Header.Set("api-key", p.apiKey)
-	httpReq.Header.Set("Content-Type", "application/json")
-
-	httpResp, err := p.httpClient.Do(httpReq)
-	if err != nil {
-		return nil, fmt.Errorf("request failed: %w", err)
-	}
-
-	if httpResp.StatusCode != http.StatusOK {
-		defer func() { _ = httpResp.Body.Close() }()
-		respBody, _ := io.ReadAll(httpResp.Body)
-		var errResp azureOpenAIErrorResponse
-		if json.Unmarshal(respBody, &errResp) == nil && errResp.Error.Message != "" {
-			return nil, fmt.Errorf("azure openai API error (%d): %s", httpResp.StatusCode, errResp.Error.Message)
-		}
-		return nil, fmt.Errorf("azure openai API error (%d): %s", httpResp.StatusCode, string(respBody))
-	}
-
-	return openaicompat.StreamSSE(httpResp.Body), nil
+	return openaicompat.PostStream(ctx, p.chatParams(), req)
 }

--- a/providers/azure_openai/azure_openai_phase3_test.go
+++ b/providers/azure_openai/azure_openai_phase3_test.go
@@ -1,0 +1,76 @@
+package azureopenai
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/ferro-labs/ai-gateway/providers/core"
+)
+
+// TestComplete_DecodesResponseWithProvider verifies the chat response is decoded
+// (id/model/content/usage) and now carries the provider name (previously
+// dropped).
+func TestComplete_DecodesResponseWithProvider(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"id":"chatcmpl-1","model":"gpt-4o","choices":[{"index":0,"message":{"role":"assistant","content":"hello"},"finish_reason":"stop"}],"usage":{"prompt_tokens":3,"completion_tokens":2,"total_tokens":5}}`)
+	}))
+	defer srv.Close()
+
+	p, err := New("test-key", srv.URL, "gpt-4o", "2024-10-21")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	resp, err := p.Complete(context.Background(), core.Request{
+		Model:    "gpt-4o",
+		Messages: []core.Message{{Role: core.RoleUser, Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	if resp.Provider != Name {
+		t.Errorf("Provider = %q, want %q", resp.Provider, Name)
+	}
+	if resp.ID != "chatcmpl-1" || resp.Model != "gpt-4o" {
+		t.Errorf("id/model = %q/%q", resp.ID, resp.Model)
+	}
+	if len(resp.Choices) != 1 || resp.Choices[0].Message.Content != "hello" {
+		t.Errorf("choices = %+v", resp.Choices)
+	}
+	if resp.Usage.PromptTokens != 3 || resp.Usage.CompletionTokens != 2 || resp.Usage.TotalTokens != 5 {
+		t.Errorf("usage = %+v", resp.Usage)
+	}
+}
+
+func TestComplete_ErrorPathReturnsAPIError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = io.WriteString(w, `{"error":{"message":"rate limited"}}`)
+	}))
+	defer srv.Close()
+
+	p, err := New("test-key", srv.URL, "gpt-4o", "2024-10-21")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	_, err = p.Complete(context.Background(), core.Request{
+		Model:    "gpt-4o",
+		Messages: []core.Message{{Role: core.RoleUser, Content: "hi"}},
+	})
+	if err == nil {
+		t.Fatal("expected error for 429")
+	}
+	if !strings.Contains(err.Error(), "rate limited") || !strings.Contains(err.Error(), "429") {
+		t.Fatalf("error = %v, want status + message", err)
+	}
+}
+
+func TestNew_RejectsInvalidBaseURL(t *testing.T) {
+	if _, err := New("k", "://bad", "dep", ""); err == nil {
+		t.Fatal("New accepted an invalid base URL")
+	}
+}

--- a/providers/azure_openai/embedding.go
+++ b/providers/azure_openai/embedding.go
@@ -75,11 +75,7 @@ func (p *Provider) Embed(ctx context.Context, req core.EmbeddingRequest) (*core.
 		return nil, fmt.Errorf("failed to read response: %w", err)
 	}
 	if httpResp.StatusCode != http.StatusOK {
-		var errResp azureOpenAIErrorResponse
-		if json.Unmarshal(respBody, &errResp) == nil && errResp.Error.Message != "" {
-			return nil, fmt.Errorf("azure openai API error (%d): %s", httpResp.StatusCode, errResp.Error.Message)
-		}
-		return nil, fmt.Errorf("azure openai API error (%d): %s", httpResp.StatusCode, string(respBody))
+		return nil, core.APIError("azure openai", httpResp.StatusCode, respBody)
 	}
 
 	var pResp embeddingResponse

--- a/providers/azure_openai/image.go
+++ b/providers/azure_openai/image.go
@@ -67,11 +67,7 @@ func (p *Provider) GenerateImage(ctx context.Context, req core.ImageRequest) (*c
 		return nil, fmt.Errorf("failed to read response: %w", err)
 	}
 	if httpResp.StatusCode != http.StatusOK {
-		var errResp azureOpenAIErrorResponse
-		if json.Unmarshal(respBody, &errResp) == nil && errResp.Error.Message != "" {
-			return nil, fmt.Errorf("azure openai API error (%d): %s", httpResp.StatusCode, errResp.Error.Message)
-		}
-		return nil, fmt.Errorf("azure openai API error (%d): %s", httpResp.StatusCode, string(respBody))
+		return nil, core.APIError("azure openai", httpResp.StatusCode, respBody)
 	}
 
 	var pResp imageResponse

--- a/providers/cohere/cohere.go
+++ b/providers/cohere/cohere.go
@@ -37,6 +37,7 @@ var (
 
 // New creates a new Cohere provider.
 func New(apiKey, baseURL string) (*Provider, error) {
+	baseURL = strings.TrimSpace(baseURL)
 	if baseURL == "" {
 		baseURL = defaultBaseURL
 	} else if err := core.ValidateBaseURL(Name, baseURL); err != nil {
@@ -223,7 +224,8 @@ func cohereMessages(messages []core.Message) []cohereRequestMessage {
 type cohereImageURLBlock struct {
 	Type     string `json:"type"`
 	ImageURL struct {
-		URL string `json:"url"`
+		URL    string `json:"url"`
+		Detail string `json:"detail,omitempty"`
 	} `json:"image_url"`
 }
 
@@ -239,6 +241,7 @@ func cohereContentParts(parts []core.ContentPart) []any {
 			if part.ImageURL != nil {
 				block := cohereImageURLBlock{Type: "image_url"}
 				block.ImageURL.URL = part.ImageURL.URL
+				block.ImageURL.Detail = part.ImageURL.Detail
 				blocks = append(blocks, block)
 			}
 		}

--- a/providers/cohere/cohere.go
+++ b/providers/cohere/cohere.go
@@ -248,13 +248,14 @@ func cohereContentParts(parts []core.ContentPart) []any {
 
 // cohereAPIError builds a provider error from a non-2xx Cohere response, whose
 // error envelope is a flat {"message":…} (not the OpenAI {"error":{…}} shape),
-// so core.APIError cannot decode it.
-func cohereAPIError(label string, status int, body []byte) error {
+// so core.APIError cannot decode it. prefix is the full message prefix (e.g.
+// "cohere API error"), unlike core.APIError's bare provider-name label.
+func cohereAPIError(prefix string, status int, body []byte) error {
 	var errResp cohereErrorResponse
 	if json.Unmarshal(body, &errResp) == nil && errResp.Message != "" {
-		return fmt.Errorf("%s (%d): %s", label, status, errResp.Message)
+		return fmt.Errorf("%s (%d): %s", prefix, status, errResp.Message)
 	}
-	return fmt.Errorf("%s (%d): %s", label, status, string(body))
+	return fmt.Errorf("%s (%d): %s", prefix, status, string(body))
 }
 
 // Complete sends a chat completion request to Cohere.

--- a/providers/cohere/cohere.go
+++ b/providers/cohere/cohere.go
@@ -39,6 +39,8 @@ var (
 func New(apiKey, baseURL string) (*Provider, error) {
 	if baseURL == "" {
 		baseURL = defaultBaseURL
+	} else if err := core.ValidateBaseURL(Name, baseURL); err != nil {
+		return nil, err
 	}
 	baseURL = strings.TrimRight(baseURL, "/")
 	return &Provider{
@@ -196,14 +198,17 @@ func cohereMessages(messages []core.Message) []cohereRequestMessage {
 			ToolCalls:  msg.ToolCalls,
 			ToolCallID: msg.ToolCallID,
 		}
-		if msg.Role == core.RoleTool {
+		switch {
+		case msg.Role == core.RoleTool:
 			cohMsg.Content = []cohereToolResultBlock{{
 				Type: "document",
 				Document: cohereToolResultDocument{
 					Data: msg.Content,
 				},
 			}}
-		} else if msg.Content != "" {
+		case len(msg.ContentParts) > 0:
+			cohMsg.Content = cohereContentParts(msg.ContentParts)
+		case msg.Content != "":
 			// Only set content when non-empty. Content is `any` with omitempty,
 			// which does not drop an empty string, so an assistant tool-call
 			// turn would otherwise emit content:"" — which Cohere v2 rejects.
@@ -212,6 +217,44 @@ func cohereMessages(messages []core.Message) []cohereRequestMessage {
 		out = append(out, cohMsg)
 	}
 	return out
+}
+
+// cohereImageURLBlock is a Cohere v2 image content block.
+type cohereImageURLBlock struct {
+	Type     string `json:"type"`
+	ImageURL struct {
+		URL string `json:"url"`
+	} `json:"image_url"`
+}
+
+// cohereContentParts translates multimodal content parts into Cohere v2 content
+// blocks (text + image_url) so vision content is forwarded rather than dropped.
+func cohereContentParts(parts []core.ContentPart) []any {
+	blocks := make([]any, 0, len(parts))
+	for _, part := range parts {
+		switch part.Type {
+		case core.ContentTypeText:
+			blocks = append(blocks, cohereContentBlock{Type: "text", Text: part.Text})
+		case "image_url":
+			if part.ImageURL != nil {
+				block := cohereImageURLBlock{Type: "image_url"}
+				block.ImageURL.URL = part.ImageURL.URL
+				blocks = append(blocks, block)
+			}
+		}
+	}
+	return blocks
+}
+
+// cohereAPIError builds a provider error from a non-2xx Cohere response, whose
+// error envelope is a flat {"message":…} (not the OpenAI {"error":{…}} shape),
+// so core.APIError cannot decode it.
+func cohereAPIError(label string, status int, body []byte) error {
+	var errResp cohereErrorResponse
+	if json.Unmarshal(body, &errResp) == nil && errResp.Message != "" {
+		return fmt.Errorf("%s (%d): %s", label, status, errResp.Message)
+	}
+	return fmt.Errorf("%s (%d): %s", label, status, string(body))
 }
 
 // Complete sends a chat completion request to Cohere.
@@ -257,11 +300,7 @@ func (p *Provider) Complete(ctx context.Context, req core.Request) (*core.Respon
 	}
 
 	if httpResp.StatusCode != http.StatusOK {
-		var errResp cohereErrorResponse
-		if json.Unmarshal(respBody, &errResp) == nil && errResp.Message != "" {
-			return nil, fmt.Errorf("cohere API error (%d): %s", httpResp.StatusCode, errResp.Message)
-		}
-		return nil, fmt.Errorf("cohere API error (%d): %s", httpResp.StatusCode, string(respBody))
+		return nil, cohereAPIError("cohere API error", httpResp.StatusCode, respBody)
 	}
 
 	var cohResp cohereResponse
@@ -415,11 +454,7 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 	if httpResp.StatusCode != http.StatusOK {
 		defer func() { _ = httpResp.Body.Close() }()
 		respBody, _ := io.ReadAll(httpResp.Body)
-		var errResp cohereErrorResponse
-		if json.Unmarshal(respBody, &errResp) == nil && errResp.Message != "" {
-			return nil, fmt.Errorf("cohere API error (%d): %s", httpResp.StatusCode, errResp.Message)
-		}
-		return nil, fmt.Errorf("cohere API error (%d): %s", httpResp.StatusCode, string(respBody))
+		return nil, cohereAPIError("cohere API error", httpResp.StatusCode, respBody)
 	}
 
 	ch := make(chan core.StreamChunk)
@@ -496,7 +531,7 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 				if json.Unmarshal(event.Delta, &delta) != nil {
 					continue
 				}
-				ch <- core.StreamChunk{
+				sc := core.StreamChunk{
 					Choices: []core.StreamChoice{
 						{
 							Index:        0,
@@ -504,6 +539,14 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 						},
 					},
 				}
+				if u := delta.Usage.Tokens; u.InputTokens > 0 || u.OutputTokens > 0 {
+					sc.Usage = &core.Usage{
+						PromptTokens:     u.InputTokens,
+						CompletionTokens: u.OutputTokens,
+						TotalTokens:      u.InputTokens + u.OutputTokens,
+					}
+				}
+				ch <- sc
 				return
 			}
 		}
@@ -628,11 +671,7 @@ func (p *Provider) Embed(ctx context.Context, req core.EmbeddingRequest) (*core.
 	}
 
 	if httpResp.StatusCode != http.StatusOK {
-		var errResp cohereErrorResponse
-		if json.Unmarshal(respBody, &errResp) == nil && errResp.Message != "" {
-			return nil, fmt.Errorf("cohere embed API error (%d): %s", httpResp.StatusCode, errResp.Message)
-		}
-		return nil, fmt.Errorf("cohere embed API error (%d): %s", httpResp.StatusCode, string(respBody))
+		return nil, cohereAPIError("cohere embed API error", httpResp.StatusCode, respBody)
 	}
 
 	var cohResp cohereEmbedResponse

--- a/providers/cohere/cohere_phase3_test.go
+++ b/providers/cohere/cohere_phase3_test.go
@@ -1,0 +1,93 @@
+package cohere
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/ferro-labs/ai-gateway/providers/core"
+)
+
+// TestComplete_ForwardsVisionContent verifies multimodal image parts are mapped
+// to Cohere content blocks instead of being dropped.
+func TestComplete_ForwardsVisionContent(t *testing.T) {
+	var body map[string]json.RawMessage
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(b, &body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"id":"x","message":{"role":"assistant","content":[{"type":"text","text":"ok"}]},"finish_reason":"COMPLETE","usage":{"tokens":{"input_tokens":1,"output_tokens":1}}}`)
+	}))
+	defer srv.Close()
+
+	p, _ := New("test-key", srv.URL)
+	if _, err := p.Complete(context.Background(), core.Request{
+		Model: "command-r-plus",
+		Messages: []core.Message{{
+			Role: core.RoleUser,
+			ContentParts: []core.ContentPart{
+				{Type: "text", Text: "what is this"},
+				{Type: "image_url", ImageURL: &core.ImageURLPart{URL: "https://example.com/cat.png"}},
+			},
+		}},
+	}); err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+
+	var msgs []struct {
+		Content json.RawMessage `json:"content"`
+	}
+	if err := json.Unmarshal(body["messages"], &msgs); err != nil {
+		t.Fatalf("decode messages: %v", err)
+	}
+	if len(msgs) == 0 || !strings.Contains(string(msgs[0].Content), "image_url") ||
+		!strings.Contains(string(msgs[0].Content), "example.com/cat.png") {
+		t.Errorf("vision image not forwarded; content=%s", msgs[0].Content)
+	}
+}
+
+// TestCompleteStream_SurfacesUsage verifies the message-end token usage is
+// surfaced on a StreamChunk (previously parsed and discarded).
+func TestCompleteStream_SurfacesUsage(t *testing.T) {
+	sse := "data: {\"type\":\"content-delta\",\"delta\":{\"message\":{\"content\":{\"text\":\"hi\"}}}}\n\n" +
+		"data: {\"type\":\"message-end\",\"delta\":{\"finish_reason\":\"COMPLETE\",\"usage\":{\"tokens\":{\"input_tokens\":7,\"output_tokens\":3}}}}\n\n"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, sse)
+	}))
+	defer srv.Close()
+
+	p, _ := New("test-key", srv.URL)
+	ch, err := p.CompleteStream(context.Background(), core.Request{
+		Model:    "command-r-plus",
+		Messages: []core.Message{{Role: core.RoleUser, Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("CompleteStream: %v", err)
+	}
+	var usage *core.Usage
+	for c := range ch {
+		if c.Error != nil {
+			t.Fatalf("stream error: %v", c.Error)
+		}
+		if c.Usage != nil {
+			usage = c.Usage
+		}
+	}
+	if usage == nil {
+		t.Fatal("no usage surfaced on cohere stream")
+	}
+	if usage.PromptTokens != 7 || usage.CompletionTokens != 3 || usage.TotalTokens != 10 {
+		t.Fatalf("usage = %+v, want 7/3/10", usage)
+	}
+}
+
+func TestNew_RejectsInvalidBaseURL(t *testing.T) {
+	if _, err := New("k", "://bad"); err == nil {
+		t.Fatal("New accepted an invalid base URL")
+	}
+}

--- a/providers/databricks/databricks.go
+++ b/providers/databricks/databricks.go
@@ -39,7 +39,8 @@ var (
 // baseURL should point at the Databricks host or the OpenAI-compatible serving
 // path. If a plain workspace host is provided, /serving-endpoints is appended.
 func New(apiKey, baseURL string) (*Provider, error) {
-	if strings.TrimSpace(baseURL) == "" {
+	baseURL = strings.TrimSpace(baseURL)
+	if baseURL == "" {
 		return nil, fmt.Errorf("databricks: baseURL is required")
 	}
 	if err := core.ValidateBaseURL(Name, baseURL); err != nil {

--- a/providers/databricks/databricks.go
+++ b/providers/databricks/databricks.go
@@ -3,9 +3,7 @@ package databricks
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"strings"
 
@@ -44,6 +42,9 @@ func New(apiKey, baseURL string) (*Provider, error) {
 	if strings.TrimSpace(baseURL) == "" {
 		return nil, fmt.Errorf("databricks: baseURL is required")
 	}
+	if err := core.ValidateBaseURL(Name, baseURL); err != nil {
+		return nil, err
+	}
 	baseURL = normalizeBaseURL(baseURL)
 	return &Provider{
 		name:       Name,
@@ -78,7 +79,6 @@ func (p *Provider) AuthHeaders() map[string]string {
 // SupportedModels returns known Databricks-hosted foundation model examples.
 func (p *Provider) SupportedModels() []string {
 	return []string{
-		"databricks-claude-3-7-sonnet",
 		"databricks-claude-sonnet-4-5",
 		"databricks-gemini-2-5-pro",
 		"databricks-gpt-oss-120b",
@@ -94,30 +94,6 @@ func (p *Provider) SupportsModel(model string) bool { return strings.TrimSpace(m
 // Models returns structured model metadata.
 func (p *Provider) Models() []core.ModelInfo {
 	return core.ModelsFromList(p.name, p.SupportedModels())
-}
-
-type embeddingRequest struct {
-	Model          string `json:"model"`
-	Input          any    `json:"input"`
-	EncodingFormat string `json:"encoding_format,omitempty"`
-	Dimensions     *int   `json:"dimensions,omitempty"`
-	User           string `json:"user,omitempty"`
-}
-
-type embeddingResponse struct {
-	Object string              `json:"object"`
-	Data   []core.Embedding    `json:"data"`
-	Model  string              `json:"model"`
-	Usage  core.EmbeddingUsage `json:"usage"`
-}
-
-type errorDetail struct {
-	Message string `json:"message"`
-	Type    string `json:"type"`
-}
-
-type errorResponse struct {
-	Error errorDetail `json:"error"`
 }
 
 // chatParams builds the shared OpenAI-compatible chat endpoint configuration.
@@ -148,57 +124,16 @@ func (p *Provider) Embed(ctx context.Context, req core.EmbeddingRequest) (*core.
 	if req.EncodingFormat != "" && req.EncodingFormat != "float" {
 		return nil, fmt.Errorf("embed: unsupported encoding_format %q; valid value is \"float\"", req.EncodingFormat)
 	}
-
-	pReq := embeddingRequest{
-		Model:          req.Model,
-		Input:          input,
-		EncodingFormat: req.EncodingFormat,
-		Dimensions:     req.Dimensions,
-		User:           req.User,
-	}
-
-	bodyReader, _, release, err := core.JSONBodyReader(pReq)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal embedding request: %w", err)
-	}
-	defer release()
-
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, p.baseURL+"/embeddings", bodyReader)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
-	}
-	httpReq.Header.Set("Authorization", "Bearer "+p.apiKey)
-	httpReq.Header.Set("Content-Type", "application/json")
-
-	httpResp, err := p.httpClient.Do(httpReq)
-	if err != nil {
-		return nil, fmt.Errorf("request failed: %w", err)
-	}
-	defer func() { _ = httpResp.Body.Close() }()
-
-	respBody, err := io.ReadAll(httpResp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read response: %w", err)
-	}
-	if httpResp.StatusCode < http.StatusOK || httpResp.StatusCode >= http.StatusMultipleChoices {
-		var errResp errorResponse
-		if json.Unmarshal(respBody, &errResp) == nil && errResp.Error.Message != "" {
-			return nil, fmt.Errorf("databricks API error (%d): %s", httpResp.StatusCode, errResp.Error.Message)
-		}
-		return nil, fmt.Errorf("databricks API error (%d): %s", httpResp.StatusCode, string(respBody))
-	}
-
-	var pResp embeddingResponse
-	if err := json.Unmarshal(respBody, &pResp); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal embedding response: %w", err)
-	}
-
-	return &core.EmbeddingResponse{
-		Object: pResp.Object,
-		Data:   pResp.Data,
-		Model:  pResp.Model,
-		Usage:  pResp.Usage,
-	}, nil
+	req.Input = input
+	return openaicompat.PostEmbeddings(ctx, openaicompat.EmbeddingParams{
+		HTTPClient: p.httpClient,
+		URL:        p.baseURL + "/embeddings",
+		Label:      "databricks",
+		Headers: map[string]string{
+			"Authorization": "Bearer " + p.apiKey,
+			"Content-Type":  "application/json",
+		},
+	}, req)
 }
 
 func normalizeEmbeddingInput(input any) (any, error) {

--- a/providers/databricks/databricks_phase3_test.go
+++ b/providers/databricks/databricks_phase3_test.go
@@ -1,0 +1,64 @@
+package databricks
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/ferro-labs/ai-gateway/providers/core"
+)
+
+func TestDatabricks_CompleteErrorPath(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = io.WriteString(w, `{"error":{"message":"endpoint overloaded"}}`)
+	}))
+	defer srv.Close()
+
+	p, err := New("test-key", srv.URL)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	_, err = p.Complete(context.Background(), core.Request{
+		Model:    "databricks-claude-sonnet-4-5",
+		Messages: []core.Message{{Role: core.RoleUser, Content: "hi"}},
+	})
+	if err == nil {
+		t.Fatal("expected error for 429")
+	}
+	if !strings.Contains(err.Error(), "endpoint overloaded") || !strings.Contains(err.Error(), "429") {
+		t.Fatalf("error = %v, want status + message", err)
+	}
+}
+
+func TestDatabricks_CompleteStreamErrorPath(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = io.WriteString(w, `{"error":{"message":"boom"}}`)
+	}))
+	defer srv.Close()
+
+	p, err := New("test-key", srv.URL)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	_, err = p.CompleteStream(context.Background(), core.Request{
+		Model:    "databricks-claude-sonnet-4-5",
+		Messages: []core.Message{{Role: core.RoleUser, Content: "hi"}},
+	})
+	if err == nil {
+		t.Fatal("expected error for 500")
+	}
+	if !strings.Contains(err.Error(), "boom") || !strings.Contains(err.Error(), "500") {
+		t.Fatalf("error = %v, want status + message", err)
+	}
+}
+
+func TestDatabricks_NewRejectsInvalidBaseURL(t *testing.T) {
+	if _, err := New("k", "://bad"); err == nil {
+		t.Fatal("New accepted an invalid base URL")
+	}
+}

--- a/providers/databricks/databricks_phase3_test.go
+++ b/providers/databricks/databricks_phase3_test.go
@@ -62,3 +62,15 @@ func TestDatabricks_NewRejectsInvalidBaseURL(t *testing.T) {
 		t.Fatal("New accepted an invalid base URL")
 	}
 }
+
+// TestDatabricks_NewTrimsWhitespaceBeforeValidating verifies a whitespace-padded
+// base URL (common from env/secrets) is trimmed before validation, not rejected.
+func TestDatabricks_NewTrimsWhitespaceBeforeValidating(t *testing.T) {
+	p, err := New("k", "  https://demo.databricks.com  ")
+	if err != nil {
+		t.Fatalf("New rejected a whitespace-padded valid URL: %v", err)
+	}
+	if !strings.HasPrefix(p.BaseURL(), "https://demo.databricks.com") {
+		t.Errorf("BaseURL = %q, want trimmed", p.BaseURL())
+	}
+}

--- a/providers/databricks/databricks_phase3_test.go
+++ b/providers/databricks/databricks_phase3_test.go
@@ -63,6 +63,32 @@ func TestDatabricks_NewRejectsInvalidBaseURL(t *testing.T) {
 	}
 }
 
+// TestDatabricks_EmbedErrorPath verifies a valid Embed request whose upstream
+// returns a non-200 surfaces the shared core.APIError behavior through
+// openaicompat.PostEmbeddings (input-validation errors are covered separately).
+func TestDatabricks_EmbedErrorPath(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = io.WriteString(w, `{"error":{"message":"embed overloaded"}}`)
+	}))
+	defer srv.Close()
+
+	p, err := New("test-key", srv.URL)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	_, err = p.Embed(context.Background(), core.EmbeddingRequest{
+		Model: "databricks-bge-large-en",
+		Input: "hello",
+	})
+	if err == nil {
+		t.Fatal("expected error for 429")
+	}
+	if !strings.Contains(err.Error(), "embed overloaded") || !strings.Contains(err.Error(), "429") {
+		t.Fatalf("error = %v, want status + upstream message", err)
+	}
+}
+
 // TestDatabricks_NewTrimsWhitespaceBeforeValidating verifies a whitespace-padded
 // base URL (common from env/secrets) is trimmed before validation, not rejected.
 func TestDatabricks_NewTrimsWhitespaceBeforeValidating(t *testing.T) {

--- a/providers/providers_list.go
+++ b/providers/providers_list.go
@@ -406,9 +406,11 @@ var allProviders = []ProviderEntry{
 	{
 		ID:           NameVertexAI,
 		Capabilities: []string{CapabilityChat, CapabilityStream, CapabilityEmbed, CapabilityImage, CapabilityProxy},
-		// project_id is the gate: if unset, skip silently.
-		// region plus one of api_key / service_account_json are required once
-		// project_id is present.
+		// project_id is the gate: if unset, skip silently. region is required
+		// once project_id is present; authentication (api key, service-account
+		// JSON, or Application Default Credentials) is resolved and validated by
+		// vertexaipkg.New, so this closure must not pre-reject the no-explicit-key
+		// case — doing so would defeat the ADC / workload-identity path.
 		EnvMappings: []EnvMapping{
 			{CfgKeyProjectID, "VERTEX_AI_PROJECT_ID", true},
 			{CfgKeyRegion, "VERTEX_AI_REGION", false},
@@ -418,9 +420,6 @@ var allProviders = []ProviderEntry{
 		Build: func(cfg ProviderConfig) (Provider, error) {
 			if cfg[CfgKeyRegion] == "" {
 				return nil, fmt.Errorf("%s: region (VERTEX_AI_REGION) is required when project_id is set", NameVertexAI)
-			}
-			if cfg[CfgKeyAPIKey] == "" && cfg[CfgKeyServiceAccountJSON] == "" {
-				return nil, fmt.Errorf("%s: either api_key (VERTEX_AI_API_KEY) or service_account_json (VERTEX_AI_SERVICE_ACCOUNT_JSON) is required", NameVertexAI)
 			}
 			return vertexaipkg.New(vertexaipkg.Options{
 				ProjectID:          cfg[CfgKeyProjectID],

--- a/providers/vertex_ai/image.go
+++ b/providers/vertex_ai/image.go
@@ -49,24 +49,47 @@ func isVertexAIUltraImageModel(model string) bool {
 }
 
 // buildImagenRequest maps a gateway ImageRequest onto the Imagen :predict shape.
-// req.Size ("WxH") is not directly mappable to Imagen and is ignored;
+// A recognized req.Size ("WxH") is mapped to the nearest Imagen aspectRatio;
 // req.ResponseFormat is ignored (Imagen returns base64 only). For ultra models,
 // sampleCount is clamped to 1.
 func buildImagenRequest(req core.ImageRequest) imagenRequest {
 	out := imagenRequest{
 		Instances: []imagenInstance{{Prompt: req.Prompt}},
 	}
+	params := imagenParameters{AspectRatio: imagenAspectRatio(req.Size)}
 	if req.N != nil {
 		count := *req.N
 		if isVertexAIUltraImageModel(req.Model) && count > 1 {
 			count = 1
 		}
-		out.Parameters = &imagenParameters{SampleCount: &count}
+		params.SampleCount = &count
 	} else if isVertexAIUltraImageModel(req.Model) {
 		one := 1
-		out.Parameters = &imagenParameters{SampleCount: &one}
+		params.SampleCount = &one
+	}
+	if params.SampleCount != nil || params.AspectRatio != "" {
+		out.Parameters = &params
 	}
 	return out
+}
+
+// imagenAspectRatio maps a common OpenAI "WxH" size to the nearest Imagen
+// aspectRatio. An unmapped or empty size returns "" (Imagen defaults to 1:1).
+func imagenAspectRatio(size string) string {
+	switch size {
+	case "1024x1024", "512x512", "256x256":
+		return "1:1"
+	case "1792x1024", "1536x1024":
+		return "16:9"
+	case "1024x1792", "1024x1536":
+		return "9:16"
+	case "1408x1024":
+		return "4:3"
+	case "1024x1408":
+		return "3:4"
+	default:
+		return ""
+	}
 }
 
 // mapImagenPredictions converts Imagen predictions to gateway images. It returns

--- a/providers/vertex_ai/vertex_ai.go
+++ b/providers/vertex_ai/vertex_ai.go
@@ -114,19 +114,34 @@ func (p *Provider) SetBaseURL(url string) { p.baseURL = url }
 // core.NonOpenAIWireProvider.
 func (*Provider) NonOpenAIWire() {}
 
-// AuthHeaders implements core.ProxiableProvider.
-func (p *Provider) AuthHeaders() map[string]string {
+// authHeader returns the single auth header for Vertex AI — the api-key header
+// when an API key is configured, otherwise a Bearer token from the token source
+// (service-account JSON or Application Default Credentials). It returns a clear
+// error when no auth is configured or a token cannot be fetched. All three call
+// sites (AuthHeaders, authorizeRequest, chatAuthHeaders) derive from this so the
+// precedence logic lives in one place.
+func (p *Provider) authHeader() (name, value string, err error) {
 	if p.apiKey != "" {
-		return map[string]string{"x-goog-api-key": p.apiKey}
+		return "x-goog-api-key", p.apiKey, nil
 	}
 	if p.tokenSource == nil {
-		return map[string]string{}
+		return "", "", fmt.Errorf("vertex-ai authorization is not configured")
 	}
 	tok, err := p.tokenSource.Token()
 	if err != nil {
+		return "", "", fmt.Errorf("vertex-ai token fetch failed: %w", err)
+	}
+	return "Authorization", "Bearer " + tok.AccessToken, nil
+}
+
+// AuthHeaders implements core.ProxiableProvider. It returns an empty map when
+// auth cannot be resolved (the proxy seam has no error channel).
+func (p *Provider) AuthHeaders() map[string]string {
+	name, value, err := p.authHeader()
+	if err != nil {
 		return map[string]string{}
 	}
-	return map[string]string{"Authorization": "Bearer " + tok.AccessToken}
+	return map[string]string{name: value}
 }
 
 // SupportedModels returns known Vertex AI model examples.
@@ -210,18 +225,11 @@ func (p *Provider) predictionEndpoint(model string) string {
 }
 
 func (p *Provider) authorizeRequest(req *http.Request) error {
-	if p.apiKey != "" {
-		req.Header.Set("x-goog-api-key", p.apiKey)
-		return nil
-	}
-	if p.tokenSource == nil {
-		return fmt.Errorf("vertex-ai authorization is not configured")
-	}
-	tok, err := p.tokenSource.Token()
+	name, value, err := p.authHeader()
 	if err != nil {
-		return fmt.Errorf("vertex-ai token fetch failed: %w", err)
+		return err
 	}
-	req.Header.Set("Authorization", "Bearer "+tok.AccessToken)
+	req.Header.Set(name, value)
 	return nil
 }
 
@@ -247,20 +255,11 @@ func vertexAIChatModelID(model string) string {
 // returning a clear error when an OAuth token cannot be fetched instead of
 // letting a missing Authorization header surface as an opaque upstream 401.
 func (p *Provider) chatAuthHeaders() (map[string]string, error) {
-	h := map[string]string{"Content-Type": "application/json"}
-	if p.apiKey != "" {
-		h["x-goog-api-key"] = p.apiKey
-		return h, nil
-	}
-	if p.tokenSource == nil {
-		return nil, fmt.Errorf("vertex-ai authorization is not configured")
-	}
-	tok, err := p.tokenSource.Token()
+	name, value, err := p.authHeader()
 	if err != nil {
-		return nil, fmt.Errorf("vertex-ai token fetch failed: %w", err)
+		return nil, err
 	}
-	h["Authorization"] = "Bearer " + tok.AccessToken
-	return h, nil
+	return map[string]string{"Content-Type": "application/json", name: value}, nil
 }
 
 func isVertexAITextEmbeddingModel(model string) bool {

--- a/providers/vertex_ai/vertex_ai.go
+++ b/providers/vertex_ai/vertex_ai.go
@@ -62,22 +62,30 @@ func New(opts Options) (*Provider, error) {
 
 	apiKey := strings.TrimSpace(opts.APIKey)
 	serviceAccountJSON := strings.TrimSpace(opts.ServiceAccountJSON)
-	if apiKey == "" && serviceAccountJSON == "" {
-		return nil, fmt.Errorf("either api key or service account JSON is required for vertex-ai provider")
-	}
 
+	// context.Background() below is intentional: the token source lives for the
+	// whole lifetime of the provider and refreshes OAuth tokens on demand across
+	// many requests. It is a construction-time/lifetime construct, not
+	// request-scoped, so binding it to any single request's context would
+	// wrongly cancel token refresh when that request completes.
 	var tokenSource oauth2.TokenSource
-	if serviceAccountJSON != "" {
+	switch {
+	case serviceAccountJSON != "":
 		cfg, err := google.JWTConfigFromJSON([]byte(serviceAccountJSON), "https://www.googleapis.com/auth/cloud-platform")
 		if err != nil {
 			return nil, fmt.Errorf("invalid Vertex AI service account JSON: %w", err)
 		}
-		// context.Background() is intentional: this token source lives for the
-		// whole lifetime of the provider and refreshes OAuth tokens on demand
-		// across many requests. It is a construction-time/lifetime construct,
-		// not request-scoped, so binding it to any single request's context
-		// would wrongly cancel token refresh when that request completes.
 		tokenSource = cfg.TokenSource(context.Background())
+	case apiKey == "":
+		// No API key or service-account JSON: fall back to Application Default
+		// Credentials (GOOGLE_APPLICATION_CREDENTIALS, gcloud, workload identity,
+		// or the GCE/GKE metadata server) so managed environments authenticate
+		// without an explicit key.
+		creds, err := google.FindDefaultCredentials(context.Background(), "https://www.googleapis.com/auth/cloud-platform")
+		if err != nil {
+			return nil, fmt.Errorf("vertex-ai requires an API key, service account JSON, or application default credentials: %w", err)
+		}
+		tokenSource = creds.TokenSource
 	}
 
 	baseURL := fmt.Sprintf("https://%s-aiplatform.googleapis.com/v1/projects/%s/locations/%s/endpoints/openapi", region, projectID, region)
@@ -126,7 +134,7 @@ func (p *Provider) SupportedModels() []string {
 	return []string{
 		"gemini-2.5-pro",
 		"gemini-2.5-flash",
-		"gemini-2.0-flash",
+		"gemini-2.5-flash-lite",
 		"gemini-embedding-001",
 		"text-embedding-005",
 		"text-embedding-004",
@@ -153,13 +161,6 @@ func (p *Provider) SupportsModel(model string) bool {
 // Models returns structured model metadata.
 func (p *Provider) Models() []core.ModelInfo {
 	return core.ModelsFromList(p.name, p.SupportedModels())
-}
-
-type vertexAIResponse struct {
-	ID      string        `json:"id"`
-	Model   string        `json:"model"`
-	Choices []core.Choice `json:"choices"`
-	Usage   core.Usage    `json:"usage"`
 }
 
 type vertexAIEmbeddingRequest struct {
@@ -228,6 +229,38 @@ func vertexAIModelID(model string) string {
 	model = strings.TrimPrefix(model, "publishers/google/models/")
 	model = strings.TrimPrefix(model, "models/")
 	return model
+}
+
+// vertexAIChatModelID prefixes a first-party model id with the required
+// "google/" publisher prefix for the OpenAI-compatible chat endpoint, unless the
+// caller already supplied a publisher prefix (Model Garden also proxies
+// non-Google publishers).
+func vertexAIChatModelID(model string) string {
+	id := vertexAIModelID(model)
+	if strings.Contains(id, "/") {
+		return id
+	}
+	return "google/" + id
+}
+
+// chatAuthHeaders builds the headers for the OpenAI-compatible chat endpoint,
+// returning a clear error when an OAuth token cannot be fetched instead of
+// letting a missing Authorization header surface as an opaque upstream 401.
+func (p *Provider) chatAuthHeaders() (map[string]string, error) {
+	h := map[string]string{"Content-Type": "application/json"}
+	if p.apiKey != "" {
+		h["x-goog-api-key"] = p.apiKey
+		return h, nil
+	}
+	if p.tokenSource == nil {
+		return nil, fmt.Errorf("vertex-ai authorization is not configured")
+	}
+	tok, err := p.tokenSource.Token()
+	if err != nil {
+		return nil, fmt.Errorf("vertex-ai token fetch failed: %w", err)
+	}
+	h["Authorization"] = "Bearer " + tok.AccessToken
+	return h, nil
 }
 
 func isVertexAITextEmbeddingModel(model string) bool {
@@ -341,79 +374,36 @@ func (p *Provider) Embed(ctx context.Context, req core.EmbeddingRequest) (*core.
 	}, nil
 }
 
-// Complete sends a chat completion request to Vertex AI.
+// Complete sends a chat completion request to Vertex AI's OpenAI-compatible
+// endpoint. The model id is normalized to the required "google/<id>" publisher
+// form before forwarding.
 func (p *Provider) Complete(ctx context.Context, req core.Request) (*core.Response, error) {
-	bodyReader, _, release, err := openaicompat.BuildBody(req, false)
+	req.Model = vertexAIChatModelID(req.Model)
+	headers, err := p.chatAuthHeaders()
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal request: %w", err)
-	}
-	defer release()
-
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, p.endpoint(), bodyReader)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
-	}
-	httpReq.Header.Set("Content-Type", "application/json")
-	if err := p.authorizeRequest(httpReq); err != nil {
 		return nil, err
 	}
-
-	httpResp, err := p.httpClient.Do(httpReq)
-	if err != nil {
-		return nil, fmt.Errorf("request failed: %w", err)
-	}
-	defer func() { _ = httpResp.Body.Close() }()
-
-	respBody, err := io.ReadAll(httpResp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read response: %w", err)
-	}
-
-	if httpResp.StatusCode != http.StatusOK {
-		return nil, core.APIError("vertex ai", httpResp.StatusCode, respBody)
-	}
-
-	var vertexResp vertexAIResponse
-	if err := json.Unmarshal(respBody, &vertexResp); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
-	}
-
-	return &core.Response{
-		ID:       vertexResp.ID,
-		Model:    vertexResp.Model,
-		Provider: p.name,
-		Choices:  vertexResp.Choices,
-		Usage:    vertexResp.Usage,
-	}, nil
+	return openaicompat.PostChat(ctx, openaicompat.ChatParams{
+		HTTPClient: p.httpClient,
+		URL:        p.endpoint(),
+		Headers:    headers,
+		Provider:   p.name,
+		Label:      "vertex ai",
+	}, req)
 }
 
 // CompleteStream sends a streaming chat completion request to Vertex AI.
 func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan core.StreamChunk, error) {
-	bodyReader, _, release, err := openaicompat.BuildBody(req, true)
+	req.Model = vertexAIChatModelID(req.Model)
+	headers, err := p.chatAuthHeaders()
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal request: %w", err)
-	}
-	defer release()
-
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, p.endpoint(), bodyReader)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
-	}
-	httpReq.Header.Set("Content-Type", "application/json")
-	if err := p.authorizeRequest(httpReq); err != nil {
 		return nil, err
 	}
-
-	httpResp, err := p.httpClient.Do(httpReq)
-	if err != nil {
-		return nil, fmt.Errorf("request failed: %w", err)
-	}
-
-	if httpResp.StatusCode != http.StatusOK {
-		defer func() { _ = httpResp.Body.Close() }()
-		respBody, _ := io.ReadAll(httpResp.Body)
-		return nil, core.APIError("vertex ai", httpResp.StatusCode, respBody)
-	}
-
-	return openaicompat.StreamSSE(httpResp.Body), nil
+	return openaicompat.PostStream(ctx, openaicompat.ChatParams{
+		HTTPClient: p.httpClient,
+		URL:        p.endpoint(),
+		Headers:    headers,
+		Provider:   p.name,
+		Label:      "vertex ai",
+	}, req)
 }

--- a/providers/vertex_ai/vertex_ai_phase3_test.go
+++ b/providers/vertex_ai/vertex_ai_phase3_test.go
@@ -1,0 +1,102 @@
+package vertexai
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/ferro-labs/ai-gateway/providers/core"
+)
+
+// vertexChatModel runs one Complete against a stub and returns the "model" field
+// of the request body the provider sent.
+func vertexChatModel(t *testing.T, reqModel string) string {
+	t.Helper()
+	var body struct {
+		Model string `json:"model"`
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(b, &body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"id":"x","model":"m","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`)
+	}))
+	defer srv.Close()
+
+	p, err := New(Options{ProjectID: "demo-project", Region: "us-central1", APIKey: testAPIKey})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	p.SetBaseURL(srv.URL)
+	if _, err := p.Complete(context.Background(), core.Request{
+		Model:    reqModel,
+		Messages: []core.Message{{Role: core.RoleUser, Content: "hi"}},
+	}); err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	return body.Model
+}
+
+// TestComplete_PrefixesGooglePublisher verifies a first-party model is sent with
+// the required "google/" publisher prefix, and an existing publisher prefix is
+// left intact.
+func TestComplete_PrefixesGooglePublisher(t *testing.T) {
+	if got := vertexChatModel(t, "gemini-2.5-flash"); got != "google/gemini-2.5-flash" {
+		t.Errorf("model = %q, want google/gemini-2.5-flash", got)
+	}
+	if got := vertexChatModel(t, "google/gemini-2.5-flash"); got != "google/gemini-2.5-flash" {
+		t.Errorf("already-prefixed model = %q, want unchanged", got)
+	}
+	if got := vertexChatModel(t, "meta/llama-3.1-405b"); got != "meta/llama-3.1-405b" {
+		t.Errorf("non-Google publisher model = %q, want unchanged", got)
+	}
+}
+
+// TestComplete_ErrorPathReturnsAPIError verifies a non-2xx chat response surfaces
+// via core.APIError.
+func TestComplete_ErrorPathReturnsAPIError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = io.WriteString(w, `{"error":{"message":"quota exceeded"}}`)
+	}))
+	defer srv.Close()
+
+	p, err := New(Options{ProjectID: "demo-project", Region: "us-central1", APIKey: testAPIKey})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	p.SetBaseURL(srv.URL)
+	_, err = p.Complete(context.Background(), core.Request{
+		Model:    "gemini-2.5-flash",
+		Messages: []core.Message{{Role: core.RoleUser, Content: "hi"}},
+	})
+	if err == nil {
+		t.Fatal("expected error for 429")
+	}
+	if got := err.Error(); !strings.Contains(got, "quota exceeded") || !strings.Contains(got, "429") {
+		t.Fatalf("error = %v, want status + upstream message", err)
+	}
+}
+
+func TestBuildImagenRequest_MapsSizeToAspectRatio(t *testing.T) {
+	cases := map[string]string{
+		"1024x1024": "1:1",
+		"1792x1024": "16:9",
+		"1024x1792": "9:16",
+		"640x480":   "",
+	}
+	for size, want := range cases {
+		got := buildImagenRequest(core.ImageRequest{Prompt: "x", Model: "imagen-4.0-generate-001", Size: size})
+		var ar string
+		if got.Parameters != nil {
+			ar = got.Parameters.AspectRatio
+		}
+		if ar != want {
+			t.Errorf("size %q -> aspectRatio %q, want %q", size, ar, want)
+		}
+	}
+}

--- a/providers/vertex_ai/vertex_ai_phase3_test.go
+++ b/providers/vertex_ai/vertex_ai_phase3_test.go
@@ -3,14 +3,80 @@ package vertexai
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
+	"golang.org/x/oauth2"
+
+	providerhttp "github.com/ferro-labs/ai-gateway/internal/httpclient"
 	"github.com/ferro-labs/ai-gateway/providers/core"
 )
+
+type fakeTokenSource struct {
+	token string
+	err   error
+}
+
+func (f fakeTokenSource) Token() (*oauth2.Token, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return &oauth2.Token{AccessToken: f.token}, nil
+}
+
+// TestComplete_UsesBearerTokenFromTokenSource covers the service-account / ADC
+// auth mode: with no API key, the OAuth token source supplies an Authorization
+// Bearer header.
+func TestComplete_UsesBearerTokenFromTokenSource(t *testing.T) {
+	var authHeader string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		authHeader = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"id":"x","model":"m","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{"total_tokens":1}}`)
+	}))
+	defer srv.Close()
+
+	p := &Provider{
+		name:        Name,
+		baseURL:     srv.URL,
+		httpClient:  providerhttp.ForProvider(Name),
+		tokenSource: fakeTokenSource{token: "tok-123"},
+	}
+	if _, err := p.Complete(context.Background(), core.Request{
+		Model:    "gemini-2.5-flash",
+		Messages: []core.Message{{Role: core.RoleUser, Content: "hi"}},
+	}); err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	if authHeader != "Bearer tok-123" {
+		t.Errorf("Authorization = %q, want Bearer tok-123", authHeader)
+	}
+}
+
+// TestComplete_TokenFetchFailureSurfaces verifies a token-source failure surfaces
+// as a clear gateway error rather than an unauthenticated request / opaque 401.
+func TestComplete_TokenFetchFailureSurfaces(t *testing.T) {
+	p := &Provider{
+		name:        Name,
+		baseURL:     "https://vertex.example",
+		httpClient:  providerhttp.ForProvider(Name),
+		tokenSource: fakeTokenSource{err: errors.New("metadata unavailable")},
+	}
+	_, err := p.Complete(context.Background(), core.Request{
+		Model:    "gemini-2.5-flash",
+		Messages: []core.Message{{Role: core.RoleUser, Content: "hi"}},
+	})
+	if err == nil {
+		t.Fatal("expected token-fetch error")
+	}
+	if !strings.Contains(err.Error(), "token fetch failed") || !strings.Contains(err.Error(), "metadata unavailable") {
+		t.Fatalf("error = %v, want wrapped token-fetch failure", err)
+	}
+}
 
 // vertexChatModel runs one Complete against a stub and returns the "model" field
 // of the request body the provider sent.

--- a/providers/vertex_ai/vertex_ai_test.go
+++ b/providers/vertex_ai/vertex_ai_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -45,9 +46,14 @@ func TestNewVertexAI_RequiresRegion(t *testing.T) {
 }
 
 func TestNewVertexAI_RequiresAuth(t *testing.T) {
+	// Force Application Default Credentials discovery to fail deterministically
+	// (bogus GOOGLE_APPLICATION_CREDENTIALS path) so the "no auth available"
+	// error path is exercised regardless of the host's ambient gcloud/metadata
+	// credentials.
+	t.Setenv("GOOGLE_APPLICATION_CREDENTIALS", filepath.Join(t.TempDir(), "does-not-exist.json"))
 	_, err := New(Options{ProjectID: "demo-project", Region: "us-central1"})
 	if err == nil {
-		t.Fatal("expected error when API key and service account JSON are both empty")
+		t.Fatal("expected error when no api key, service account JSON, or ADC is available")
 	}
 }
 

--- a/providers/vertex_ai_build_test.go
+++ b/providers/vertex_ai_build_test.go
@@ -1,0 +1,37 @@
+package providers
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestVertexAIBuild_NoExplicitKeyReachesADC verifies the vertex-ai factory no
+// longer rejects the no-api-key / no-service-account config before New() runs,
+// so the Application Default Credentials (workload-identity) path is reachable.
+// With ADC forced unavailable, the error must come from New()'s ADC-aware
+// validation, not a pre-flight factory guard.
+func TestVertexAIBuild_NoExplicitKeyReachesADC(t *testing.T) {
+	t.Setenv("GOOGLE_APPLICATION_CREDENTIALS", filepath.Join(t.TempDir(), "none.json"))
+
+	entry, ok := GetProviderEntry(NameVertexAI)
+	if !ok {
+		t.Fatal("vertex-ai provider entry not found")
+	}
+
+	_, err := entry.Build(ProviderConfig{
+		CfgKeyProjectID: "demo",
+		CfgKeyRegion:    "us-central1",
+	})
+	if err == nil {
+		// ADC happened to be available on this host; the guard relaxation still
+		// holds (no pre-flight rejection), which is the point of the fix.
+		return
+	}
+	if strings.Contains(err.Error(), "either api_key") {
+		t.Fatalf("factory still pre-rejects the no-key case, defeating ADC: %v", err)
+	}
+	if !strings.Contains(err.Error(), "application default credentials") {
+		t.Fatalf("error = %v, want New()'s ADC-aware validation error", err)
+	}
+}


### PR DESCRIPTION
## Summary

Phase 3 of the provider-readiness remediation: **Enterprise Endpoints & Cohere** — Vertex AI, Azure OpenAI, Azure AI Foundry, Databricks, and Cohere. Aligns these five providers on request/response correctness and consolidates their hand-rolled HTTP onto the shared OpenAI-compatible helpers (`openaicompat.PostChat/PostStream/PostEmbeddings`, `core.APIError`, `core.ValidateBaseURL`).

No breaking API changes relative to v1.1.11 — `Provider`/`ProxiableProvider`/plugin contracts unchanged. Ships as **v1.1.12**.

## What changed

**Vertex AI**
- Prefix first-party chat/stream models with the required `google/` publisher segment (HIGH); an existing publisher prefix (e.g. Model Garden `meta/`) is left intact.
- Adopt `openaicompat.PostChat/PostStream` (drop the duplicated response struct) while pre-fetching the OAuth token so a fetch failure is a clear error, not an opaque 401.
- Fall back to Application Default Credentials when no API key or service-account JSON is configured (workload identity / GCE-GKE metadata).
- Map a recognized image size to the Imagen aspect ratio; drop the retired `gemini-2.0-flash`.

**Azure AI Foundry**
- Migrate the chat endpoint to the GA `{endpoint}/openai/v1/chat/completions` route (no `api-version`) — the Model Inference `/models` route is being retired by the vendor (verified against Microsoft docs, retirement May 30 2026). Adopt the shared helpers; send `extra-parameters: drop`.

**Azure OpenAI**
- Adopt `openaicompat.PostChat/PostStream` — drops the duplicated response/error structs, routes all error sites (chat/embed/image) through `core.APIError`, and restores the response provider name the hand-rolled decoder dropped.

**Databricks**
- Route Embed through `openaicompat.PostEmbeddings` (drop ~90 LOC + inline error struct); drop the retired `databricks-claude-3-7-sonnet`; add a tuned transport preset for serving-endpoint cold starts.

**Cohere**
- Forward multimodal image content as Cohere v2 content blocks (was dropped); surface message-end streaming token usage (was parsed and discarded); one shared `cohereAPIError` helper (Cohere's flat `{message}` error envelope differs from the OpenAI shape `core.APIError` decodes).

**All five**: base-URL validation at construction; wire-level error-path + behavior tests.

## Deferred (documented as roadmap)
- Cohere: catalog refresh + `response_format` mapping + `/v2/embed` migration + live discovery + rerank seam.
- Azure Foundry: embeddings on the same surface; transport preset.
- Azure OpenAI: opt-in GA v1 mode.
- Databricks: live discovery; Responses API.
- Vertex AI: api-key-vs-endpoint auth pairing (needs a live GCP call to confirm; api-key retained + ADC fallback added).

## Test plan
- [x] `make fmt lint test` green; full `-race` suite clean.
- [x] Per-provider wire tests: vertex-ai google/ prefix + error path + Imagen size; azure-openai decode/provider + error path; azure-foundry v1-route + extra-parameters + error path; databricks chat/stream error paths; cohere vision + streaming usage.
- [x] Catalog-coverage test green (fallback `models[0]` resolves in the bundled pricing catalog).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Azure AI Foundry now routes through the newer OpenAI-compatible chat endpoint.
  * Vertex AI can fall back to default cloud credentials when no explicit API credentials are set.
  * Image generation now maps common requested sizes to the correct Imagen aspect ratios.
* **Bug Fixes**
  * Improved multimodal (vision) request forwarding and streaming token usage reporting for Cohere.
  * Standardized request/response handling and clearer upstream error messages across providers.
  * Refreshed the advertised model catalog by removing retired entries and adjusting model mappings.
* **Chores**
  * Updated v1.1.12 release notes (enterprise endpoint & provider-fidelity fixes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->