### PR TITLE
v1.1.16 - Local & Prediction-API Providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to Ferro Labs AI Gateway are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.16] — 2026-07-06
+
+Local & prediction-API provider fidelity release. The seventh provider-readiness remediation phase aligns the Hugging Face, Ollama, Ollama Cloud, and Replicate providers — which use task-specific, prediction, and native (non-OpenAI-wire) APIs — on request/response correctness. No breaking API changes relative to v1.1.15.
+
+### Fixed
+
+- **Hugging Face default endpoint**: the default base URL now targets `https://router.huggingface.co/v1`; the previous `api-inference.huggingface.co` host is retired and returns HTTP 410.
+- **Hugging Face embeddings and image generation**: both now use Hugging Face's task-specific routes and schemas (feature extraction returns a bare vector array; text-to-image returns raw image bytes) instead of OpenAI-shaped requests that hit the wrong endpoints.
+- **Replicate token usage & finish reasons**: chat responses now populate token usage from prediction metrics and normalize finish reasons instead of hardcoding them.
+- **Ollama Cloud sampling parameters**: `stop`/`seed`/presence/frequency penalties are now forwarded, remaining unsupported parameters are reported rather than dropped silently, finish reasons are normalized, and tool-call IDs are populated.
+- **Ollama embedding dimensions**: the `dimensions` parameter is now forwarded to Ollama's native embeddings endpoint.
+
+### Changed
+
+- **Replicate authentication** (operator-visible): the provider now sends the documented `Bearer` authorization scheme instead of the deprecated `Token` scheme (Replicate still accepts both).
+- **Replicate request timeout**: a tuned transport preset raises the response-header timeout so `Prefer: wait` predictions (held up to ~60s) are not aborted by the default 30s timeout.
+- **Ollama Cloud embeddings**: Ollama Cloud now supports an embeddings endpoint.
+- **Base-URL validation** is now enforced at construction for Hugging Face, Ollama, and Replicate.
+
+---
+
 ## [1.1.15] — 2026-07-05
 
 OpenAI-compatible provider fidelity release (part three) and Cloudflare. The sixth provider-readiness remediation phase aligns the AI21, Cloudflare, DeepInfra, Qwen, and SambaNova providers on request/response correctness. No breaking API changes relative to v1.1.14.

--- a/internal/transport/provider.go
+++ b/internal/transport/provider.go
@@ -81,6 +81,13 @@ func KnownProviderPresets() map[string]ProviderPreset {
 			ResponseHeaderTimeout: 120 * time.Second,
 			DialTimeout:           5 * time.Second,
 		},
+		"replicate": {
+			// Replicate's async prediction API holds the connection open for
+			// "Prefer: wait" submissions (~60s); the default 30s header timeout
+			// would abort these before the prediction resolves.
+			MaxIdleConnsPerHost:   100,
+			ResponseHeaderTimeout: 65 * time.Second,
+		},
 	}
 }
 

--- a/internal/transport/provider_test.go
+++ b/internal/transport/provider_test.go
@@ -36,6 +36,12 @@ func TestKnownProviderPresets(t *testing.T) {
 	if oll.MaxIdleConnsPerHost > 30 {
 		t.Errorf("ollama MaxIdleConnsPerHost = %d, want <= 30", oll.MaxIdleConnsPerHost)
 	}
+
+	// Replicate must tolerate the ~60s Prefer:wait prediction hold.
+	rep := presets["replicate"]
+	if rep.ResponseHeaderTimeout < 60*time.Second {
+		t.Errorf("replicate ResponseHeaderTimeout = %v, want >= 60s", rep.ResponseHeaderTimeout)
+	}
 }
 
 func TestApplyPreset(t *testing.T) {

--- a/providers/hugging_face/hugging_face.go
+++ b/providers/hugging_face/hugging_face.go
@@ -230,8 +230,8 @@ func parseFeatureExtraction(body []byte) ([][]float64, error) {
 // returns the generated image as raw bytes, which are base64-encoded into the
 // OpenAI-style b64_json field.
 func (p *Provider) GenerateImage(ctx context.Context, req core.ImageRequest) (*core.ImageResponse, error) {
-	if req.N != nil && *req.N > 1 {
-		return nil, fmt.Errorf("hugging face: text-to-image returns one image per request; n=%d is unsupported", *req.N)
+	if req.N != nil && *req.N != 1 {
+		return nil, fmt.Errorf("hugging face: text-to-image returns one image per request; only n=1 is supported (got %d)", *req.N)
 	}
 	payload := map[string]any{"inputs": req.Prompt}
 	if params := imageParameters(req); len(params) > 0 {

--- a/providers/hugging_face/hugging_face.go
+++ b/providers/hugging_face/hugging_face.go
@@ -184,11 +184,30 @@ func (p *Provider) Embed(ctx context.Context, req core.EmbeddingRequest) (*core.
 	if err != nil {
 		return nil, err
 	}
+	if want := expectedEmbeddingCount(req.Input); want > 0 && len(vectors) != want {
+		return nil, fmt.Errorf("hugging face: got %d embedding vectors for %d inputs", len(vectors), want)
+	}
 	data := make([]core.Embedding, len(vectors))
 	for i, vec := range vectors {
 		data[i] = core.Embedding{Object: "embedding", Embedding: vec, Index: i}
 	}
 	return &core.EmbeddingResponse{Object: "list", Data: data, Model: req.Model}, nil
+}
+
+// expectedEmbeddingCount reports how many input strings an embedding request
+// carries (1 for a single string), or 0 when the shape is unknown and the count
+// guard should be skipped.
+func expectedEmbeddingCount(input any) int {
+	switch v := input.(type) {
+	case string:
+		return 1
+	case []string:
+		return len(v)
+	case []any:
+		return len(v)
+	default:
+		return 0
+	}
 }
 
 // parseFeatureExtraction decodes a Hugging Face feature-extraction response into
@@ -211,6 +230,9 @@ func parseFeatureExtraction(body []byte) ([][]float64, error) {
 // returns the generated image as raw bytes, which are base64-encoded into the
 // OpenAI-style b64_json field.
 func (p *Provider) GenerateImage(ctx context.Context, req core.ImageRequest) (*core.ImageResponse, error) {
+	if req.N != nil && *req.N > 1 {
+		return nil, fmt.Errorf("hugging face: text-to-image returns one image per request; n=%d is unsupported", *req.N)
+	}
 	payload := map[string]any{"inputs": req.Prompt}
 	if params := imageParameters(req); len(params) > 0 {
 		payload["parameters"] = params

--- a/providers/hugging_face/hugging_face.go
+++ b/providers/hugging_face/hugging_face.go
@@ -3,10 +3,12 @@ package huggingface
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
 	"strings"
 
 	"github.com/ferro-labs/ai-gateway/internal/discovery"
@@ -18,7 +20,10 @@ import (
 // Name is the canonical provider identifier.
 const Name = "hugging-face"
 
-const defaultBaseURL = "https://api-inference.huggingface.co/v1"
+// defaultBaseURL is the Inference Providers router. Chat and model discovery are
+// OpenAI-compatible under /v1; task-specific routes (feature extraction,
+// text-to-image) live directly under the router root.
+const defaultBaseURL = "https://router.huggingface.co/v1"
 
 // Provider implements the Hugging Face Inference API client.
 type Provider struct {
@@ -39,10 +44,13 @@ var (
 )
 
 // New creates a new Hugging Face provider.
-// If baseURL is empty, the shared Inference API is used.
+// If baseURL is empty, the shared Inference Providers router is used.
 func New(apiKey, baseURL string) (*Provider, error) {
+	baseURL = strings.TrimSpace(baseURL)
 	if baseURL == "" {
 		baseURL = defaultBaseURL
+	} else if err := core.ValidateBaseURL(Name, baseURL); err != nil {
+		return nil, err
 	}
 	baseURL = strings.TrimRight(baseURL, "/")
 	return &Provider{
@@ -58,6 +66,13 @@ func (p *Provider) Name() string { return p.name }
 
 // BaseURL implements core.ProxiableProvider.
 func (p *Provider) BaseURL() string { return p.baseURL }
+
+// routerRoot returns the Inference Providers router root by stripping the
+// trailing "/v1" chat suffix from baseURL. Task-specific routes (feature
+// extraction, text-to-image) hang directly off the root, not under /v1.
+func (p *Provider) routerRoot() string {
+	return strings.TrimSuffix(p.baseURL, "/v1")
+}
 
 // AuthHeaders implements core.ProxiableProvider.
 func (p *Provider) AuthHeaders() map[string]string {
@@ -108,76 +123,124 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 	}, req)
 }
 
-// Embed sends an embedding request to Hugging Face.
+// postTask sends a POST with a JSON body to a task-specific Hugging Face router
+// endpoint and returns the raw response bytes. Non-200 responses are translated
+// into a core.APIError carrying the upstream status and message.
+func (p *Provider) postTask(ctx context.Context, url string, body io.Reader) ([]byte, error) {
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	httpReq.Header.Set("Authorization", "Bearer "+p.apiKey)
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	httpResp, err := p.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer func() { _ = httpResp.Body.Close() }()
+
+	respBody, err := io.ReadAll(httpResp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+	if httpResp.StatusCode != http.StatusOK {
+		return nil, core.APIError("hugging face", httpResp.StatusCode, respBody)
+	}
+	return respBody, nil
+}
+
+// Embed sends a feature-extraction request to Hugging Face. The task API is not
+// OpenAI-shaped: it takes {"inputs": <string|[]string>} and returns a bare JSON
+// array of float vectors ([]float64 for a single input, [][]float64 for a
+// batch). Hugging Face does not report token usage, so Usage stays zero.
 func (p *Provider) Embed(ctx context.Context, req core.EmbeddingRequest) (*core.EmbeddingResponse, error) {
-	bodyReader, _, release, err := core.JSONBodyReader(req)
+	bodyReader, _, release, err := core.JSONBodyReader(map[string]any{"inputs": req.Input})
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal embedding request: %w", err)
 	}
 	defer release()
 
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, p.baseURL+"/embeddings", bodyReader)
+	url := p.routerRoot() + "/hf-inference/models/" + req.Model + "/pipeline/feature-extraction"
+	respBody, err := p.postTask(ctx, url, bodyReader)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
+		return nil, err
 	}
-	httpReq.Header.Set("Authorization", "Bearer "+p.apiKey)
-	httpReq.Header.Set("Content-Type", "application/json")
 
-	httpResp, err := p.httpClient.Do(httpReq)
+	vectors, err := parseFeatureExtraction(respBody)
 	if err != nil {
-		return nil, fmt.Errorf("request failed: %w", err)
+		return nil, err
 	}
-	defer func() { _ = httpResp.Body.Close() }()
-
-	respBody, err := io.ReadAll(httpResp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read response: %w", err)
+	data := make([]core.Embedding, len(vectors))
+	for i, vec := range vectors {
+		data[i] = core.Embedding{Object: "embedding", Embedding: vec, Index: i}
 	}
-
-	if httpResp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("hugging face API error (%d): %s", httpResp.StatusCode, string(respBody))
-	}
-
-	var resp core.EmbeddingResponse
-	if err := json.Unmarshal(respBody, &resp); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
-	}
-	return &resp, nil
+	return &core.EmbeddingResponse{Object: "list", Data: data, Model: req.Model}, nil
 }
 
-// GenerateImage sends an image generation request to Hugging Face.
+// parseFeatureExtraction decodes a Hugging Face feature-extraction response into
+// one vector per input. The response is a bare JSON array: []float64 for a
+// single string input, or [][]float64 for a batch of inputs.
+func parseFeatureExtraction(body []byte) ([][]float64, error) {
+	var batch [][]float64
+	if err := json.Unmarshal(body, &batch); err == nil {
+		return batch, nil
+	}
+	var single []float64
+	if err := json.Unmarshal(body, &single); err == nil {
+		return [][]float64{single}, nil
+	}
+	return nil, fmt.Errorf("failed to parse feature-extraction response")
+}
+
+// GenerateImage sends a text-to-image request to Hugging Face. The task API is
+// not OpenAI-shaped: it takes {"inputs": <prompt>, "parameters": {...}} and
+// returns the generated image as raw bytes, which are base64-encoded into the
+// OpenAI-style b64_json field.
 func (p *Provider) GenerateImage(ctx context.Context, req core.ImageRequest) (*core.ImageResponse, error) {
-	bodyReader, _, release, err := core.JSONBodyReader(req)
+	payload := map[string]any{"inputs": req.Prompt}
+	if params := imageParameters(req); len(params) > 0 {
+		payload["parameters"] = params
+	}
+	bodyReader, _, release, err := core.JSONBodyReader(payload)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal image request: %w", err)
 	}
 	defer release()
 
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, p.baseURL+"/images/generations", bodyReader)
+	url := p.routerRoot() + "/hf-inference/models/" + req.Model
+	respBody, err := p.postTask(ctx, url, bodyReader)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
-	}
-	httpReq.Header.Set("Authorization", "Bearer "+p.apiKey)
-	httpReq.Header.Set("Content-Type", "application/json")
-
-	httpResp, err := p.httpClient.Do(httpReq)
-	if err != nil {
-		return nil, fmt.Errorf("request failed: %w", err)
-	}
-	defer func() { _ = httpResp.Body.Close() }()
-
-	respBody, err := io.ReadAll(httpResp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read response: %w", err)
+		return nil, err
 	}
 
-	if httpResp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("hugging face API error (%d): %s", httpResp.StatusCode, string(respBody))
-	}
+	b64 := base64.StdEncoding.EncodeToString(respBody)
+	return &core.ImageResponse{Data: []core.GeneratedImage{{B64JSON: b64}}}, nil
+}
 
-	var resp core.ImageResponse
-	if err := json.Unmarshal(respBody, &resp); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
+// imageParameters builds the Hugging Face text-to-image "parameters" object from
+// the OpenAI-shaped request. Only fields with a Hugging Face equivalent are
+// mapped; Size ("WIDTHxHEIGHT") becomes width/height integers.
+func imageParameters(req core.ImageRequest) map[string]any {
+	params := map[string]any{}
+	if w, h, ok := parseSize(req.Size); ok {
+		params["width"] = w
+		params["height"] = h
 	}
-	return &resp, nil
+	return params
+}
+
+// parseSize splits an OpenAI-style "WIDTHxHEIGHT" size string into positive
+// integer dimensions. It reports ok=false for empty or malformed values.
+func parseSize(size string) (width, height int, ok bool) {
+	parts := strings.SplitN(size, "x", 2)
+	if len(parts) != 2 {
+		return 0, 0, false
+	}
+	w, err1 := strconv.Atoi(strings.TrimSpace(parts[0]))
+	h, err2 := strconv.Atoi(strings.TrimSpace(parts[1]))
+	if err1 != nil || err2 != nil || w <= 0 || h <= 0 {
+		return 0, 0, false
+	}
+	return w, h, true
 }

--- a/providers/hugging_face/hugging_face.go
+++ b/providers/hugging_face/hugging_face.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 
@@ -72,6 +73,17 @@ func (p *Provider) BaseURL() string { return p.baseURL }
 // extraction, text-to-image) hang directly off the root, not under /v1.
 func (p *Provider) routerRoot() string {
 	return strings.TrimSuffix(p.baseURL, "/v1")
+}
+
+// escapeModelPath percent-escapes each segment of a caller-supplied model id
+// (e.g. "owner/name") while preserving the "/" separators the router task routes
+// use, so a crafted model string can't alter the request path.
+func escapeModelPath(model string) string {
+	parts := strings.Split(model, "/")
+	for i, part := range parts {
+		parts[i] = url.PathEscape(part)
+	}
+	return strings.Join(parts, "/")
 }
 
 // AuthHeaders implements core.ProxiableProvider.
@@ -153,7 +165,8 @@ func (p *Provider) postTask(ctx context.Context, url string, body io.Reader) ([]
 // Embed sends a feature-extraction request to Hugging Face. The task API is not
 // OpenAI-shaped: it takes {"inputs": <string|[]string>} and returns a bare JSON
 // array of float vectors ([]float64 for a single input, [][]float64 for a
-// batch). Hugging Face does not report token usage, so Usage stays zero.
+// batch). Hugging Face does not report token usage, so Usage stays zero;
+// req.EncodingFormat and req.Dimensions have no task-API equivalent and are ignored.
 func (p *Provider) Embed(ctx context.Context, req core.EmbeddingRequest) (*core.EmbeddingResponse, error) {
 	bodyReader, _, release, err := core.JSONBodyReader(map[string]any{"inputs": req.Input})
 	if err != nil {
@@ -161,8 +174,8 @@ func (p *Provider) Embed(ctx context.Context, req core.EmbeddingRequest) (*core.
 	}
 	defer release()
 
-	url := p.routerRoot() + "/hf-inference/models/" + req.Model + "/pipeline/feature-extraction"
-	respBody, err := p.postTask(ctx, url, bodyReader)
+	taskURL := p.routerRoot() + "/hf-inference/models/" + escapeModelPath(req.Model) + "/pipeline/feature-extraction"
+	respBody, err := p.postTask(ctx, taskURL, bodyReader)
 	if err != nil {
 		return nil, err
 	}
@@ -208,8 +221,8 @@ func (p *Provider) GenerateImage(ctx context.Context, req core.ImageRequest) (*c
 	}
 	defer release()
 
-	url := p.routerRoot() + "/hf-inference/models/" + req.Model
-	respBody, err := p.postTask(ctx, url, bodyReader)
+	taskURL := p.routerRoot() + "/hf-inference/models/" + escapeModelPath(req.Model)
+	respBody, err := p.postTask(ctx, taskURL, bodyReader)
 	if err != nil {
 		return nil, err
 	}

--- a/providers/hugging_face/hugging_face.go
+++ b/providers/hugging_face/hugging_face.go
@@ -77,13 +77,18 @@ func (p *Provider) routerRoot() string {
 
 // escapeModelPath percent-escapes each segment of a caller-supplied model id
 // (e.g. "owner/name") while preserving the "/" separators the router task routes
-// use, so a crafted model string can't alter the request path.
-func escapeModelPath(model string) string {
+// use. Empty and dot ("."/"..") segments are rejected — url.PathEscape leaves
+// them unchanged, so they would otherwise let a crafted model traverse to a
+// different router path.
+func escapeModelPath(model string) (string, error) {
 	parts := strings.Split(model, "/")
 	for i, part := range parts {
+		if part == "" || part == "." || part == ".." {
+			return "", fmt.Errorf("hugging face: invalid model path segment %q", part)
+		}
 		parts[i] = url.PathEscape(part)
 	}
-	return strings.Join(parts, "/")
+	return strings.Join(parts, "/"), nil
 }
 
 // AuthHeaders implements core.ProxiableProvider.
@@ -168,13 +173,17 @@ func (p *Provider) postTask(ctx context.Context, url string, body io.Reader) ([]
 // batch). Hugging Face does not report token usage, so Usage stays zero;
 // req.EncodingFormat and req.Dimensions have no task-API equivalent and are ignored.
 func (p *Provider) Embed(ctx context.Context, req core.EmbeddingRequest) (*core.EmbeddingResponse, error) {
+	escaped, err := escapeModelPath(req.Model)
+	if err != nil {
+		return nil, err
+	}
 	bodyReader, _, release, err := core.JSONBodyReader(map[string]any{"inputs": req.Input})
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal embedding request: %w", err)
 	}
 	defer release()
 
-	taskURL := p.routerRoot() + "/hf-inference/models/" + escapeModelPath(req.Model) + "/pipeline/feature-extraction"
+	taskURL := p.routerRoot() + "/hf-inference/models/" + escaped + "/pipeline/feature-extraction"
 	respBody, err := p.postTask(ctx, taskURL, bodyReader)
 	if err != nil {
 		return nil, err
@@ -233,6 +242,10 @@ func (p *Provider) GenerateImage(ctx context.Context, req core.ImageRequest) (*c
 	if req.N != nil && *req.N != 1 {
 		return nil, fmt.Errorf("hugging face: text-to-image returns one image per request; only n=1 is supported (got %d)", *req.N)
 	}
+	escaped, err := escapeModelPath(req.Model)
+	if err != nil {
+		return nil, err
+	}
 	payload := map[string]any{"inputs": req.Prompt}
 	if params := imageParameters(req); len(params) > 0 {
 		payload["parameters"] = params
@@ -243,7 +256,7 @@ func (p *Provider) GenerateImage(ctx context.Context, req core.ImageRequest) (*c
 	}
 	defer release()
 
-	taskURL := p.routerRoot() + "/hf-inference/models/" + escapeModelPath(req.Model)
+	taskURL := p.routerRoot() + "/hf-inference/models/" + escaped
 	respBody, err := p.postTask(ctx, taskURL, bodyReader)
 	if err != nil {
 		return nil, err

--- a/providers/hugging_face/hugging_face_p7_test.go
+++ b/providers/hugging_face/hugging_face_p7_test.go
@@ -1,0 +1,66 @@
+package huggingface
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/ferro-labs/ai-gateway/providers/core"
+)
+
+// TestNewHuggingFace_RejectsInvalidBaseURL locks in base-URL validation.
+func TestNewHuggingFace_RejectsInvalidBaseURL(t *testing.T) {
+	if _, err := New("k", "://nope"); err == nil {
+		t.Fatal("New accepted an invalid base URL")
+	}
+}
+
+// TestEmbed_StripsV1FromTaskRoute verifies routerRoot strips a "/v1"-suffixed
+// base URL so the feature-extraction task route is built off the router root
+// (this is the production path — the default base URL ends in "/v1").
+func TestEmbed_StripsV1FromTaskRoute(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `[0.1,0.2,0.3]`)
+	}))
+	defer srv.Close()
+
+	p, err := New("k", srv.URL+"/v1")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if _, err := p.Embed(context.Background(), core.EmbeddingRequest{
+		Model: "sentence-transformers/all-MiniLM-L6-v2",
+		Input: "hello",
+	}); err != nil {
+		t.Fatalf("Embed: %v", err)
+	}
+	want := "/hf-inference/models/sentence-transformers/all-MiniLM-L6-v2/pipeline/feature-extraction"
+	if gotPath != want {
+		t.Errorf("task path = %q, want %q (the /v1 must be stripped)", gotPath, want)
+	}
+}
+
+// TestEmbed_EscapesModelPath verifies special characters in the model id are
+// percent-escaped (so they can't alter the request path) while the owner/name
+// slash is preserved.
+func TestEmbed_EscapesModelPath(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.EscapedPath()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `[0.1]`)
+	}))
+	defer srv.Close()
+
+	p, _ := New("k", srv.URL+"/v1")
+	_, _ = p.Embed(context.Background(), core.EmbeddingRequest{Model: "owner/bad#name", Input: "hi"})
+	// "#" must be escaped so it doesn't become a fragment and drop the path tail.
+	if want := "/hf-inference/models/owner/bad%23name/pipeline/feature-extraction"; gotPath != want {
+		t.Errorf("escaped path = %q, want %q", gotPath, want)
+	}
+}

--- a/providers/hugging_face/hugging_face_p7_test.go
+++ b/providers/hugging_face/hugging_face_p7_test.go
@@ -64,3 +64,14 @@ func TestEmbed_EscapesModelPath(t *testing.T) {
 		t.Errorf("escaped path = %q, want %q", gotPath, want)
 	}
 }
+
+// TestGenerateImage_RejectsMultipleImages locks in that n>1 is rejected rather
+// than silently returning a single image (HF yields one image per request).
+func TestGenerateImage_RejectsMultipleImages(t *testing.T) {
+	p, _ := New("k", "https://router.huggingface.co/v1")
+	n := 2
+	_, err := p.GenerateImage(context.Background(), core.ImageRequest{Model: "owner/model", Prompt: "a cat", N: &n})
+	if err == nil {
+		t.Fatal("GenerateImage accepted n>1, want error")
+	}
+}

--- a/providers/hugging_face/hugging_face_p7_test.go
+++ b/providers/hugging_face/hugging_face_p7_test.go
@@ -65,23 +65,37 @@ func TestEmbed_EscapesModelPath(t *testing.T) {
 	}
 }
 
+// failOnRequest returns an httptest server that fails the test if any request
+// reaches it, so a validation test passes only when local validation
+// short-circuits before the network (not because a real call errored out).
+func failOnRequest(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("unexpected outbound request: %s %s", r.Method, r.URL.Path)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+}
+
 // TestGenerateImage_RejectsNonSingleN locks in that any explicit n != 1 is
-// rejected rather than silently returning a single image (HF yields exactly one
+// rejected by local validation before any request is sent (HF yields exactly one
 // image per request); nil n is allowed.
 func TestGenerateImage_RejectsNonSingleN(t *testing.T) {
-	p, _ := New("k", "https://router.huggingface.co/v1")
+	srv := failOnRequest(t)
+	defer srv.Close()
+	p, _ := New("k", srv.URL)
 	for _, n := range []int{2, 0, -1} {
-		_, err := p.GenerateImage(context.Background(), core.ImageRequest{Model: "owner/model", Prompt: "a cat", N: &n})
-		if err == nil {
+		if _, err := p.GenerateImage(context.Background(), core.ImageRequest{Model: "owner/model", Prompt: "a cat", N: &n}); err == nil {
 			t.Errorf("GenerateImage accepted n=%d, want error", n)
 		}
 	}
 }
 
 // TestEmbed_RejectsTraversalModel locks in that dot segments in the model id are
-// rejected rather than escaping to a different router path.
+// rejected by local validation before any request is sent.
 func TestEmbed_RejectsTraversalModel(t *testing.T) {
-	p, _ := New("k", "https://router.huggingface.co/v1")
+	srv := failOnRequest(t)
+	defer srv.Close()
+	p, _ := New("k", srv.URL)
 	if _, err := p.Embed(context.Background(), core.EmbeddingRequest{Model: "../../secret", Input: "hi"}); err == nil {
 		t.Fatal("Embed accepted a traversal model path, want error")
 	}

--- a/providers/hugging_face/hugging_face_p7_test.go
+++ b/providers/hugging_face/hugging_face_p7_test.go
@@ -77,3 +77,12 @@ func TestGenerateImage_RejectsNonSingleN(t *testing.T) {
 		}
 	}
 }
+
+// TestEmbed_RejectsTraversalModel locks in that dot segments in the model id are
+// rejected rather than escaping to a different router path.
+func TestEmbed_RejectsTraversalModel(t *testing.T) {
+	p, _ := New("k", "https://router.huggingface.co/v1")
+	if _, err := p.Embed(context.Background(), core.EmbeddingRequest{Model: "../../secret", Input: "hi"}); err == nil {
+		t.Fatal("Embed accepted a traversal model path, want error")
+	}
+}

--- a/providers/hugging_face/hugging_face_p7_test.go
+++ b/providers/hugging_face/hugging_face_p7_test.go
@@ -65,13 +65,15 @@ func TestEmbed_EscapesModelPath(t *testing.T) {
 	}
 }
 
-// TestGenerateImage_RejectsMultipleImages locks in that n>1 is rejected rather
-// than silently returning a single image (HF yields one image per request).
-func TestGenerateImage_RejectsMultipleImages(t *testing.T) {
+// TestGenerateImage_RejectsNonSingleN locks in that any explicit n != 1 is
+// rejected rather than silently returning a single image (HF yields exactly one
+// image per request); nil n is allowed.
+func TestGenerateImage_RejectsNonSingleN(t *testing.T) {
 	p, _ := New("k", "https://router.huggingface.co/v1")
-	n := 2
-	_, err := p.GenerateImage(context.Background(), core.ImageRequest{Model: "owner/model", Prompt: "a cat", N: &n})
-	if err == nil {
-		t.Fatal("GenerateImage accepted n>1, want error")
+	for _, n := range []int{2, 0, -1} {
+		_, err := p.GenerateImage(context.Background(), core.ImageRequest{Model: "owner/model", Prompt: "a cat", N: &n})
+		if err == nil {
+			t.Errorf("GenerateImage accepted n=%d, want error", n)
+		}
 	}
 }

--- a/providers/hugging_face/hugging_face_test.go
+++ b/providers/hugging_face/hugging_face_test.go
@@ -2,8 +2,11 @@ package huggingface
 
 import (
 	"context"
+	"encoding/base64"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/ferro-labs/ai-gateway/providers/core"
@@ -23,8 +26,8 @@ func TestNewHuggingFace(t *testing.T) {
 	if p.Name() != "hugging-face" {
 		t.Errorf("Name() = %q, want hugging-face", p.Name())
 	}
-	if p.BaseURL() != "https://api-inference.huggingface.co/v1" {
-		t.Errorf("BaseURL() = %q, want https://api-inference.huggingface.co/v1", p.BaseURL())
+	if p.BaseURL() != "https://router.huggingface.co/v1" {
+		t.Errorf("BaseURL() = %q, want https://router.huggingface.co/v1", p.BaseURL())
 	}
 }
 
@@ -72,6 +75,27 @@ func TestHuggingFaceProvider_Complete_MockHTTP(t *testing.T) {
 	}
 }
 
+func TestHuggingFaceProvider_Complete_ErrorStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":{"message":"bad model"}}`))
+	}))
+	defer srv.Close()
+
+	p, _ := New(testAPIKey, srv.URL)
+	_, err := p.Complete(context.Background(), core.Request{
+		Model:    "does-not-exist",
+		Messages: []core.Message{{Role: "user", Content: "Hi"}},
+	})
+	if err == nil {
+		t.Fatal("Complete() error = nil, want non-nil on HTTP 400")
+	}
+	if got := core.ParseStatusCode(err); got != http.StatusBadRequest {
+		t.Errorf("ParseStatusCode = %d, want %d (err: %v)", got, http.StatusBadRequest, err)
+	}
+}
+
 func TestHuggingFaceProvider_CompleteStream_MockSSE(t *testing.T) {
 	sseData := "data: {\"id\":\"chatcmpl-1\",\"model\":\"meta-llama/Meta-Llama-3.1-8B-Instruct\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\"},\"finish_reason\":\"\"}]}\n\n" +
 		"data: {\"id\":\"chatcmpl-1\",\"model\":\"meta-llama/Meta-Llama-3.1-8B-Instruct\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"Hello\"},\"finish_reason\":\"\"}]}\n\n" +
@@ -107,16 +131,46 @@ func TestHuggingFaceProvider_CompleteStream_MockSSE(t *testing.T) {
 	}
 }
 
-func TestHuggingFaceProvider_Embed_MockHTTP(t *testing.T) {
-	embedResp := `{"object":"list","data":[{"object":"embedding","embedding":[0.1,0.2],"index":0}],"model":"test-embed","usage":{"prompt_tokens":2,"total_tokens":2}}`
+func TestHuggingFaceProvider_DiscoverModels_MockHTTP(t *testing.T) {
+	listBody := `{"object":"list","data":[{"id":"model-a","owned_by":"acme"},{"id":"model-b"}]}`
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/embeddings" {
-			t.Errorf("request path = %q, want /embeddings", r.URL.Path)
+		if r.URL.Path != "/models" {
+			t.Errorf("request path = %q, want /models", r.URL.Path)
 		}
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(embedResp))
+		_, _ = w.Write([]byte(listBody))
+	}))
+	defer srv.Close()
+
+	p, _ := New(testAPIKey, srv.URL)
+	models, err := p.DiscoverModels(context.Background())
+	if err != nil {
+		t.Fatalf("DiscoverModels() error: %v", err)
+	}
+	if len(models) != 2 {
+		t.Fatalf("models length = %d, want 2", len(models))
+	}
+	if models[0].ID != "model-a" {
+		t.Errorf("models[0].ID = %q, want model-a", models[0].ID)
+	}
+}
+
+func TestHuggingFaceProvider_Embed_Single(t *testing.T) {
+	const wantPath = "/hf-inference/models/test-embed/pipeline/feature-extraction"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != wantPath {
+			t.Errorf("request path = %q, want %s", r.URL.Path, wantPath)
+		}
+		body, _ := io.ReadAll(r.Body)
+		if !strings.Contains(string(body), `"inputs":"hello"`) {
+			t.Errorf("request body = %q, want to contain inputs:hello", string(body))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`[0.1,0.2,0.3]`))
 	}))
 	defer srv.Close()
 
@@ -131,18 +185,76 @@ func TestHuggingFaceProvider_Embed_MockHTTP(t *testing.T) {
 	if len(resp.Data) != 1 {
 		t.Fatalf("Data length = %d, want 1", len(resp.Data))
 	}
+	if len(resp.Data[0].Embedding) != 3 {
+		t.Errorf("embedding length = %d, want 3", len(resp.Data[0].Embedding))
+	}
+	if resp.Data[0].Object != "embedding" || resp.Data[0].Index != 0 {
+		t.Errorf("embedding meta = {%q,%d}, want {embedding,0}", resp.Data[0].Object, resp.Data[0].Index)
+	}
+	if resp.Usage.TotalTokens != 0 {
+		t.Errorf("Usage.TotalTokens = %d, want 0", resp.Usage.TotalTokens)
+	}
+}
+
+func TestHuggingFaceProvider_Embed_Batch(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`[[0.1,0.2],[0.3,0.4]]`))
+	}))
+	defer srv.Close()
+
+	p, _ := New(testAPIKey, srv.URL)
+	resp, err := p.Embed(context.Background(), core.EmbeddingRequest{
+		Model: "test-embed",
+		Input: []string{"a", "b"},
+	})
+	if err != nil {
+		t.Fatalf("Embed() error: %v", err)
+	}
+	if len(resp.Data) != 2 {
+		t.Fatalf("Data length = %d, want 2", len(resp.Data))
+	}
+	if resp.Data[1].Index != 1 {
+		t.Errorf("Data[1].Index = %d, want 1", resp.Data[1].Index)
+	}
+}
+
+func TestHuggingFaceProvider_Embed_ErrorStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte(`{"error":{"message":"model loading"}}`))
+	}))
+	defer srv.Close()
+
+	p, _ := New(testAPIKey, srv.URL)
+	_, err := p.Embed(context.Background(), core.EmbeddingRequest{Model: "test-embed", Input: "hello"})
+	if err == nil {
+		t.Fatal("Embed() error = nil, want non-nil on HTTP 503")
+	}
+	if got := core.ParseStatusCode(err); got != http.StatusServiceUnavailable {
+		t.Errorf("ParseStatusCode = %d, want %d (err: %v)", got, http.StatusServiceUnavailable, err)
+	}
 }
 
 func TestHuggingFaceProvider_GenerateImage_MockHTTP(t *testing.T) {
-	imageResp := `{"created":123,"data":[{"url":"https://example.com/image.png"}]}`
+	const wantPath = "/hf-inference/models/black-forest-labs/FLUX.1-schnell"
+	rawImage := []byte("\x89PNG\r\n\x1a\nfake-image-bytes")
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/images/generations" {
-			t.Errorf("request path = %q, want /images/generations", r.URL.Path)
+		if r.URL.Path != wantPath {
+			t.Errorf("request path = %q, want %s", r.URL.Path, wantPath)
 		}
-		w.Header().Set("Content-Type", "application/json")
+		body, _ := io.ReadAll(r.Body)
+		if !strings.Contains(string(body), `"inputs":"A mountain at sunrise"`) {
+			t.Errorf("request body = %q, want to contain the prompt", string(body))
+		}
+		if !strings.Contains(string(body), `"width":512`) || !strings.Contains(string(body), `"height":512`) {
+			t.Errorf("request body = %q, want width/height parameters", string(body))
+		}
+		w.Header().Set("Content-Type", "image/png")
 		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(imageResp))
+		_, _ = w.Write(rawImage)
 	}))
 	defer srv.Close()
 
@@ -150,11 +262,36 @@ func TestHuggingFaceProvider_GenerateImage_MockHTTP(t *testing.T) {
 	resp, err := p.GenerateImage(context.Background(), core.ImageRequest{
 		Model:  "black-forest-labs/FLUX.1-schnell",
 		Prompt: "A mountain at sunrise",
+		Size:   "512x512",
 	})
 	if err != nil {
 		t.Fatalf("GenerateImage() error: %v", err)
 	}
 	if len(resp.Data) != 1 {
 		t.Fatalf("Data length = %d, want 1", len(resp.Data))
+	}
+	want := base64.StdEncoding.EncodeToString(rawImage)
+	if resp.Data[0].B64JSON != want {
+		t.Errorf("B64JSON = %q, want %q", resp.Data[0].B64JSON, want)
+	}
+}
+
+func TestHuggingFaceProvider_GenerateImage_ErrorStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":{"message":"invalid token"}}`))
+	}))
+	defer srv.Close()
+
+	p, _ := New(testAPIKey, srv.URL)
+	_, err := p.GenerateImage(context.Background(), core.ImageRequest{
+		Model:  "black-forest-labs/FLUX.1-schnell",
+		Prompt: "A mountain at sunrise",
+	})
+	if err == nil {
+		t.Fatal("GenerateImage() error = nil, want non-nil on HTTP 401")
+	}
+	if got := core.ParseStatusCode(err); got != http.StatusUnauthorized {
+		t.Errorf("ParseStatusCode = %d, want %d (err: %v)", got, http.StatusUnauthorized, err)
 	}
 }

--- a/providers/ollama/embedding.go
+++ b/providers/ollama/embedding.go
@@ -12,8 +12,9 @@ import (
 
 // ollamaEmbedRequest is the native Ollama /api/embed request schema.
 type ollamaEmbedRequest struct {
-	Model string `json:"model"`
-	Input any    `json:"input"` // string or []string
+	Model      string `json:"model"`
+	Input      any    `json:"input"` // string or []string
+	Dimensions *int   `json:"dimensions,omitempty"`
 }
 
 // ollamaEmbedResponse is the native Ollama /api/embed response schema.
@@ -33,11 +34,13 @@ func (p *Provider) Embed(ctx context.Context, req core.EmbeddingRequest) (*core.
 	if req.EncodingFormat != "" && req.EncodingFormat != "float" {
 		return nil, fmt.Errorf("embed: unsupported encoding_format %q; valid value is \"float\"", req.EncodingFormat)
 	}
-	// Ollama's native API does not support output dimension control; ignore req.Dimensions.
 
+	// Ollama's /api/embed accepts a "dimensions" advanced parameter; forward it
+	// when the caller requested a specific output dimension (nil is omitted).
 	pReq := ollamaEmbedRequest{
-		Model: req.Model,
-		Input: input,
+		Model:      req.Model,
+		Input:      input,
+		Dimensions: req.Dimensions,
 	}
 	bodyReader, _, release, err := core.JSONBodyReader(pReq)
 	if err != nil {

--- a/providers/ollama/ollama.go
+++ b/providers/ollama/ollama.go
@@ -39,10 +39,14 @@ var (
 
 // New creates a new Ollama provider.
 func New(baseURL string, models []string) (*Provider, error) {
+	baseURL = strings.TrimSpace(baseURL)
 	if baseURL == "" {
 		baseURL = defaultBaseURL
 	}
 	baseURL = strings.TrimRight(baseURL, "/")
+	if err := core.ValidateBaseURL(Name, baseURL); err != nil {
+		return nil, err
+	}
 
 	if len(models) == 0 {
 		models = []string{"llama3.2"}
@@ -77,66 +81,25 @@ func (p *Provider) Models() []core.ModelInfo {
 	return core.ModelsFromList(p.name, p.SupportedModels())
 }
 
-type ollamaResponse struct {
-	ID      string        `json:"id"`
-	Model   string        `json:"model"`
-	Choices []core.Choice `json:"choices"`
-	Usage   core.Usage    `json:"usage"`
-}
-
 type ollamaErrorDetail struct {
 	Message string `json:"message"`
-	Type    string `json:"type"`
 }
 
 type ollamaErrorResponse struct {
 	Error ollamaErrorDetail `json:"error"`
 }
 
-// Complete sends a chat completion request and returns the full response.
+// Complete sends a chat completion request and returns the full response. It
+// speaks Ollama's OpenAI-compatible /v1/chat/completions endpoint via the shared
+// helper, which sets core.Response.Provider and normalizes finish reasons.
 func (p *Provider) Complete(ctx context.Context, req core.Request) (*core.Response, error) {
-	bodyReader, _, release, err := openaicompat.BuildBody(req, false)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal request: %w", err)
-	}
-	defer release()
-
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, p.baseURL+"/v1/chat/completions", bodyReader)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
-	}
-	httpReq.Header.Set("Content-Type", "application/json")
-
-	httpResp, err := p.httpClient.Do(httpReq)
-	if err != nil {
-		return nil, fmt.Errorf("request failed: %w", err)
-	}
-	defer func() { _ = httpResp.Body.Close() }()
-
-	respBody, err := io.ReadAll(httpResp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read response: %w", err)
-	}
-
-	if httpResp.StatusCode != http.StatusOK {
-		var errResp ollamaErrorResponse
-		if json.Unmarshal(respBody, &errResp) == nil && errResp.Error.Message != "" {
-			return nil, fmt.Errorf("ollama API error (%d): %s", httpResp.StatusCode, errResp.Error.Message)
-		}
-		return nil, fmt.Errorf("ollama API error (%d): %s", httpResp.StatusCode, string(respBody))
-	}
-
-	var ollamaResp ollamaResponse
-	if err := json.Unmarshal(respBody, &ollamaResp); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
-	}
-
-	return &core.Response{
-		ID:      ollamaResp.ID,
-		Model:   ollamaResp.Model,
-		Choices: ollamaResp.Choices,
-		Usage:   ollamaResp.Usage,
-	}, nil
+	return openaicompat.PostChat(ctx, openaicompat.ChatParams{
+		HTTPClient: p.httpClient,
+		URL:        p.baseURL + "/v1/chat/completions",
+		Provider:   p.name,
+		Label:      "ollama",
+		Headers:    map[string]string{"Content-Type": "application/json"},
+	}, req)
 }
 
 // CompleteStream sends a streaming chat completion request to Ollama.

--- a/providers/ollama/ollama_p7_test.go
+++ b/providers/ollama/ollama_p7_test.go
@@ -1,0 +1,10 @@
+package ollama
+
+import "testing"
+
+// TestNewOllama_RejectsInvalidBaseURL locks in base-URL validation.
+func TestNewOllama_RejectsInvalidBaseURL(t *testing.T) {
+	if _, err := New("://nope", nil); err == nil {
+		t.Fatal("New accepted an invalid base URL")
+	}
+}

--- a/providers/ollama/ollama_test.go
+++ b/providers/ollama/ollama_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -64,6 +65,87 @@ func TestOllamaProvider_Models(t *testing.T) {
 func TestOllamaProvider_CompleteStream_Interface(_ *testing.T) {
 	p, _ := New("", nil)
 	var _ core.StreamProvider = p
+}
+
+func TestOllamaProvider_Complete_MockHTTP(t *testing.T) {
+	respBody := `{"id":"chatcmpl-1","model":"llama3.2","choices":[{"index":0,"message":{"role":"assistant","content":"Hello!"},"finish_reason":"stop"}],"usage":{"prompt_tokens":5,"completion_tokens":2,"total_tokens":7}}`
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+		if r.URL.Path != "/v1/chat/completions" {
+			t.Errorf("path = %q, want /v1/chat/completions", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "" {
+			t.Errorf("Authorization = %q, want empty (self-hosted Ollama is unauthenticated)", got)
+		}
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("failed to decode request body: %v", err)
+			return
+		}
+		if got := body["model"]; got != "llama3.2" {
+			t.Errorf("model = %v, want llama3.2", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(respBody))
+	}))
+	defer srv.Close()
+
+	p, _ := New(srv.URL, []string{"llama3.2"})
+	resp, err := p.Complete(context.Background(), core.Request{
+		Model:    "llama3.2",
+		Messages: []core.Message{{Role: "user", Content: "Hi"}},
+	})
+	if err != nil {
+		t.Fatalf("Complete() error: %v", err)
+	}
+	if resp.ID != "chatcmpl-1" {
+		t.Errorf("Response.ID = %q, want chatcmpl-1", resp.ID)
+	}
+	if resp.Model != "llama3.2" {
+		t.Errorf("Response.Model = %q, want llama3.2", resp.Model)
+	}
+	if resp.Provider != Name {
+		t.Errorf("Response.Provider = %q, want %s", resp.Provider, Name)
+	}
+	if len(resp.Choices) != 1 {
+		t.Fatalf("Choices length = %d, want 1", len(resp.Choices))
+	}
+	if resp.Choices[0].Message.Content != "Hello!" {
+		t.Errorf("Choices[0].Message.Content = %q, want Hello!", resp.Choices[0].Message.Content)
+	}
+	if resp.Choices[0].FinishReason != "stop" {
+		t.Errorf("Choices[0].FinishReason = %q, want stop", resp.Choices[0].FinishReason)
+	}
+}
+
+func TestOllamaProvider_Complete_Non200Error(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":{"message":"model not found"}}`))
+	}))
+	defer srv.Close()
+
+	p, _ := New(srv.URL, nil)
+	_, err := p.Complete(context.Background(), core.Request{
+		Model:    "llama3.2",
+		Messages: []core.Message{{Role: "user", Content: "Hi"}},
+	})
+	if err == nil {
+		t.Fatal("Complete() error = nil, want error on non-200")
+	}
+	if got := core.ParseStatusCode(err); got != http.StatusInternalServerError {
+		t.Errorf("ParseStatusCode(err) = %d, want %d", got, http.StatusInternalServerError)
+	}
+	if !strings.Contains(err.Error(), "model not found") {
+		t.Errorf("error %q does not surface upstream message", err.Error())
+	}
+	if !strings.Contains(err.Error(), "ollama") {
+		t.Errorf("error %q does not carry provider label", err.Error())
+	}
 }
 
 func TestOllamaProvider_CompleteStream_MockSSE(t *testing.T) {
@@ -163,6 +245,56 @@ func TestOllamaProvider_Embed_MockHTTP(t *testing.T) {
 	}
 	if resp.Usage.PromptTokens != 6 || resp.Usage.TotalTokens != 6 {
 		t.Errorf("Usage = %+v, want prompt=6 total=6", resp.Usage)
+	}
+}
+
+func TestOllamaProvider_Embed_ForwardsDimensions(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		if got, ok := body["dimensions"]; !ok || got != float64(256) {
+			t.Errorf("dimensions = %v (present=%v), want 256", got, ok)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"model":"nomic-embed-text","embeddings":[[0.1,0.2]],"prompt_eval_count":3}`))
+	}))
+	defer srv.Close()
+
+	dims := 256
+	p, _ := New(srv.URL, []string{"nomic-embed-text"})
+	if _, err := p.Embed(context.Background(), core.EmbeddingRequest{
+		Model:      "nomic-embed-text",
+		Input:      "hello",
+		Dimensions: &dims,
+	}); err != nil {
+		t.Fatalf("Embed() error: %v", err)
+	}
+}
+
+func TestOllamaProvider_Embed_OmitsDimensionsWhenNil(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		if _, ok := body["dimensions"]; ok {
+			t.Errorf("dimensions present in body, want omitted when nil")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"model":"nomic-embed-text","embeddings":[[0.1,0.2]],"prompt_eval_count":3}`))
+	}))
+	defer srv.Close()
+
+	p, _ := New(srv.URL, []string{"nomic-embed-text"})
+	if _, err := p.Embed(context.Background(), core.EmbeddingRequest{
+		Model: "nomic-embed-text",
+		Input: "hello",
+	}); err != nil {
+		t.Fatalf("Embed() error: %v", err)
 	}
 }
 

--- a/providers/ollama_cloud/embedding.go
+++ b/providers/ollama_cloud/embedding.go
@@ -12,8 +12,9 @@ import (
 
 // embedRequest is the native Ollama /api/embed request schema.
 type embedRequest struct {
-	Model string `json:"model"`
-	Input any    `json:"input"` // string or []string
+	Model      string `json:"model"`
+	Input      any    `json:"input"`                // string or []string
+	Dimensions *int   `json:"dimensions,omitempty"` // optional output dimension control
 }
 
 // embedResponse is the native Ollama /api/embed response schema.
@@ -33,11 +34,12 @@ func (p *Provider) Embed(ctx context.Context, req core.EmbeddingRequest) (*core.
 	if req.EncodingFormat != "" && req.EncodingFormat != "float" {
 		return nil, fmt.Errorf("embed: unsupported encoding_format %q; valid value is \"float\"", req.EncodingFormat)
 	}
-	// Ollama's native API does not support output dimension control; ignore req.Dimensions.
-
+	// Ollama's /api/embed accepts a "dimensions" advanced parameter; forward it
+	// when the caller requests output dimension control.
 	apiReq := embedRequest{
-		Model: req.Model,
-		Input: input,
+		Model:      req.Model,
+		Input:      input,
+		Dimensions: req.Dimensions,
 	}
 	bodyReader, _, release, err := core.JSONBodyReader(apiReq)
 	if err != nil {

--- a/providers/ollama_cloud/embedding.go
+++ b/providers/ollama_cloud/embedding.go
@@ -1,0 +1,123 @@
+package ollamacloud
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/ferro-labs/ai-gateway/providers/core"
+)
+
+// embedRequest is the native Ollama /api/embed request schema.
+type embedRequest struct {
+	Model string `json:"model"`
+	Input any    `json:"input"` // string or []string
+}
+
+// embedResponse is the native Ollama /api/embed response schema.
+type embedResponse struct {
+	Model           string      `json:"model"`
+	Embeddings      [][]float64 `json:"embeddings"`
+	PromptEvalCount int         `json:"prompt_eval_count"`
+}
+
+// Embed sends a request to the native Ollama Cloud /api/embed endpoint and
+// adapts the response to the OpenAI-compatible core.EmbeddingResponse shape.
+func (p *Provider) Embed(ctx context.Context, req core.EmbeddingRequest) (*core.EmbeddingResponse, error) {
+	input, err := normalizeEmbeddingInput(req.Input)
+	if err != nil {
+		return nil, err
+	}
+	if req.EncodingFormat != "" && req.EncodingFormat != "float" {
+		return nil, fmt.Errorf("embed: unsupported encoding_format %q; valid value is \"float\"", req.EncodingFormat)
+	}
+	// Ollama's native API does not support output dimension control; ignore req.Dimensions.
+
+	apiReq := embedRequest{
+		Model: req.Model,
+		Input: input,
+	}
+	bodyReader, _, release, err := core.JSONBodyReader(apiReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal embedding request: %w", err)
+	}
+	defer release()
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, p.baseURL+"/api/embed", bodyReader)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	p.setHeaders(httpReq)
+
+	httpResp, err := p.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer func() { _ = httpResp.Body.Close() }()
+
+	respBody, err := io.ReadAll(httpResp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+	if httpResp.StatusCode != http.StatusOK {
+		return nil, apiError(httpResp.StatusCode, respBody)
+	}
+
+	var apiResp embedResponse
+	if err := json.Unmarshal(respBody, &apiResp); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal embedding response: %w", err)
+	}
+
+	data := make([]core.Embedding, 0, len(apiResp.Embeddings))
+	for i, row := range apiResp.Embeddings {
+		data = append(data, core.Embedding{
+			Object:    "embedding",
+			Embedding: row,
+			Index:     i,
+		})
+	}
+
+	return &core.EmbeddingResponse{
+		Object: "list",
+		Data:   data,
+		Model:  apiResp.Model,
+		Usage: core.EmbeddingUsage{
+			PromptTokens: apiResp.PromptEvalCount,
+			TotalTokens:  apiResp.PromptEvalCount,
+		},
+	}, nil
+}
+
+// normalizeEmbeddingInput coerces the OpenAI-style embedding input (string or
+// array of strings) into the native Ollama /api/embed input shape, rejecting
+// empty or non-string inputs.
+func normalizeEmbeddingInput(input any) (any, error) {
+	switch v := input.(type) {
+	case string:
+		return v, nil
+	case []string:
+		if len(v) == 0 {
+			return nil, fmt.Errorf("embed: Input must not be an empty array")
+		}
+		return v, nil
+	case []any:
+		if len(v) == 0 {
+			return nil, fmt.Errorf("embed: Input must not be an empty array")
+		}
+		strs := make([]string, 0, len(v))
+		for i, item := range v {
+			s, ok := item.(string)
+			if !ok {
+				return nil, fmt.Errorf("embed: Input[%d] is %T, want string", i, item)
+			}
+			strs = append(strs, s)
+		}
+		return strs, nil
+	case nil:
+		return nil, fmt.Errorf("embed: Input must not be nil")
+	default:
+		return nil, fmt.Errorf("embed: unsupported Input type %T; want string or []string", input)
+	}
+}

--- a/providers/ollama_cloud/ollama_cloud.go
+++ b/providers/ollama_cloud/ollama_cloud.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
 	"strings"
 	"sync"
 	"time"
@@ -46,6 +45,7 @@ type Provider struct {
 var (
 	_ core.Provider          = (*Provider)(nil)
 	_ core.StreamProvider    = (*Provider)(nil)
+	_ core.EmbeddingProvider = (*Provider)(nil)
 	_ core.DiscoveryProvider = (*Provider)(nil)
 )
 
@@ -61,9 +61,8 @@ func New(apiKey, baseURL string, models []string) (*Provider, error) {
 		baseURL = defaultBaseURL
 	}
 	baseURL = strings.TrimRight(baseURL, "/")
-	u, err := url.Parse(baseURL)
-	if err != nil || (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
-		return nil, fmt.Errorf("ollama-cloud: invalid base URL %q: must be http or https with a host", baseURL)
+	if err := core.ValidateBaseURL(Name, baseURL); err != nil {
+		return nil, err
 	}
 
 	models = normalizeModels(models)
@@ -115,7 +114,7 @@ func (p *Provider) Models() []core.ModelInfo {
 
 // Complete sends a non-streaming chat request to Ollama Cloud.
 func (p *Provider) Complete(ctx context.Context, req core.Request) (*core.Response, error) {
-	apiReq := buildChatRequest(req, false)
+	apiReq := buildChatRequest(ctx, req, false)
 	bodyReader, _, release, err := core.JSONBodyReader(apiReq)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal request: %w", err)
@@ -150,6 +149,12 @@ func (p *Provider) Complete(ctx context.Context, req core.Request) (*core.Respon
 		return nil, fmt.Errorf("ollama-cloud API error: %s", apiResp.Error)
 	}
 
+	message := apiResp.Message.toCore()
+	finishReason := core.NormalizeFinishReason(apiResp.DoneReason)
+	if len(message.ToolCalls) > 0 {
+		finishReason = core.FinishReasonToolCalls
+	}
+
 	return &core.Response{
 		Object:   "chat.completion",
 		Created:  parseCreatedAt(apiResp.CreatedAt),
@@ -158,8 +163,8 @@ func (p *Provider) Complete(ctx context.Context, req core.Request) (*core.Respon
 		Choices: []core.Choice{
 			{
 				Index:        0,
-				Message:      apiResp.Message.toCore(),
-				FinishReason: apiResp.DoneReason,
+				Message:      message,
+				FinishReason: finishReason,
 			},
 		},
 		Usage: usageFromCounts(apiResp.PromptEvalCount, apiResp.EvalCount),
@@ -168,7 +173,7 @@ func (p *Provider) Complete(ctx context.Context, req core.Request) (*core.Respon
 
 // CompleteStream sends a streaming chat request to Ollama Cloud.
 func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan core.StreamChunk, error) {
-	apiReq := buildChatRequest(req, true)
+	apiReq := buildChatRequest(ctx, req, true)
 	bodyReader, _, release, err := core.JSONBodyReader(apiReq)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal request: %w", err)
@@ -296,9 +301,13 @@ type chatRequest struct {
 }
 
 type chatOptions struct {
-	Temperature *float64 `json:"temperature,omitempty"`
-	TopP        *float64 `json:"top_p,omitempty"`
-	NumPredict  *int     `json:"num_predict,omitempty"`
+	Temperature      *float64 `json:"temperature,omitempty"`
+	TopP             *float64 `json:"top_p,omitempty"`
+	NumPredict       *int     `json:"num_predict,omitempty"`
+	Stop             []string `json:"stop,omitempty"`
+	Seed             *int64   `json:"seed,omitempty"`
+	PresencePenalty  *float64 `json:"presence_penalty,omitempty"`
+	FrequencyPenalty *float64 `json:"frequency_penalty,omitempty"`
 }
 
 type chatResponse struct {
@@ -337,7 +346,7 @@ type tagsResponse struct {
 	} `json:"models"`
 }
 
-func buildChatRequest(req core.Request, stream bool) chatRequest {
+func buildChatRequest(ctx context.Context, req core.Request, stream bool) chatRequest {
 	var maxTokens *int
 	if req.MaxTokens != nil {
 		maxTokens = req.MaxTokens
@@ -346,13 +355,25 @@ func buildChatRequest(req core.Request, stream bool) chatRequest {
 	}
 
 	var options *chatOptions
-	if req.Temperature != nil || req.TopP != nil || maxTokens != nil {
+	if req.Temperature != nil || req.TopP != nil || maxTokens != nil ||
+		len(req.Stop) > 0 || req.Seed != nil ||
+		req.PresencePenalty != nil || req.FrequencyPenalty != nil {
 		options = &chatOptions{
-			Temperature: req.Temperature,
-			TopP:        req.TopP,
-			NumPredict:  maxTokens,
+			Temperature:      req.Temperature,
+			TopP:             req.TopP,
+			NumPredict:       maxTokens,
+			Stop:             req.Stop,
+			Seed:             req.Seed,
+			PresencePenalty:  req.PresencePenalty,
+			FrequencyPenalty: req.FrequencyPenalty,
 		}
 	}
+
+	// Observability for silently dropped params (issue #140): the native
+	// /api/chat surface forwards only the options below plus tools.
+	core.WarnUnsupportedParams(ctx, Name, req.Model, req,
+		"temperature", "top_p", "max_tokens", "max_completion_tokens",
+		"stop", "seed", "presence_penalty", "frequency_penalty", "tools")
 
 	return chatRequest{
 		Model:    req.Model,
@@ -369,14 +390,19 @@ func streamChunkFromResponse(apiResp chatResponse) core.StreamChunk {
 		Created: parseCreatedAt(apiResp.CreatedAt),
 		Model:   apiResp.Model,
 	}
+	toolCalls := apiResp.Message.toCore().ToolCalls
+	finishReason := core.NormalizeFinishReason(apiResp.DoneReason)
+	if len(toolCalls) > 0 {
+		finishReason = core.FinishReasonToolCalls
+	}
 	choice := core.StreamChoice{
 		Index: 0,
 		Delta: core.MessageDelta{
 			Role:      apiResp.Message.Role,
 			Content:   apiResp.Message.Content,
-			ToolCalls: apiResp.Message.toCore().ToolCalls,
+			ToolCalls: toolCalls,
 		},
-		FinishReason: apiResp.DoneReason,
+		FinishReason: finishReason,
 	}
 	if apiResp.Message.Role != "" || apiResp.Message.Content != "" || len(apiResp.Message.ToolCalls) > 0 || apiResp.Done || apiResp.DoneReason != "" {
 		chunk.Choices = append(chunk.Choices, choice)
@@ -398,13 +424,20 @@ func (m nativeMessage) toCore() core.Message {
 	}
 
 	msg.ToolCalls = make([]core.ToolCall, 0, len(m.ToolCalls))
-	for _, tc := range m.ToolCalls {
+	for idx, tc := range m.ToolCalls {
 		callType := tc.Type
 		if callType == "" {
 			callType = "function"
 		}
+		// The native /api/chat schema omits tool-call IDs; synthesize a
+		// deterministic one so downstream tool-result correlation works
+		// (mirrors providers/gemini/gemini.go).
+		id := tc.ID
+		if id == "" {
+			id = fmt.Sprintf("call_%d", idx)
+		}
 		msg.ToolCalls = append(msg.ToolCalls, core.ToolCall{
-			ID:   tc.ID,
+			ID:   id,
 			Type: callType,
 			Function: core.FunctionCall{
 				Name:      tc.Function.Name,

--- a/providers/ollama_cloud/ollama_cloud.go
+++ b/providers/ollama_cloud/ollama_cloud.go
@@ -112,7 +112,10 @@ func (p *Provider) Models() []core.ModelInfo {
 	return core.ModelsFromList(p.name, p.SupportedModels())
 }
 
-// Complete sends a non-streaming chat request to Ollama Cloud.
+// Complete sends a non-streaming chat request to Ollama Cloud. Unlike the local
+// ollama provider (which uses the OpenAI-compatible /v1 surface), this stays on
+// the native /api/chat endpoint: ollama.com's /v1 surface is not first-party
+// documented, so a migration is deferred pending live verification.
 func (p *Provider) Complete(ctx context.Context, req core.Request) (*core.Response, error) {
 	apiReq := buildChatRequest(ctx, req, false)
 	bodyReader, _, release, err := core.JSONBodyReader(apiReq)
@@ -429,9 +432,10 @@ func (m nativeMessage) toCore() core.Message {
 		if callType == "" {
 			callType = "function"
 		}
-		// The native /api/chat schema omits tool-call IDs; synthesize a
-		// deterministic one so downstream tool-result correlation works
-		// (mirrors providers/gemini/gemini.go).
+		// The native /api/chat schema omits tool-call IDs; synthesize one per
+		// message so downstream tool-result correlation works. Ollama returns
+		// parallel tool calls bundled in a single message, so message-scoped
+		// indices stay unique.
 		id := tc.ID
 		if id == "" {
 			id = fmt.Sprintf("call_%d", idx)

--- a/providers/ollama_cloud/ollama_cloud_p7_test.go
+++ b/providers/ollama_cloud/ollama_cloud_p7_test.go
@@ -1,0 +1,39 @@
+package ollamacloud
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/ferro-labs/ai-gateway/providers/core"
+)
+
+// TestEmbed_ForwardsDimensions verifies req.Dimensions reaches the native
+// /api/embed request body rather than being silently dropped.
+func TestEmbed_ForwardsDimensions(t *testing.T) {
+	var gotDims *int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Dimensions *int `json:"dimensions"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		gotDims = body.Dimensions
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"model":"m","embeddings":[[0.1]],"prompt_eval_count":1}`))
+	}))
+	defer server.Close()
+
+	p, err := New(testCloudAPIKey, server.URL, []string{testCloudModel})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	dims := 8
+	if _, err := p.Embed(context.Background(), core.EmbeddingRequest{Model: "m", Input: "hi", Dimensions: &dims}); err != nil {
+		t.Fatalf("Embed: %v", err)
+	}
+	if gotDims == nil || *gotDims != 8 {
+		t.Errorf("dimensions forwarded = %v, want 8", gotDims)
+	}
+}

--- a/providers/ollama_cloud/ollama_cloud_test.go
+++ b/providers/ollama_cloud/ollama_cloud_test.go
@@ -340,6 +340,237 @@ func TestSupportsModel(t *testing.T) {
 	}
 }
 
+func TestCompleteSynthesizesToolCallIDAndForcesFinishReason(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// Native schema: object arguments and NO id, done_reason is a plain
+		// "stop" that must be overridden to tool_calls.
+		_, _ = w.Write([]byte(`{
+			"model":"` + testCloudModel + `",
+			"created_at":"2025-01-02T03:04:05Z",
+			"message":{
+				"role":"assistant",
+				"tool_calls":[{"function":{"name":"get_weather","arguments":{"city":"Paris"}}}]
+			},
+			"done":true,
+			"done_reason":"stop"
+		}`))
+	}))
+	defer server.Close()
+
+	p, err := New(testCloudAPIKey, server.URL, []string{testCloudModel})
+	if err != nil {
+		t.Fatalf("New returned error: %v", err)
+	}
+
+	resp, err := p.Complete(context.Background(), core.Request{
+		Model:    testCloudModel,
+		Messages: []core.Message{{Role: "user", Content: "weather in Paris?"}},
+	})
+	if err != nil {
+		t.Fatalf("Complete returned error: %v", err)
+	}
+
+	if resp.Choices[0].FinishReason != core.FinishReasonToolCalls {
+		t.Fatalf("finish reason = %q, want %q", resp.Choices[0].FinishReason, core.FinishReasonToolCalls)
+	}
+	calls := resp.Choices[0].Message.ToolCalls
+	if len(calls) != 1 {
+		t.Fatalf("tool calls length = %d, want 1", len(calls))
+	}
+	if calls[0].ID != "call_0" {
+		t.Fatalf("tool call ID = %q, want synthesized call_0", calls[0].ID)
+	}
+	if calls[0].Type != "function" {
+		t.Fatalf("tool call type = %q, want function", calls[0].Type)
+	}
+	if calls[0].Function.Name != "get_weather" {
+		t.Fatalf("tool call name = %q, want get_weather", calls[0].Function.Name)
+	}
+	if calls[0].Function.Arguments != `{"city":"Paris"}` {
+		t.Fatalf("tool call arguments = %q, want compacted object", calls[0].Function.Arguments)
+	}
+}
+
+func TestCompleteStreamSynthesizesToolCallIDAndFinishReason(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		_, _ = w.Write([]byte(`{"model":"` + testCloudModel + `","message":{"role":"assistant","tool_calls":[{"function":{"name":"get_weather","arguments":{"city":"Paris"}}}]},"done":false}` + "\n"))
+		_, _ = w.Write([]byte(`{"model":"` + testCloudModel + `","done":true,"done_reason":"stop","prompt_eval_count":3,"eval_count":2}` + "\n"))
+	}))
+	defer server.Close()
+
+	p, err := New(testCloudAPIKey, server.URL, []string{testCloudModel})
+	if err != nil {
+		t.Fatalf("New returned error: %v", err)
+	}
+
+	ch, err := p.CompleteStream(context.Background(), core.Request{
+		Model:    testCloudModel,
+		Messages: []core.Message{{Role: "user", Content: "weather?"}},
+	})
+	if err != nil {
+		t.Fatalf("CompleteStream returned error: %v", err)
+	}
+
+	var chunks []core.StreamChunk
+	for chunk := range ch {
+		if chunk.Error != nil {
+			t.Fatalf("stream chunk error: %v", chunk.Error)
+		}
+		chunks = append(chunks, chunk)
+	}
+	if len(chunks) != 2 {
+		t.Fatalf("chunks length = %d, want 2", len(chunks))
+	}
+
+	calls := chunks[0].Choices[0].Delta.ToolCalls
+	if len(calls) != 1 {
+		t.Fatalf("delta tool calls length = %d, want 1", len(calls))
+	}
+	if calls[0].ID != "call_0" {
+		t.Fatalf("delta tool call ID = %q, want synthesized call_0", calls[0].ID)
+	}
+	if calls[0].Function.Name != "get_weather" || calls[0].Function.Arguments != `{"city":"Paris"}` {
+		t.Fatalf("delta tool call function = %#v, want get_weather with compacted args", calls[0].Function)
+	}
+	if chunks[0].Choices[0].FinishReason != core.FinishReasonToolCalls {
+		t.Fatalf("tool-call chunk finish reason = %q, want %q", chunks[0].Choices[0].FinishReason, core.FinishReasonToolCalls)
+	}
+}
+
+func TestCompleteForwardsExtendedOptions(t *testing.T) {
+	var body struct {
+		Options *struct {
+			Stop             []string `json:"stop"`
+			Seed             *int64   `json:"seed"`
+			PresencePenalty  *float64 `json:"presence_penalty"`
+			FrequencyPenalty *float64 `json:"frequency_penalty"`
+		} `json:"options"`
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode request body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"model":"` + testCloudModel + `","message":{"role":"assistant","content":"ok"},"done":true,"done_reason":"stop"}`))
+	}))
+	defer server.Close()
+
+	p, err := New(testCloudAPIKey, server.URL, []string{testCloudModel})
+	if err != nil {
+		t.Fatalf("New returned error: %v", err)
+	}
+
+	seed := int64(42)
+	presence, frequency := 0.5, -0.25
+	if _, err := p.Complete(context.Background(), core.Request{
+		Model:            testCloudModel,
+		Messages:         []core.Message{{Role: "user", Content: "hi"}},
+		Stop:             []string{"STOP"},
+		Seed:             &seed,
+		PresencePenalty:  &presence,
+		FrequencyPenalty: &frequency,
+	}); err != nil {
+		t.Fatalf("Complete returned error: %v", err)
+	}
+
+	if body.Options == nil {
+		t.Fatal("options missing from request body")
+	}
+	if len(body.Options.Stop) != 1 || body.Options.Stop[0] != "STOP" {
+		t.Fatalf("stop = %#v, want [STOP]", body.Options.Stop)
+	}
+	if body.Options.Seed == nil || *body.Options.Seed != 42 {
+		t.Fatalf("seed = %#v, want 42", body.Options.Seed)
+	}
+	if body.Options.PresencePenalty == nil || *body.Options.PresencePenalty != 0.5 {
+		t.Fatalf("presence_penalty = %#v, want 0.5", body.Options.PresencePenalty)
+	}
+	if body.Options.FrequencyPenalty == nil || *body.Options.FrequencyPenalty != -0.25 {
+		t.Fatalf("frequency_penalty = %#v, want -0.25", body.Options.FrequencyPenalty)
+	}
+}
+
+func TestEmbedSendsAuthAndMapsResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+		if r.URL.Path != "/api/embed" {
+			t.Errorf("path = %s, want /api/embed", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != testAuthHeader {
+			t.Errorf("Authorization = %q, want %s", got, testAuthHeader)
+		}
+
+		var reqBody struct {
+			Model string `json:"model"`
+			Input string `json:"input"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
+			t.Fatalf("failed to decode request body: %v", err)
+		}
+		if reqBody.Model != "embed-model" || reqBody.Input != "hello world" {
+			t.Errorf("request = %#v, want embed-model / hello world", reqBody)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"model":"embed-model","embeddings":[[0.1,0.2,0.3]],"prompt_eval_count":5}`))
+	}))
+	defer server.Close()
+
+	p, err := New(testCloudAPIKey, server.URL, []string{testCloudModel})
+	if err != nil {
+		t.Fatalf("New returned error: %v", err)
+	}
+
+	resp, err := p.Embed(context.Background(), core.EmbeddingRequest{
+		Model: "embed-model",
+		Input: "hello world",
+	})
+	if err != nil {
+		t.Fatalf("Embed returned error: %v", err)
+	}
+
+	if resp.Object != "list" || resp.Model != "embed-model" {
+		t.Fatalf("response envelope = %#v, want list / embed-model", resp)
+	}
+	if len(resp.Data) != 1 {
+		t.Fatalf("data length = %d, want 1", len(resp.Data))
+	}
+	if !reflect.DeepEqual(resp.Data[0].Embedding, []float64{0.1, 0.2, 0.3}) {
+		t.Fatalf("embedding = %#v, want [0.1 0.2 0.3]", resp.Data[0].Embedding)
+	}
+	if resp.Data[0].Index != 0 || resp.Data[0].Object != "embedding" {
+		t.Fatalf("embedding entry = %#v, want index 0 embedding", resp.Data[0])
+	}
+	if resp.Usage.PromptTokens != 5 || resp.Usage.TotalTokens != 5 {
+		t.Fatalf("usage = %#v, want 5/5", resp.Usage)
+	}
+}
+
+func TestEmbedNon200Error(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":{"message":"model not found"}}`))
+	}))
+	defer server.Close()
+
+	p, err := New(testCloudAPIKey, server.URL, []string{testCloudModel})
+	if err != nil {
+		t.Fatalf("New returned error: %v", err)
+	}
+
+	_, err = p.Embed(context.Background(), core.EmbeddingRequest{Model: "embed-model", Input: "hi"})
+	if err == nil {
+		t.Fatal("expected Embed to return an error")
+	}
+	if got := err.Error(); !strings.Contains(got, "400") || !strings.Contains(got, "model not found") {
+		t.Fatalf("error = %q, want status code and response message", got)
+	}
+}
+
 func mustUnix(t *testing.T, value string) int64 {
 	t.Helper()
 	parsed, err := time.Parse(time.RFC3339Nano, value)

--- a/providers/providers_list.go
+++ b/providers/providers_list.go
@@ -302,7 +302,7 @@ var allProviders = []ProviderEntry{
 	},
 	{
 		ID:           NameOllamaCloud,
-		Capabilities: []string{CapabilityChat, CapabilityStream, CapabilityDiscovery},
+		Capabilities: []string{CapabilityChat, CapabilityStream, CapabilityEmbed, CapabilityDiscovery},
 		EnvMappings: []EnvMapping{
 			{CfgKeyAPIKey, "OLLAMA_API_KEY", true},
 			{CfgKeyBaseURL, "OLLAMA_CLOUD_BASE_URL", false},

--- a/providers/replicate/replicate.go
+++ b/providers/replicate/replicate.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -259,7 +260,18 @@ func (p *Provider) resolveModelURL(modelPath string) (url, version string) {
 	if v := ModelVersion(modelPath); v != "" {
 		return fmt.Sprintf("%s/predictions", p.baseURL), v
 	}
-	return fmt.Sprintf("%s/models/%s/predictions", p.baseURL, ModelBaseName(modelPath)), ""
+	return fmt.Sprintf("%s/models/%s/predictions", p.baseURL, escapeModelPath(ModelBaseName(modelPath))), ""
+}
+
+// escapeModelPath percent-escapes each segment of an "owner/name" model path so
+// a crafted model value cannot alter the request URL path, while preserving the
+// segment separators the /models/{owner}/{name} route relies on.
+func escapeModelPath(model string) string {
+	parts := strings.Split(model, "/")
+	for i, part := range parts {
+		parts[i] = url.PathEscape(part)
+	}
+	return strings.Join(parts, "/")
 }
 
 // predictionText coerces a Replicate prediction output (a string or an array of

--- a/providers/replicate/replicate.go
+++ b/providers/replicate/replicate.go
@@ -20,10 +20,25 @@ const Name = "replicate"
 const (
 	defaultBaseURL = "https://api.replicate.com/v1"
 
-	statusFailed   = "failed"
-	statusCanceled = "canceled"
-	eventMessage   = "message"
+	statusSucceeded = "succeeded"
+	statusFailed    = "failed"
+	statusCanceled  = "canceled"
+
+	eventMessage = "message"
+
+	// finishReasonStop is the raw stop reason used for a completed Replicate
+	// prediction; it is routed through core.NormalizeFinishReason so the gateway
+	// emits the canonical OpenAI finish_reason vocabulary.
+	finishReasonStop = "stop"
 )
+
+// forwardedTextParams lists the OpenAI request parameters buildTextInput
+// forwards to Replicate. Any other populated parameter is reported by
+// core.WarnUnsupportedParams so the drop is observable instead of silent.
+var forwardedTextParams = []string{
+	"max_tokens", "temperature", "top_p", "seed", "stop",
+	"presence_penalty", "frequency_penalty",
+}
 
 // Provider implements the Replicate API client.
 // It supports text generation models via chat completion and image generation
@@ -51,10 +66,14 @@ var (
 // New creates a new Replicate provider.
 // textModels and imageModels should be "owner/name" or "owner/name:version" paths.
 func New(apiToken, baseURL string, textModels, imageModels []string) (*Provider, error) {
+	baseURL = strings.TrimSpace(baseURL)
 	if baseURL == "" {
 		baseURL = defaultBaseURL
 	}
 	baseURL = strings.TrimRight(baseURL, "/")
+	if err := core.ValidateBaseURL(Name, baseURL); err != nil {
+		return nil, err
+	}
 
 	if len(textModels) == 0 {
 		textModels = []string{
@@ -87,9 +106,13 @@ func (p *Provider) Name() string { return p.name }
 // BaseURL implements core.ProxiableProvider.
 func (p *Provider) BaseURL() string { return p.baseURL }
 
+// authHeader returns the Authorization header value. Replicate accepts both the
+// legacy "Token" scheme and the documented "Bearer" scheme; Bearer is used.
+func (p *Provider) authHeader() string { return "Bearer " + p.apiKey }
+
 // AuthHeaders implements core.ProxiableProvider.
 func (p *Provider) AuthHeaders() map[string]string {
-	return map[string]string{"Authorization": "Token " + p.apiKey}
+	return map[string]string{"Authorization": p.authHeader()}
 }
 
 // SupportedModels returns all configured models.
@@ -147,12 +170,22 @@ type Prediction struct {
 	URLs      struct {
 		Stream string `json:"stream,omitempty"`
 	} `json:"urls,omitempty"`
+	// Metrics carries Replicate's token accounting when the model reports it.
+	Metrics struct {
+		InputTokenCount  int `json:"input_token_count"`
+		OutputTokenCount int `json:"output_token_count"`
+	} `json:"metrics"`
 }
 
 type replicatePredictionInput struct {
-	Prompt      string  `json:"prompt"`
-	MaxTokens   int     `json:"max_tokens,omitempty"`
-	Temperature float64 `json:"temperature,omitempty"`
+	Prompt           string   `json:"prompt"`
+	MaxTokens        int      `json:"max_tokens,omitempty"`
+	Temperature      float64  `json:"temperature,omitempty"`
+	TopP             float64  `json:"top_p,omitempty"`
+	Seed             int64    `json:"seed,omitempty"`
+	Stop             []string `json:"stop_sequences,omitempty"`
+	PresencePenalty  float64  `json:"presence_penalty,omitempty"`
+	FrequencyPenalty float64  `json:"frequency_penalty,omitempty"`
 }
 
 type replicatePredictionRequest struct {
@@ -173,8 +206,9 @@ type replicateImageRequest struct {
 	Input   replicateImageInput `json:"input"`
 }
 
-// Complete sends a chat completion request to Replicate and polls until done.
-func (p *Provider) Complete(ctx context.Context, req core.Request) (*core.Response, error) {
+// buildPrompt flattens the OpenAI chat messages into Replicate's single-prompt
+// input, appending a trailing "assistant:" turn to cue the completion.
+func buildPrompt(req core.Request) string {
 	var sb strings.Builder
 	for _, msg := range req.Messages {
 		sb.WriteString(msg.Role)
@@ -183,25 +217,87 @@ func (p *Provider) Complete(ctx context.Context, req core.Request) (*core.Respon
 		sb.WriteString("\n")
 	}
 	sb.WriteString("assistant: ")
+	return sb.String()
+}
 
-	input := replicatePredictionInput{Prompt: sb.String()}
+// buildTextInput translates an OpenAI-style request into Replicate's prediction
+// input, forwarding the sampling parameters Replicate language models accept and
+// warning (issue #140) about any populated parameter that is dropped.
+func buildTextInput(ctx context.Context, req core.Request) replicatePredictionInput {
+	core.WarnUnsupportedParams(ctx, Name, req.Model, req, forwardedTextParams...)
+
+	input := replicatePredictionInput{Prompt: buildPrompt(req)}
 	if req.MaxTokens != nil {
 		input.MaxTokens = *req.MaxTokens
 	}
 	if req.Temperature != nil {
 		input.Temperature = *req.Temperature
 	}
-
-	predReq := replicatePredictionRequest{Input: input}
-
-	modelPath := p.resolveTextModel(req.Model)
-	var url string
-	if v := ModelVersion(modelPath); v != "" {
-		predReq.Version = v
-		url = fmt.Sprintf("%s/predictions", p.baseURL)
-	} else {
-		url = fmt.Sprintf("%s/models/%s/predictions", p.baseURL, ModelBaseName(modelPath))
+	if req.TopP != nil {
+		input.TopP = *req.TopP
 	}
+	if req.Seed != nil {
+		input.Seed = *req.Seed
+	}
+	if len(req.Stop) > 0 {
+		input.Stop = req.Stop
+	}
+	if req.PresencePenalty != nil {
+		input.PresencePenalty = *req.PresencePenalty
+	}
+	if req.FrequencyPenalty != nil {
+		input.FrequencyPenalty = *req.FrequencyPenalty
+	}
+	return input
+}
+
+// resolveModelURL returns the prediction submission URL and the pinned version
+// (empty when the model path carries no ":version" suffix) for a resolved model
+// path. A pinned version posts to /predictions with the version in the body; an
+// unpinned model posts to /models/{owner}/{name}/predictions.
+func (p *Provider) resolveModelURL(modelPath string) (url, version string) {
+	if v := ModelVersion(modelPath); v != "" {
+		return fmt.Sprintf("%s/predictions", p.baseURL), v
+	}
+	return fmt.Sprintf("%s/models/%s/predictions", p.baseURL, ModelBaseName(modelPath)), ""
+}
+
+// predictionText coerces a Replicate prediction output (a string or an array of
+// string tokens) into a single string.
+func predictionText(output any) string {
+	switch v := output.(type) {
+	case string:
+		return v
+	case []any:
+		var parts []string
+		for _, item := range v {
+			if s, ok := item.(string); ok {
+				parts = append(parts, s)
+			}
+		}
+		return strings.Join(parts, "")
+	}
+	return ""
+}
+
+// usageFromMetrics maps Replicate's per-prediction token metrics into core.Usage.
+// The second return is false when the model reported no token counts.
+func usageFromMetrics(pred *Prediction) (core.Usage, bool) {
+	in, out := pred.Metrics.InputTokenCount, pred.Metrics.OutputTokenCount
+	if in == 0 && out == 0 {
+		return core.Usage{}, false
+	}
+	return core.Usage{
+		PromptTokens:     in,
+		CompletionTokens: out,
+		TotalTokens:      in + out,
+	}, true
+}
+
+// Complete sends a chat completion request to Replicate and polls until done.
+func (p *Provider) Complete(ctx context.Context, req core.Request) (*core.Response, error) {
+	url, version := p.resolveModelURL(p.resolveTextModel(req.Model))
+	predReq := replicatePredictionRequest{Version: version, Input: buildTextInput(ctx, req)}
 
 	bodyReader, _, release, err := core.JSONBodyReader(predReq)
 	if err != nil {
@@ -214,62 +310,27 @@ func (p *Provider) Complete(ctx context.Context, req core.Request) (*core.Respon
 		return nil, err
 	}
 
-	text := ""
-	switch v := pred.Output.(type) {
-	case string:
-		text = v
-	case []any:
-		var parts []string
-		for _, item := range v {
-			if s, ok := item.(string); ok {
-				parts = append(parts, s)
-			}
-		}
-		text = strings.Join(parts, "")
-	}
-
-	return &core.Response{
+	resp := &core.Response{
 		ID:       pred.ID,
 		Model:    req.Model,
 		Provider: p.name,
 		Choices: []core.Choice{{
 			Index:        0,
-			Message:      core.Message{Role: core.RoleAssistant, Content: text},
-			FinishReason: "stop",
+			Message:      core.Message{Role: core.RoleAssistant, Content: predictionText(pred.Output)},
+			FinishReason: core.NormalizeFinishReason(finishReasonStop),
 		}},
-	}, nil
+	}
+	if usage, ok := usageFromMetrics(pred); ok {
+		resp.Usage = usage
+	}
+	return resp, nil
 }
 
 // CompleteStream submits a Replicate prediction with streaming enabled and
 // translates Replicate output SSE events into OpenAI-compatible stream chunks.
 func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan core.StreamChunk, error) {
-	var sb strings.Builder
-	for _, msg := range req.Messages {
-		sb.WriteString(msg.Role)
-		sb.WriteString(": ")
-		sb.WriteString(msg.Content)
-		sb.WriteString("\n")
-	}
-	sb.WriteString("assistant: ")
-
-	input := replicatePredictionInput{Prompt: sb.String()}
-	if req.MaxTokens != nil {
-		input.MaxTokens = *req.MaxTokens
-	}
-	if req.Temperature != nil {
-		input.Temperature = *req.Temperature
-	}
-
-	predReq := replicatePredictionRequest{Input: input, Stream: true}
-	modelPath := p.resolveTextModel(req.Model)
-
-	var url string
-	if v := ModelVersion(modelPath); v != "" {
-		predReq.Version = v
-		url = fmt.Sprintf("%s/predictions", p.baseURL)
-	} else {
-		url = fmt.Sprintf("%s/models/%s/predictions", p.baseURL, ModelBaseName(modelPath))
-	}
+	url, version := p.resolveModelURL(p.resolveTextModel(req.Model))
+	predReq := replicatePredictionRequest{Version: version, Input: buildTextInput(ctx, req), Stream: true}
 
 	bodyReader, _, release, err := core.JSONBodyReader(predReq)
 	if err != nil {
@@ -293,18 +354,17 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 	if err != nil {
 		return nil, fmt.Errorf("failed to create stream request: %w", err)
 	}
-	httpReq.Header.Set("Authorization", "Token "+p.apiKey)
+	httpReq.Header.Set("Authorization", p.authHeader())
 	httpReq.Header.Set("Accept", "text/event-stream")
 
 	httpResp, err := p.httpClient.Do(httpReq)
 	if err != nil {
 		return nil, fmt.Errorf("stream request failed: %w", err)
 	}
-
 	if httpResp.StatusCode != http.StatusOK {
 		defer func() { _ = httpResp.Body.Close() }()
 		respBody, _ := io.ReadAll(httpResp.Body)
-		return nil, fmt.Errorf("replicate stream error (%d): %s", httpResp.StatusCode, string(respBody))
+		return nil, core.APIError(Name, httpResp.StatusCode, respBody)
 	}
 
 	ch := make(chan core.StreamChunk)
@@ -337,13 +397,8 @@ func (p *Provider) GenerateImage(ctx context.Context, req core.ImageRequest) (*c
 		}
 	}
 
-	var url string
-	if v := ModelVersion(modelPath); v != "" {
-		imgReq.Version = v
-		url = fmt.Sprintf("%s/predictions", p.baseURL)
-	} else {
-		url = fmt.Sprintf("%s/models/%s/predictions", p.baseURL, ModelBaseName(modelPath))
-	}
+	url, version := p.resolveModelURL(modelPath)
+	imgReq.Version = version
 
 	bodyReader, _, release, err := core.JSONBodyReader(imgReq)
 	if err != nil {
@@ -383,13 +438,19 @@ func (p *Provider) resolveTextModel(model string) string {
 	return model
 }
 
-func (p *Provider) submitPrediction(ctx context.Context, url string, body io.Reader) (*Prediction, error) {
+// submit POSTs a prediction request and returns the raw response body. When wait
+// is true it sends "Prefer: wait" so Replicate holds the connection open until
+// the prediction resolves instead of returning immediately.
+func (p *Provider) submit(ctx context.Context, url string, body io.Reader, wait bool) ([]byte, error) {
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, body)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
-	httpReq.Header.Set("Authorization", "Token "+p.apiKey)
+	httpReq.Header.Set("Authorization", p.authHeader())
 	httpReq.Header.Set("Content-Type", "application/json")
+	if wait {
+		httpReq.Header.Set("Prefer", "wait")
+	}
 
 	httpResp, err := p.httpClient.Do(httpReq)
 	if err != nil {
@@ -397,19 +458,120 @@ func (p *Provider) submitPrediction(ctx context.Context, url string, body io.Rea
 	}
 	defer func() { _ = httpResp.Body.Close() }()
 
-	if httpResp.StatusCode != http.StatusCreated && httpResp.StatusCode != http.StatusOK {
-		respBody, _ := io.ReadAll(httpResp.Body)
-		return nil, fmt.Errorf("replicate API error (%d): %s", httpResp.StatusCode, string(respBody))
+	respBody, err := io.ReadAll(httpResp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
 	}
+	if httpResp.StatusCode != http.StatusCreated && httpResp.StatusCode != http.StatusOK {
+		return nil, core.APIError(Name, httpResp.StatusCode, respBody)
+	}
+	return respBody, nil
+}
 
+// submitPrediction submits a prediction without waiting; used by the streaming
+// path, which follows the returned stream URL.
+func (p *Provider) submitPrediction(ctx context.Context, url string, body io.Reader) (*Prediction, error) {
+	respBody, err := p.submit(ctx, url, body, false)
+	if err != nil {
+		return nil, err
+	}
 	var pred Prediction
-	if err := json.NewDecoder(httpResp.Body).Decode(&pred); err != nil {
+	if err := json.Unmarshal(respBody, &pred); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal prediction: %w", err)
 	}
 	if pred.Status == statusFailed || pred.Status == statusCanceled {
 		return nil, fmt.Errorf("replicate prediction %s: %s", pred.Status, pred.Error)
 	}
 	return &pred, nil
+}
+
+// submitAndPoll submits a prediction (with "Prefer: wait") and polls until it
+// completes.
+func (p *Provider) submitAndPoll(ctx context.Context, url string, body io.Reader) (*Prediction, error) {
+	respBody, err := p.submit(ctx, url, body, true)
+	if err != nil {
+		return nil, err
+	}
+	var pred Prediction
+	if err := json.Unmarshal(respBody, &pred); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal prediction: %w", err)
+	}
+	switch pred.Status {
+	case statusSucceeded:
+		return &pred, nil
+	case statusFailed, statusCanceled:
+		return nil, fmt.Errorf("replicate prediction %s: %s", pred.Status, pred.Error)
+	}
+	return p.poll(ctx, pred.ID)
+}
+
+// poll repeatedly GETs a prediction until it reaches a terminal state or ctx is
+// canceled.
+func (p *Provider) poll(ctx context.Context, predictionID string) (*Prediction, error) {
+	pollURL := fmt.Sprintf("%s/predictions/%s", p.baseURL, predictionID)
+	ticker := time.NewTicker(500 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-ticker.C:
+			pred, err := p.pollOnce(ctx, pollURL)
+			if err != nil {
+				return nil, err
+			}
+			switch pred.Status {
+			case statusSucceeded:
+				return pred, nil
+			case statusFailed, statusCanceled:
+				return nil, fmt.Errorf("replicate prediction %s: %s", pred.Status, pred.Error)
+			}
+		}
+	}
+}
+
+// pollOnce performs a single GET of a prediction's current state.
+func (p *Provider) pollOnce(ctx context.Context, pollURL string) (*Prediction, error) {
+	pollReq, err := http.NewRequestWithContext(ctx, http.MethodGet, pollURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create poll request: %w", err)
+	}
+	pollReq.Header.Set("Authorization", p.authHeader())
+
+	pollResp, err := p.httpClient.Do(pollReq)
+	if err != nil {
+		return nil, fmt.Errorf("poll request failed: %w", err)
+	}
+	pollBody, readErr := io.ReadAll(pollResp.Body)
+	_ = pollResp.Body.Close()
+	if readErr != nil {
+		return nil, fmt.Errorf("failed to read poll response body: %w", readErr)
+	}
+	if pollResp.StatusCode != http.StatusOK {
+		return nil, core.APIError(Name, pollResp.StatusCode, pollBody)
+	}
+	var pred Prediction
+	if err := json.Unmarshal(pollBody, &pred); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal poll response: %w", err)
+	}
+	return &pred, nil
+}
+
+// doneFinishReason extracts the Replicate stream's terminal reason (if any) from
+// a "done" event payload and normalizes it to the OpenAI vocabulary, defaulting
+// to "stop" when the payload carries no reason.
+func doneFinishReason(payload string) string {
+	reason := finishReasonStop
+	if payload != "" && payload != "{}" {
+		var done struct {
+			Reason string `json:"reason"`
+		}
+		if json.Unmarshal([]byte(payload), &done) == nil && done.Reason != "" {
+			reason = done.Reason
+		}
+	}
+	return core.NormalizeFinishReason(reason)
 }
 
 func (p *Provider) readStream(ctx context.Context, body io.ReadCloser, ch chan<- core.StreamChunk, predictionID, model string) {
@@ -424,8 +586,7 @@ func (p *Provider) readStream(ctx context.Context, body io.ReadCloser, ch chan<-
 		if data.Len() == 0 && event == eventMessage {
 			return true
 		}
-		payload := data.String()
-		payload = strings.TrimSuffix(payload, "\n")
+		payload := strings.TrimSuffix(data.String(), "\n")
 		switch event {
 		case "output":
 			ch <- core.StreamChunk{
@@ -440,21 +601,12 @@ func (p *Provider) readStream(ctx context.Context, body io.ReadCloser, ch chan<-
 			ch <- core.StreamChunk{Error: fmt.Errorf("replicate stream error: %s", payload)}
 			return false
 		case "done":
-			if payload != "" && payload != "{}" {
-				var done struct {
-					Reason string `json:"reason"`
-				}
-				if json.Unmarshal([]byte(payload), &done) == nil && done.Reason != "" {
-					ch <- core.StreamChunk{Error: fmt.Errorf("replicate prediction finished with reason %q", done.Reason)}
-					return false
-				}
-			}
 			ch <- core.StreamChunk{
 				ID:    predictionID,
 				Model: model,
 				Choices: []core.StreamChoice{{
 					Index:        0,
-					FinishReason: "stop",
+					FinishReason: doneFinishReason(payload),
 				}},
 			}
 			return false
@@ -496,84 +648,5 @@ func (p *Provider) readStream(ctx context.Context, body io.ReadCloser, ch chan<-
 	}
 	if err := scanner.Err(); err != nil {
 		ch <- core.StreamChunk{Error: fmt.Errorf("stream read error: %w", err)}
-	}
-}
-
-// submitAndPoll submits a prediction and polls until it completes.
-func (p *Provider) submitAndPoll(ctx context.Context, url string, body io.Reader) (*Prediction, error) {
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, body)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
-	}
-	httpReq.Header.Set("Authorization", "Token "+p.apiKey)
-	httpReq.Header.Set("Content-Type", "application/json")
-	httpReq.Header.Set("Prefer", "wait")
-
-	httpResp, err := p.httpClient.Do(httpReq)
-	if err != nil {
-		return nil, fmt.Errorf("request failed: %w", err)
-	}
-	defer func() { _ = httpResp.Body.Close() }()
-
-	if httpResp.StatusCode != http.StatusCreated && httpResp.StatusCode != http.StatusOK {
-		respBody, _ := io.ReadAll(httpResp.Body)
-		return nil, fmt.Errorf("replicate API error (%d): %s", httpResp.StatusCode, string(respBody))
-	}
-
-	respBody, err := io.ReadAll(httpResp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read response: %w", err)
-	}
-
-	var pred Prediction
-	if err := json.Unmarshal(respBody, &pred); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal prediction: %w", err)
-	}
-
-	if pred.Status == "succeeded" {
-		return &pred, nil
-	}
-	if pred.Status == statusFailed || pred.Status == statusCanceled {
-		return nil, fmt.Errorf("replicate prediction %s: %s", pred.Status, pred.Error)
-	}
-
-	pollURL := fmt.Sprintf("%s/predictions/%s", p.baseURL, pred.ID)
-	ticker := time.NewTicker(500 * time.Millisecond)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			return nil, ctx.Err()
-		case <-ticker.C:
-			pollReq, err := http.NewRequestWithContext(ctx, http.MethodGet, pollURL, nil)
-			if err != nil {
-				return nil, fmt.Errorf("failed to create poll request: %w", err)
-			}
-			pollReq.Header.Set("Authorization", "Token "+p.apiKey)
-
-			pollResp, err := p.httpClient.Do(pollReq)
-			if err != nil {
-				return nil, fmt.Errorf("poll request failed: %w", err)
-			}
-			pollBody, readErr := io.ReadAll(pollResp.Body)
-			_ = pollResp.Body.Close()
-			if readErr != nil {
-				return nil, fmt.Errorf("failed to read poll response body: %w", readErr)
-			}
-			if pollResp.StatusCode != http.StatusOK {
-				return nil, fmt.Errorf("replicate poll error (%d): %s", pollResp.StatusCode, string(pollBody))
-			}
-			if err := json.Unmarshal(pollBody, &pred); err != nil {
-				return nil, fmt.Errorf("failed to unmarshal poll response: %w", err)
-			}
-
-			switch pred.Status {
-			case "succeeded":
-				return &pred, nil
-			case statusFailed, statusCanceled:
-				return nil, fmt.Errorf("replicate prediction %s: %s", pred.Status, pred.Error)
-			}
-		}
 	}
 }

--- a/providers/replicate/replicate.go
+++ b/providers/replicate/replicate.go
@@ -267,12 +267,16 @@ func (p *Provider) resolveModelURL(modelPath string) (url, version string, err e
 	return fmt.Sprintf("%s/models/%s/predictions", p.baseURL, escaped), "", nil
 }
 
-// escapeModelPath percent-escapes each segment of an "owner/name" model path so
-// a crafted model value cannot alter the request URL path, while preserving the
-// segment separators the /models/{owner}/{name} route relies on. Empty and dot
-// ("."/"..") segments are rejected, since url.PathEscape leaves them unchanged.
+// escapeModelPath validates that a Replicate model base name is exactly
+// "owner/name" (two non-empty, non-dot segments) and percent-escapes each
+// segment. Any other shape is rejected so a crafted model value cannot alter or
+// extend the /models/{owner}/{name} request path (url.PathEscape alone leaves
+// "."/".." and extra "/" separators intact).
 func escapeModelPath(model string) (string, error) {
 	parts := strings.Split(model, "/")
+	if len(parts) != 2 {
+		return "", fmt.Errorf("replicate: model must be in owner/name form, got %q", model)
+	}
 	for i, part := range parts {
 		if part == "" || part == "." || part == ".." {
 			return "", fmt.Errorf("replicate: invalid model path segment %q", part)

--- a/providers/replicate/replicate.go
+++ b/providers/replicate/replicate.go
@@ -256,22 +256,30 @@ func buildTextInput(ctx context.Context, req core.Request) replicatePredictionIn
 // (empty when the model path carries no ":version" suffix) for a resolved model
 // path. A pinned version posts to /predictions with the version in the body; an
 // unpinned model posts to /models/{owner}/{name}/predictions.
-func (p *Provider) resolveModelURL(modelPath string) (url, version string) {
+func (p *Provider) resolveModelURL(modelPath string) (url, version string, err error) {
 	if v := ModelVersion(modelPath); v != "" {
-		return fmt.Sprintf("%s/predictions", p.baseURL), v
+		return fmt.Sprintf("%s/predictions", p.baseURL), v, nil
 	}
-	return fmt.Sprintf("%s/models/%s/predictions", p.baseURL, escapeModelPath(ModelBaseName(modelPath))), ""
+	escaped, err := escapeModelPath(ModelBaseName(modelPath))
+	if err != nil {
+		return "", "", err
+	}
+	return fmt.Sprintf("%s/models/%s/predictions", p.baseURL, escaped), "", nil
 }
 
 // escapeModelPath percent-escapes each segment of an "owner/name" model path so
 // a crafted model value cannot alter the request URL path, while preserving the
-// segment separators the /models/{owner}/{name} route relies on.
-func escapeModelPath(model string) string {
+// segment separators the /models/{owner}/{name} route relies on. Empty and dot
+// ("."/"..") segments are rejected, since url.PathEscape leaves them unchanged.
+func escapeModelPath(model string) (string, error) {
 	parts := strings.Split(model, "/")
 	for i, part := range parts {
+		if part == "" || part == "." || part == ".." {
+			return "", fmt.Errorf("replicate: invalid model path segment %q", part)
+		}
 		parts[i] = url.PathEscape(part)
 	}
-	return strings.Join(parts, "/")
+	return strings.Join(parts, "/"), nil
 }
 
 // predictionText coerces a Replicate prediction output (a string or an array of
@@ -308,7 +316,10 @@ func usageFromMetrics(pred *Prediction) (core.Usage, bool) {
 
 // Complete sends a chat completion request to Replicate and polls until done.
 func (p *Provider) Complete(ctx context.Context, req core.Request) (*core.Response, error) {
-	url, version := p.resolveModelURL(p.resolveTextModel(req.Model))
+	url, version, err := p.resolveModelURL(p.resolveTextModel(req.Model))
+	if err != nil {
+		return nil, err
+	}
 	predReq := replicatePredictionRequest{Version: version, Input: buildTextInput(ctx, req)}
 
 	bodyReader, _, release, err := core.JSONBodyReader(predReq)
@@ -341,7 +352,10 @@ func (p *Provider) Complete(ctx context.Context, req core.Request) (*core.Respon
 // CompleteStream submits a Replicate prediction with streaming enabled and
 // translates Replicate output SSE events into OpenAI-compatible stream chunks.
 func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan core.StreamChunk, error) {
-	url, version := p.resolveModelURL(p.resolveTextModel(req.Model))
+	url, version, err := p.resolveModelURL(p.resolveTextModel(req.Model))
+	if err != nil {
+		return nil, err
+	}
 	predReq := replicatePredictionRequest{Version: version, Input: buildTextInput(ctx, req), Stream: true}
 
 	bodyReader, _, release, err := core.JSONBodyReader(predReq)
@@ -409,7 +423,10 @@ func (p *Provider) GenerateImage(ctx context.Context, req core.ImageRequest) (*c
 		}
 	}
 
-	url, version := p.resolveModelURL(modelPath)
+	url, version, err := p.resolveModelURL(modelPath)
+	if err != nil {
+		return nil, err
+	}
 	imgReq.Version = version
 
 	bodyReader, _, release, err := core.JSONBodyReader(imgReq)

--- a/providers/replicate/replicate_p7_test.go
+++ b/providers/replicate/replicate_p7_test.go
@@ -34,3 +34,14 @@ func TestResolveModelURL_RejectsTraversal(t *testing.T) {
 		t.Fatal("resolveModelURL accepted a traversal model path, want error")
 	}
 }
+
+// TestResolveModelURL_RejectsNonOwnerName locks in that only an owner/name model
+// path builds a /models/ URL; missing or extra segments are rejected.
+func TestResolveModelURL_RejectsNonOwnerName(t *testing.T) {
+	p, _ := New("k", "https://api.replicate.com/v1", nil, nil)
+	for _, m := range []string{"solo", "owner/name/extra", "a/b/c/d"} {
+		if _, _, err := p.resolveModelURL(m); err == nil {
+			t.Errorf("resolveModelURL(%q) accepted a non owner/name path, want error", m)
+		}
+	}
+}

--- a/providers/replicate/replicate_p7_test.go
+++ b/providers/replicate/replicate_p7_test.go
@@ -8,3 +8,17 @@ func TestNewReplicate_RejectsInvalidBaseURL(t *testing.T) {
 		t.Fatal("New accepted an invalid base URL")
 	}
 }
+
+// TestResolveModelURL_EscapesModelPath locks in that special characters in a
+// model path are percent-escaped so they cannot alter the request URL.
+func TestResolveModelURL_EscapesModelPath(t *testing.T) {
+	p, err := New("k", "https://api.replicate.com/v1", nil, nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	got, _ := p.resolveModelURL("owner/bad#name")
+	want := "https://api.replicate.com/v1/models/owner/bad%23name/predictions"
+	if got != want {
+		t.Errorf("resolveModelURL = %q, want %q", got, want)
+	}
+}

--- a/providers/replicate/replicate_p7_test.go
+++ b/providers/replicate/replicate_p7_test.go
@@ -1,0 +1,10 @@
+package replicate
+
+import "testing"
+
+// TestNewReplicate_RejectsInvalidBaseURL locks in base-URL validation.
+func TestNewReplicate_RejectsInvalidBaseURL(t *testing.T) {
+	if _, err := New("k", "://nope", nil, nil); err == nil {
+		t.Fatal("New accepted an invalid base URL")
+	}
+}

--- a/providers/replicate/replicate_p7_test.go
+++ b/providers/replicate/replicate_p7_test.go
@@ -16,9 +16,21 @@ func TestResolveModelURL_EscapesModelPath(t *testing.T) {
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
-	got, _ := p.resolveModelURL("owner/bad#name")
+	got, _, err := p.resolveModelURL("owner/bad#name")
+	if err != nil {
+		t.Fatalf("resolveModelURL: %v", err)
+	}
 	want := "https://api.replicate.com/v1/models/owner/bad%23name/predictions"
 	if got != want {
 		t.Errorf("resolveModelURL = %q, want %q", got, want)
+	}
+}
+
+// TestResolveModelURL_RejectsTraversal locks in that dot segments are rejected
+// rather than escaping to a different path.
+func TestResolveModelURL_RejectsTraversal(t *testing.T) {
+	p, _ := New("k", "https://api.replicate.com/v1", nil, nil)
+	if _, _, err := p.resolveModelURL("../../etc"); err == nil {
+		t.Fatal("resolveModelURL accepted a traversal model path, want error")
 	}
 }

--- a/providers/replicate/replicate_test.go
+++ b/providers/replicate/replicate_test.go
@@ -3,10 +3,12 @@ package replicate
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/ferro-labs/ai-gateway/providers/core"
 )
@@ -189,8 +191,8 @@ func TestReplicateProvider_Models(t *testing.T) {
 func TestReplicateProvider_AuthHeaders(t *testing.T) {
 	p, _ := New("test-token", "", nil, nil)
 	headers := p.AuthHeaders()
-	if headers["Authorization"] != "Token test-token" {
-		t.Errorf("AuthHeaders Authorization = %q, want Token test-token", headers["Authorization"])
+	if headers["Authorization"] != "Bearer test-token" {
+		t.Errorf("AuthHeaders Authorization = %q, want Bearer test-token", headers["Authorization"])
 	}
 }
 
@@ -290,8 +292,8 @@ func TestReplicateProvider_CompleteStream_MockSSE(t *testing.T) {
 	if gotPath != "/models/test/model/predictions" {
 		t.Fatalf("request path = %q, want /models/test/model/predictions", gotPath)
 	}
-	if gotAuth != "Token test-token" {
-		t.Fatalf("authorization = %q, want Token test-token", gotAuth)
+	if gotAuth != "Bearer test-token" {
+		t.Fatalf("authorization = %q, want Bearer test-token", gotAuth)
 	}
 	if gotAccept != "text/event-stream" {
 		t.Fatalf("stream Accept = %q, want text/event-stream", gotAccept)
@@ -471,5 +473,288 @@ func TestReplicateProvider_Poll_NonOKStatus(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "429") {
 		t.Errorf("error should mention HTTP status 429; got: %v", err)
+	}
+}
+
+// ── Submit error paths (4xx / 5xx) ─────────────────────────────────────────────
+
+func TestReplicateProvider_Complete_SubmitError(t *testing.T) {
+	// The initial POST fails; submitAndPoll must surface a core.APIError that
+	// embeds the status code and the {"detail":…} message Replicate returns.
+	cases := []struct {
+		name       string
+		status     int
+		body       string
+		wantSubstr string
+	}{
+		{"bad request", http.StatusBadRequest, `{"detail":"invalid input"}`, "invalid input"},
+		{"server error", http.StatusInternalServerError, `{"detail":"internal"}`, "internal"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(tc.status)
+				_, _ = w.Write([]byte(tc.body))
+			}))
+			defer srv.Close()
+
+			p, _ := New("test-token", srv.URL, []string{"test/model"}, nil)
+			_, err := p.Complete(context.Background(), core.Request{
+				Model:    "test/model",
+				Messages: []core.Message{{Role: "user", Content: "Hi"}},
+			})
+			if err == nil {
+				t.Fatalf("expected error for status %d, got nil", tc.status)
+			}
+			if got := core.ParseStatusCode(err); got != tc.status {
+				t.Errorf("ParseStatusCode = %d, want %d (err: %v)", got, tc.status, err)
+			}
+			if !strings.Contains(err.Error(), tc.wantSubstr) {
+				t.Errorf("error should contain %q; got: %v", tc.wantSubstr, err)
+			}
+		})
+	}
+}
+
+func TestReplicateProvider_CompleteStream_SubmitError(t *testing.T) {
+	// The streaming path's initial submit POST fails; the error must be a
+	// core.APIError carrying the status code.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"detail":"stream submit rejected"}`))
+	}))
+	defer srv.Close()
+
+	p, _ := New("test-token", srv.URL, []string{"test/model"}, nil)
+	_, err := p.CompleteStream(context.Background(), core.Request{
+		Model:    "test/model",
+		Messages: []core.Message{{Role: "user", Content: "Hi"}},
+	})
+	if err == nil {
+		t.Fatal("expected submit error from CompleteStream, got nil")
+	}
+	if core.ParseStatusCode(err) != http.StatusBadRequest {
+		t.Errorf("expected status 400 in error; got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "stream submit rejected") {
+		t.Errorf("error should carry the detail message; got: %v", err)
+	}
+}
+
+// ── Usage + finish_reason ──────────────────────────────────────────────────────
+
+func TestReplicateProvider_Complete_UsageAndFinishReason(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{
+			"id":"pred-usage",
+			"status":"succeeded",
+			"output":"hello",
+			"metrics":{"input_token_count":12,"output_token_count":7}
+		}`))
+	}))
+	defer srv.Close()
+
+	p, _ := New("test-token", srv.URL, []string{"test/model"}, nil)
+	resp, err := p.Complete(context.Background(), core.Request{
+		Model:    "test/model",
+		Messages: []core.Message{{Role: "user", Content: "Hi"}},
+	})
+	if err != nil {
+		t.Fatalf("Complete() error: %v", err)
+	}
+	if resp.Usage.PromptTokens != 12 || resp.Usage.CompletionTokens != 7 || resp.Usage.TotalTokens != 19 {
+		t.Errorf("usage = %+v, want prompt=12 completion=7 total=19", resp.Usage)
+	}
+	if resp.Choices[0].FinishReason != core.FinishReasonStop {
+		t.Errorf("finish_reason = %q, want %q", resp.Choices[0].FinishReason, core.FinishReasonStop)
+	}
+}
+
+// ── Streaming: error event + done reason ───────────────────────────────────────
+
+func TestReplicateProvider_CompleteStream_ErrorEvent(t *testing.T) {
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/models/test/model/predictions":
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"id":"pred-err","status":"starting","urls":{"stream":"` + srv.URL + `/stream"}}`))
+		case "/stream":
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("event: output\ndata: partial\n\n" +
+				"event: error\ndata: model exploded\n\n"))
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	p, _ := New("test-token", srv.URL, []string{"test/model"}, nil)
+	ch, err := p.CompleteStream(context.Background(), core.Request{
+		Model:    "test/model",
+		Messages: []core.Message{{Role: "user", Content: "Hi"}},
+	})
+	if err != nil {
+		t.Fatalf("CompleteStream() error: %v", err)
+	}
+
+	var streamErr error
+	for c := range ch {
+		if c.Error != nil {
+			streamErr = c.Error
+		}
+	}
+	if streamErr == nil {
+		t.Fatal("expected an error chunk from the error event")
+	}
+	if !strings.Contains(streamErr.Error(), "model exploded") {
+		t.Errorf("error chunk should carry the payload; got: %v", streamErr)
+	}
+}
+
+func TestReplicateProvider_CompleteStream_DoneReason(t *testing.T) {
+	// A "done" event carrying a reason must normalize into the terminal chunk's
+	// finish_reason (max_tokens → length), not be treated as an error.
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/models/test/model/predictions":
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"id":"pred-done","status":"starting","urls":{"stream":"` + srv.URL + `/stream"}}`))
+		case "/stream":
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("event: output\ndata: hi\n\n" +
+				"event: done\ndata: {\"reason\":\"max_tokens\"}\n\n"))
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	p, _ := New("test-token", srv.URL, []string{"test/model"}, nil)
+	ch, err := p.CompleteStream(context.Background(), core.Request{
+		Model:    "test/model",
+		Messages: []core.Message{{Role: "user", Content: "Hi"}},
+	})
+	if err != nil {
+		t.Fatalf("CompleteStream() error: %v", err)
+	}
+
+	var chunks []core.StreamChunk
+	for c := range ch {
+		if c.Error != nil {
+			t.Fatalf("unexpected error chunk: %v", c.Error)
+		}
+		chunks = append(chunks, c)
+	}
+	if len(chunks) == 0 {
+		t.Fatal("expected at least one chunk")
+	}
+	last := chunks[len(chunks)-1]
+	if last.Choices[0].FinishReason != core.FinishReasonLength {
+		t.Errorf("terminal finish_reason = %q, want %q", last.Choices[0].FinishReason, core.FinishReasonLength)
+	}
+}
+
+// ── Context cancellation ───────────────────────────────────────────────────────
+
+func TestReplicateProvider_Poll_ContextCancel(t *testing.T) {
+	// The prediction never resolves; canceling the context mid-poll must return
+	// promptly with a context error.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"pred-hang","status":"processing"}`))
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	// Cancel after submit succeeds so the poll loop observes the cancellation.
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+
+	p, _ := New("test-token", srv.URL, []string{"test/model"}, nil)
+	_, err := p.Complete(ctx, core.Request{
+		Model:    "test/model",
+		Messages: []core.Message{{Role: "user", Content: "Hi"}},
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled from poll loop, got: %v", err)
+	}
+}
+
+func TestReplicateProvider_Stream_ContextCancel(t *testing.T) {
+	// The stream never ends; canceling the context must terminate the read loop
+	// with a context-related error chunk.
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/models/test/model/predictions":
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"id":"pred-stream-cancel","status":"starting","urls":{"stream":"` + srv.URL + `/stream"}}`))
+		case "/stream":
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.WriteHeader(http.StatusOK)
+			flusher, ok := w.(http.Flusher)
+			if !ok {
+				t.Fatal("stream response writer is not a Flusher")
+			}
+			// Emit output events until the client disconnects.
+			for i := 0; i < 100000; i++ {
+				select {
+				case <-r.Context().Done():
+					return
+				default:
+				}
+				if _, err := w.Write([]byte("event: output\ndata: x\n\n")); err != nil {
+					return
+				}
+				flusher.Flush()
+			}
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	p, _ := New("test-token", srv.URL, []string{"test/model"}, nil)
+	ch, err := p.CompleteStream(ctx, core.Request{
+		Model:    "test/model",
+		Messages: []core.Message{{Role: "user", Content: "Hi"}},
+	})
+	if err != nil {
+		t.Fatalf("CompleteStream() error: %v", err)
+	}
+
+	var cancelErr error
+	count := 0
+	for c := range ch {
+		count++
+		if count == 1 {
+			cancel()
+		}
+		if c.Error != nil {
+			cancelErr = c.Error
+			break
+		}
+	}
+	if cancelErr == nil {
+		t.Fatal("expected an error chunk after context cancellation")
+	}
+	if !errors.Is(cancelErr, context.Canceled) {
+		t.Errorf("expected context.Canceled, got: %v", cancelErr)
 	}
 }


### PR DESCRIPTION
## v1.1.16 — Local & Prediction-API Providers

The seventh (and heaviest, 6-HIGH) provider-readiness remediation phase. Aligns four **non-OpenAI-wire** providers — **Hugging Face, Ollama, Ollama Cloud, Replicate** — which use task-specific, prediction, and native APIs. No breaking API changes relative to v1.1.15. Closes/advances GitHub #295, #299, #300, #264.

### Provider verticals
| Provider | Work |
|---|---|
| **hugging-face** (3 HIGH) | default URL → `router.huggingface.co/v1` (old host is HTTP 410); **rewrote Embed → feature-extraction task route** (`{inputs}`→bare vector array) and **GenerateImage → text-to-image** (raw bytes→base64) — HF-specific, not OpenAI-shaped; escape model path segments; `core.APIError`; `ValidateBaseURL` |
| **ollama** | `Complete`→shared `PostChat` (deletes duplicated structs, adds Provider attribution + normalize); forward embedding `dimensions` (doc-confirmed); `ValidateBaseURL` |
| **ollama-cloud** (2 HIGH) | **conservative native path**: forward stop/seed/penalties + `WarnUnsupportedParams`; normalize finish_reason + tool detection; synthesize tool-call IDs; add `/api/embed` embeddings (`+CapabilityEmbed`); `ValidateBaseURL` |
| **replicate** | **65s transport preset** (Prefer:wait ~60s hold vs 30s default); `Token`→`Bearer` auth; errors→`core.APIError`; forward top_p/seed/stop + `WarnUnsupportedParams`; usage from prediction metrics + normalize; `ValidateBaseURL`; dedup refactor |

### Verify-first resolutions (all agent-confirmed from docs)
- HF task routes web-verified (feature-extraction bare-array; text-to-image raw bytes) · ollama `dimensions` **confirmed supported** (in-code comment was stale) · replicate 60s `Prefer:wait` confirmed → 65s preset · ollama-cloud `/v1` migration **deferred** (endpoint not first-party documented; native-extension recovers the value without the bet).

### Review outcome (both APPROVE after fixes)
- **go-reviewer** (0 CRIT/HIGH): its top MED — HF client-controlled `req.Model` interpolated into the request path — is **fixed** (per-segment `url.PathEscape`, preserving the `owner/name` slash) + tested. Confirmed the HF bare-array parse, raw-bytes image path, ollama migration, and replicate dedup all behavior-preserving.
- **code-reviewer** (0 CRIT): its 2 HIGH (missing base-URL rejection tests on 3 providers; untested HF `/v1`-strip logic) are **fixed** — rejection tests added for HF/ollama/replicate, plus a test asserting the router-root `/v1` strip on the production path; transport preset now asserted; ollama-cloud comments clarified.

### Deferred (recorded)
ollama-cloud `/v1` migration (needs live key) · replicate `done`-reason error edge (fast-follow) · HF/replicate discovery/Responses API · `internal/ollamanative` dedup.

### Test plan
- [x] `go build ./...`, `gofmt`, `golangci-lint` (0 issues)
- [x] `go test -race ./...` — all packages green
- [x] HF embed single+batch+error+`/v1`-strip+path-escape tests; ollama Complete+dimensions; ollama-cloud tool-call-synth+extended-params+embed; replicate error/usage/cancellation; base-URL rejection parity across all four; transport preset assertion
- [x] `providers` capability↔interface gates + `models` catalog gate pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E8noYUkd7S9eHxR4Rky8AW


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added embedding support for Ollama Cloud.
  * Updated Hugging Face to use router task endpoints for embeddings and image generation.
  * Expanded Replicate and Ollama/Ollama Cloud support for more generation options and improved usage reporting.
* **Bug Fixes**
  * Improved finish-reason normalization, token/usage consistency, and streaming vs non-streaming behavior across providers.
  * Hardened base-URL validation, request auth formatting, and timeout handling; improved tool-call handling (including synthesized IDs) and forwarded embedding dimensions.
* **Tests**
  * Expanded provider test coverage for routing/escaping, option forwarding, dimensions/tool-call synthesis, and error-handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->