### PR TITLE
v1.1.13 - OpenAI-Compat Providers I

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to Ferro Labs AI Gateway are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.13] — 2026-07-04
+
+OpenAI-compatible provider fidelity release (part one). The fourth provider-readiness remediation phase aligns the Mistral, DeepSeek, Together, Fireworks, Cerebras, and Groq providers on request/response correctness, and adds two shared improvements that benefit every OpenAI-compatible provider. No breaking API changes relative to v1.1.12.
+
+### Fixed
+
+- **Mistral sampling seed**: the `seed` parameter is now sent as Mistral's `random_seed` field (Mistral ignores the standard `seed`), so a requested seed actually takes effect.
+- **Mistral embedding dimensions**: the embeddings `dimensions` parameter is now sent as Mistral's `output_dimension` field.
+- **DeepSeek model list**: `deepseek-v4-flash` and `deepseek-v4-pro` are now advertised, ahead of the retirement of `deepseek-chat`/`deepseek-reasoner`.
+- **Groq model catalog**: the two decommissioned models (`mixtral-8x7b-32768`, `gemma2-9b-it`) are removed and current production models (`openai/gpt-oss-120b`, `openai/gpt-oss-20b`) added.
+- **DeepSeek error and finish_reason handling**: chat errors now use the shared error envelope, and finish reasons are normalized to the canonical OpenAI vocabulary on both the streaming and non-streaming paths.
+
+### Changed
+
+- **Streaming token usage** (all OpenAI-compatible providers): streaming requests now set `stream_options.include_usage`, so providers that gate the terminal usage chunk on that flag report streaming token usage.
+- **finish_reason normalization** (all OpenAI-compatible providers): the shared chat and stream decoders normalize provider-specific finish reasons (e.g. Mistral's `model_length` → `length`) to the canonical OpenAI vocabulary.
+- **Together default API domain** (operator-visible): the default base URL is now `https://api.together.ai` (the current documented host) instead of the legacy `https://api.together.xyz`; deployments pinned to the old domain can still override it via `TOGETHER_BASE_URL`.
+- **DeepSeek model discovery**: DeepSeek now supports live `/models` discovery, so its advertised model list can self-update.
+- **Shared base-URL validation**: Mistral, DeepSeek, Together, Fireworks, Cerebras, and Groq now validate the configured base URL at construction, and Cerebras and Groq forward only the modern `max_completion_tokens` field.
+
+---
+
 ## [1.1.12] — 2026-07-04
 
 Enterprise-endpoint & Cohere fidelity release. The third provider-readiness remediation phase aligns the Vertex AI, Azure OpenAI, Azure AI Foundry, Databricks, and Cohere providers on request/response correctness and consolidates their hand-rolled HTTP onto the shared OpenAI-compatible helpers. No breaking API changes relative to v1.1.11.

--- a/internal/openaicompat/complete.go
+++ b/internal/openaicompat/complete.go
@@ -32,10 +32,26 @@ type ChatParams struct {
 	Headers    map[string]string // auth + content-type
 	Provider   string            // sets core.Response.Provider
 	Label      string            // human-facing name for error messages
+
+	// BodyTransform, when set, reshapes the outgoing request body (e.g. to rename
+	// a wire field like Mistral's seed→random_seed) while keeping the shared
+	// response decoding, error handling, and finish_reason normalization. It
+	// receives the request with Stream and StreamOptions already applied.
+	BodyTransform func(core.Request) any
 }
 
 func newChatRequest(ctx context.Context, p ChatParams, req core.Request, stream bool) (*http.Response, func(), error) {
-	bodyReader, _, release, err := BuildBody(req, stream)
+	var (
+		bodyReader io.Reader
+		release    func()
+		err        error
+	)
+	if p.BodyTransform != nil {
+		req.Stream = stream
+		bodyReader, _, release, err = core.JSONBodyReader(p.BodyTransform(req))
+	} else {
+		bodyReader, _, release, err = BuildBody(req, stream)
+	}
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to marshal request: %w", err)
 	}

--- a/internal/openaicompat/complete.go
+++ b/internal/openaicompat/complete.go
@@ -78,6 +78,11 @@ func PostChat(ctx context.Context, p ChatParams, req core.Request) (*core.Respon
 	if err := json.Unmarshal(respBody, &pResp); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
 	}
+	// Normalize provider-specific finish reasons (e.g. Mistral's model_length)
+	// to the canonical OpenAI vocabulary for every OpenAI-compatible provider.
+	for i := range pResp.Choices {
+		pResp.Choices[i].FinishReason = core.NormalizeFinishReason(pResp.Choices[i].FinishReason)
+	}
 	return &core.Response{
 		ID:       pResp.ID,
 		Model:    pResp.Model,
@@ -91,6 +96,11 @@ func PostChat(ctx context.Context, p ChatParams, req core.Request) (*core.Respon
 // channel of decoded chunks (see StreamSSE). The non-200 body is drained and
 // surfaced as an error before any goroutine is started.
 func PostStream(ctx context.Context, p ChatParams, req core.Request) (<-chan core.StreamChunk, error) {
+	// Request a terminal usage chunk for cost/metrics tracking unless the caller
+	// already configured stream_options.
+	if req.StreamOptions == nil {
+		req.StreamOptions = &core.StreamOptions{IncludeUsage: true}
+	}
 	httpResp, release, err := newChatRequest(ctx, p, req, true)
 	if err != nil {
 		return nil, err

--- a/internal/openaicompat/complete_test.go
+++ b/internal/openaicompat/complete_test.go
@@ -1,0 +1,77 @@
+package openaicompat
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/ferro-labs/ai-gateway/providers/core"
+)
+
+// TestPostStream_SetsIncludeUsage verifies the shared streaming path requests a
+// terminal usage chunk (stream_options.include_usage) so every OpenAI-compatible
+// provider reports streaming usage.
+func TestPostStream_SetsIncludeUsage(t *testing.T) {
+	var body map[string]json.RawMessage
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(b, &body)
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, "data: [DONE]\n\n")
+	}))
+	defer srv.Close()
+
+	ch, err := PostStream(context.Background(), ChatParams{
+		HTTPClient: srv.Client(),
+		URL:        srv.URL,
+		Headers:    map[string]string{"Content-Type": "application/json"},
+		Provider:   "test",
+		Label:      "test",
+	}, core.Request{Model: "m", Messages: []core.Message{{Role: core.RoleUser, Content: "hi"}}})
+	if err != nil {
+		t.Fatalf("PostStream: %v", err)
+	}
+	var n int
+	for range ch {
+		n++
+	}
+	if n != 0 {
+		t.Errorf("expected 0 chunks for a [DONE]-only stream, got %d", n)
+	}
+
+	so, ok := body["stream_options"]
+	if !ok {
+		t.Fatal("stream_options not set on streaming request")
+	}
+	if !strings.Contains(string(so), "include_usage") {
+		t.Errorf("stream_options = %s, want include_usage", so)
+	}
+}
+
+// TestPostChat_NormalizesFinishReason verifies a provider-specific finish reason
+// (Mistral's model_length) is normalized to the canonical OpenAI value.
+func TestPostChat_NormalizesFinishReason(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"id":"x","model":"m","choices":[{"index":0,"message":{"role":"assistant","content":"hi"},"finish_reason":"model_length"}],"usage":{"total_tokens":1}}`)
+	}))
+	defer srv.Close()
+
+	resp, err := PostChat(context.Background(), ChatParams{
+		HTTPClient: srv.Client(),
+		URL:        srv.URL,
+		Headers:    map[string]string{"Content-Type": "application/json"},
+		Provider:   "test",
+		Label:      "test",
+	}, core.Request{Model: "m", Messages: []core.Message{{Role: core.RoleUser, Content: "hi"}}})
+	if err != nil {
+		t.Fatalf("PostChat: %v", err)
+	}
+	if resp.Choices[0].FinishReason != core.FinishReasonLength {
+		t.Errorf("finish_reason = %q, want length (normalized from model_length)", resp.Choices[0].FinishReason)
+	}
+}

--- a/internal/openaicompat/complete_test.go
+++ b/internal/openaicompat/complete_test.go
@@ -75,3 +75,16 @@ func TestPostChat_NormalizesFinishReason(t *testing.T) {
 		t.Errorf("finish_reason = %q, want length (normalized from model_length)", resp.Choices[0].FinishReason)
 	}
 }
+
+// TestDecodeStreamChunk_NormalizesFinishReason verifies the shared stream decoder
+// normalizes a provider-specific finish reason directly (not only through a
+// provider round-trip).
+func TestDecodeStreamChunk_NormalizesFinishReason(t *testing.T) {
+	chunk, err := DecodeStreamChunk([]byte(`{"choices":[{"index":0,"delta":{},"finish_reason":"model_length"}]}`))
+	if err != nil {
+		t.Fatalf("DecodeStreamChunk: %v", err)
+	}
+	if chunk.Choices[0].FinishReason != core.FinishReasonLength {
+		t.Errorf("finish_reason = %q, want length", chunk.Choices[0].FinishReason)
+	}
+}

--- a/internal/openaicompat/embedding.go
+++ b/internal/openaicompat/embedding.go
@@ -16,6 +16,12 @@ type EmbeddingParams struct {
 	URL        string            // full embeddings endpoint URL
 	Headers    map[string]string // auth + content-type
 	Label      string            // human-facing name for error messages
+
+	// BodyTransform, when set, reshapes the outgoing embeddings body (e.g. to
+	// rename a wire field like Mistral's dimensions→output_dimension) while
+	// keeping the shared response decoding. It receives the request and the
+	// normalized input.
+	BodyTransform func(req core.EmbeddingRequest, input any) any
 }
 
 // embeddingBody is the OpenAI-shaped embeddings request body.
@@ -46,13 +52,17 @@ func PostEmbeddings(ctx context.Context, p EmbeddingParams, req core.EmbeddingRe
 		return nil, err
 	}
 
-	bodyReader, _, release, err := core.JSONBodyReader(embeddingBody{
+	var payload any = embeddingBody{
 		Model:          req.Model,
 		Input:          input,
 		EncodingFormat: req.EncodingFormat,
 		Dimensions:     req.Dimensions,
 		User:           req.User,
-	})
+	}
+	if p.BodyTransform != nil {
+		payload = p.BodyTransform(req, input)
+	}
+	bodyReader, _, release, err := core.JSONBodyReader(payload)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal embedding request: %w", err)
 	}

--- a/internal/openaicompat/stream.go
+++ b/internal/openaicompat/stream.go
@@ -18,6 +18,11 @@ func DecodeStreamChunk(data []byte) (core.StreamChunk, error) {
 	if err := json.Unmarshal(data, &chunk); err != nil {
 		return core.StreamChunk{}, fmt.Errorf("failed to unmarshal stream chunk: %w", err)
 	}
+	// Normalize provider-specific finish reasons to the canonical OpenAI
+	// vocabulary for every OpenAI-compatible provider.
+	for i := range chunk.Choices {
+		chunk.Choices[i].FinishReason = core.NormalizeFinishReason(chunk.Choices[i].FinishReason)
+	}
 	return chunk, nil
 }
 

--- a/providers/cerebras/cerebras.go
+++ b/providers/cerebras/cerebras.go
@@ -37,8 +37,11 @@ var (
 
 // New creates a new Cerebras provider.
 func New(apiKey, baseURL string) (*Provider, error) {
+	baseURL = strings.TrimSpace(baseURL)
 	if baseURL == "" {
 		baseURL = defaultBaseURL
+	} else if err := core.ValidateBaseURL(Name, baseURL); err != nil {
+		return nil, err
 	}
 	baseURL = strings.TrimRight(baseURL, "/")
 	return &Provider{
@@ -87,6 +90,9 @@ func (p *Provider) DiscoverModels(ctx context.Context) ([]core.ModelInfo, error)
 
 // Complete sends a chat completion request to Cerebras.
 func (p *Provider) Complete(ctx context.Context, req core.Request) (*core.Response, error) {
+	// Cerebras validates max_completion_tokens, not the legacy max_tokens; the
+	// gateway seam sets both, so forward only the modern field.
+	req.PreferCompletionTokens()
 	return openaicompat.PostChat(ctx, openaicompat.ChatParams{
 		HTTPClient: p.httpClient,
 		URL:        p.baseURL + "/chat/completions",
@@ -98,6 +104,9 @@ func (p *Provider) Complete(ctx context.Context, req core.Request) (*core.Respon
 
 // CompleteStream sends a streaming chat completion request to Cerebras.
 func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan core.StreamChunk, error) {
+	// Cerebras validates max_completion_tokens, not the legacy max_tokens; the
+	// gateway seam sets both, so forward only the modern field.
+	req.PreferCompletionTokens()
 	return openaicompat.PostStream(ctx, openaicompat.ChatParams{
 		HTTPClient: p.httpClient,
 		URL:        p.baseURL + "/chat/completions",

--- a/providers/cerebras/cerebras_test.go
+++ b/providers/cerebras/cerebras_test.go
@@ -207,6 +207,23 @@ func TestCerebrasProvider_Complete_PrefersMaxCompletionTokens(t *testing.T) {
 	}
 }
 
+// TestCerebrasProvider_Complete_ForwardsMaxTokensWhenAlone verifies a legacy
+// request that sets only max_tokens still forwards it (PreferCompletionTokens is
+// a no-op when max_completion_tokens is absent).
+func TestCerebrasProvider_Complete_ForwardsMaxTokensWhenAlone(t *testing.T) {
+	body := captureCerebrasChatBody(t, core.Request{
+		Model:     "llama-3.3-70b",
+		Messages:  []core.Message{{Role: "user", Content: "Hi"}},
+		MaxTokens: intPtr(256),
+	})
+	if got := string(body["max_tokens"]); got != "256" {
+		t.Errorf("max_tokens = %s, want 256 (a max_tokens-only request must still forward it)", got)
+	}
+	if _, ok := body["max_completion_tokens"]; ok {
+		t.Errorf("max_completion_tokens must not appear for a max_tokens-only request, body=%v", body)
+	}
+}
+
 func TestCerebrasProvider_Complete_ErrorStatus(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/providers/cerebras/cerebras_test.go
+++ b/providers/cerebras/cerebras_test.go
@@ -2,8 +2,11 @@ package cerebras
 
 import (
 	"context"
+	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/ferro-labs/ai-gateway/providers/core"
@@ -133,5 +136,151 @@ func TestCerebrasProvider_Complete_MockHTTP(t *testing.T) {
 	}
 	if len(resp.Choices) == 0 {
 		t.Error("expected at least one choice")
+	}
+}
+
+func intPtr(i int) *int { return &i }
+
+func float64Ptr(f float64) *float64 { return &f }
+
+// captureCerebrasChatBody runs one Complete against a stub server and returns the
+// raw JSON keys the provider sent, so tests can assert the outgoing wire body.
+func captureCerebrasChatBody(t *testing.T, req core.Request) map[string]json.RawMessage {
+	t.Helper()
+	var body map[string]json.RawMessage
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+		if r.URL.Path != "/chat/completions" {
+			t.Errorf("path = %q, want /chat/completions", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != testBearerAPIKey {
+			t.Errorf("Authorization = %q, want %s", got, testBearerAPIKey)
+		}
+		b, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(b, &body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"id":"cmpl-1","object":"chat.completion","model":"llama-3.3-70b","choices":[{"index":0,"message":{"role":"assistant","content":"hi"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`)
+	}))
+	defer srv.Close()
+
+	p, _ := New("test-key", srv.URL)
+	if _, err := p.Complete(context.Background(), req); err != nil {
+		t.Fatalf("Complete() error: %v", err)
+	}
+	return body
+}
+
+// TestCerebrasProvider_Complete_RequestBody asserts the outgoing chat request
+// carries the expected method, path, Bearer auth, model, and a sampling param.
+func TestCerebrasProvider_Complete_RequestBody(t *testing.T) {
+	body := captureCerebrasChatBody(t, core.Request{
+		Model:       "llama-3.3-70b",
+		Messages:    []core.Message{{Role: "user", Content: "Hi"}},
+		Temperature: float64Ptr(0.7),
+	})
+	if got := string(body["model"]); got != `"llama-3.3-70b"` {
+		t.Errorf("model = %s, want \"llama-3.3-70b\"", got)
+	}
+	if got := string(body["temperature"]); got != "0.7" {
+		t.Errorf("temperature = %s, want 0.7", got)
+	}
+}
+
+// TestCerebrasProvider_Complete_PrefersMaxCompletionTokens verifies that when the
+// gateway seam sets both max_tokens and max_completion_tokens, Cerebras forwards
+// only max_completion_tokens (the field its chat API validates) and drops the
+// legacy max_tokens.
+func TestCerebrasProvider_Complete_PrefersMaxCompletionTokens(t *testing.T) {
+	body := captureCerebrasChatBody(t, core.Request{
+		Model:               "llama-3.3-70b",
+		Messages:            []core.Message{{Role: "user", Content: "Hi"}},
+		MaxTokens:           intPtr(256),
+		MaxCompletionTokens: intPtr(256),
+	})
+	if _, ok := body["max_tokens"]; ok {
+		t.Errorf("max_tokens must not be sent when max_completion_tokens present, body=%v", body)
+	}
+	if got := string(body["max_completion_tokens"]); got != "256" {
+		t.Errorf("max_completion_tokens = %s, want 256", got)
+	}
+}
+
+func TestCerebrasProvider_Complete_ErrorStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"error":{"message":"rate limited","type":"rate_limit"}}`))
+	}))
+	defer srv.Close()
+
+	p, _ := New("test-key", srv.URL)
+	_, err := p.Complete(context.Background(), core.Request{
+		Model:    "llama-3.3-70b",
+		Messages: []core.Message{{Role: "user", Content: "Hi"}},
+	})
+	if err == nil {
+		t.Fatal("Complete() error = nil, want upstream error")
+	}
+	if code := core.ParseStatusCode(err); code != http.StatusTooManyRequests {
+		t.Errorf("ParseStatusCode = %d, want 429 (err=%v)", code, err)
+	}
+	if !strings.Contains(err.Error(), "rate limited") {
+		t.Errorf("error = %v, want rate limited message", err)
+	}
+}
+
+func TestCerebrasProvider_CompleteStream_ErrorStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":{"message":"boom","type":"server_error"}}`))
+	}))
+	defer srv.Close()
+
+	p, _ := New("test-key", srv.URL)
+	_, err := p.CompleteStream(context.Background(), core.Request{
+		Model:    "llama-3.3-70b",
+		Messages: []core.Message{{Role: "user", Content: "Hi"}},
+	})
+	if err == nil {
+		t.Fatal("CompleteStream() error = nil, want upstream error")
+	}
+	if code := core.ParseStatusCode(err); code != http.StatusInternalServerError {
+		t.Errorf("ParseStatusCode = %d, want 500 (err=%v)", code, err)
+	}
+}
+
+func TestCerebrasProvider_DiscoverModels(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("method = %q, want GET", r.Method)
+		}
+		if r.URL.Path != "/models" {
+			t.Errorf("path = %q, want /models", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != testBearerAPIKey {
+			t.Errorf("Authorization = %q, want %s", got, testBearerAPIKey)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"object":"list","data":[{"id":"llama-3.3-70b","object":"model","created":1700000000,"owned_by":"Cerebras"},{"id":"qwen-3-32b","object":"model"}]}`))
+	}))
+	defer srv.Close()
+
+	p, _ := New("test-key", srv.URL)
+	models, err := p.DiscoverModels(context.Background())
+	if err != nil {
+		t.Fatalf("DiscoverModels() error: %v", err)
+	}
+	if len(models) != 2 {
+		t.Fatalf("expected 2 models, got %d", len(models))
+	}
+	if models[0].ID != "llama-3.3-70b" || models[0].OwnedBy != "Cerebras" {
+		t.Errorf("unexpected model[0]: %+v", models[0])
+	}
+	if models[1].OwnedBy != "cerebras" {
+		t.Errorf("model[1] owned_by fallback = %q, want cerebras", models[1].OwnedBy)
 	}
 }

--- a/providers/core/chat.go
+++ b/providers/core/chat.go
@@ -184,11 +184,18 @@ type Request struct {
 	TopLogProbs *int `json:"top_logprobs,omitempty"`
 
 	// Streaming
-	Stream bool `json:"stream,omitempty"`
+	Stream        bool           `json:"stream,omitempty"`
+	StreamOptions *StreamOptions `json:"stream_options,omitempty"`
 
 	// Misc
 	User      string             `json:"user,omitempty"`
 	LogitBias map[string]float64 `json:"logit_bias,omitempty"`
+}
+
+// StreamOptions carries the OpenAI stream_options object. IncludeUsage requests a
+// terminal usage chunk on the stream so cost and metrics tracking work.
+type StreamOptions struct {
+	IncludeUsage bool `json:"include_usage,omitempty"`
 }
 
 // NormalizeCompletionTokenLimits fills max_tokens from max_completion_tokens

--- a/providers/deepseek/deepseek.go
+++ b/providers/deepseek/deepseek.go
@@ -164,6 +164,12 @@ func (p *Provider) Complete(ctx context.Context, req core.Request) (*core.Respon
 	if err := json.Unmarshal(respBody, &pResp); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
 	}
+	// Normalize finish reasons to the canonical OpenAI vocabulary, matching the
+	// shared streaming path (the hand-rolled decode here is kept only to capture
+	// DeepSeek's extended cache/reasoning usage).
+	for i := range pResp.Choices {
+		pResp.Choices[i].FinishReason = core.NormalizeFinishReason(pResp.Choices[i].FinishReason)
+	}
 
 	return &core.Response{
 		ID:       pResp.ID,

--- a/providers/deepseek/deepseek.go
+++ b/providers/deepseek/deepseek.go
@@ -7,9 +7,9 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
 	"strings"
 
+	"github.com/ferro-labs/ai-gateway/internal/discovery"
 	providerhttp "github.com/ferro-labs/ai-gateway/internal/httpclient"
 	"github.com/ferro-labs/ai-gateway/internal/openaicompat"
 	"github.com/ferro-labs/ai-gateway/providers/core"
@@ -34,18 +34,22 @@ type Provider struct {
 var (
 	_ core.Provider          = (*Provider)(nil)
 	_ core.StreamProvider    = (*Provider)(nil)
+	_ core.DiscoveryProvider = (*Provider)(nil)
 	_ core.ProxiableProvider = (*Provider)(nil)
 )
 
 // New creates a new DeepSeek provider.
 func New(apiKey, baseURL string) (*Provider, error) {
+	baseURL = strings.TrimSpace(baseURL)
 	if baseURL == "" {
 		baseURL = defaultBaseURL
 	}
 	baseURL = strings.TrimRight(baseURL, "/")
-	u, err := url.Parse(baseURL)
-	if err != nil || (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
-		return nil, fmt.Errorf("deepseek: invalid base URL %q: must be http or https with a host", baseURL)
+	// DeepSeek's chat and models paths already carry the /v1 prefix, so trim a
+	// trailing /v1 to avoid doubling it when callers pass ".../v1" as the base.
+	baseURL = strings.TrimSuffix(baseURL, "/v1")
+	if err := core.ValidateBaseURL(Name, baseURL); err != nil {
+		return nil, err
 	}
 	return &Provider{
 		name:       Name,
@@ -71,6 +75,8 @@ func (p *Provider) SupportedModels() []string {
 	return []string{
 		"deepseek-chat",
 		"deepseek-reasoner",
+		"deepseek-v4-flash",
+		"deepseek-v4-pro",
 	}
 }
 
@@ -82,6 +88,11 @@ func (p *Provider) SupportsModel(model string) bool {
 // Models returns structured model metadata.
 func (p *Provider) Models() []core.ModelInfo {
 	return core.ModelsFromList(p.name, p.SupportedModels())
+}
+
+// DiscoverModels fetches the live model list from the DeepSeek /v1/models endpoint.
+func (p *Provider) DiscoverModels(ctx context.Context) ([]core.ModelInfo, error) {
+	return discovery.DiscoverOpenAICompatibleModels(ctx, p.httpClient, p.baseURL+"/v1/models", p.apiKey, p.name)
 }
 
 // ------------------------------------------------------------------ types ---
@@ -119,15 +130,6 @@ func (u usage) toCore() core.Usage {
 	}
 }
 
-type errorDetail struct {
-	Message string `json:"message"`
-	Type    string `json:"type"`
-}
-
-type errorResponse struct {
-	Error errorDetail `json:"error"`
-}
-
 // Complete sends a chat completion request to DeepSeek.
 func (p *Provider) Complete(ctx context.Context, req core.Request) (*core.Response, error) {
 	bodyReader, _, release, err := openaicompat.BuildBody(req, false)
@@ -155,11 +157,7 @@ func (p *Provider) Complete(ctx context.Context, req core.Request) (*core.Respon
 	}
 
 	if httpResp.StatusCode != http.StatusOK {
-		var errResp errorResponse
-		if json.Unmarshal(respBody, &errResp) == nil && errResp.Error.Message != "" {
-			return nil, fmt.Errorf("deepseek API error (%d): %s", httpResp.StatusCode, errResp.Error.Message)
-		}
-		return nil, fmt.Errorf("deepseek API error (%d): %s", httpResp.StatusCode, string(respBody))
+		return nil, core.APIError("deepseek", httpResp.StatusCode, respBody)
 	}
 
 	var pResp response

--- a/providers/deepseek/deepseek_p4_test.go
+++ b/providers/deepseek/deepseek_p4_test.go
@@ -1,0 +1,36 @@
+package deepseek
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/ferro-labs/ai-gateway/providers/core"
+)
+
+// TestDeepSeekProvider_Complete_NormalizesFinishReason verifies the hand-rolled
+// non-streaming decode normalizes finish reasons to the canonical OpenAI
+// vocabulary, matching the shared streaming path.
+func TestDeepSeekProvider_Complete_NormalizesFinishReason(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"x","model":"deepseek-chat","choices":[{"index":0,"message":{"role":"assistant","content":"hi"},"finish_reason":"model_length"}],"usage":{"total_tokens":1}}`))
+	}))
+	defer srv.Close()
+
+	p, err := New("test-key", srv.URL)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	resp, err := p.Complete(context.Background(), core.Request{
+		Model:    "deepseek-chat",
+		Messages: []core.Message{{Role: core.RoleUser, Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	if resp.Choices[0].FinishReason != core.FinishReasonLength {
+		t.Errorf("finish_reason = %q, want length (normalized from model_length)", resp.Choices[0].FinishReason)
+	}
+}

--- a/providers/deepseek/deepseek_test.go
+++ b/providers/deepseek/deepseek_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -18,6 +19,22 @@ func TestNewDeepSeek(t *testing.T) {
 	}
 	if p.Name() != "deepseek" {
 		t.Errorf("Name() = %q, want deepseek", p.Name())
+	}
+}
+
+func TestNewDeepSeek_InvalidBaseURL(t *testing.T) {
+	if _, err := New("test-key", "://bad"); err == nil {
+		t.Error("New() with invalid base URL should return an error")
+	}
+}
+
+func TestNewDeepSeek_TrimsTrailingV1(t *testing.T) {
+	p, err := New("test-key", "https://api.deepseek.com/v1")
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+	if p.BaseURL() != "https://api.deepseek.com" {
+		t.Errorf("BaseURL() = %q, want https://api.deepseek.com", p.BaseURL())
 	}
 }
 
@@ -127,6 +144,63 @@ func TestDeepSeekProvider_Complete_Integration(t *testing.T) {
 		t.Error("Response ID is empty")
 	}
 	t.Logf("Response: %+v", resp)
+}
+
+func TestDeepSeekProvider_Complete_ErrorStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":{"message":"Invalid API key","type":"authentication_error"}}`))
+	}))
+	defer srv.Close()
+
+	p, _ := New("bad-key", srv.URL)
+	_, err := p.Complete(context.Background(), core.Request{
+		Model:    "deepseek-chat",
+		Messages: []core.Message{{Role: core.RoleUser, Content: "hi"}},
+	})
+	if err == nil {
+		t.Fatal("Complete() expected an error for 401 response")
+	}
+	if code := core.ParseStatusCode(err); code != http.StatusUnauthorized {
+		t.Errorf("ParseStatusCode() = %d, want 401", code)
+	}
+	if !strings.Contains(err.Error(), "Invalid API key") {
+		t.Errorf("error = %q, want it to contain the upstream message", err.Error())
+	}
+}
+
+func TestDeepSeekProvider_DiscoverModels(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("method = %q, want GET", r.Method)
+		}
+		if r.URL.Path != "/v1/models" {
+			t.Errorf("path = %q, want /v1/models", r.URL.Path)
+		}
+		if r.Header.Get("Authorization") != "Bearer test-key" {
+			t.Errorf("Authorization = %q, want Bearer test-key", r.Header.Get("Authorization"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"object":"list","data":[{"id":"deepseek-chat","object":"model","owned_by":"deepseek"},{"id":"deepseek-reasoner","object":"model"}]}`))
+	}))
+	defer srv.Close()
+
+	p, _ := New("test-key", srv.URL)
+	models, err := p.DiscoverModels(context.Background())
+	if err != nil {
+		t.Fatalf("DiscoverModels() error: %v", err)
+	}
+	if len(models) != 2 {
+		t.Fatalf("expected 2 models, got %d", len(models))
+	}
+	if models[0].ID != "deepseek-chat" || models[0].OwnedBy != "deepseek" {
+		t.Errorf("unexpected model[0]: %+v", models[0])
+	}
+	if models[1].OwnedBy != "deepseek" {
+		t.Errorf("model[1] owned_by fallback = %q, want deepseek", models[1].OwnedBy)
+	}
 }
 
 func intPtr(i int) *int { return &i }

--- a/providers/fireworks/fireworks.go
+++ b/providers/fireworks/fireworks.go
@@ -38,8 +38,11 @@ var (
 
 // New creates a new Fireworks AI provider.
 func New(apiKey, baseURL string) (*Provider, error) {
+	baseURL = strings.TrimSpace(baseURL)
 	if baseURL == "" {
 		baseURL = defaultBaseURL
+	} else if err := core.ValidateBaseURL(Name, baseURL); err != nil {
+		return nil, err
 	}
 	baseURL = strings.TrimRight(baseURL, "/")
 	return &Provider{

--- a/providers/fireworks/fireworks_phase3_test.go
+++ b/providers/fireworks/fireworks_phase3_test.go
@@ -1,0 +1,95 @@
+package fireworks
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/ferro-labs/ai-gateway/providers/core"
+)
+
+// TestNew_RejectsInvalidBaseURL verifies the constructor fails fast when the base
+// URL is not a valid absolute http(s) URL with a host.
+func TestNew_RejectsInvalidBaseURL(t *testing.T) {
+	if _, err := New(testAPIKey, "://nope"); err == nil {
+		t.Fatal("New() accepted an invalid base URL, want error")
+	}
+}
+
+// TestFireworksProvider_Complete_UpstreamError verifies a non-2xx chat response
+// surfaces an error carrying both the HTTP status and the upstream message.
+func TestFireworksProvider_Complete_UpstreamError(t *testing.T) {
+	tests := []struct {
+		name    string
+		status  int
+		message string
+	}{
+		{"rate-limited", http.StatusTooManyRequests, "slow down"},
+		{"server-error", http.StatusInternalServerError, "internal boom"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != testChatPath {
+					t.Errorf("path = %q, want %s", r.URL.Path, testChatPath)
+				}
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(tc.status)
+				_, _ = w.Write([]byte(`{"error":{"message":"` + tc.message + `"}}`))
+			}))
+			defer srv.Close()
+
+			p, _ := New(testAPIKey, srv.URL)
+			_, err := p.Complete(context.Background(), core.Request{
+				Model:    testChatModel,
+				Messages: []core.Message{{Role: "user", Content: "Hi"}},
+			})
+			if err == nil {
+				t.Fatal("Complete() error = nil, want upstream error")
+			}
+			if got := core.ParseStatusCode(err); got != tc.status {
+				t.Errorf("ParseStatusCode(err) = %d, want %d", got, tc.status)
+			}
+			if !strings.Contains(err.Error(), tc.message) {
+				t.Errorf("error = %v, want it to contain %q", err, tc.message)
+			}
+		})
+	}
+}
+
+// TestFireworksProvider_DiscoverModels verifies live discovery issues a GET to
+// /v1/models with bearer auth and parses the returned model metadata.
+func TestFireworksProvider_DiscoverModels(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("method = %q, want GET", r.Method)
+		}
+		if r.URL.Path != "/v1/models" {
+			t.Errorf("path = %q, want /v1/models", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != testBearerAPIKey {
+			t.Errorf("Authorization = %q, want %s", got, testBearerAPIKey)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"object":"list","data":[{"id":"` + testChatModel + `","object":"model","created":1700000000,"owned_by":"fireworks"}]}`))
+	}))
+	defer srv.Close()
+
+	p, _ := New(testAPIKey, srv.URL)
+	models, err := p.DiscoverModels(context.Background())
+	if err != nil {
+		t.Fatalf("DiscoverModels() error: %v", err)
+	}
+	if len(models) != 1 {
+		t.Fatalf("expected 1 model, got %d", len(models))
+	}
+	if models[0].ID != testChatModel {
+		t.Errorf("model[0].ID = %q, want %s", models[0].ID, testChatModel)
+	}
+	if models[0].OwnedBy != "fireworks" {
+		t.Errorf("model[0].OwnedBy = %q, want fireworks", models[0].OwnedBy)
+	}
+}

--- a/providers/fireworks/fireworks_test.go
+++ b/providers/fireworks/fireworks_test.go
@@ -17,6 +17,8 @@ const (
 	testAPIKey              = "test-key"
 	testBearerAPIKey        = "Bearer test-key"
 	testChatCompletionsPath = "/chat/completions"
+	testChatPath            = "/v1/chat/completions"
+	testChatModel           = "accounts/fireworks/models/llama-v3p1-8b-instruct"
 	testEmbeddingModel      = "accounts/fireworks/models/qwen3-embedding-0p6b"
 )
 
@@ -87,7 +89,8 @@ func TestFireworksProvider_CompleteStream_MockSSE(t *testing.T) {
 		"data: {\"id\":\"cmpl-1\",\"model\":\"accounts/fireworks/models/llama-v3p1-8b-instruct\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n" +
 		"data: [DONE]\n\n"
 
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assertFireworksChatRequest(t, r)
 		w.Header().Set("Content-Type", "text/event-stream")
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte(sseData))
@@ -96,7 +99,7 @@ func TestFireworksProvider_CompleteStream_MockSSE(t *testing.T) {
 
 	p, _ := New("test-key", srv.URL)
 	ch, err := p.CompleteStream(context.Background(), core.Request{
-		Model:    "accounts/fireworks/models/llama-v3p1-8b-instruct",
+		Model:    testChatModel,
 		Messages: []core.Message{{Role: "user", Content: "Hi"}},
 	})
 	if err != nil {
@@ -122,7 +125,8 @@ func TestFireworksProvider_CompleteStream_MockSSE(t *testing.T) {
 func TestFireworksProvider_Complete_MockHTTP(t *testing.T) {
 	respBody := `{"id":"cmpl-1","model":"accounts/fireworks/models/llama-v3p1-8b-instruct","choices":[{"index":0,"message":{"role":"assistant","content":"Hello!"},"finish_reason":"stop"}],"usage":{"prompt_tokens":5,"completion_tokens":2,"total_tokens":7}}`
 
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assertFireworksChatRequest(t, r)
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte(respBody))
@@ -131,7 +135,7 @@ func TestFireworksProvider_Complete_MockHTTP(t *testing.T) {
 
 	p, _ := New("test-key", srv.URL)
 	resp, err := p.Complete(context.Background(), core.Request{
-		Model:    "accounts/fireworks/models/llama-v3p1-8b-instruct",
+		Model:    testChatModel,
 		Messages: []core.Message{{Role: "user", Content: "Hi"}},
 	})
 	if err != nil {
@@ -142,6 +146,29 @@ func TestFireworksProvider_Complete_MockHTTP(t *testing.T) {
 	}
 	if len(resp.Choices) == 0 {
 		t.Error("expected at least one choice")
+	}
+}
+
+// assertFireworksChatRequest verifies the outbound chat request shape: a POST to
+// /v1/chat/completions carrying bearer auth and the forwarded model field.
+func assertFireworksChatRequest(t *testing.T, r *http.Request) {
+	t.Helper()
+	if r.Method != http.MethodPost {
+		t.Errorf("method = %s, want POST", r.Method)
+	}
+	if r.URL.Path != testChatPath {
+		t.Errorf("path = %q, want %s", r.URL.Path, testChatPath)
+	}
+	if got := r.Header.Get("Authorization"); got != testBearerAPIKey {
+		t.Errorf("Authorization = %q, want %s", got, testBearerAPIKey)
+	}
+	var body map[string]any
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		t.Errorf("failed to decode request body: %v", err)
+		return
+	}
+	if got := body["model"]; got != testChatModel {
+		t.Errorf("model = %v, want %s", got, testChatModel)
 	}
 }
 

--- a/providers/groq/groq.go
+++ b/providers/groq/groq.go
@@ -3,9 +3,7 @@ package groq
 
 import (
 	"context"
-	"fmt"
 	"net/http"
-	"net/url"
 	"strings"
 
 	"github.com/ferro-labs/ai-gateway/internal/discovery"
@@ -39,14 +37,14 @@ var (
 
 // New creates a new Groq provider.
 func New(apiKey, baseURL string) (*Provider, error) {
+	baseURL = strings.TrimSpace(baseURL)
 	if baseURL == "" {
 		baseURL = defaultBaseURL
 	}
-	baseURL = strings.TrimRight(baseURL, "/")
-	u, err := url.Parse(baseURL)
-	if err != nil || (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
-		return nil, fmt.Errorf("groq: invalid base URL %q: must be http or https with a host", baseURL)
+	if err := core.ValidateBaseURL(Name, baseURL); err != nil {
+		return nil, err
 	}
+	baseURL = strings.TrimRight(baseURL, "/")
 	return &Provider{
 		name:       Name,
 		apiKey:     apiKey,
@@ -71,8 +69,8 @@ func (p *Provider) SupportedModels() []string {
 	return []string{
 		"llama-3.3-70b-versatile",
 		"llama-3.1-8b-instant",
-		"mixtral-8x7b-32768",
-		"gemma2-9b-it",
+		"openai/gpt-oss-120b",
+		"openai/gpt-oss-20b",
 	}
 }
 
@@ -93,6 +91,8 @@ func (p *Provider) DiscoverModels(ctx context.Context) ([]core.ModelInfo, error)
 
 // Complete sends a chat completion request to Groq.
 func (p *Provider) Complete(ctx context.Context, req core.Request) (*core.Response, error) {
+	// Forward only the modern max_completion_tokens (mirrors the OpenAI surface).
+	req.PreferCompletionTokens()
 	return openaicompat.PostChat(ctx, openaicompat.ChatParams{
 		HTTPClient: p.httpClient,
 		URL:        p.baseURL + "/v1/chat/completions",
@@ -104,6 +104,8 @@ func (p *Provider) Complete(ctx context.Context, req core.Request) (*core.Respon
 
 // CompleteStream sends a streaming chat completion request to Groq.
 func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan core.StreamChunk, error) {
+	// Forward only the modern max_completion_tokens (mirrors the OpenAI surface).
+	req.PreferCompletionTokens()
 	return openaicompat.PostStream(ctx, openaicompat.ChatParams{
 		HTTPClient: p.httpClient,
 		URL:        p.baseURL + "/v1/chat/completions",

--- a/providers/groq/groq_p4_test.go
+++ b/providers/groq/groq_p4_test.go
@@ -1,0 +1,52 @@
+package groq
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/ferro-labs/ai-gateway/providers/core"
+)
+
+// TestGroqProvider_Complete_PrefersMaxCompletionTokens verifies that when the
+// gateway seam populates both token-limit fields, groq forwards only the modern
+// max_completion_tokens.
+func TestGroqProvider_Complete_PrefersMaxCompletionTokens(t *testing.T) {
+	var captured map[string]json.RawMessage
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(b, &captured)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"id":"x","model":"m","choices":[{"index":0,"message":{"role":"assistant","content":"hi"},"finish_reason":"stop"}],"usage":{}}`)
+	}))
+	defer srv.Close()
+
+	p, err := New("test-key", srv.URL)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if _, err := p.Complete(context.Background(), core.Request{
+		Model:               "llama-3.1-8b-instant",
+		Messages:            []core.Message{{Role: core.RoleUser, Content: "hi"}},
+		MaxTokens:           intp(64),
+		MaxCompletionTokens: intp(64),
+	}); err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	if _, ok := captured["max_tokens"]; ok {
+		t.Errorf("body contains max_tokens, want only max_completion_tokens")
+	}
+	if _, ok := captured["max_completion_tokens"]; !ok {
+		t.Error("body missing max_completion_tokens")
+	}
+}
+
+// TestNewGroq_RejectsInvalidBaseURL locks in the shared base-URL validation.
+func TestNewGroq_RejectsInvalidBaseURL(t *testing.T) {
+	if _, err := New("k", "://bad"); err == nil {
+		t.Fatal("New accepted an invalid base URL")
+	}
+}

--- a/providers/groq/groq_test.go
+++ b/providers/groq/groq_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -99,6 +100,78 @@ func TestGroqProvider_CompleteStream_MockSSE(t *testing.T) {
 	}
 	if chunks[2].Choices[0].Delta.Content != " there" {
 		t.Errorf("delta content = %q, want ' there'", chunks[2].Choices[0].Delta.Content)
+	}
+}
+
+func TestGroqProvider_Complete_ParamsAndAuth(t *testing.T) {
+	var gotPath, gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"chatcmpl-1","model":"llama-3.1-8b-instant","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":5,"completion_tokens":1,"total_tokens":6}}`))
+	}))
+	defer srv.Close()
+
+	p, _ := New("test-key", srv.URL)
+	resp, err := p.Complete(context.Background(), core.Request{
+		Model:    "llama-3.1-8b-instant",
+		Messages: []core.Message{{Role: "user", Content: "Hi"}},
+	})
+	if err != nil {
+		t.Fatalf("Complete() error: %v", err)
+	}
+	if gotPath != "/v1/chat/completions" {
+		t.Errorf("request path = %q, want /v1/chat/completions", gotPath)
+	}
+	if gotAuth != "Bearer test-key" {
+		t.Errorf("Authorization = %q, want Bearer test-key", gotAuth)
+	}
+	if resp.ID != "chatcmpl-1" {
+		t.Errorf("Response.ID = %q, want chatcmpl-1", resp.ID)
+	}
+}
+
+func TestGroqProvider_Complete_ErrorStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"error":{"message":"rate limited"}}`))
+	}))
+	defer srv.Close()
+
+	p, _ := New("test-key", srv.URL)
+	_, err := p.Complete(context.Background(), core.Request{
+		Model:    "llama-3.1-8b-instant",
+		Messages: []core.Message{{Role: "user", Content: "Hi"}},
+	})
+	if err == nil {
+		t.Fatal("Complete() expected error on 429, got nil")
+	}
+	if !strings.Contains(err.Error(), "groq API error (429)") {
+		t.Errorf("error = %q, want it to contain %q", err.Error(), "groq API error (429)")
+	}
+}
+
+func TestGroqProvider_CompleteStream_ErrorStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":{"message":"boom"}}`))
+	}))
+	defer srv.Close()
+
+	p, _ := New("test-key", srv.URL)
+	_, err := p.CompleteStream(context.Background(), core.Request{
+		Model:    "llama-3.1-8b-instant",
+		Messages: []core.Message{{Role: "user", Content: "Hi"}},
+	})
+	if err == nil {
+		t.Fatal("CompleteStream() expected error on 500, got nil")
+	}
+	if !strings.Contains(err.Error(), "groq API error (500)") {
+		t.Errorf("error = %q, want it to contain %q", err.Error(), "groq API error (500)")
 	}
 }
 

--- a/providers/mistral/embedding.go
+++ b/providers/mistral/embedding.go
@@ -8,15 +8,39 @@ import (
 	"github.com/ferro-labs/ai-gateway/providers/core"
 )
 
+// mistralEmbeddingBody reshapes the OpenAI-shaped embeddings body for Mistral,
+// which expects "output_dimension" instead of the standard "dimensions" field.
+type mistralEmbeddingBody struct {
+	Model           string `json:"model"`
+	Input           any    `json:"input"`
+	EncodingFormat  string `json:"encoding_format,omitempty"`
+	OutputDimension *int   `json:"output_dimension,omitempty"`
+	User            string `json:"user,omitempty"`
+}
+
+// mistralEmbeddingTransform maps core.EmbeddingRequest onto Mistral's embeddings
+// body, renaming dimensions → output_dimension. input is the normalized wire
+// form (string or []string) produced by the shared helper.
+func mistralEmbeddingTransform(req core.EmbeddingRequest, input any) any {
+	return mistralEmbeddingBody{
+		Model:           req.Model,
+		Input:           input,
+		EncodingFormat:  req.EncodingFormat,
+		OutputDimension: req.Dimensions,
+		User:            req.User,
+	}
+}
+
 // Embed sends an OpenAI-compatible embedding request to Mistral.
 func (p *Provider) Embed(ctx context.Context, req core.EmbeddingRequest) (*core.EmbeddingResponse, error) {
 	if req.EncodingFormat != "" && req.EncodingFormat != "float" {
 		return nil, fmt.Errorf("embed: unsupported encoding_format %q; valid value is \"float\"", req.EncodingFormat)
 	}
 	return openaicompat.PostEmbeddings(ctx, openaicompat.EmbeddingParams{
-		HTTPClient: p.httpClient,
-		URL:        p.baseURL + "/v1/embeddings",
-		Headers:    map[string]string{"Authorization": "Bearer " + p.apiKey, "Content-Type": "application/json"},
-		Label:      "mistral",
+		HTTPClient:    p.httpClient,
+		URL:           p.baseURL + "/v1/embeddings",
+		Headers:       map[string]string{"Authorization": "Bearer " + p.apiKey, "Content-Type": "application/json"},
+		Label:         "mistral",
+		BodyTransform: mistralEmbeddingTransform,
 	}, req)
 }

--- a/providers/mistral/mistral.go
+++ b/providers/mistral/mistral.go
@@ -38,8 +38,11 @@ var (
 
 // New creates a new Mistral provider.
 func New(apiKey, baseURL string) (*Provider, error) {
+	baseURL = strings.TrimSpace(baseURL)
 	if baseURL == "" {
 		baseURL = defaultBaseURL
+	} else if err := core.ValidateBaseURL(Name, baseURL); err != nil {
+		return nil, err
 	}
 	baseURL = strings.TrimRight(baseURL, "/")
 	return &Provider{
@@ -94,24 +97,49 @@ func (p *Provider) DiscoverModels(ctx context.Context) ([]core.ModelInfo, error)
 	return discovery.DiscoverOpenAICompatibleModels(ctx, p.httpClient, p.baseURL+"/v1/models", p.apiKey, p.name)
 }
 
+// mistralChatBody reshapes the OpenAI-shaped chat body for Mistral's API, which
+// ignores the standard "seed" field and instead honours "random_seed". The
+// embedded core.Request forwards every other OpenAI field unchanged. The Seed
+// field shadows the promoted core.Request.Seed at a shallower depth and is left
+// nil (omitempty) so "seed" is never emitted on the wire; RandomSeed carries the
+// value under Mistral's expected key.
+//
+// A json:"-" shadow does not work here: encoding/json drops "-" fields entirely,
+// so the promoted core.Request.Seed would still be emitted. A same-named field
+// that dominates by depth and is omitted via omitempty is what actually
+// suppresses it (verified by TestMistralProvider_Complete_SeedRewrite).
+type mistralChatBody struct {
+	core.Request
+	Seed       *int64 `json:"seed,omitempty"`        // shadows core.Request.Seed; always nil so "seed" is suppressed
+	RandomSeed *int64 `json:"random_seed,omitempty"` // Mistral's seed field
+}
+
+// mistralChatTransform maps core.Request onto Mistral's chat body, renaming
+// seed → random_seed.
+func mistralChatTransform(req core.Request) any {
+	return mistralChatBody{Request: req, RandomSeed: req.Seed}
+}
+
 // Complete sends a chat completion request to Mistral.
 func (p *Provider) Complete(ctx context.Context, req core.Request) (*core.Response, error) {
 	return openaicompat.PostChat(ctx, openaicompat.ChatParams{
-		HTTPClient: p.httpClient,
-		URL:        p.baseURL + "/v1/chat/completions",
-		Provider:   p.name,
-		Label:      "mistral",
-		Headers:    map[string]string{"Authorization": "Bearer " + p.apiKey, "Content-Type": "application/json"},
+		HTTPClient:    p.httpClient,
+		URL:           p.baseURL + "/v1/chat/completions",
+		Provider:      p.name,
+		Label:         "mistral",
+		Headers:       map[string]string{"Authorization": "Bearer " + p.apiKey, "Content-Type": "application/json"},
+		BodyTransform: mistralChatTransform,
 	}, req)
 }
 
 // CompleteStream sends a streaming chat completion request to Mistral.
 func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan core.StreamChunk, error) {
 	return openaicompat.PostStream(ctx, openaicompat.ChatParams{
-		HTTPClient: p.httpClient,
-		URL:        p.baseURL + "/v1/chat/completions",
-		Provider:   p.name,
-		Label:      "mistral",
-		Headers:    map[string]string{"Authorization": "Bearer " + p.apiKey, "Content-Type": "application/json"},
+		HTTPClient:    p.httpClient,
+		URL:           p.baseURL + "/v1/chat/completions",
+		Provider:      p.name,
+		Label:         "mistral",
+		Headers:       map[string]string{"Authorization": "Bearer " + p.apiKey, "Content-Type": "application/json"},
+		BodyTransform: mistralChatTransform,
 	}, req)
 }

--- a/providers/mistral/mistral_test.go
+++ b/providers/mistral/mistral_test.go
@@ -139,6 +139,158 @@ func TestMistralProvider_CompleteStream_MockSSE(t *testing.T) {
 	}
 }
 
+func TestMistralProvider_Complete_Success_MockHTTP(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+		if r.URL.Path != "/v1/chat/completions" {
+			t.Errorf("path = %q, want /v1/chat/completions", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-key" {
+			t.Errorf("Authorization = %q, want Bearer test-key", got)
+		}
+		if got := r.Header.Get("Content-Type"); got != "application/json" {
+			t.Errorf("Content-Type = %q, want application/json", got)
+		}
+
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode request body: %v", err)
+		}
+		if got := body["model"]; got != "mistral-large-latest" {
+			t.Errorf("model = %v, want mistral-large-latest", got)
+		}
+		msgs, ok := body["messages"].([]any)
+		if !ok || len(msgs) != 1 {
+			t.Fatalf("messages = %#v, want 1-element array", body["messages"])
+		}
+		if m0, _ := msgs[0].(map[string]any); m0["role"] != "user" || m0["content"] != "Hi" {
+			t.Errorf("messages[0] = %#v, want {role:user, content:Hi}", msgs[0])
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		// finish_reason "model_length" exercises the shared normalization to "length".
+		_, _ = w.Write([]byte(`{"id":"chatcmpl-abc","object":"chat.completion","model":"mistral-large-latest","choices":[{"index":0,"message":{"role":"assistant","content":"Hello!"},"finish_reason":"model_length"}],"usage":{"prompt_tokens":5,"completion_tokens":2,"total_tokens":7}}`))
+	}))
+	defer srv.Close()
+
+	p, _ := New("test-key", srv.URL)
+	resp, err := p.Complete(context.Background(), core.Request{
+		Model:    "mistral-large-latest",
+		Messages: []core.Message{{Role: "user", Content: "Hi"}},
+	})
+	if err != nil {
+		t.Fatalf("Complete() error: %v", err)
+	}
+	if resp.ID != "chatcmpl-abc" {
+		t.Errorf("ID = %q, want chatcmpl-abc", resp.ID)
+	}
+	if resp.Model != "mistral-large-latest" {
+		t.Errorf("Model = %q, want mistral-large-latest", resp.Model)
+	}
+	if resp.Provider != "mistral" {
+		t.Errorf("Provider = %q, want mistral", resp.Provider)
+	}
+	if len(resp.Choices) != 1 {
+		t.Fatalf("Choices length = %d, want 1", len(resp.Choices))
+	}
+	if resp.Choices[0].Message.Content != "Hello!" {
+		t.Errorf("Choices[0].Message.Content = %q, want Hello!", resp.Choices[0].Message.Content)
+	}
+	if resp.Choices[0].FinishReason != "length" {
+		t.Errorf("Choices[0].FinishReason = %q, want length (normalized from model_length)", resp.Choices[0].FinishReason)
+	}
+	if resp.Usage.PromptTokens != 5 || resp.Usage.CompletionTokens != 2 || resp.Usage.TotalTokens != 7 {
+		t.Errorf("Usage = %+v, want prompt=5 completion=2 total=7", resp.Usage)
+	}
+}
+
+func TestMistralProvider_Complete_UpstreamError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/chat/completions" {
+			t.Errorf("path = %q, want /v1/chat/completions", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":{"message":"invalid model","type":"invalid_request_error"}}`))
+	}))
+	defer srv.Close()
+
+	p, _ := New("test-key", srv.URL)
+	_, err := p.Complete(context.Background(), core.Request{
+		Model:    "bogus-model",
+		Messages: []core.Message{{Role: "user", Content: "Hi"}},
+	})
+	if err == nil {
+		t.Fatal("Complete() error = nil, want upstream error")
+	}
+	if !strings.Contains(err.Error(), "invalid model") {
+		t.Fatalf("error = %v, want invalid model message", err)
+	}
+}
+
+func TestMistralProvider_Complete_SeedRewrite(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("failed to decode request body: %v", err)
+		}
+		if _, ok := body["seed"]; ok {
+			t.Errorf("body contains %q, want it suppressed in favor of random_seed", "seed")
+		}
+		if got := body["random_seed"]; got != float64(42) {
+			t.Errorf("random_seed = %#v, want 42", got)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"chatcmpl-1","model":"mistral-large-latest","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`))
+	}))
+	defer srv.Close()
+
+	seed := int64(42)
+	p, _ := New("test-key", srv.URL)
+	if _, err := p.Complete(context.Background(), core.Request{
+		Model:    "mistral-large-latest",
+		Messages: []core.Message{{Role: "user", Content: "Hi"}},
+		Seed:     &seed,
+	}); err != nil {
+		t.Fatalf("Complete() error: %v", err)
+	}
+}
+
+func TestMistralProvider_Embed_DimensionsRewrite(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("failed to decode request body: %v", err)
+		}
+		if _, ok := body["dimensions"]; ok {
+			t.Errorf("body contains %q, want it renamed to output_dimension", "dimensions")
+		}
+		if got := body["output_dimension"]; got != float64(256) {
+			t.Errorf("output_dimension = %#v, want 256", got)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"object":"list","data":[{"object":"embedding","embedding":[0.1,0.2],"index":0}],"model":"` + testEmbeddingModel + `","usage":{"prompt_tokens":1,"total_tokens":1}}`))
+	}))
+	defer srv.Close()
+
+	dims := 256
+	p, _ := New("test-key", srv.URL)
+	if _, err := p.Embed(context.Background(), core.EmbeddingRequest{
+		Model:      testEmbeddingModel,
+		Input:      "hello",
+		Dimensions: &dims,
+	}); err != nil {
+		t.Fatalf("Embed() error: %v", err)
+	}
+}
+
 func TestMistralProvider_Embed_Interface(_ *testing.T) {
 	p, _ := New("test-key", "")
 	var _ core.EmbeddingProvider = p

--- a/providers/providers_list.go
+++ b/providers/providers_list.go
@@ -187,7 +187,7 @@ var allProviders = []ProviderEntry{
 	},
 	{
 		ID:           NameDeepSeek,
-		Capabilities: []string{CapabilityChat, CapabilityStream, CapabilityProxy},
+		Capabilities: []string{CapabilityChat, CapabilityStream, CapabilityDiscovery, CapabilityProxy},
 		EnvMappings: []EnvMapping{
 			{CfgKeyAPIKey, "DEEPSEEK_API_KEY", true},
 			{CfgKeyBaseURL, "DEEPSEEK_BASE_URL", false},

--- a/providers/together/embedding.go
+++ b/providers/together/embedding.go
@@ -16,7 +16,7 @@ func (p *Provider) Embed(ctx context.Context, req core.EmbeddingRequest) (*core.
 	return openaicompat.PostEmbeddings(ctx, openaicompat.EmbeddingParams{
 		HTTPClient: p.httpClient,
 		URL:        p.baseURL + "/v1/embeddings",
-		Headers:    map[string]string{"Authorization": "Bearer " + p.apiKey, "Content-Type": "application/json"},
+		Headers:    p.headers(),
 		Label:      "together",
 	}, req)
 }

--- a/providers/together/together.go
+++ b/providers/together/together.go
@@ -3,9 +3,7 @@ package together
 
 import (
 	"context"
-	"fmt"
 	"net/http"
-	"net/url"
 	"strings"
 
 	"github.com/ferro-labs/ai-gateway/internal/discovery"
@@ -17,8 +15,11 @@ import (
 const (
 	// Name is the canonical identifier for the Together AI provider.
 	// Re-exported as providers.NameTogether in providers/names.go.
-	Name           = "together"
-	defaultBaseURL = "https://api.together.xyz"
+	Name = "together"
+	// defaultBaseURL is Together AI's current documented API domain. Users
+	// pinned to the legacy api.together.xyz host can override it via New's
+	// baseURL argument.
+	defaultBaseURL = "https://api.together.ai"
 )
 
 // Provider implements the core.Provider interface for Together AI.
@@ -40,13 +41,13 @@ var (
 
 // New creates a new Together AI provider.
 func New(apiKey, baseURL string) (*Provider, error) {
+	baseURL = strings.TrimSpace(baseURL)
 	if baseURL == "" {
 		baseURL = defaultBaseURL
 	}
 	baseURL = strings.TrimRight(baseURL, "/")
-	u, err := url.Parse(baseURL)
-	if err != nil || (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
-		return nil, fmt.Errorf("together: invalid base URL %q: must be http or https with a host", baseURL)
+	if err := core.ValidateBaseURL(Name, baseURL); err != nil {
+		return nil, err
 	}
 	return &Provider{
 		name:       Name,
@@ -54,6 +55,14 @@ func New(apiKey, baseURL string) (*Provider, error) {
 		baseURL:    baseURL,
 		httpClient: providerhttp.ForProvider(Name),
 	}, nil
+}
+
+// headers returns the auth and content-type headers for Together AI requests.
+func (p *Provider) headers() map[string]string {
+	return map[string]string{
+		"Authorization": "Bearer " + p.apiKey,
+		"Content-Type":  "application/json",
+	}
 }
 
 // Name implements core.Provider.
@@ -105,7 +114,7 @@ func (p *Provider) Complete(ctx context.Context, req core.Request) (*core.Respon
 		URL:        p.baseURL + "/v1/chat/completions",
 		Provider:   p.name,
 		Label:      "together",
-		Headers:    map[string]string{"Authorization": "Bearer " + p.apiKey, "Content-Type": "application/json"},
+		Headers:    p.headers(),
 	}, req)
 }
 
@@ -116,6 +125,6 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 		URL:        p.baseURL + "/v1/chat/completions",
 		Provider:   p.name,
 		Label:      "together",
-		Headers:    map[string]string{"Authorization": "Bearer " + p.apiKey, "Content-Type": "application/json"},
+		Headers:    p.headers(),
 	}, req)
 }

--- a/providers/together/together_p4_test.go
+++ b/providers/together/together_p4_test.go
@@ -1,0 +1,22 @@
+package together
+
+import "testing"
+
+// TestNewTogether_DefaultDomain verifies the zero-value base URL resolves to the
+// current api.together.ai host (migrated from the legacy .xyz domain).
+func TestNewTogether_DefaultDomain(t *testing.T) {
+	p, err := New("test-key", "")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if got := p.BaseURL(); got != "https://api.together.ai" {
+		t.Errorf("default BaseURL() = %q, want https://api.together.ai", got)
+	}
+}
+
+// TestNewTogether_RejectsInvalidBaseURL locks in the shared base-URL validation.
+func TestNewTogether_RejectsInvalidBaseURL(t *testing.T) {
+	if _, err := New("k", "://bad"); err == nil {
+		t.Fatal("New accepted an invalid base URL")
+	}
+}

--- a/providers/together/together_test.go
+++ b/providers/together/together_test.go
@@ -5,12 +5,10 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"reflect"
 	"strings"
 	"sync/atomic"
 	"testing"
-	"time"
 
 	"github.com/ferro-labs/ai-gateway/providers/core"
 )
@@ -143,28 +141,93 @@ func TestTogetherProvider_CompleteStream_MockSSE(t *testing.T) {
 	}
 }
 
-func TestTogetherProvider_Complete_Integration(t *testing.T) {
-	apiKey := os.Getenv("TOGETHER_API_KEY")
-	if apiKey == "" {
-		t.Skip("Skipping: TOGETHER_API_KEY not set")
-	}
+func TestTogetherProvider_Complete_MockHTTP(t *testing.T) {
+	const model = "meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+		if r.URL.Path != "/v1/chat/completions" {
+			t.Errorf("path = %q, want /v1/chat/completions", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-key" {
+			t.Errorf("Authorization = %q, want Bearer test-key", got)
+		}
+		if got := r.Header.Get("Content-Type"); got != "application/json" {
+			t.Errorf("Content-Type = %q, want application/json", got)
+		}
 
-	p, _ := New(apiKey, "")
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode request body: %v", err)
+		}
+		if got := body["model"]; got != model {
+			t.Errorf("model = %v, want %s", got, model)
+		}
 
-	resp, err := p.Complete(ctx, core.Request{
-		Model:     "meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo",
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"cmpl-42","object":"chat.completion","model":"` + model + `","choices":[{"index":0,"message":{"role":"assistant","content":"test ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":5,"completion_tokens":2,"total_tokens":7}}`))
+	}))
+	defer srv.Close()
+
+	p, _ := New("test-key", srv.URL)
+	resp, err := p.Complete(context.Background(), core.Request{
+		Model:     model,
 		Messages:  []core.Message{{Role: "user", Content: "Say 'test ok' and nothing else."}},
 		MaxTokens: intPtr(10),
 	})
 	if err != nil {
 		t.Fatalf("Complete() error: %v", err)
 	}
-	if resp.ID == "" {
-		t.Error("Response ID is empty")
+	if resp.ID != "cmpl-42" {
+		t.Errorf("ID = %q, want cmpl-42", resp.ID)
 	}
-	t.Logf("Response: %+v", resp)
+	if resp.Model != model {
+		t.Errorf("Model = %q, want %s", resp.Model, model)
+	}
+	if len(resp.Choices) != 1 {
+		t.Fatalf("Choices length = %d, want 1", len(resp.Choices))
+	}
+	if resp.Choices[0].Message.Content != "test ok" {
+		t.Errorf("content = %q, want test ok", resp.Choices[0].Message.Content)
+	}
+	if resp.Choices[0].FinishReason != "stop" {
+		t.Errorf("finish_reason = %q, want stop", resp.Choices[0].FinishReason)
+	}
+	if resp.Usage.TotalTokens != 7 {
+		t.Errorf("Usage.TotalTokens = %d, want 7", resp.Usage.TotalTokens)
+	}
+}
+
+func TestTogetherProvider_Complete_UpstreamError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/chat/completions" {
+			t.Errorf("path = %q, want /v1/chat/completions", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"error":{"message":"rate limited","type":"rate_limit"}}`))
+	}))
+	defer srv.Close()
+
+	p, _ := New("test-key", srv.URL)
+	_, err := p.Complete(context.Background(), core.Request{
+		Model:    "meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo",
+		Messages: []core.Message{{Role: "user", Content: "Hi"}},
+	})
+	if err == nil {
+		t.Fatal("Complete() error = nil, want upstream error")
+	}
+	if !strings.Contains(err.Error(), "together API error (429)") {
+		t.Errorf("error = %q, want it to contain %q", err.Error(), "together API error (429)")
+	}
+	if !strings.Contains(err.Error(), "rate limited") {
+		t.Errorf("error = %q, want upstream message %q", err.Error(), "rate limited")
+	}
+	if got := core.ParseStatusCode(err); got != 429 {
+		t.Errorf("ParseStatusCode = %d, want 429", got)
+	}
 }
 
 func intPtr(i int) *int { return &i }


### PR DESCRIPTION
## v1.1.13 — OpenAI-Compat Providers I

The fourth provider-readiness remediation phase. Aligns six OpenAI-compatible "thin" providers — **Mistral, DeepSeek, Together, Fireworks, Cerebras, Groq** — on request/response correctness, and lands two shared improvements that benefit **every** OpenAI-compatible provider. No breaking API changes relative to v1.1.12.

### Shared foundation (benefits all ~20 openaicompat providers)

- **`stream_options.include_usage` forwarding** — new `core.Request.StreamOptions`; the shared streaming path defaults `include_usage: true` (only when the caller hasn't set it), so providers that gate the terminal usage chunk on that flag now report streaming token usage.
- **finish_reason normalization** — the shared `PostChat` and stream decoders run every `finish_reason` through `core.NormalizeFinishReason` (e.g. Mistral's `model_length` → `length`).
- **`BodyTransform` hook** — an optional reshape point on the chat/embed helpers so a provider can rename wire fields (Mistral's `seed`→`random_seed`, `dimensions`→`output_dimension`) **while keeping** the shared decode/error/normalization — no hand-rolled request path, no drift. Nil-default preserves prior behavior exactly.

### Provider verticals

| Provider | Changes |
|---|---|
| **deepseek** (HIGH) | +`deepseek-v4-flash`/`-pro`; wired live `/models` discovery + `CapabilityDiscovery`; errors → `core.APIError`; finish_reason normalized on **both** paths; `/v1` trailing-trim; base-URL validation |
| **groq** | catalog refresh (dropped decommissioned `mixtral-8x7b-32768`/`gemma2-9b-it`, added `openai/gpt-oss-120b`/`-20b`); `core.ValidateBaseURL`; `PreferCompletionTokens`; error + auth wire tests |
| **mistral** | `seed`→`random_seed`, `dimensions`→`output_dimension` (via `BodyTransform`); base-URL validation; wire + error tests |
| **cerebras** | base-URL validation; `PreferCompletionTokens` (+ wire assert); discovery/error/request-body tests |
| **together** | default domain `api.together.xyz` → **`api.together.ai`** (operator-visible; override via `TOGETHER_BASE_URL`); `headers()` helper; `core.ValidateBaseURL`; offline Complete + error tests |
| **fireworks** | `core.ValidateBaseURL`; discovery/error/request-body tests |

### Review outcome

- **go-reviewer: APPROVE** (no CRITICAL/HIGH) — independently reproduced the Mistral json depth-dominance to confirm the `seed` suppression is well-defined Go behavior; confirmed the `StreamOptions` change is local (value-param `req`, only defaults when nil) and finish_reason normalization is idempotent.
- **code-reviewer: 1 HIGH + 4 MED addressed** — the HIGH (deepseek non-streaming path skipped the new finish_reason normalization) is **fixed**; added the missing wire tests for groq `max_completion_tokens` preference, together's default domain, groq/together base-URL rejection, and a direct stream-decoder normalization case.

### Deferred (recorded, not lost)

- **Uniform `/v1` trailing-trim**: deepseek now trims a trailing `/v1` from its base URL to avoid `/v1/v1/...` doubling; the same operator footgun exists for together/fireworks/groq/mistral. Doing it right is a shared `NormalizeBaseURL` helper adopted fleet-wide — tracked as a foundation follow-up rather than scattered per-provider here.
- Roadmap items unchanged from the phase ledger (Responses API surfaces, image generation for fireworks/together, deepseek V4 thinking/reasoning_effort passthrough, cerebras Batch API).

### Test plan

- [x] `go build ./...`, `gofmt`, `golangci-lint` (0 issues)
- [x] `go test -race ./...` — all 71+ packages green
- [x] New wire-level tests assert actual request bodies (seed/random_seed suppression, output_dimension rename, max_completion_tokens preference, stream_options.include_usage) and error-path status/message propagation
- [x] `models` catalog-coverage gate + `providers` stability gate pass (groq/deepseek `models[0]` resolve in the bundled catalog)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added live model discovery for supported providers (including DeepSeek and Cerebras-related updates).
  * Enhanced streaming responses to standardize finish reasons and include terminal usage when enabled.

* **Bug Fixes**
  * Normalized `finish_reason` across chat and streaming for OpenAI-compatible providers.
  * Improved request fidelity for seeds and embeddings (including provider-specific field rewrites).
  * Fixed token-limit forwarding to prefer `max_completion_tokens` where supported.
  * Tightened base URL handling and validation, and updated Together’s default API domain.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->