### PR TITLE
test(providers): add error-path coverage for qwen provider

### DIFF
--- a/providers/qwen/qwen_test.go
+++ b/providers/qwen/qwen_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/ferro-labs/ai-gateway/providers/core"
@@ -201,5 +202,65 @@ func TestQwenProvider_Embed_InvalidEncodingFormat(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("Embed() error = nil, want unsupported encoding_format error")
+	}
+}
+
+// TestQwenProvider_Complete_ErrorStatus verifies that a non-2xx chat response is
+// surfaced as a normalized provider error (with the upstream status code and
+// message) rather than being decoded as a successful completion.
+func TestQwenProvider_Complete_ErrorStatus(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		body       string
+		wantMsg    string
+	}{
+		{
+			name:       "401 unauthorized",
+			statusCode: http.StatusUnauthorized,
+			body:       `{"error":{"message":"Invalid API key","type":"authentication_error"}}`,
+			wantMsg:    "Invalid API key",
+		},
+		{
+			name:       "429 rate limited",
+			statusCode: http.StatusTooManyRequests,
+			body:       `{"error":{"message":"Rate limit exceeded","type":"rate_limit_error"}}`,
+			wantMsg:    "Rate limit exceeded",
+		},
+		{
+			name:       "500 internal server error",
+			statusCode: http.StatusInternalServerError,
+			body:       `{"error":{"message":"Internal server error","type":"server_error"}}`,
+			wantMsg:    "Internal server error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(tt.statusCode)
+				_, _ = w.Write([]byte(tt.body))
+			}))
+			defer srv.Close()
+
+			p, _ := New("bad-key", srv.URL)
+			resp, err := p.Complete(context.Background(), core.Request{
+				Model:    "qwen-plus",
+				Messages: []core.Message{{Role: "user", Content: "Hi"}},
+			})
+			if err == nil {
+				t.Fatalf("Complete() error = nil, want an error for %d response", tt.statusCode)
+			}
+			if resp != nil {
+				t.Errorf("Complete() resp = %+v, want nil on error", resp)
+			}
+			if code := core.ParseStatusCode(err); code != tt.statusCode {
+				t.Errorf("ParseStatusCode() = %d, want %d", code, tt.statusCode)
+			}
+			if !strings.Contains(err.Error(), tt.wantMsg) {
+				t.Errorf("error = %q, want it to contain upstream message %q", err.Error(), tt.wantMsg)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary
  
Adds error-path test coverage for the **qwen** provider. Its test suite only exercised successful (2xx) responses; this adds a table-driven test asserting that non-2xx upstream responses are surfaced as normalized provider errors.
  
## Type of change
  
- [x] Refactor / code quality
  
## Related issues
  
Part of #304 — thanks for the go-ahead!
  
## Changes
  
- Add `TestQwenProvider_Complete_ErrorStatus` — table-driven cases for HTTP 401, 429 and 500 from a mock upstream (`httptest`).
- Assert `Complete` returns an error (nil response), that `core.ParseStatusCode(err)` matches the upstream status, and that the upstream error message is preserved.
  
## Testing
                                                                                                                                                                      
- [x] Existing tests pass (`go test ./...`)                                                                                                                         
- [x] New unit tests added (if applicable)                                                                                                                          
- [ ] Manually tested against a live provider (if provider change)                                                                                                  
                                                                                                                                                                      
`go test -short -race ./providers/qwen/` → all pass (15 tests, incl. 3 new subtests)