### PR TITLE
fix: uniform environment-variable substitution across config

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,6 +354,8 @@ mcp_servers:
     timeout_seconds: 30
 ```
 
+When loading YAML/JSON through `LoadConfig`, the gateway expands `$VAR` and `${VAR}` references in MCP headers, plugin config, and observability exporter config before those components are initialized. This keeps secrets in environment variables instead of hard-coding them in config files.
+
 See [config.example.yaml](config.example.yaml) and [config.example.json](config.example.json) for the full template with all options.
 
 ### Key environment variables
@@ -442,7 +444,7 @@ observability:
 
 Standard `OTEL_*` environment variables (e.g. `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_TRACES_SAMPLER`) always take precedence over the config file — this matches the OTel SDK convention and is required for predictable container deployments.
 
-`observability.tracing.headers` lets you send OTLP traces to authenticated managed backends (Datadog, New Relic, Honeycomb, Grafana Cloud) by setting vendor-specific headers such as API keys. Values support `${ENV_VAR}` interpolation so secrets are never stored literally in the config file. The standard `OTEL_EXPORTER_OTLP_HEADERS` environment variable also applies per OTel convention.
+`observability.tracing.headers` lets you send OTLP traces to authenticated managed backends (Datadog, New Relic, Honeycomb, Grafana Cloud) by setting vendor-specific headers such as API keys. Values support `${ENV_VAR}` interpolation so secrets are never stored literally in the config file. The standard `OTEL_EXPORTER_OTLP_HEADERS` environment variable also applies per OTel convention. Observability exporter `config` blocks loaded from YAML/JSON also support `$VAR` and `${VAR}` interpolation.
 
 The **endpoint scheme selects transport security**: an `https://` endpoint uses TLS, while an `http://` endpoint or a bare `host:port` (e.g. `localhost:4317`) connects in plaintext. Managed backends require the `https://` form.
 

--- a/config.example.json
+++ b/config.example.json
@@ -1,6 +1,7 @@
 {
   "_max_request_bytes_comment": "Max request body bytes for /v1/* and admin write routes. Default: 10485760 (10 MiB). Exceeding returns HTTP 413.",
   "max_request_bytes": 10485760,
+  "_env_interpolation_comment": "LoadConfig expands $VAR and ${VAR} in MCP headers, plugin config, and observability exporter config.",
   "strategy": {
     "mode": "fallback",
     "_unpriced_strategy_comment": "cost-optimized only: fallback (default) | skip | allow",

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -105,6 +105,7 @@ aliases:
   code: deepseek-coder
 
 # Optional plugins
+# Plugin config string values loaded via LoadConfig support $VAR / ${VAR} interpolation.
 plugins:
   - name: word-filter
     type: guardrail
@@ -194,6 +195,7 @@ mcp_servers:
   - name: database
     url: "https://mcp-db.internal/mcp"
     headers:
+      # Values loaded via LoadConfig support $VAR / ${VAR} interpolation.
       Authorization: "Bearer ${MCP_DB_TOKEN}"
     allowed_tools:
       - query_readonly
@@ -228,6 +230,7 @@ observability:
 
   # exporters lists plugin observability exporters that receive
   # gateway.request.completed / gateway.request.failed events.
+  # Config string values loaded via LoadConfig support $VAR / ${VAR} interpolation.
   # Each entry names a factory registered via observability.RegisterExporter
   # in a plugin's init().  Unrecognised names emit a warning and are skipped
   # (non-fatal).  No built-in exporters ship with this repo — they are

--- a/config.go
+++ b/config.go
@@ -80,8 +80,9 @@ type ExporterConfig struct {
 	// Enabled gates the exporter. Set to false to temporarily disable
 	// without removing the config block.
 	Enabled bool `json:"enabled" yaml:"enabled"`
-	// Config is the exporter-specific configuration map. Passed
-	// verbatim to Exporter.Init at gateway startup.
+	// Config is the exporter-specific configuration map. When loaded via
+	// LoadConfig, string values may reference environment variables using $VAR
+	// or ${VAR}; resolved values are passed to Exporter.Init at gateway startup.
 	Config map[string]any `json:"config,omitempty" yaml:"config,omitempty"`
 }
 
@@ -240,7 +241,8 @@ type CircuitBreakerConfig struct {
 	Timeout string `json:"timeout" yaml:"timeout"`
 }
 
-// PluginConfig holds plugin configuration.
+// PluginConfig holds plugin configuration. When loaded via LoadConfig, string
+// values in Config may reference environment variables using $VAR or ${VAR}.
 type PluginConfig struct {
 	Name    string         `json:"name" yaml:"name"`
 	Type    string         `json:"type" yaml:"type"`

--- a/config_load.go
+++ b/config_load.go
@@ -34,7 +34,85 @@ func LoadConfig(path string) (*Config, error) {
 		return nil, fmt.Errorf("unsupported config file extension %q: use .json, .yaml, or .yml", ext)
 	}
 
+	resolveEnv(&cfg)
+
 	return &cfg, nil
+}
+
+// resolveEnv materialises environment-variable references in config sections
+// that carry user/plugin-owned secrets. It intentionally leaves
+// observability.tracing.headers alone: those are still resolved lazily by
+// internal/otel so programmatic configs keep the historical behaviour.
+func resolveEnv(cfg *Config) {
+	if cfg == nil {
+		return
+	}
+
+	for i := range cfg.MCPServers {
+		cfg.MCPServers[i].Headers = resolveEnvStringMap(cfg.MCPServers[i].Headers, true)
+	}
+
+	for i := range cfg.Observability.Exporters {
+		cfg.Observability.Exporters[i].Config = resolveEnvAnyMap(cfg.Observability.Exporters[i].Config)
+	}
+
+	for i := range cfg.Plugins {
+		cfg.Plugins[i].Config = resolveEnvAnyMap(cfg.Plugins[i].Config)
+	}
+}
+
+func resolveEnvStringMap(raw map[string]string, skipEmpty bool) map[string]string {
+	if len(raw) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(raw))
+	for k, v := range raw {
+		resolved := os.Expand(v, os.Getenv)
+		if skipEmpty && resolved == "" {
+			continue
+		}
+		out[k] = resolved
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func resolveEnvAnyMap(raw map[string]any) map[string]any {
+	if raw == nil {
+		return nil
+	}
+	out := make(map[string]any, len(raw))
+	for k, v := range raw {
+		out[k] = resolveEnvAnyValue(v)
+	}
+	return out
+}
+
+func resolveEnvAnyValue(v any) any {
+	switch val := v.(type) {
+	case string:
+		return os.Expand(val, os.Getenv)
+	case map[string]any:
+		return resolveEnvAnyMap(val)
+	case map[string]string:
+		return resolveEnvStringMap(val, false)
+	case []any:
+		out := make([]any, len(val))
+		for i, elem := range val {
+			out[i] = resolveEnvAnyValue(elem)
+		}
+		return out
+	case []string:
+		out := make([]string, len(val))
+		for i, elem := range val {
+			out[i] = os.Expand(elem, os.Getenv)
+		}
+		return out
+	default:
+		return v
+	}
 }
 
 // ValidateConfig validates a Config for correctness.

--- a/config_load_test.go
+++ b/config_load_test.go
@@ -1,6 +1,7 @@
 package aigateway
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -43,6 +44,119 @@ func TestLoadConfig_CostOptimizedUnpricedStrategy(t *testing.T) {
 	}
 	if cfg.Strategy.UnpricedStrategy != unpricedStrategySkip {
 		t.Errorf("expected unpriced_strategy %q, got %q", unpricedStrategySkip, cfg.Strategy.UnpricedStrategy)
+	}
+}
+
+func TestLoadConfig_ResolvesEnvReferences(t *testing.T) {
+	t.Setenv("FERRO_TEST_MCP_TOKEN", "mcp-token")
+	t.Setenv("FERRO_TEST_EXPORTER_KEY", "exporter-key")
+	t.Setenv("FERRO_TEST_EXPORTER_HOST", "trace.example.com")
+	t.Setenv("FERRO_TEST_PLUGIN_DSN", "sqlite:///tmp/requests.db")
+	t.Setenv("FERRO_TEST_PLUGIN_TOKEN", "plugin-token")
+	t.Setenv("FERRO_TEST_EMPTY", "")
+
+	mcpTokenRef := "${" + "FERRO_TEST_MCP_TOKEN" + "}"
+	exporterKeyRef := "${" + "FERRO_TEST_EXPORTER_KEY" + "}"
+	exporterHostRef := "${" + "FERRO_TEST_EXPORTER_HOST" + "}"
+	pluginDSNRef := "${" + "FERRO_TEST_PLUGIN_DSN" + "}"
+	pluginTokenRef := "${" + "FERRO_TEST_PLUGIN_TOKEN" + "}"
+	emptyRef := "${" + "FERRO_TEST_EMPTY" + "}"
+
+	data := fmt.Sprintf(`
+strategy:
+  mode: single
+targets:
+  - virtual_key: openai
+mcp_servers:
+  - name: database
+    url: https://mcp-db.internal/mcp
+    headers:
+      Authorization: "Bearer %s"
+      X-Empty: "%s"
+observability:
+  exporters:
+    - name: langsmith
+      enabled: true
+      config:
+        api_key: "%s"
+        endpoint: "https://%s/v1"
+        nested:
+          token: "prefix-%s"
+        list:
+          - "%s"
+          - false
+plugins:
+  - name: request-logger
+    type: logging
+    stage: before_request
+    enabled: true
+    config:
+      dsn: "%s"
+      nested:
+        token: "%s"
+      list:
+        - "%s"
+        - 7
+`, mcpTokenRef, emptyRef, exporterKeyRef, exporterHostRef, exporterKeyRef, exporterKeyRef, pluginDSNRef, pluginTokenRef, pluginTokenRef)
+	path := writeTempFile(t, "config.yaml", data)
+
+	cfg, err := LoadConfig(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got := cfg.MCPServers[0].Headers["Authorization"]; got != "Bearer mcp-token" {
+		t.Errorf("MCP Authorization header = %q, want %q", got, "Bearer mcp-token")
+	}
+	if _, ok := cfg.MCPServers[0].Headers["X-Empty"]; ok {
+		t.Errorf("MCP X-Empty header should be omitted when env resolves empty: %v", cfg.MCPServers[0].Headers)
+	}
+
+	exporterCfg := cfg.Observability.Exporters[0].Config
+	if got := exporterCfg["api_key"]; got != "exporter-key" {
+		t.Errorf("exporter api_key = %v, want exporter-key", got)
+	}
+	if got := exporterCfg["endpoint"]; got != "https://trace.example.com/v1" {
+		t.Errorf("exporter endpoint = %v, want https://trace.example.com/v1", got)
+	}
+	exporterNested, ok := exporterCfg["nested"].(map[string]any)
+	if !ok {
+		t.Fatalf("exporter nested config: expected map[string]any, got %T", exporterCfg["nested"])
+	}
+	if got := exporterNested["token"]; got != "prefix-exporter-key" {
+		t.Errorf("exporter nested token = %v, want prefix-exporter-key", got)
+	}
+	exporterList, ok := exporterCfg["list"].([]any)
+	if !ok {
+		t.Fatalf("exporter list config: expected []any, got %T", exporterCfg["list"])
+	}
+	if got := exporterList[0]; got != "exporter-key" {
+		t.Errorf("exporter list[0] = %v, want exporter-key", got)
+	}
+	if got := exporterList[1]; got != false {
+		t.Errorf("exporter list[1] = %v, want false", got)
+	}
+
+	pluginCfg := cfg.Plugins[0].Config
+	if got := pluginCfg["dsn"]; got != "sqlite:///tmp/requests.db" {
+		t.Errorf("plugin dsn = %v, want sqlite:///tmp/requests.db", got)
+	}
+	pluginNested, ok := pluginCfg["nested"].(map[string]any)
+	if !ok {
+		t.Fatalf("plugin nested config: expected map[string]any, got %T", pluginCfg["nested"])
+	}
+	if got := pluginNested["token"]; got != "plugin-token" {
+		t.Errorf("plugin nested token = %v, want plugin-token", got)
+	}
+	pluginList, ok := pluginCfg["list"].([]any)
+	if !ok {
+		t.Fatalf("plugin list config: expected []any, got %T", pluginCfg["list"])
+	}
+	if got := pluginList[0]; got != "plugin-token" {
+		t.Errorf("plugin list[0] = %v, want plugin-token", got)
+	}
+	if got := pluginList[1]; got != 7 {
+		t.Errorf("plugin list[1] = %v, want 7", got)
 	}
 }
 

--- a/internal/admin/config_scrub.go
+++ b/internal/admin/config_scrub.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 
 	aigateway "github.com/ferro-labs/ai-gateway"
+	"github.com/ferro-labs/ai-gateway/mcp"
 )
 
 // isEnvRef reports whether s is a bare environment-variable reference of the
@@ -157,6 +158,7 @@ func scrubAnyMap(m map[string]any) map[string]any {
 //
 // Fields scrubbed:
 //   - Observability.Tracing.Headers (map[string]string)
+//   - each MCPServers[i].Headers (map[string]string)
 //   - each Observability.Exporters[i].Config (map[string]any)
 //   - each Plugins[i].Config (map[string]interface{})
 //
@@ -165,6 +167,15 @@ func scrubAnyMap(m map[string]any) map[string]any {
 // environment at runtime.
 func scrubConfigSecrets(cfg aigateway.Config) aigateway.Config {
 	cfg.Observability.Tracing.Headers = scrubStringMap(cfg.Observability.Tracing.Headers)
+
+	if cfg.MCPServers != nil {
+		servers := make([]mcp.ServerConfig, len(cfg.MCPServers))
+		for i, server := range cfg.MCPServers {
+			server.Headers = scrubStringMap(server.Headers)
+			servers[i] = server
+		}
+		cfg.MCPServers = servers
+	}
 
 	if cfg.Observability.Exporters != nil {
 		exporters := make([]aigateway.ExporterConfig, len(cfg.Observability.Exporters))

--- a/internal/admin/handlers_test.go
+++ b/internal/admin/handlers_test.go
@@ -14,6 +14,7 @@ import (
 
 	aigateway "github.com/ferro-labs/ai-gateway"
 	"github.com/ferro-labs/ai-gateway/internal/requestlog"
+	"github.com/ferro-labs/ai-gateway/mcp"
 	"github.com/go-chi/chi/v5"
 )
 
@@ -1683,6 +1684,16 @@ func TestGetConfigRedactsSecrets(t *testing.T) {
 	cfg := aigateway.Config{
 		Strategy: aigateway.StrategyConfig{Mode: aigateway.ModeSingle},
 		Targets:  []aigateway.Target{{VirtualKey: "openai"}},
+		MCPServers: []mcp.ServerConfig{
+			{
+				Name: "tools",
+				URL:  "https://mcp.example.com/mcp",
+				Headers: map[string]string{
+					"Authorization": "literal-mcp-secret",
+					"X-Env":         "${MCP_TOKEN}",
+				},
+			},
+		},
 		Observability: aigateway.ObservabilityConfig{
 			Tracing: aigateway.TracingConfig{
 				Headers: map[string]string{
@@ -1748,6 +1759,17 @@ func TestGetConfigRedactsSecrets(t *testing.T) {
 		t.Errorf("X-Api-Key header: got %q, want ${MY_API_KEY}", got)
 	}
 
+	// MCP literal header value must be redacted; env references must be preserved.
+	if len(respCfg.MCPServers) == 0 {
+		t.Fatal("expected MCP servers in response")
+	}
+	if got := respCfg.MCPServers[0].Headers["Authorization"]; got != "[REDACTED]" {
+		t.Errorf("MCP Authorization header: got %q, want [REDACTED]", got)
+	}
+	if got := respCfg.MCPServers[0].Headers["X-Env"]; got != "${MCP_TOKEN}" {
+		t.Errorf("MCP X-Env header: got %q, want ${MCP_TOKEN}", got)
+	}
+
 	// Exporter string config must be redacted.
 	if len(respCfg.Observability.Exporters) == 0 {
 		t.Fatal("expected exporters in response")
@@ -1772,6 +1794,9 @@ func TestGetConfigRedactsSecrets(t *testing.T) {
 	liveCfg := cm.GetConfig()
 	if got := liveCfg.Observability.Tracing.Headers["Authorization"]; got != "literal-secret-value" {
 		t.Errorf("live config Authorization mutated: got %q, want literal-secret-value", got)
+	}
+	if got := liveCfg.MCPServers[0].Headers["Authorization"]; got != "literal-mcp-secret" {
+		t.Errorf("live config MCP Authorization mutated: got %q, want literal-mcp-secret", got)
 	}
 	if got := liveCfg.Observability.Exporters[0].Config["api_key"].(string); got != "literal-ls-key" {
 		t.Errorf("live config api_key mutated: got %q, want literal-ls-key", got)

--- a/mcp/config.go
+++ b/mcp/config.go
@@ -17,8 +17,8 @@ type ServerConfig struct {
 	// URL is the Streamable HTTP endpoint (e.g. "https://mcp.example.com/mcp").
 	URL string `json:"url" yaml:"url"`
 	// Headers are additional HTTP headers sent with every MCP request
-	// (e.g. authorization tokens). Values may reference environment variables
-	// via shell-style ${VAR} substitution performed by the caller.
+	// (e.g. authorization tokens). When loaded via aigateway.LoadConfig,
+	// values may reference environment variables using $VAR or ${VAR}.
 	Headers map[string]string `json:"headers,omitempty" yaml:"headers,omitempty"`
 	// AllowedTools restricts which tools from this server are exposed to the LLM.
 	// An empty slice means all discovered tools are allowed.


### PR DESCRIPTION
## Summary

Adds a single `LoadConfig` env-resolution pass so `${ENV}` / `$ENV` placeholders are materialized consistently for MCP headers, observability exporter config, and plugin config.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] New provider
- [ ] New plugin
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Performance improvement
- [ ] Refactor / code quality
- [x] Documentation / comments only
- [ ] CI / tooling

## Related issues

Fixes #283

## Changes

- Add `resolveEnv(*Config)` in `LoadConfig` for MCP headers, exporter config, and plugin config.
- Recursively expand string values inside exporter/plugin config maps and slices.
- Mirror OTLP header behavior for MCP headers by dropping headers that resolve to an empty value.
- Redact MCP headers from admin config responses so resolved secrets are not exposed.
- Document env interpolation in README, examples, and config comments.

## Testing

- [x] Existing tests pass (`go test ./...`)
- [x] New unit tests added (if applicable)
- [ ] Manually tested against a live provider (if provider change)

Ran:

```sh
go test -count=1 ./...
```
