### PR TITLE
v1.1.14 - OpenAI-Compat Providers II

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@
 - **Unified factory** — `providers/factory.go` holds types/constants; `providers/providers_list.go` holds all built-in `ProviderEntry` records. Auto-registration via `AllProviders()` means `main.go` never needs editing for new providers.
 - **`providers/core/` split** — interfaces in `contracts.go`; shared types split into `chat.go`, `stream.go`, `embedding.go`, `image.go`, `model.go`, `constants.go`, `errors.go`.
 - **Single source of truth for name constants** — `providers/names.go` re-exports `NameXxx` from each subpackage's `const Name`.
-- **`internal/discovery/`** — shared OpenAI-compatible model discovery helper used by fireworks, hugging_face, perplexity, xai.
+- **`internal/discovery/`** — shared OpenAI-compatible model discovery helper used by many OpenAI-compatible providers (fireworks, xai, moonshot, nvidia-nim, novita, …).
 - **Provider coverage** — OpenAI, Anthropic, Gemini, Groq, Bedrock, Vertex AI, Hugging Face, Cerebras, Cloudflare, Databricks, DeepInfra, Moonshot, Novita, NVIDIA NIM, OpenRouter, Qwen, SambaNova, and more.
 - **Built-in OSS plugins** — word filter, max token, response cache, request logger, rate limit, budget.
 - **Admin API** — dashboard, key management, usage stats, request logs, config history/rollback (`internal/admin/handlers.go`).
@@ -138,7 +138,7 @@ ai-gateway/
 | `internal/otel/config.go` | OTel `Config` (endpoint, protocol, sample_ratio, privacy_level, shutdown_grace) + `Validate()` |
 | `internal/redact/redact.go` | `Redactor` applied to span/event error messages |
 | `internal/strategies/strategy.go` | `Strategy` interface |
-| `internal/discovery/openai_compat.go` | `DiscoverOpenAICompatibleModels` — shared by fireworks, hugging_face, perplexity, xai |
+| `internal/discovery/openai_compat.go` | `DiscoverOpenAICompatibleModels` — shared by many OpenAI-compatible providers (fireworks, xai, moonshot, nvidia-nim, …) |
 | `cmd/ferrogw/main.go` | HTTP server setup and entry point |
 | `internal/admin/middleware.go` | Bearer token auth middleware |
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to Ferro Labs AI Gateway are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.1.14] — 2026-07-04
+## [1.1.14] — 2026-07-05
 
 OpenAI-compatible provider fidelity release (part two). The fifth provider-readiness remediation phase aligns the xAI, OpenRouter, Moonshot, NVIDIA NIM, Perplexity, and Novita providers on request/response correctness, and adds shared improvements that benefit every OpenAI-compatible provider. No breaking API changes relative to v1.1.13.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to Ferro Labs AI Gateway are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.14] — 2026-07-04
+
+OpenAI-compatible provider fidelity release (part two). The fifth provider-readiness remediation phase aligns the xAI, OpenRouter, Moonshot, NVIDIA NIM, Perplexity, and Novita providers on request/response correctness, and adds shared improvements that benefit every OpenAI-compatible provider. No breaking API changes relative to v1.1.13.
+
+### Fixed
+
+- **Reasoning & cache token usage** (xAI, OpenRouter, and every OpenAI-compatible provider): usage reported in the nested OpenAI form (`prompt_tokens_details.cached_tokens`, `completion_tokens_details.reasoning_tokens`) is now decoded into the reported token counts on both the chat and streaming paths instead of being dropped.
+- **Perplexity Sonar metadata**: citations, search results, images, and related questions are now surfaced (under a `provider_metadata` response field) instead of being discarded.
+- **Perplexity model discovery**: the always-failing discovery call (it targeted a nonexistent endpoint and returned the wrong model family) is removed; the static Sonar model list is authoritative.
+- **Perplexity model list**: the retired `sonar-reasoning` model is removed (`sonar-reasoning-pro` replaces it).
+- **NVIDIA NIM embeddings**: now route through the shared embeddings path, so errors surface consistently and `input_type` is forwarded.
+- **xAI image responses**: decode into the canonical image response type and route errors through the shared error envelope; the `user` field is now forwarded, and `size`/`quality`/`style` are reported as dropped when a Grok image model ignores them.
+- **parallel_tool_calls**: a client-supplied `parallel_tool_calls` is now forwarded to the provider instead of being dropped at the HTTP boundary.
+
+### Changed
+
+- **Live model discovery** added for Moonshot and NVIDIA NIM (self-updating model lists); the Moonshot and xAI static fallback lists were refreshed.
+- **Base-URL validation** is now enforced at construction for xAI, OpenRouter, Moonshot, NVIDIA NIM, Perplexity, and Novita.
+- **OpenRouter embeddings**: OpenRouter now supports the embeddings endpoint via the shared helper.
+
+---
+
 ## [1.1.13] — 2026-07-04
 
 OpenAI-compatible provider fidelity release (part one). The fourth provider-readiness remediation phase aligns the Mistral, DeepSeek, Together, Fireworks, Cerebras, and Groq providers on request/response correctness, and adds two shared improvements that benefit every OpenAI-compatible provider. No breaking API changes relative to v1.1.12.

--- a/internal/handler/chatrequest.go
+++ b/internal/handler/chatrequest.go
@@ -31,6 +31,7 @@ type routeChatCompletionRequest struct {
 	Stream              bool                      `json:"stream,omitempty"`
 	User                string                    `json:"user,omitempty"`
 	LogitBias           map[string]float64        `json:"logit_bias,omitempty"`
+	ParallelToolCalls   *bool                     `json:"parallel_tool_calls,omitempty"`
 }
 
 type routeChatMessage struct {
@@ -59,7 +60,7 @@ func putRouteChatCompletionRequest(r *routeChatCompletionRequest) {
 	chatRequestPool.Put(r)
 }
 
-// reset clears all 19 fields before returning to the pool.
+// reset clears all 20 fields before returning to the pool.
 // SECURITY: every field must be listed explicitly. Missing a field
 // leaks one tenant's data to another in the multi-tenant gateway.
 func (r *routeChatCompletionRequest) reset() {
@@ -82,6 +83,7 @@ func (r *routeChatCompletionRequest) reset() {
 	r.Stream = false            // field 17: bool
 	r.User = ""                 // field 18: string
 	r.LogitBias = nil           // field 19: map[string]float64
+	r.ParallelToolCalls = nil   // field 20: *bool
 }
 
 // DecodeChatCompletionRequest decodes the JSON body into a providers.Request.
@@ -128,6 +130,7 @@ func DecodeChatCompletionRequest(r io.Reader) (providers.Request, error) {
 		Stream:              wire.Stream,
 		User:                wire.User,
 		LogitBias:           wire.LogitBias,
+		ParallelToolCalls:   wire.ParallelToolCalls,
 	}, nil
 }
 

--- a/internal/handler/chatrequest_test.go
+++ b/internal/handler/chatrequest_test.go
@@ -1,0 +1,32 @@
+package handler
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestDecodeChatCompletionRequest_ParallelToolCalls verifies parallel_tool_calls
+// survives HTTP decode into the request and is forwarded on the wire by the
+// shared marshal.
+func TestDecodeChatCompletionRequest_ParallelToolCalls(t *testing.T) {
+	req, err := DecodeChatCompletionRequest(strings.NewReader(
+		`{"model":"gpt-4","messages":[{"role":"user","content":"hi"}],"parallel_tool_calls":false}`))
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if req.ParallelToolCalls == nil {
+		t.Fatal("parallel_tool_calls not decoded (nil)")
+	}
+	if *req.ParallelToolCalls {
+		t.Errorf("parallel_tool_calls = true, want false")
+	}
+
+	b, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(b), `"parallel_tool_calls":false`) {
+		t.Errorf("marshaled request missing parallel_tool_calls: %s", b)
+	}
+}

--- a/internal/openaicompat/complete.go
+++ b/internal/openaicompat/complete.go
@@ -38,6 +38,11 @@ type ChatParams struct {
 	// response decoding, error handling, and finish_reason normalization. It
 	// receives the request with Stream and StreamOptions already applied.
 	BodyTransform func(core.Request) any
+
+	// ExtraResponseFields, when set, captures these top-level response fields
+	// (e.g. Perplexity's "citations", "search_results") into core.Response.Metadata,
+	// surfacing provider-specific data the canonical response shape doesn't model.
+	ExtraResponseFields []string
 }
 
 func newChatRequest(ctx context.Context, p ChatParams, req core.Request, stream bool) (*http.Response, func(), error) {
@@ -99,13 +104,45 @@ func PostChat(ctx context.Context, p ChatParams, req core.Request) (*core.Respon
 	for i := range pResp.Choices {
 		pResp.Choices[i].FinishReason = core.NormalizeFinishReason(pResp.Choices[i].FinishReason)
 	}
-	return &core.Response{
+	resp := &core.Response{
 		ID:       pResp.ID,
 		Model:    pResp.Model,
 		Provider: p.Provider,
 		Choices:  pResp.Choices,
 		Usage:    pResp.Usage,
-	}, nil
+	}
+	if meta := captureExtraFields(respBody, p.ExtraResponseFields); meta != nil {
+		resp.Metadata = meta
+	}
+	return resp, nil
+}
+
+// captureExtraFields decodes the named top-level response fields into a metadata
+// map, used to surface provider-specific data (e.g. Perplexity citations) that
+// the canonical response shape does not model. Returns nil when nothing matches.
+func captureExtraFields(body []byte, fields []string) map[string]any {
+	if len(fields) == 0 {
+		return nil
+	}
+	var raw map[string]json.RawMessage
+	if json.Unmarshal(body, &raw) != nil {
+		return nil
+	}
+	meta := make(map[string]any, len(fields))
+	for _, k := range fields {
+		rawVal, ok := raw[k]
+		if !ok {
+			continue
+		}
+		var v any
+		if json.Unmarshal(rawVal, &v) == nil {
+			meta[k] = v
+		}
+	}
+	if len(meta) == 0 {
+		return nil
+	}
+	return meta
 }
 
 // PostStream sends a streaming OpenAI-compatible chat completion and returns a

--- a/internal/openaicompat/complete_test.go
+++ b/internal/openaicompat/complete_test.go
@@ -88,3 +88,57 @@ func TestDecodeStreamChunk_NormalizesFinishReason(t *testing.T) {
 		t.Errorf("finish_reason = %q, want length", chunk.Choices[0].FinishReason)
 	}
 }
+
+// TestPostChat_CapturesExtraResponseFields verifies opt-in capture of
+// provider-specific top-level response fields into core.Response.Metadata.
+func TestPostChat_CapturesExtraResponseFields(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"id":"x","model":"sonar","choices":[{"index":0,"message":{"role":"assistant","content":"hi"},"finish_reason":"stop"}],"usage":{"total_tokens":1},"citations":["https://a.example","https://b.example"]}`)
+	}))
+	defer srv.Close()
+
+	resp, err := PostChat(context.Background(), ChatParams{
+		HTTPClient:          srv.Client(),
+		URL:                 srv.URL,
+		Headers:             map[string]string{"Content-Type": "application/json"},
+		Provider:            "test",
+		Label:               "test",
+		ExtraResponseFields: []string{"citations", "search_results"},
+	}, core.Request{Model: "sonar", Messages: []core.Message{{Role: core.RoleUser, Content: "hi"}}})
+	if err != nil {
+		t.Fatalf("PostChat: %v", err)
+	}
+	cits, ok := resp.Metadata["citations"].([]any)
+	if !ok || len(cits) != 2 {
+		t.Fatalf("Metadata[citations] = %#v, want a 2-element slice", resp.Metadata["citations"])
+	}
+	if _, ok := resp.Metadata["search_results"]; ok {
+		t.Error("search_results (absent upstream) must not appear in metadata")
+	}
+}
+
+// TestPostEmbeddings_ForwardsInputType verifies the shared embeddings body now
+// forwards the input_type field.
+func TestPostEmbeddings_ForwardsInputType(t *testing.T) {
+	var body map[string]json.RawMessage
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(b, &body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"object":"list","data":[{"index":0,"embedding":[0.1]}],"model":"m","usage":{}}`)
+	}))
+	defer srv.Close()
+
+	if _, err := PostEmbeddings(context.Background(), EmbeddingParams{
+		HTTPClient: srv.Client(),
+		URL:        srv.URL,
+		Headers:    map[string]string{"Content-Type": "application/json"},
+		Label:      "test",
+	}, core.EmbeddingRequest{Model: "m", Input: "hello", InputType: "query"}); err != nil {
+		t.Fatalf("PostEmbeddings: %v", err)
+	}
+	if got := string(body["input_type"]); got != `"query"` {
+		t.Errorf("input_type = %s, want \"query\"", got)
+	}
+}

--- a/internal/openaicompat/embedding.go
+++ b/internal/openaicompat/embedding.go
@@ -30,6 +30,7 @@ type embeddingBody struct {
 	Input          any    `json:"input"`
 	EncodingFormat string `json:"encoding_format,omitempty"`
 	Dimensions     *int   `json:"dimensions,omitempty"`
+	InputType      string `json:"input_type,omitempty"`
 	User           string `json:"user,omitempty"`
 }
 
@@ -57,6 +58,7 @@ func PostEmbeddings(ctx context.Context, p EmbeddingParams, req core.EmbeddingRe
 		Input:          input,
 		EncodingFormat: req.EncodingFormat,
 		Dimensions:     req.Dimensions,
+		InputType:      req.InputType,
 		User:           req.User,
 	}
 	if p.BodyTransform != nil {

--- a/providers/core/chat.go
+++ b/providers/core/chat.go
@@ -187,6 +187,9 @@ type Request struct {
 	Stream        bool           `json:"stream,omitempty"`
 	StreamOptions *StreamOptions `json:"stream_options,omitempty"`
 
+	// Tools
+	ParallelToolCalls *bool `json:"parallel_tool_calls,omitempty"`
+
 	// Misc
 	User      string             `json:"user,omitempty"`
 	LogitBias map[string]float64 `json:"logit_bias,omitempty"`
@@ -264,6 +267,11 @@ type Response struct {
 	Choices  []Choice `json:"choices"`
 	Usage    Usage    `json:"usage"`
 
+	// Metadata carries provider-specific top-level response fields (e.g.
+	// Perplexity's citations/search_results) captured on request via
+	// ChatParams.ExtraResponseFields. Nil unless requested.
+	Metadata map[string]any `json:"metadata,omitempty"`
+
 	// OverheadMs is the gateway processing overhead in milliseconds
 	// (total latency minus provider call duration). Excluded from JSON
 	// responses; exposed via the X-Gateway-Overhead-Ms response header.
@@ -286,4 +294,33 @@ type Usage struct {
 	ReasoningTokens  int `json:"reasoning_tokens,omitempty"`
 	CacheReadTokens  int `json:"cache_read_tokens,omitempty"`
 	CacheWriteTokens int `json:"cache_write_tokens,omitempty"`
+}
+
+// UnmarshalJSON decodes the OpenAI usage object, folding the nested
+// prompt_tokens_details.cached_tokens and completion_tokens_details.reasoning_tokens
+// into the flat CacheReadTokens/ReasoningTokens fields so providers that report
+// usage in the nested form (OpenRouter, xAI, …) surface it consistently. An
+// explicit flat field takes precedence when both are present.
+func (u *Usage) UnmarshalJSON(data []byte) error {
+	type usageAlias Usage // avoid recursing into this method
+	var raw struct {
+		usageAlias
+		PromptTokensDetails *struct {
+			CachedTokens int `json:"cached_tokens"`
+		} `json:"prompt_tokens_details"`
+		CompletionTokensDetails *struct {
+			ReasoningTokens int `json:"reasoning_tokens"`
+		} `json:"completion_tokens_details"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	*u = Usage(raw.usageAlias)
+	if u.CacheReadTokens == 0 && raw.PromptTokensDetails != nil {
+		u.CacheReadTokens = raw.PromptTokensDetails.CachedTokens
+	}
+	if u.ReasoningTokens == 0 && raw.CompletionTokensDetails != nil {
+		u.ReasoningTokens = raw.CompletionTokensDetails.ReasoningTokens
+	}
+	return nil
 }

--- a/providers/core/chat.go
+++ b/providers/core/chat.go
@@ -269,8 +269,10 @@ type Response struct {
 
 	// Metadata carries provider-specific top-level response fields (e.g.
 	// Perplexity's citations/search_results) captured on request via
-	// ChatParams.ExtraResponseFields. Nil unless requested.
-	Metadata map[string]any `json:"metadata,omitempty"`
+	// ChatParams.ExtraResponseFields. Serialized under "provider_metadata" (not
+	// "metadata", which OpenAI reserves for client-supplied tags). Nil unless
+	// requested.
+	Metadata map[string]any `json:"provider_metadata,omitempty"`
 
 	// OverheadMs is the gateway processing overhead in milliseconds
 	// (total latency minus provider call duration). Excluded from JSON
@@ -299,8 +301,8 @@ type Usage struct {
 // UnmarshalJSON decodes the OpenAI usage object, folding the nested
 // prompt_tokens_details.cached_tokens and completion_tokens_details.reasoning_tokens
 // into the flat CacheReadTokens/ReasoningTokens fields so providers that report
-// usage in the nested form (OpenRouter, xAI, …) surface it consistently. An
-// explicit flat field takes precedence when both are present.
+// usage in the nested form (OpenRouter, xAI, …) surface it consistently. A
+// nonzero flat field takes precedence over the nested value.
 func (u *Usage) UnmarshalJSON(data []byte) error {
 	type usageAlias Usage // avoid recursing into this method
 	var raw struct {

--- a/providers/core/embedding.go
+++ b/providers/core/embedding.go
@@ -8,9 +8,10 @@ type EmbeddingRequest struct {
 	EncodingFormat string `json:"encoding_format,omitempty"`
 	Dimensions     *int   `json:"dimensions,omitempty"`
 	User           string `json:"user,omitempty"`
-	// InputType is a non-OpenAI extension used by providers (e.g. Cohere) that
-	// distinguish embedding intent — "search_document", "search_query",
-	// "classification", "clustering". Empty lets the provider pick a default.
+	// InputType is a non-OpenAI extension for providers that distinguish
+	// embedding intent — "search_document", "search_query", "classification",
+	// "clustering". Forwarded by the shared embeddings body (Cohere, NVIDIA NIM,
+	// OpenRouter, …). Empty lets the provider pick a default.
 	InputType string `json:"input_type,omitempty"`
 }
 

--- a/providers/core/usage_test.go
+++ b/providers/core/usage_test.go
@@ -1,0 +1,36 @@
+package core
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestUsage_UnmarshalNestedDetails verifies the nested OpenAI usage details fold
+// into the flat extended fields.
+func TestUsage_UnmarshalNestedDetails(t *testing.T) {
+	var u Usage
+	if err := json.Unmarshal([]byte(`{"prompt_tokens":10,"completion_tokens":20,"total_tokens":30,"prompt_tokens_details":{"cached_tokens":4},"completion_tokens_details":{"reasoning_tokens":7}}`), &u); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if u.CacheReadTokens != 4 {
+		t.Errorf("CacheReadTokens = %d, want 4 (from prompt_tokens_details)", u.CacheReadTokens)
+	}
+	if u.ReasoningTokens != 7 {
+		t.Errorf("ReasoningTokens = %d, want 7 (from completion_tokens_details)", u.ReasoningTokens)
+	}
+	if u.PromptTokens != 10 || u.CompletionTokens != 20 || u.TotalTokens != 30 {
+		t.Errorf("flat fields not preserved: %+v", u)
+	}
+}
+
+// TestUsage_FlatFieldTakesPrecedence verifies an explicit flat field wins over
+// the nested detail when both are present.
+func TestUsage_FlatFieldTakesPrecedence(t *testing.T) {
+	var u Usage
+	if err := json.Unmarshal([]byte(`{"cache_read_tokens":9,"prompt_tokens_details":{"cached_tokens":4}}`), &u); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if u.CacheReadTokens != 9 {
+		t.Errorf("CacheReadTokens = %d, want 9 (flat precedence)", u.CacheReadTokens)
+	}
+}

--- a/providers/moonshot/moonshot.go
+++ b/providers/moonshot/moonshot.go
@@ -91,15 +91,9 @@ func (p *Provider) DiscoverModels(ctx context.Context) ([]core.ModelInfo, error)
 	return discovery.DiscoverOpenAICompatibleModels(ctx, p.httpClient, p.baseURL+"/models", p.apiKey, p.name)
 }
 
-// Complete sends a chat completion request to Moonshot.
-//
-// Usage accounting: when Moonshot reports cache-hit tokens in the standard
-// OpenAI-compatible nested form (usage.prompt_tokens_details.cached_tokens), the
-// shared core.Usage decode folds them into CacheReadTokens automatically, so no
-// provider-local usage decode is needed. A non-standard top-level
-// usage.cached_tokens field is unverified against the live API; if the vendor
-// emits that flat shape it would require a moonshot-local usage decode (as
-// deepseek does for prompt_cache_hit_tokens).
+// Complete sends a chat completion request to Moonshot. Cache-hit tokens
+// reported in the standard nested form (usage.prompt_tokens_details.cached_tokens)
+// are folded into CacheReadTokens by the shared core.Usage decode.
 func (p *Provider) Complete(ctx context.Context, req core.Request) (*core.Response, error) {
 	return openaicompat.PostChat(ctx, openaicompat.ChatParams{
 		HTTPClient: p.httpClient,

--- a/providers/moonshot/moonshot.go
+++ b/providers/moonshot/moonshot.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/ferro-labs/ai-gateway/internal/discovery"
 	providerhttp "github.com/ferro-labs/ai-gateway/internal/httpclient"
 	"github.com/ferro-labs/ai-gateway/internal/openaicompat"
 	"github.com/ferro-labs/ai-gateway/providers/core"
@@ -29,15 +30,22 @@ type Provider struct {
 var (
 	_ core.Provider          = (*Provider)(nil)
 	_ core.StreamProvider    = (*Provider)(nil)
+	_ core.DiscoveryProvider = (*Provider)(nil)
 	_ core.ProxiableProvider = (*Provider)(nil)
 )
 
 // New creates a new Moonshot provider.
 func New(apiKey, baseURL string) (*Provider, error) {
+	baseURL = strings.TrimSpace(baseURL)
 	if baseURL == "" {
 		baseURL = defaultBaseURL
 	}
 	baseURL = strings.TrimRight(baseURL, "/")
+	// Moonshot's default base URL already carries the /v1 prefix, so unlike
+	// deepseek we do not trim a trailing /v1 — native paths append directly to it.
+	if err := core.ValidateBaseURL(Name, baseURL); err != nil {
+		return nil, err
+	}
 	return &Provider{
 		name:       Name,
 		apiKey:     apiKey,
@@ -76,7 +84,22 @@ func (p *Provider) Models() []core.ModelInfo {
 	return core.ModelsFromList(p.name, p.SupportedModels())
 }
 
+// DiscoverModels fetches the live model list from the Moonshot /v1/models
+// endpoint. The base URL already carries the /v1 prefix, so the models path is
+// baseURL+"/models" (not baseURL+"/v1/models").
+func (p *Provider) DiscoverModels(ctx context.Context) ([]core.ModelInfo, error) {
+	return discovery.DiscoverOpenAICompatibleModels(ctx, p.httpClient, p.baseURL+"/models", p.apiKey, p.name)
+}
+
 // Complete sends a chat completion request to Moonshot.
+//
+// Usage accounting: when Moonshot reports cache-hit tokens in the standard
+// OpenAI-compatible nested form (usage.prompt_tokens_details.cached_tokens), the
+// shared core.Usage decode folds them into CacheReadTokens automatically, so no
+// provider-local usage decode is needed. A non-standard top-level
+// usage.cached_tokens field is unverified against the live API; if the vendor
+// emits that flat shape it would require a moonshot-local usage decode (as
+// deepseek does for prompt_cache_hit_tokens).
 func (p *Provider) Complete(ctx context.Context, req core.Request) (*core.Response, error) {
 	return openaicompat.PostChat(ctx, openaicompat.ChatParams{
 		HTTPClient: p.httpClient,

--- a/providers/moonshot/moonshot_p5b_test.go
+++ b/providers/moonshot/moonshot_p5b_test.go
@@ -1,0 +1,10 @@
+package moonshot
+
+import "testing"
+
+// TestNewMoonshot_RejectsInvalidBaseURL locks in the base-URL validation.
+func TestNewMoonshot_RejectsInvalidBaseURL(t *testing.T) {
+	if _, err := New("k", "://bad"); err == nil {
+		t.Fatal("New accepted an invalid base URL")
+	}
+}

--- a/providers/moonshot/moonshot_test.go
+++ b/providers/moonshot/moonshot_test.go
@@ -2,8 +2,10 @@ package moonshot
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/ferro-labs/ai-gateway/providers/core"
@@ -136,5 +138,134 @@ func TestMoonshotProvider_Complete_MockHTTP(t *testing.T) {
 	}
 	if len(resp.Choices) == 0 {
 		t.Error("expected at least one choice")
+	}
+}
+
+func TestMoonshotProvider_Complete_ErrorStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":{"message":"Invalid API key","type":"authentication_error"}}`))
+	}))
+	defer srv.Close()
+
+	p, _ := New("bad-key", srv.URL)
+	_, err := p.Complete(context.Background(), core.Request{
+		Model:    "kimi-latest",
+		Messages: []core.Message{{Role: core.RoleUser, Content: "hi"}},
+	})
+	if err == nil {
+		t.Fatal("Complete() expected an error for 401 response")
+	}
+	if code := core.ParseStatusCode(err); code != http.StatusUnauthorized {
+		t.Errorf("ParseStatusCode() = %d, want 401", code)
+	}
+	if !strings.Contains(err.Error(), "Invalid API key") {
+		t.Errorf("error = %q, want it to contain the upstream message", err.Error())
+	}
+}
+
+func TestMoonshotProvider_Complete_ForwardsRequestBody(t *testing.T) {
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %q, want POST", r.Method)
+		}
+		if r.URL.Path != "/chat/completions" {
+			t.Errorf("path = %q, want /chat/completions", r.URL.Path)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("failed to decode request body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"cmpl-1","model":"kimi-latest","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}]}`))
+	}))
+	defer srv.Close()
+
+	p, _ := New("test-key", srv.URL)
+	_, err := p.Complete(context.Background(), core.Request{
+		Model:    "kimi-latest",
+		Messages: []core.Message{{Role: core.RoleUser, Content: "Hi"}},
+	})
+	if err != nil {
+		t.Fatalf("Complete() error: %v", err)
+	}
+
+	if gotBody["model"] != "kimi-latest" {
+		t.Errorf("forwarded model = %v, want kimi-latest", gotBody["model"])
+	}
+	msgs, ok := gotBody["messages"].([]any)
+	if !ok || len(msgs) != 1 {
+		t.Fatalf("forwarded messages = %#v, want 1 message", gotBody["messages"])
+	}
+	msg, _ := msgs[0].(map[string]any)
+	if msg["role"] != core.RoleUser || msg["content"] != "Hi" {
+		t.Errorf("forwarded message = %#v, want role=user content=Hi", msg)
+	}
+}
+
+// TestMoonshotProvider_Complete_NestedUsage asserts the shared core.Usage decode
+// folds Moonshot's OpenAI-standard nested cache-token accounting
+// (usage.prompt_tokens_details.cached_tokens) into CacheReadTokens without any
+// provider-local usage decode. See the note on Complete() re: the unverified
+// flat-field (top-level usage.cached_tokens) case.
+func TestMoonshotProvider_Complete_NestedUsage(t *testing.T) {
+	respBody := `{"id":"cmpl-1","model":"kimi-latest","choices":[{"index":0,"message":{"role":"assistant","content":"Hi"},"finish_reason":"stop"}],` +
+		`"usage":{"prompt_tokens":100,"completion_tokens":20,"total_tokens":120,"prompt_tokens_details":{"cached_tokens":64}}}`
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(respBody))
+	}))
+	defer srv.Close()
+
+	p, _ := New("test-key", srv.URL)
+	resp, err := p.Complete(context.Background(), core.Request{
+		Model:    "kimi-latest",
+		Messages: []core.Message{{Role: core.RoleUser, Content: "Hi"}},
+	})
+	if err != nil {
+		t.Fatalf("Complete() error: %v", err)
+	}
+	if resp.Usage.PromptTokens != 100 || resp.Usage.CompletionTokens != 20 || resp.Usage.TotalTokens != 120 {
+		t.Errorf("Usage = %+v, want prompt=100 completion=20 total=120", resp.Usage)
+	}
+	if resp.Usage.CacheReadTokens != 64 {
+		t.Errorf("Usage.CacheReadTokens = %d, want 64 (from prompt_tokens_details.cached_tokens)", resp.Usage.CacheReadTokens)
+	}
+}
+
+func TestMoonshotProvider_DiscoverModels(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("method = %q, want GET", r.Method)
+		}
+		if r.URL.Path != "/models" {
+			t.Errorf("path = %q, want /models", r.URL.Path)
+		}
+		if r.Header.Get("Authorization") != "Bearer test-key" {
+			t.Errorf("Authorization = %q, want Bearer test-key", r.Header.Get("Authorization"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"object":"list","data":[{"id":"kimi-k2.5","object":"model","owned_by":"moonshot"},{"id":"kimi-latest","object":"model"}]}`))
+	}))
+	defer srv.Close()
+
+	p, _ := New("test-key", srv.URL)
+	models, err := p.DiscoverModels(context.Background())
+	if err != nil {
+		t.Fatalf("DiscoverModels() error: %v", err)
+	}
+	if len(models) != 2 {
+		t.Fatalf("expected 2 models, got %d", len(models))
+	}
+	if models[0].ID != "kimi-k2.5" || models[0].OwnedBy != "moonshot" {
+		t.Errorf("unexpected model[0]: %+v", models[0])
+	}
+	if models[1].OwnedBy != "moonshot" {
+		t.Errorf("model[1] owned_by fallback = %q, want moonshot", models[1].OwnedBy)
 	}
 }

--- a/providers/novita/novita.go
+++ b/providers/novita/novita.go
@@ -38,10 +38,14 @@ var (
 
 // New creates a new Novita provider.
 func New(apiKey, baseURL string) (*Provider, error) {
+	baseURL = strings.TrimSpace(baseURL)
 	if baseURL == "" {
 		baseURL = defaultBaseURL
 	}
 	baseURL = strings.TrimRight(baseURL, "/")
+	if err := core.ValidateBaseURL(Name, baseURL); err != nil {
+		return nil, err
+	}
 	return &Provider{
 		name:       Name,
 		apiKey:     apiKey,

--- a/providers/novita/novita_p5_test.go
+++ b/providers/novita/novita_p5_test.go
@@ -1,0 +1,133 @@
+package novita
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/ferro-labs/ai-gateway/providers/core"
+)
+
+// TestNew_RejectsInvalidBaseURL verifies the constructor fails fast when the base
+// URL is not a valid absolute http(s) URL with a host.
+func TestNew_RejectsInvalidBaseURL(t *testing.T) {
+	if _, err := New("test-key", "://nope"); err == nil {
+		t.Fatal("New() accepted an invalid base URL, want error")
+	}
+}
+
+// TestNovitaProvider_Complete_UpstreamError verifies a non-2xx chat response
+// surfaces an error carrying both the HTTP status and the upstream message.
+func TestNovitaProvider_Complete_UpstreamError(t *testing.T) {
+	tests := []struct {
+		name    string
+		status  int
+		message string
+	}{
+		{"rate-limited", http.StatusTooManyRequests, "slow down"},
+		{"server-error", http.StatusInternalServerError, "internal boom"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != testChatPath {
+					t.Errorf("path = %q, want %s", r.URL.Path, testChatPath)
+				}
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(tc.status)
+				_, _ = w.Write([]byte(`{"error":{"message":"` + tc.message + `"}}`))
+			}))
+			defer srv.Close()
+
+			p, _ := New("test-key", srv.URL)
+			_, err := p.Complete(context.Background(), core.Request{
+				Model:    testChatModel,
+				Messages: []core.Message{{Role: "user", Content: "Hi"}},
+			})
+			if err == nil {
+				t.Fatal("Complete() error = nil, want upstream error")
+			}
+			if got := core.ParseStatusCode(err); got != tc.status {
+				t.Errorf("ParseStatusCode(err) = %d, want %d", got, tc.status)
+			}
+			if !strings.Contains(err.Error(), "novita API error") {
+				t.Errorf("error = %v, want it to contain %q", err, "novita API error")
+			}
+			if !strings.Contains(err.Error(), tc.message) {
+				t.Errorf("error = %v, want it to contain %q", err, tc.message)
+			}
+		})
+	}
+}
+
+// TestNovitaProvider_CompleteStream_UpstreamError verifies a non-2xx streaming
+// response is drained and surfaced as an error before any chunk is produced.
+func TestNovitaProvider_CompleteStream_UpstreamError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != testChatPath {
+			t.Errorf("path = %q, want %s", r.URL.Path, testChatPath)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte(`{"error":{"message":"upstream unavailable"}}`))
+	}))
+	defer srv.Close()
+
+	p, _ := New("test-key", srv.URL)
+	ch, err := p.CompleteStream(context.Background(), core.Request{
+		Model:    testChatModel,
+		Messages: []core.Message{{Role: "user", Content: "Hi"}},
+	})
+	if err == nil {
+		t.Fatal("CompleteStream() error = nil, want upstream error")
+	}
+	if ch != nil {
+		t.Error("CompleteStream() channel = non-nil, want nil on error")
+	}
+	if got := core.ParseStatusCode(err); got != http.StatusServiceUnavailable {
+		t.Errorf("ParseStatusCode(err) = %d, want %d", got, http.StatusServiceUnavailable)
+	}
+	if !strings.Contains(err.Error(), "novita API error") {
+		t.Errorf("error = %v, want it to contain %q", err, "novita API error")
+	}
+	if !strings.Contains(err.Error(), "upstream unavailable") {
+		t.Errorf("error = %v, want it to contain %q", err, "upstream unavailable")
+	}
+}
+
+// TestNovitaProvider_DiscoverModels verifies live discovery issues a GET to
+// /models with bearer auth and parses the returned model metadata.
+func TestNovitaProvider_DiscoverModels(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("method = %q, want GET", r.Method)
+		}
+		if r.URL.Path != "/models" {
+			t.Errorf("path = %q, want /models", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != testBearerAPIKey {
+			t.Errorf("Authorization = %q, want %s", got, testBearerAPIKey)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"object":"list","data":[{"id":"` + testChatModel + `","object":"model","created":1700000000,"owned_by":"novita"}]}`))
+	}))
+	defer srv.Close()
+
+	p, _ := New("test-key", srv.URL)
+	models, err := p.DiscoverModels(context.Background())
+	if err != nil {
+		t.Fatalf("DiscoverModels() error: %v", err)
+	}
+	if len(models) != 1 {
+		t.Fatalf("expected 1 model, got %d", len(models))
+	}
+	if models[0].ID != testChatModel {
+		t.Errorf("model[0].ID = %q, want %s", models[0].ID, testChatModel)
+	}
+	if models[0].OwnedBy != "novita" {
+		t.Errorf("model[0].OwnedBy = %q, want novita", models[0].OwnedBy)
+	}
+}

--- a/providers/novita/novita_test.go
+++ b/providers/novita/novita_test.go
@@ -16,6 +16,8 @@ import (
 const (
 	testBearerAPIKey   = "Bearer test-key"
 	testEmbeddingModel = "baai/bge-m3"
+	testChatModel      = "deepseek/deepseek-v3.2"
+	testChatPath       = "/chat/completions"
 )
 
 func TestNewNovita(t *testing.T) {
@@ -85,7 +87,8 @@ func TestNovitaProvider_CompleteStream_MockSSE(t *testing.T) {
 		"data: {\"id\":\"cmpl-1\",\"model\":\"deepseek/deepseek-v3.2\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n" +
 		"data: [DONE]\n\n"
 
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assertNovitaChatRequest(t, r)
 		w.Header().Set("Content-Type", "text/event-stream")
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte(sseData))
@@ -120,7 +123,8 @@ func TestNovitaProvider_CompleteStream_MockSSE(t *testing.T) {
 func TestNovitaProvider_Complete_MockHTTP(t *testing.T) {
 	respBody := `{"id":"cmpl-1","model":"deepseek/deepseek-v3.2","choices":[{"index":0,"message":{"role":"assistant","content":"Hello!"},"finish_reason":"stop"}],"usage":{"prompt_tokens":5,"completion_tokens":2,"total_tokens":7}}`
 
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assertNovitaChatRequest(t, r)
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte(respBody))
@@ -129,7 +133,7 @@ func TestNovitaProvider_Complete_MockHTTP(t *testing.T) {
 
 	p, _ := New("test-key", srv.URL)
 	resp, err := p.Complete(context.Background(), core.Request{
-		Model:    "deepseek/deepseek-v3.2",
+		Model:    testChatModel,
 		Messages: []core.Message{{Role: "user", Content: "Hi"}},
 	})
 	if err != nil {
@@ -140,6 +144,33 @@ func TestNovitaProvider_Complete_MockHTTP(t *testing.T) {
 	}
 	if len(resp.Choices) == 0 {
 		t.Error("expected at least one choice")
+	}
+}
+
+// assertNovitaChatRequest verifies the outbound chat request shape: a POST to
+// /chat/completions carrying bearer auth and the forwarded model and messages.
+func assertNovitaChatRequest(t *testing.T, r *http.Request) {
+	t.Helper()
+	if r.Method != http.MethodPost {
+		t.Errorf("method = %s, want POST", r.Method)
+	}
+	if r.URL.Path != testChatPath {
+		t.Errorf("path = %q, want %s", r.URL.Path, testChatPath)
+	}
+	if got := r.Header.Get("Authorization"); got != testBearerAPIKey {
+		t.Errorf("Authorization = %q, want %s", got, testBearerAPIKey)
+	}
+	var body map[string]any
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		t.Errorf("failed to decode request body: %v", err)
+		return
+	}
+	if got := body["model"]; got != testChatModel {
+		t.Errorf("model = %v, want %s", got, testChatModel)
+	}
+	msgs, ok := body["messages"].([]any)
+	if !ok || len(msgs) == 0 {
+		t.Errorf("messages = %#v, want non-empty array", body["messages"])
 	}
 }
 

--- a/providers/nvidia_nim/nvidia_nim.go
+++ b/providers/nvidia_nim/nvidia_nim.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strings"
 
+	discov "github.com/ferro-labs/ai-gateway/internal/discovery"
 	providerhttp "github.com/ferro-labs/ai-gateway/internal/httpclient"
 	"github.com/ferro-labs/ai-gateway/internal/openaicompat"
 	"github.com/ferro-labs/ai-gateway/providers/core"
@@ -32,12 +33,17 @@ var (
 	_ core.StreamProvider    = (*Provider)(nil)
 	_ core.ProxiableProvider = (*Provider)(nil)
 	_ core.EmbeddingProvider = (*Provider)(nil)
+	_ core.DiscoveryProvider = (*Provider)(nil)
 )
 
 // New creates a new NVIDIA NIM provider.
 func New(apiKey, baseURL string) (*Provider, error) {
+	baseURL = strings.TrimSpace(baseURL)
 	if baseURL == "" {
 		baseURL = defaultBaseURL
+	}
+	if err := core.ValidateBaseURL(Name, baseURL); err != nil {
+		return nil, err
 	}
 	baseURL = strings.TrimRight(baseURL, "/")
 	return &Provider{
@@ -76,6 +82,11 @@ func (p *Provider) SupportsModel(_ string) bool { return true }
 // Models returns structured model metadata.
 func (p *Provider) Models() []core.ModelInfo {
 	return core.ModelsFromList(p.name, p.SupportedModels())
+}
+
+// DiscoverModels fetches the live model list from the NVIDIA NIM /models endpoint.
+func (p *Provider) DiscoverModels(ctx context.Context) ([]core.ModelInfo, error) {
+	return discov.DiscoverOpenAICompatibleModels(ctx, p.httpClient, p.baseURL+"/models", p.apiKey, p.name)
 }
 
 // chatParams builds the shared OpenAI-compatible chat endpoint configuration.

--- a/providers/nvidia_nim/nvidia_nim_test.go
+++ b/providers/nvidia_nim/nvidia_nim_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/ferro-labs/ai-gateway/providers/core"
@@ -13,7 +14,10 @@ import (
 
 const testBearerAPIKey = "Bearer test-key"
 
-const testEmbeddingModel = "nvidia/nv-embedqa-e5-v5"
+const (
+	testEmbeddingModel = "nvidia/nv-embedqa-e5-v5"
+	testChatModel      = "nvidia/Llama-3.1-Nemotron-70B-Instruct"
+)
 
 func TestNewNVIDIANIM(t *testing.T) {
 	p, err := New("test-key", "")
@@ -213,5 +217,123 @@ func TestNVIDIANIMProvider_Embed_NoInputTypeDefaultInjection(t *testing.T) {
 	p, _ := New("test-key", srv.URL)
 	if _, err := p.Embed(context.Background(), core.EmbeddingRequest{Model: testEmbeddingModel, Input: "hi"}); err != nil {
 		t.Fatalf("Embed() error: %v", err)
+	}
+}
+
+// TestNewNVIDIANIM_RejectsInvalidBaseURL verifies the constructor fails fast when
+// the base URL is not a valid absolute http(s) URL with a host.
+func TestNewNVIDIANIM_RejectsInvalidBaseURL(t *testing.T) {
+	if _, err := New("test-key", "://nope"); err == nil {
+		t.Fatal("New() accepted an invalid base URL, want error")
+	}
+}
+
+func TestNVIDIANIMProvider_Complete_UpstreamError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"error":{"message":"rate limited"}}`))
+	}))
+	defer srv.Close()
+
+	p, _ := New("test-key", srv.URL)
+	_, err := p.Complete(context.Background(), core.Request{
+		Model:    testChatModel,
+		Messages: []core.Message{{Role: "user", Content: "Hi"}},
+	})
+	if err == nil {
+		t.Fatal("Complete() error = nil, want upstream error")
+	}
+	if got := core.ParseStatusCode(err); got != http.StatusTooManyRequests {
+		t.Errorf("ParseStatusCode(err) = %d, want %d", got, http.StatusTooManyRequests)
+	}
+	if !strings.Contains(err.Error(), "rate limited") {
+		t.Errorf("error = %v, want it to contain %q", err, "rate limited")
+	}
+}
+
+func TestNVIDIANIMProvider_CompleteStream_UpstreamError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":{"message":"internal boom"}}`))
+	}))
+	defer srv.Close()
+
+	p, _ := New("test-key", srv.URL)
+	_, err := p.CompleteStream(context.Background(), core.Request{
+		Model:    testChatModel,
+		Messages: []core.Message{{Role: "user", Content: "Hi"}},
+	})
+	if err == nil {
+		t.Fatal("CompleteStream() error = nil, want upstream error")
+	}
+	if got := core.ParseStatusCode(err); got != http.StatusInternalServerError {
+		t.Errorf("ParseStatusCode(err) = %d, want %d", got, http.StatusInternalServerError)
+	}
+	if !strings.Contains(err.Error(), "internal boom") {
+		t.Errorf("error = %v, want it to contain %q", err, "internal boom")
+	}
+}
+
+func TestNVIDIANIMProvider_Embed_UpstreamError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/embeddings" {
+			t.Errorf("path = %q, want /embeddings", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":{"message":"input_type required"}}`))
+	}))
+	defer srv.Close()
+
+	p, _ := New("test-key", srv.URL)
+	_, err := p.Embed(context.Background(), core.EmbeddingRequest{
+		Model: testEmbeddingModel,
+		Input: "hello",
+	})
+	if err == nil {
+		t.Fatal("Embed() error = nil, want upstream error")
+	}
+	if got := core.ParseStatusCode(err); got != http.StatusBadRequest {
+		t.Errorf("ParseStatusCode(err) = %d, want %d", got, http.StatusBadRequest)
+	}
+	if !strings.Contains(err.Error(), "input_type required") {
+		t.Errorf("error = %v, want it to contain %q", err, "input_type required")
+	}
+}
+
+// TestNVIDIANIMProvider_DiscoverModels verifies live discovery issues a GET to
+// /models with bearer auth and parses the returned model metadata.
+func TestNVIDIANIMProvider_DiscoverModels(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("method = %q, want GET", r.Method)
+		}
+		if r.URL.Path != "/models" {
+			t.Errorf("path = %q, want /models", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != testBearerAPIKey {
+			t.Errorf("Authorization = %q, want %s", got, testBearerAPIKey)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"object":"list","data":[{"id":"` + testChatModel + `","object":"model","created":1700000000,"owned_by":"nvidia-nim"}]}`))
+	}))
+	defer srv.Close()
+
+	p, _ := New("test-key", srv.URL)
+	models, err := p.DiscoverModels(context.Background())
+	if err != nil {
+		t.Fatalf("DiscoverModels() error: %v", err)
+	}
+	if len(models) != 1 {
+		t.Fatalf("expected 1 model, got %d", len(models))
+	}
+	if models[0].ID != testChatModel {
+		t.Errorf("model[0].ID = %q, want %s", models[0].ID, testChatModel)
+	}
+	if models[0].OwnedBy != "nvidia-nim" {
+		t.Errorf("model[0].OwnedBy = %q, want nvidia-nim", models[0].OwnedBy)
 	}
 }

--- a/providers/openrouter/embedding.go
+++ b/providers/openrouter/embedding.go
@@ -1,4 +1,4 @@
-package nvidianim
+package openrouter
 
 import (
 	"context"
@@ -8,9 +8,7 @@ import (
 	"github.com/ferro-labs/ai-gateway/providers/core"
 )
 
-// Embed sends an OpenAI-compatible embedding request to NVIDIA NIM.
-// req.InputType is forwarded verbatim by the shared body builder with no default
-// injection; NeMo retriever models require it or respond with HTTP 400.
+// Embed sends an OpenAI-compatible embedding request to OpenRouter.
 func (p *Provider) Embed(ctx context.Context, req core.EmbeddingRequest) (*core.EmbeddingResponse, error) {
 	if req.EncodingFormat != "" && req.EncodingFormat != "float" {
 		return nil, fmt.Errorf("embed: unsupported encoding_format %q; valid value is \"float\"", req.EncodingFormat)
@@ -19,6 +17,6 @@ func (p *Provider) Embed(ctx context.Context, req core.EmbeddingRequest) (*core.
 		HTTPClient: p.httpClient,
 		URL:        p.baseURL + "/embeddings",
 		Headers:    map[string]string{"Authorization": "Bearer " + p.apiKey, "Content-Type": "application/json"},
-		Label:      "nvidia nim",
+		Label:      "openrouter",
 	}, req)
 }

--- a/providers/openrouter/openrouter.go
+++ b/providers/openrouter/openrouter.go
@@ -33,12 +33,16 @@ var (
 	_ core.StreamProvider    = (*Provider)(nil)
 	_ core.ProxiableProvider = (*Provider)(nil)
 	_ core.DiscoveryProvider = (*Provider)(nil)
+	_ core.EmbeddingProvider = (*Provider)(nil)
 )
 
 // New creates a new OpenRouter provider.
 func New(apiKey, baseURL string) (*Provider, error) {
+	baseURL = strings.TrimSpace(baseURL)
 	if baseURL == "" {
 		baseURL = defaultBaseURL
+	} else if err := core.ValidateBaseURL(Name, baseURL); err != nil {
+		return nil, err
 	}
 	baseURL = strings.TrimRight(baseURL, "/")
 	return &Provider{

--- a/providers/openrouter/openrouter.go
+++ b/providers/openrouter/openrouter.go
@@ -41,7 +41,8 @@ func New(apiKey, baseURL string) (*Provider, error) {
 	baseURL = strings.TrimSpace(baseURL)
 	if baseURL == "" {
 		baseURL = defaultBaseURL
-	} else if err := core.ValidateBaseURL(Name, baseURL); err != nil {
+	}
+	if err := core.ValidateBaseURL(Name, baseURL); err != nil {
 		return nil, err
 	}
 	baseURL = strings.TrimRight(baseURL, "/")

--- a/providers/openrouter/openrouter_p5_test.go
+++ b/providers/openrouter/openrouter_p5_test.go
@@ -1,0 +1,166 @@
+package openrouter
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/ferro-labs/ai-gateway/providers/core"
+)
+
+const testEmbeddingModel = "text-embedding-3-small"
+
+// TestOpenRouterProvider_Embed_Interface guards the compile-time contract.
+func TestOpenRouterProvider_Embed_Interface(_ *testing.T) {
+	p, _ := New("test-key", "")
+	var _ core.EmbeddingProvider = p
+}
+
+// TestOpenRouterProvider_Embed_MockHTTP asserts the embedding request targets
+// POST /embeddings with Bearer auth and returns the decoded embedding.
+func TestOpenRouterProvider_Embed_MockHTTP(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+		if r.URL.Path != "/embeddings" {
+			t.Errorf("path = %q, want /embeddings", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != testBearerAPIKey {
+			t.Errorf("Authorization = %q, want %s", got, testBearerAPIKey)
+		}
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		if body["model"] != testEmbeddingModel {
+			t.Errorf("model = %v, want %s", body["model"], testEmbeddingModel)
+		}
+		if body["input"] != "hello world" {
+			t.Errorf("input = %v, want hello world", body["input"])
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"object":"list","data":[{"object":"embedding","embedding":[0.1,0.2],"index":0}],"model":"` + testEmbeddingModel + `","usage":{"prompt_tokens":3,"total_tokens":3}}`))
+	}))
+	defer srv.Close()
+
+	p, _ := New("test-key", srv.URL)
+	resp, err := p.Embed(context.Background(), core.EmbeddingRequest{Model: testEmbeddingModel, Input: "hello world"})
+	if err != nil {
+		t.Fatalf("Embed() error: %v", err)
+	}
+	if resp.Object != "list" || resp.Model != testEmbeddingModel {
+		t.Errorf("resp = %+v, want list/%s", resp, testEmbeddingModel)
+	}
+	if len(resp.Data) != 1 || resp.Data[0].Index != 0 || !reflect.DeepEqual(resp.Data[0].Embedding, []float64{0.1, 0.2}) {
+		t.Errorf("Data = %+v, want one embedding at index 0", resp.Data)
+	}
+	if resp.Usage.PromptTokens != 3 || resp.Usage.TotalTokens != 3 {
+		t.Errorf("Usage = %+v, want prompt=3 total=3", resp.Usage)
+	}
+}
+
+// TestOpenRouterProvider_Embed_InvalidEncodingFormat rejects unsupported
+// encoding formats before any network call.
+func TestOpenRouterProvider_Embed_InvalidEncodingFormat(t *testing.T) {
+	p, _ := New("test-key", "http://127.0.0.1:0")
+	_, err := p.Embed(context.Background(), core.EmbeddingRequest{
+		Model:          testEmbeddingModel,
+		Input:          "hi",
+		EncodingFormat: "base64",
+	})
+	if err == nil {
+		t.Fatal("Embed() error = nil, want unsupported encoding_format error")
+	}
+}
+
+// TestOpenRouterProvider_Complete_NestedUsage exercises the shared core.Usage
+// nested-usage decode: OpenAI-style prompt_tokens_details.cached_tokens and
+// completion_tokens_details.reasoning_tokens must surface on core.Usage.
+func TestOpenRouterProvider_Complete_NestedUsage(t *testing.T) {
+	respBody := `{"id":"cmpl-1","model":"openrouter/auto","choices":[{"index":0,"message":{"role":"assistant","content":"Hello!"},"finish_reason":"stop"}],"usage":{"prompt_tokens":30,"completion_tokens":20,"total_tokens":50,"prompt_tokens_details":{"cached_tokens":8},"completion_tokens_details":{"reasoning_tokens":12}}}`
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(respBody))
+	}))
+	defer srv.Close()
+
+	p, _ := New("test-key", srv.URL)
+	resp, err := p.Complete(context.Background(), core.Request{
+		Model:    "openrouter/auto",
+		Messages: []core.Message{{Role: "user", Content: "Hi"}},
+	})
+	if err != nil {
+		t.Fatalf("Complete() error: %v", err)
+	}
+	if resp.Usage.ReasoningTokens != 12 {
+		t.Errorf("Usage.ReasoningTokens = %d, want 12", resp.Usage.ReasoningTokens)
+	}
+	if resp.Usage.CacheReadTokens != 8 {
+		t.Errorf("Usage.CacheReadTokens = %d, want 8", resp.Usage.CacheReadTokens)
+	}
+}
+
+// TestOpenRouterProvider_Complete_ErrorPath asserts a non-2xx chat response is
+// surfaced as a core.APIError carrying the upstream status and message.
+func TestOpenRouterProvider_Complete_ErrorPath(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":{"message":"boom"}}`))
+	}))
+	defer srv.Close()
+
+	p, _ := New("test-key", srv.URL)
+	_, err := p.Complete(context.Background(), core.Request{
+		Model:    "openrouter/auto",
+		Messages: []core.Message{{Role: "user", Content: "Hi"}},
+	})
+	if err == nil {
+		t.Fatal("Complete() error = nil, want error for 500")
+	}
+	if !strings.Contains(err.Error(), "boom") || !strings.Contains(err.Error(), "500") {
+		t.Errorf("error = %v, want status 500 + upstream message", err)
+	}
+}
+
+// TestOpenRouterProvider_DiscoverModels asserts live model enumeration hits
+// GET /models with Bearer auth and decodes the returned list.
+func TestOpenRouterProvider_DiscoverModels(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("method = %q, want GET", r.Method)
+		}
+		if r.URL.Path != "/models" {
+			t.Errorf("path = %q, want /models", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != testBearerAPIKey {
+			t.Errorf("Authorization = %q, want %s", got, testBearerAPIKey)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"object":"list","data":[{"id":"openrouter/auto","object":"model","created":1700000000,"owned_by":"openrouter"}]}`))
+	}))
+	defer srv.Close()
+
+	p, _ := New("test-key", srv.URL)
+	models, err := p.DiscoverModels(context.Background())
+	if err != nil {
+		t.Fatalf("DiscoverModels() error: %v", err)
+	}
+	if len(models) != 1 {
+		t.Fatalf("expected 1 model, got %d", len(models))
+	}
+	if models[0].ID != "openrouter/auto" {
+		t.Errorf("model[0].ID = %q, want openrouter/auto", models[0].ID)
+	}
+	if models[0].OwnedBy != "openrouter" {
+		t.Errorf("model[0].OwnedBy = %q, want openrouter", models[0].OwnedBy)
+	}
+}

--- a/providers/openrouter/openrouter_p5b_test.go
+++ b/providers/openrouter/openrouter_p5b_test.go
@@ -1,0 +1,10 @@
+package openrouter
+
+import "testing"
+
+// TestNewOpenRouter_RejectsInvalidBaseURL locks in the base-URL validation.
+func TestNewOpenRouter_RejectsInvalidBaseURL(t *testing.T) {
+	if _, err := New("k", "://bad"); err == nil {
+		t.Fatal("New accepted an invalid base URL")
+	}
+}

--- a/providers/perplexity/perplexity.go
+++ b/providers/perplexity/perplexity.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"strings"
 
-	discov "github.com/ferro-labs/ai-gateway/internal/discovery"
 	providerhttp "github.com/ferro-labs/ai-gateway/internal/httpclient"
 	"github.com/ferro-labs/ai-gateway/internal/openaicompat"
 	"github.com/ferro-labs/ai-gateway/providers/core"
@@ -32,13 +31,16 @@ var (
 	_ core.Provider          = (*Provider)(nil)
 	_ core.StreamProvider    = (*Provider)(nil)
 	_ core.ProxiableProvider = (*Provider)(nil)
-	_ core.DiscoveryProvider = (*Provider)(nil)
 )
 
 // New creates a new Perplexity provider.
 func New(apiKey, baseURL string) (*Provider, error) {
+	baseURL = strings.TrimSpace(baseURL)
 	if baseURL == "" {
 		baseURL = defaultBaseURL
+	}
+	if err := core.ValidateBaseURL(Name, baseURL); err != nil {
+		return nil, err
 	}
 	baseURL = strings.TrimRight(baseURL, "/")
 	return &Provider{
@@ -65,7 +67,6 @@ func (p *Provider) SupportedModels() []string {
 	return []string{
 		"sonar",
 		"sonar-pro",
-		"sonar-reasoning",
 		"sonar-reasoning-pro",
 		"sonar-deep-research",
 	}
@@ -81,11 +82,6 @@ func (p *Provider) Models() []core.ModelInfo {
 	return core.ModelsFromList(p.name, p.SupportedModels())
 }
 
-// DiscoverModels fetches the live model list from the Perplexity /models endpoint.
-func (p *Provider) DiscoverModels(ctx context.Context) ([]core.ModelInfo, error) {
-	return discov.DiscoverOpenAICompatibleModels(ctx, p.httpClient, p.baseURL+"/models", p.apiKey, p.name)
-}
-
 // Complete sends a chat completion request to Perplexity.
 func (p *Provider) Complete(ctx context.Context, req core.Request) (*core.Response, error) {
 	return openaicompat.PostChat(ctx, openaicompat.ChatParams{
@@ -94,6 +90,8 @@ func (p *Provider) Complete(ctx context.Context, req core.Request) (*core.Respon
 		Provider:   p.name,
 		Label:      "perplexity",
 		Headers:    map[string]string{"Authorization": "Bearer " + p.apiKey, "Content-Type": "application/json"},
+		// Capture Sonar's top-level search metadata into core.Response.Metadata.
+		ExtraResponseFields: []string{"citations", "search_results", "images", "related_questions"},
 	}, req)
 }
 

--- a/providers/perplexity/perplexity_test.go
+++ b/providers/perplexity/perplexity_test.go
@@ -139,3 +139,67 @@ func TestPerplexityProvider_Complete_MockHTTP(t *testing.T) {
 		t.Error("expected at least one choice")
 	}
 }
+
+// TestPerplexityProvider_Complete_CapturesCitations verifies the Sonar-specific
+// top-level "citations" field is surfaced into core.Response.Metadata via the
+// shared ExtraResponseFields seam.
+func TestPerplexityProvider_Complete_CapturesCitations(t *testing.T) {
+	respBody := `{"id":"chatcmpl-1","model":"sonar","choices":[{"index":0,"message":{"role":"assistant","content":"Hello!"},"finish_reason":"stop"}],"citations":["https://example.com/a","https://example.com/b"],"usage":{"prompt_tokens":5,"completion_tokens":2,"total_tokens":7}}`
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(respBody))
+	}))
+	defer srv.Close()
+
+	p, _ := New("test-key", srv.URL)
+	resp, err := p.Complete(context.Background(), core.Request{
+		Model:    "sonar",
+		Messages: []core.Message{{Role: "user", Content: "Hi"}},
+	})
+	if err != nil {
+		t.Fatalf("Complete() error: %v", err)
+	}
+	if resp.Metadata == nil {
+		t.Fatal("expected Metadata to be populated with citations")
+	}
+	citations, ok := resp.Metadata["citations"].([]any)
+	if !ok {
+		t.Fatalf("Metadata[\"citations\"] = %T, want []any", resp.Metadata["citations"])
+	}
+	if len(citations) != 2 {
+		t.Errorf("len(citations) = %d, want 2", len(citations))
+	}
+}
+
+// TestPerplexityProvider_Complete_ErrorStatus verifies a non-2xx chat response is
+// surfaced as a provider error rather than a decoded response.
+func TestPerplexityProvider_Complete_ErrorStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":{"message":"invalid api key"}}`))
+	}))
+	defer srv.Close()
+
+	p, _ := New("test-key", srv.URL)
+	resp, err := p.Complete(context.Background(), core.Request{
+		Model:    "sonar",
+		Messages: []core.Message{{Role: "user", Content: "Hi"}},
+	})
+	if err == nil {
+		t.Fatal("expected error for non-2xx response, got nil")
+	}
+	if resp != nil {
+		t.Errorf("expected nil response on error, got %+v", resp)
+	}
+}
+
+// TestNewPerplexity_InvalidBaseURL verifies a malformed base URL is rejected at
+// construction time.
+func TestNewPerplexity_InvalidBaseURL(t *testing.T) {
+	if _, err := New(testAPIKey, "not-a-url"); err == nil {
+		t.Error("expected error for invalid base URL, got nil")
+	}
+}

--- a/providers/providers_list.go
+++ b/providers/providers_list.go
@@ -253,7 +253,7 @@ var allProviders = []ProviderEntry{
 	},
 	{
 		ID:           NameMoonshot,
-		Capabilities: []string{CapabilityChat, CapabilityStream, CapabilityProxy},
+		Capabilities: []string{CapabilityChat, CapabilityStream, CapabilityDiscovery, CapabilityProxy},
 		EnvMappings: []EnvMapping{
 			{CfgKeyAPIKey, "MOONSHOT_API_KEY", true},
 			{CfgKeyBaseURL, "MOONSHOT_BASE_URL", false},
@@ -275,7 +275,7 @@ var allProviders = []ProviderEntry{
 	},
 	{
 		ID:           NameNVIDIANIM,
-		Capabilities: []string{CapabilityChat, CapabilityStream, CapabilityEmbed, CapabilityProxy},
+		Capabilities: []string{CapabilityChat, CapabilityStream, CapabilityEmbed, CapabilityDiscovery, CapabilityProxy},
 		EnvMappings: []EnvMapping{
 			{CfgKeyAPIKey, "NVIDIA_NIM_API_KEY", true},
 			{CfgKeyBaseURL, "NVIDIA_NIM_BASE_URL", false},
@@ -329,7 +329,7 @@ var allProviders = []ProviderEntry{
 	},
 	{
 		ID:           NameOpenRouter,
-		Capabilities: []string{CapabilityChat, CapabilityStream, CapabilityDiscovery, CapabilityProxy},
+		Capabilities: []string{CapabilityChat, CapabilityStream, CapabilityEmbed, CapabilityDiscovery, CapabilityProxy},
 		EnvMappings: []EnvMapping{
 			{CfgKeyAPIKey, "OPENROUTER_API_KEY", true},
 			{CfgKeyBaseURL, "OPENROUTER_BASE_URL", false},
@@ -340,7 +340,7 @@ var allProviders = []ProviderEntry{
 	},
 	{
 		ID:           NamePerplexity,
-		Capabilities: []string{CapabilityChat, CapabilityStream, CapabilityDiscovery, CapabilityProxy},
+		Capabilities: []string{CapabilityChat, CapabilityStream, CapabilityProxy},
 		EnvMappings: []EnvMapping{
 			{CfgKeyAPIKey, "PERPLEXITY_API_KEY", true},
 			{CfgKeyBaseURL, "PERPLEXITY_BASE_URL", false},

--- a/providers/xai/image.go
+++ b/providers/xai/image.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/ferro-labs/ai-gateway/internal/logging"
 	"github.com/ferro-labs/ai-gateway/providers/core"
 )
 
@@ -19,34 +20,29 @@ type xaiImageRequest struct {
 	Prompt         string `json:"prompt"`
 	N              *int   `json:"n,omitempty"`
 	ResponseFormat string `json:"response_format,omitempty"`
-}
-
-// xaiImageResponse is the OpenAI-compatible response body for xAI image
-// generation.
-type xaiImageResponse struct {
-	Created int64 `json:"created"`
-	Data    []struct {
-		URL           string `json:"url"`
-		B64JSON       string `json:"b64_json"`
-		RevisedPrompt string `json:"revised_prompt"`
-	} `json:"data"`
-}
-
-// xaiImageErrorResponse mirrors the OpenAI-compatible error envelope.
-type xaiImageErrorResponse struct {
-	Error struct {
-		Message string `json:"message"`
-	} `json:"error"`
+	User           string `json:"user,omitempty"`
 }
 
 // GenerateImage sends an image generation request to xAI (Grok image models).
 // It is OpenAI-compatible against the /images/generations endpoint.
 func (p *Provider) GenerateImage(ctx context.Context, req core.ImageRequest) (*core.ImageResponse, error) {
+	// grok-2-image ignores size/quality/style. Surface the drop instead of
+	// discarding it silently so the caller can observe the mismatch.
+	if dropped := droppedImageParams(req); len(dropped) > 0 {
+		logging.FromContext(ctx).Warn(
+			"xai image models ignore size/quality/style request parameter(s); dropping",
+			"provider", p.name,
+			"model", req.Model,
+			"dropped_params", dropped,
+		)
+	}
+
 	payload := xaiImageRequest{
 		Model:          req.Model,
 		Prompt:         req.Prompt,
 		N:              req.N,
 		ResponseFormat: req.ResponseFormat,
+		User:           req.User,
 	}
 
 	body, contentLen, release, err := core.JSONBodyReader(payload)
@@ -69,39 +65,39 @@ func (p *Provider) GenerateImage(ctx context.Context, req core.ImageRequest) (*c
 	}
 	defer func() { _ = httpResp.Body.Close() }()
 
-	if httpResp.StatusCode != http.StatusOK {
-		respBody, readErr := io.ReadAll(httpResp.Body)
-		if readErr != nil {
-			return nil, fmt.Errorf("xai: failed to read error response: %w", readErr)
-		}
-		var errResp xaiImageErrorResponse
-		if json.Unmarshal(respBody, &errResp) == nil && errResp.Error.Message != "" {
-			return nil, fmt.Errorf("xai API error (%d): %s", httpResp.StatusCode, errResp.Error.Message)
-		}
-		return nil, fmt.Errorf("xai API error (%d): %s", httpResp.StatusCode, string(respBody))
+	respBody, err := io.ReadAll(httpResp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("xai: failed to read image response: %w", err)
 	}
 
-	var decoded xaiImageResponse
-	if err := json.NewDecoder(httpResp.Body).Decode(&decoded); err != nil {
+	if httpResp.StatusCode != http.StatusOK {
+		return nil, core.APIError("xai", httpResp.StatusCode, respBody)
+	}
+
+	var decoded core.ImageResponse
+	if err := json.Unmarshal(respBody, &decoded); err != nil {
 		return nil, fmt.Errorf("xai: failed to decode image response: %w", err)
 	}
 
-	images := make([]core.GeneratedImage, len(decoded.Data))
-	for i, d := range decoded.Data {
-		images[i] = core.GeneratedImage{
-			URL:           d.URL,
-			B64JSON:       d.B64JSON,
-			RevisedPrompt: d.RevisedPrompt,
-		}
+	if decoded.Created == 0 {
+		decoded.Created = time.Now().Unix()
 	}
 
-	created := decoded.Created
-	if created == 0 {
-		created = time.Now().Unix()
-	}
+	return &decoded, nil
+}
 
-	return &core.ImageResponse{
-		Created: created,
-		Data:    images,
-	}, nil
+// droppedImageParams returns, in stable order, the image request parameters that
+// xAI's Grok image models ignore but that the caller populated.
+func droppedImageParams(req core.ImageRequest) []string {
+	var dropped []string
+	if req.Size != "" {
+		dropped = append(dropped, "size")
+	}
+	if req.Quality != "" {
+		dropped = append(dropped, "quality")
+	}
+	if req.Style != "" {
+		dropped = append(dropped, "style")
+	}
+	return dropped
 }

--- a/providers/xai/xai.go
+++ b/providers/xai/xai.go
@@ -38,10 +38,14 @@ var (
 
 // New creates a new xAI provider.
 func New(apiKey, baseURL string) (*Provider, error) {
+	baseURL = strings.TrimSpace(baseURL)
 	if baseURL == "" {
 		baseURL = defaultBaseURL
 	}
 	baseURL = strings.TrimRight(baseURL, "/")
+	if err := core.ValidateBaseURL(Name, baseURL); err != nil {
+		return nil, err
+	}
 	return &Provider{
 		name:       Name,
 		apiKey:     apiKey,
@@ -63,10 +67,21 @@ func (p *Provider) AuthHeaders() map[string]string {
 
 // SupportedModels returns the static list of known xAI models.
 func (p *Provider) SupportedModels() []string {
+	// grok-2-latest is kept first because the model catalog resolves it as
+	// xai/grok-2-latest (see models/catalog_backup.json). SupportsModel accepts
+	// any grok*/xai* name by prefix, so the grok-3/grok-4 entries below are for
+	// discovery/listing surfaces.
 	return []string{
 		"grok-2-latest",
 		"grok-2-vision-latest",
 		"grok-beta",
+		"grok-3",
+		"grok-3-mini",
+		"grok-4",
+		"grok-4-latest",
+		"grok-4-fast-reasoning",
+		"grok-4-fast-non-reasoning",
+		"grok-code-fast-1",
 		"grok-2-image",
 		"grok-2-image-1212",
 		"grok-2-image-latest",

--- a/providers/xai/xai_p5_test.go
+++ b/providers/xai/xai_p5_test.go
@@ -10,12 +10,9 @@ import (
 	"github.com/ferro-labs/ai-gateway/providers/core"
 )
 
-// TestXAIProvider_Complete_NestedUsage verifies that xAI's nested usage
-// accounting (completion_tokens_details.reasoning_tokens and
-// prompt_tokens_details.cached_tokens) is surfaced onto the canonical
-// core.Usage. This exercises the shared openaicompat/core.Usage decode; on a
-// worktree that predates that foundation the ReasoningTokens/CacheReadTokens
-// assertions fail until the shared change is integrated.
+// TestXAIProvider_Complete_NestedUsage verifies xAI's nested usage accounting
+// (completion_tokens_details.reasoning_tokens and prompt_tokens_details.cached_tokens)
+// is surfaced onto the canonical core.Usage.
 func TestXAIProvider_Complete_NestedUsage(t *testing.T) {
 	respBody := `{"id":"chatcmpl-1","model":"grok-4","choices":[{"index":0,"message":{"role":"assistant","content":"Hi"},"finish_reason":"stop"}],"usage":{"prompt_tokens":20,"completion_tokens":8,"total_tokens":28,"completion_tokens_details":{"reasoning_tokens":5},"prompt_tokens_details":{"cached_tokens":12}}}`
 

--- a/providers/xai/xai_p5_test.go
+++ b/providers/xai/xai_p5_test.go
@@ -1,0 +1,136 @@
+package xai
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/ferro-labs/ai-gateway/providers/core"
+)
+
+// TestXAIProvider_Complete_NestedUsage verifies that xAI's nested usage
+// accounting (completion_tokens_details.reasoning_tokens and
+// prompt_tokens_details.cached_tokens) is surfaced onto the canonical
+// core.Usage. This exercises the shared openaicompat/core.Usage decode; on a
+// worktree that predates that foundation the ReasoningTokens/CacheReadTokens
+// assertions fail until the shared change is integrated.
+func TestXAIProvider_Complete_NestedUsage(t *testing.T) {
+	respBody := `{"id":"chatcmpl-1","model":"grok-4","choices":[{"index":0,"message":{"role":"assistant","content":"Hi"},"finish_reason":"stop"}],"usage":{"prompt_tokens":20,"completion_tokens":8,"total_tokens":28,"completion_tokens_details":{"reasoning_tokens":5},"prompt_tokens_details":{"cached_tokens":12}}}`
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/chat/completions" {
+			t.Errorf("request path = %q, want /chat/completions", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(respBody))
+	}))
+	defer srv.Close()
+
+	p, _ := New("test-key", srv.URL)
+	resp, err := p.Complete(context.Background(), core.Request{
+		Model:    "grok-4",
+		Messages: []core.Message{{Role: "user", Content: "Hi"}},
+	})
+	if err != nil {
+		t.Fatalf("Complete() error: %v", err)
+	}
+	if resp.Usage.ReasoningTokens != 5 {
+		t.Errorf("Usage.ReasoningTokens = %d, want 5 (nested completion_tokens_details.reasoning_tokens)", resp.Usage.ReasoningTokens)
+	}
+	if resp.Usage.CacheReadTokens != 12 {
+		t.Errorf("Usage.CacheReadTokens = %d, want 12 (nested prompt_tokens_details.cached_tokens)", resp.Usage.CacheReadTokens)
+	}
+}
+
+// TestXAIProvider_Complete_ErrorStatus verifies the chat error path returns a
+// core.APIError carrying the upstream status code and message.
+func TestXAIProvider_Complete_ErrorStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":{"message":"bad model"}}`))
+	}))
+	defer srv.Close()
+
+	p, _ := New("test-key", srv.URL)
+	_, err := p.Complete(context.Background(), core.Request{
+		Model:    "grok-4",
+		Messages: []core.Message{{Role: "user", Content: "Hi"}},
+	})
+	if err == nil {
+		t.Fatal("expected error for non-2xx chat response, got nil")
+	}
+	if !strings.Contains(err.Error(), "xai API error (400)") {
+		t.Errorf("error = %q, want it to contain %q", err.Error(), "xai API error (400)")
+	}
+	if !strings.Contains(err.Error(), "bad model") {
+		t.Errorf("error = %q, want it to contain upstream message %q", err.Error(), "bad model")
+	}
+}
+
+// TestXAIProvider_GenerateImage_ErrorStatus verifies the image error path
+// returns a core.APIError carrying the upstream status code and message.
+func TestXAIProvider_GenerateImage_ErrorStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":{"message":"upstream boom"}}`))
+	}))
+	defer srv.Close()
+
+	p, _ := New("test-key", srv.URL)
+	_, err := p.GenerateImage(context.Background(), core.ImageRequest{
+		Model:  "grok-2-image",
+		Prompt: "a red apple",
+	})
+	if err == nil {
+		t.Fatal("expected error for non-2xx image response, got nil")
+	}
+	if !strings.Contains(err.Error(), "xai API error (500)") {
+		t.Errorf("error = %q, want it to contain %q", err.Error(), "xai API error (500)")
+	}
+	if !strings.Contains(err.Error(), "upstream boom") {
+		t.Errorf("error = %q, want it to contain upstream message %q", err.Error(), "upstream boom")
+	}
+}
+
+// TestXAIProvider_DiscoverModels verifies live model discovery against an
+// OpenAI-compatible /models endpoint.
+func TestXAIProvider_DiscoverModels(t *testing.T) {
+	respBody := `{"object":"list","data":[{"id":"grok-4","object":"model","owned_by":"xai"},{"id":"grok-3","object":"model","owned_by":"xai"}]}`
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/models" {
+			t.Errorf("request path = %q, want /models", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-key" {
+			t.Errorf("Authorization = %q, want Bearer test-key", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(respBody))
+	}))
+	defer srv.Close()
+
+	p, _ := New("test-key", srv.URL)
+	models, err := p.DiscoverModels(context.Background())
+	if err != nil {
+		t.Fatalf("DiscoverModels() error: %v", err)
+	}
+	if len(models) != 2 {
+		t.Fatalf("DiscoverModels() returned %d models, want 2", len(models))
+	}
+	found := false
+	for _, m := range models {
+		if m.ID == "grok-4" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("DiscoverModels() = %+v, want a model with ID grok-4", models)
+	}
+}

--- a/providers/xai/xai_p5b_test.go
+++ b/providers/xai/xai_p5b_test.go
@@ -1,0 +1,43 @@
+package xai
+
+import (
+	"testing"
+
+	"github.com/ferro-labs/ai-gateway/providers/core"
+)
+
+// TestDroppedImageParams verifies the warn-on-drop helper reports exactly the
+// image parameters Grok image models ignore.
+func TestDroppedImageParams(t *testing.T) {
+	cases := []struct {
+		name string
+		req  core.ImageRequest
+		want []string
+	}{
+		{"none", core.ImageRequest{}, nil},
+		{"size", core.ImageRequest{Size: "1024x1024"}, []string{"size"}},
+		{"quality", core.ImageRequest{Quality: "hd"}, []string{"quality"}},
+		{"style", core.ImageRequest{Style: "vivid"}, []string{"style"}},
+		{"all", core.ImageRequest{Size: "1024x1024", Quality: "hd", Style: "vivid"}, []string{"size", "quality", "style"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := droppedImageParams(tc.req)
+			if len(got) != len(tc.want) {
+				t.Fatalf("droppedImageParams = %v, want %v", got, tc.want)
+			}
+			for i := range tc.want {
+				if got[i] != tc.want[i] {
+					t.Errorf("droppedImageParams[%d] = %q, want %q", i, got[i], tc.want[i])
+				}
+			}
+		})
+	}
+}
+
+// TestNewXAI_RejectsInvalidBaseURL locks in the base-URL validation.
+func TestNewXAI_RejectsInvalidBaseURL(t *testing.T) {
+	if _, err := New("k", "://bad"); err == nil {
+		t.Fatal("New accepted an invalid base URL")
+	}
+}


### PR DESCRIPTION
## v1.1.14 — OpenAI-Compat Providers II

The fifth provider-readiness remediation phase. Aligns six OpenAI-compatible providers — **xAI, OpenRouter, Moonshot, NVIDIA NIM, Perplexity, Novita** — on request/response correctness, plus shared enablers that benefit **every** OpenAI-compatible provider. No breaking API changes relative to v1.1.13.

### Shared foundation (benefits all ~20 openaicompat providers)
- **Nested usage decode** — `core.Usage.UnmarshalJSON` folds `prompt_tokens_details.cached_tokens` + `completion_tokens_details.reasoning_tokens` into the flat reasoning/cache fields, so providers that report usage in the nested form (xAI, OpenRouter) surface it on chat **and** streaming — one change, no per-provider decode.
- **Response metadata seam** — `core.Response.Metadata` (wire key `provider_metadata`) + opt-in `ChatParams.ExtraResponseFields` capture, surfacing provider-specific top-level data (Perplexity citations/search_results).
- **`input_type`** forwarded by the shared embeddings body; **`parallel_tool_calls`** added to `core.Request` and wired end-to-end through the HTTP decode path.

### Provider verticals
| Provider | Changes |
|---|---|
| **xai** | image.go → `core.ImageResponse` + `core.APIError`, forward `user`, warn dropped `size`/`quality`/`style`, `ValidateBaseURL`, grok-3/4 refresh; nested usage via shared decode |
| **openrouter** | new embeddings via `PostEmbeddings` (`CapabilityEmbed`), `ValidateBaseURL`, nested usage; stream-leak = known false-positive (skipped) |
| **perplexity** (2 HIGH) | drop the always-404 discovery, surface Sonar citations via `provider_metadata`, remove retired `sonar-reasoning`, `ValidateBaseURL` |
| **nvidia-nim** | adopt shared embeddings helper + error envelope (**−107 LOC**), wire discovery, `ValidateBaseURL` |
| **moonshot** | wire live discovery, `ValidateBaseURL`, tests; nested usage via shared decode (flat-field variant noted unverified) |
| **novita** | `ValidateBaseURL` + discovery/error/request tests; the "max_tokens-required" HIGH is a **verified non-issue** (OpenAI-wire = optional) |

### Review outcome (both HIGHs fixed)
- **go-reviewer**: confirmed the `UnmarshalJSON` type-alias is recursion-safe with **zero double-count risk** (native providers build `core.Usage` via struct literals). Its HIGH — `parallel_tool_calls` unreachable from the HTTP decode struct — is **fixed** (wired through the decode path + pool reset + test).
- **code-reviewer**: its HIGH (untested `droppedImageParams`) is **fixed** (unit test); MED parity/doc items addressed (base-URL rejection tests for xai/moonshot/openrouter, `AGENTS.md` discovery list, `provider_metadata` rename to avoid the OpenAI `metadata` clash).

### Deferred (recorded)
- `core.Request.Extra` passthrough map for provider-native params (novita `top_k`/`enable_thinking`, openrouter routing).
- Streaming citations for Perplexity (chat-only for now); `sonar-reasoning` still in the bundled pricing catalog (follow-up refresh; `SupportsModel` is permissive).
- Responses API surfaces (xai/openrouter); xai image `aspect_ratio`/`resolution`.

### Test plan
- [x] `go build ./...`, `gofmt`, `golangci-lint` (0 issues)
- [x] `go test -race ./...` — all 71+ packages green
- [x] New wire-level tests assert nested-usage decode, citations capture, `parallel_tool_calls` decode+forward, embeddings `input_type`, `droppedImageParams`, base-URL rejection, and error-path status/message propagation
- [x] `providers` capability↔interface stability gates + `models` catalog-coverage gate pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E8noYUkd7S9eHxR4Rky8AW


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for `parallel_tool_calls` in chat requests.
  * Added opt-in capture of extra top-level OpenAI-compatible chat response fields into response metadata (e.g., citations/search/image fields).
  * Added/expanded live model discovery for Moonshot and NVIDIA NIM; improved embeddings support (including OpenRouter and `input_type` forwarding).

* **Bug Fixes**
  * Improved usage parsing (including cached/reasoning token details) and more consistent error reporting for non-2xx responses.
  * Tightened base-URL trimming/validation/normalization across providers; improved xAI image parameter handling and response decoding.

* **Changed**
  * Removed live model discovery capability from Perplexity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->