### PR TITLE
fix(plugin): enforce failure policy by type

### DIFF
--- a/gateway_test.go
+++ b/gateway_test.go
@@ -1707,7 +1707,7 @@ func TestGateway_RouteStream_AfterPluginRejectRunsOnError(t *testing.T) {
 	var onErrorCalls int
 	_ = gw.RegisterPlugin(plugin.StageAfterRequest, &testPlugin{
 		name: "after",
-		typ:  plugin.TypeLogging,
+		typ:  plugin.TypeGuardrail,
 		execFn: func(_ context.Context, pctx *plugin.Context) error {
 			pctx.Reject = true
 			pctx.Reason = "after plugin rejected"
@@ -1763,7 +1763,7 @@ func TestGateway_Route_AfterPluginRejectRunsOnError(t *testing.T) {
 	var onErrorCalls int
 	_ = gw.RegisterPlugin(plugin.StageAfterRequest, &testPlugin{
 		name: "after",
-		typ:  plugin.TypeLogging,
+		typ:  plugin.TypeGuardrail,
 		execFn: func(_ context.Context, pctx *plugin.Context) error {
 			pctx.Reject = true
 			pctx.Reason = "after plugin rejected"
@@ -1792,6 +1792,114 @@ func TestGateway_Route_AfterPluginRejectRunsOnError(t *testing.T) {
 	}
 	if onErrorCalls != 1 {
 		t.Fatalf("on-error plugin calls = %d, want 1", onErrorCalls)
+	}
+}
+
+func TestGateway_Route_AfterLoggingPanicStaysNonFatal(t *testing.T) {
+	gw, _ := New(Config{
+		Strategy: StrategyConfig{Mode: ModeSingle},
+		Targets:  []Target{{VirtualKey: mockProviderName}},
+	})
+	gw.RegisterProvider(&mockProvider{
+		name:   mockProviderName,
+		models: []string{"gpt-4o"},
+		resp:   &providers.Response{ID: "r1", Model: "gpt-4o", Provider: mockProviderName},
+	})
+
+	var onErrorCalls int
+	_ = gw.RegisterPlugin(plugin.StageAfterRequest, &testPlugin{
+		name: "after-logger",
+		typ:  plugin.TypeLogging,
+		execFn: func(context.Context, *plugin.Context) error {
+			panic("log sink down")
+		},
+	})
+	_ = gw.RegisterPlugin(plugin.StageOnError, &testPlugin{
+		name: "on-error",
+		typ:  plugin.TypeLogging,
+		execFn: func(context.Context, *plugin.Context) error {
+			onErrorCalls++
+			return nil
+		},
+	})
+
+	resp, err := gw.Route(context.Background(), providers.Request{
+		Model:    "gpt-4o",
+		Messages: []providers.Message{{Role: "user", Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("Route() error = %v, want nil", err)
+	}
+	if resp.ID != "r1" {
+		t.Fatalf("response ID = %q, want r1", resp.ID)
+	}
+	if onErrorCalls != 0 {
+		t.Fatalf("on-error plugin calls = %d, want 0", onErrorCalls)
+	}
+}
+
+func TestGateway_RouteStream_AfterLoggingErrorStaysNonFatal(t *testing.T) {
+	gw, _ := New(Config{
+		Strategy: StrategyConfig{Mode: ModeSingle},
+		Targets:  []Target{{VirtualKey: mockProviderName}},
+	})
+	gw.RegisterProvider(&mockStreamProvider{
+		mockProvider: mockProvider{name: mockProviderName, models: []string{"gpt-4o"}},
+		streamFn: func(context.Context, providers.Request) (<-chan providers.StreamChunk, error) {
+			ch := make(chan providers.StreamChunk, 2)
+			ch <- providers.StreamChunk{
+				Model: "gpt-4o",
+				Choices: []providers.StreamChoice{{
+					Index:        0,
+					Delta:        providers.MessageDelta{Role: "assistant", Content: "ok"},
+					FinishReason: "stop",
+				}},
+			}
+			ch <- providers.StreamChunk{
+				Usage: &providers.Usage{PromptTokens: 1, CompletionTokens: 1, TotalTokens: 2},
+			}
+			close(ch)
+			return ch, nil
+		},
+	})
+
+	var onErrorCalls int
+	_ = gw.RegisterPlugin(plugin.StageAfterRequest, &testPlugin{
+		name: "after-logger",
+		typ:  plugin.TypeLogging,
+		execFn: func(context.Context, *plugin.Context) error {
+			return fmt.Errorf("log sink down")
+		},
+	})
+	_ = gw.RegisterPlugin(plugin.StageOnError, &testPlugin{
+		name: "on-error",
+		typ:  plugin.TypeLogging,
+		execFn: func(context.Context, *plugin.Context) error {
+			onErrorCalls++
+			return nil
+		},
+	})
+
+	ch, err := gw.RouteStream(context.Background(), providers.Request{
+		Model:    "gpt-4o",
+		Messages: []providers.Message{{Role: "user", Content: "hi"}},
+		Stream:   true,
+	})
+	if err != nil {
+		t.Fatalf("RouteStream: %v", err)
+	}
+	var chunks int
+	for chunk := range ch {
+		chunks++
+		if chunk.Error != nil {
+			t.Fatalf("stream chunk error = %v, want nil", chunk.Error)
+		}
+	}
+	if chunks == 0 {
+		t.Fatal("expected stream chunks")
+	}
+	if onErrorCalls != 0 {
+		t.Fatalf("on-error plugin calls = %d, want 0", onErrorCalls)
 	}
 }
 

--- a/plugin/manager.go
+++ b/plugin/manager.go
@@ -37,6 +37,50 @@ func pluginAttrs(name, kind, stage string) []attribute.KeyValue {
 	}
 }
 
+func pluginFailsClosed(pluginType PluginType) bool {
+	switch pluginType {
+	case TypeLogging, TypeMetrics, TypeTransform:
+		return false
+	default:
+		return true
+	}
+}
+
+func handlePluginFailure(p Plugin, stage Stage, pctx *Context, err error) error {
+	if err == nil && !pctx.Reject {
+		return nil
+	}
+	if pluginFailsClosed(p.Type()) {
+		return rejectionErrorFor(p, stage, pctx, err)
+	}
+
+	rejected := pctx.Reject
+	reason := rejectionReason(pctx, err)
+	pctx.Reject = false
+	pctx.Reason = ""
+	if err != nil {
+		logging.Logger.Warn("fail-open plugin error ignored", "plugin", p.Name(), "type", p.Type(), "stage", stage, "error", err)
+	}
+	if rejected {
+		logging.Logger.Warn("fail-open plugin rejection ignored", "plugin", p.Name(), "type", p.Type(), "stage", stage, "reason", reason)
+	}
+	return nil
+}
+
+func rejectionErrorFor(p Plugin, stage Stage, pctx *Context, err error) *RejectionError {
+	return &RejectionError{Plugin: p.Name(), PluginType: p.Type(), Stage: stage, Reason: rejectionReason(pctx, err)}
+}
+
+func rejectionReason(pctx *Context, err error) string {
+	if pctx.Reason != "" {
+		return pctx.Reason
+	}
+	if err != nil {
+		return err.Error()
+	}
+	return defaultRejectionReason
+}
+
 // Manager manages plugin lifecycle and execution.
 type Manager struct {
 	before      []Plugin
@@ -100,30 +144,16 @@ func (m *Manager) Register(stage Stage, p Plugin) error {
 	return nil
 }
 
-// RunBefore executes all before-request plugins. Returns an error if a plugin
-// rejects the request.
+// RunBefore executes all before-request plugins. Fail-closed plugin errors or
+// rejections abort the request; fail-open plugin failures are logged and ignored.
 func (m *Manager) RunBefore(ctx context.Context, pctx *Context) error {
 	m.mu.RLock()
 	plugins := m.before
 	m.mu.RUnlock()
 	for _, p := range plugins {
 		err := m.executePlugin(ctx, p, pctx, string(StageBeforeRequest))
-		if err != nil {
-			if pctx.Reject {
-				reason := pctx.Reason
-				if reason == "" {
-					reason = err.Error()
-				}
-				return &RejectionError{Plugin: p.Name(), PluginType: p.Type(), Stage: StageBeforeRequest, Reason: reason}
-			}
-			return fmt.Errorf("plugin %s failed: %w", p.Name(), err)
-		}
-		if pctx.Reject {
-			reason := pctx.Reason
-			if reason == "" {
-				reason = defaultRejectionReason
-			}
-			return &RejectionError{Plugin: p.Name(), PluginType: p.Type(), Stage: StageBeforeRequest, Reason: reason}
+		if failureErr := handlePluginFailure(p, StageBeforeRequest, pctx, err); failureErr != nil {
+			return failureErr
 		}
 		if pctx.Skip {
 			break
@@ -132,26 +162,16 @@ func (m *Manager) RunBefore(ctx context.Context, pctx *Context) error {
 	return nil
 }
 
-// RunAfter executes all after-request plugins.
+// RunAfter executes all after-request plugins. Fail-closed plugin errors or
+// rejections abort the response; fail-open plugin failures are logged and ignored.
 func (m *Manager) RunAfter(ctx context.Context, pctx *Context) error {
 	m.mu.RLock()
 	plugins := m.after
 	m.mu.RUnlock()
 	for _, p := range plugins {
 		err := m.executePlugin(ctx, p, pctx, string(StageAfterRequest))
-		if pctx.Reject {
-			reason := pctx.Reason
-			if reason == "" {
-				if err != nil {
-					reason = err.Error()
-				} else {
-					reason = defaultRejectionReason
-				}
-			}
-			return &RejectionError{Plugin: p.Name(), PluginType: p.Type(), Stage: StageAfterRequest, Reason: reason}
-		}
-		if err != nil {
-			logging.Logger.Warn("after-request plugin error", "plugin", p.Name(), "error", err)
+		if failureErr := handlePluginFailure(p, StageAfterRequest, pctx, err); failureErr != nil {
+			return failureErr
 		}
 		if pctx.Skip {
 			break

--- a/plugin/plugin_test.go
+++ b/plugin/plugin_test.go
@@ -179,11 +179,77 @@ func TestManager_RunBefore_PanicReturnsError(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected panic to be converted to an error")
 	}
+	var rejection *RejectionError
+	if !errors.As(err, &rejection) {
+		t.Fatalf("expected RejectionError, got %T", err)
+	}
+	if rejection.PluginType != TypeGuardrail {
+		t.Fatalf("plugin type = %q, want %q", rejection.PluginType, TypeGuardrail)
+	}
 	if !strings.Contains(err.Error(), "plugin panic-guard panicked") {
 		t.Fatalf("error = %q, want plugin panic context", err.Error())
 	}
 	if strings.Contains(err.Error(), "runtime/debug.Stack") {
 		t.Fatalf("error = %q, should not expose panic stack", err.Error())
+	}
+}
+
+func TestManager_RunBefore_FailOpenPluginFailureDoesNotAbort(t *testing.T) {
+	tests := []struct {
+		name   string
+		typ    PluginType
+		execFn func(context.Context, *Context) error
+	}{
+		{
+			name: "logging error",
+			typ:  TypeLogging,
+			execFn: func(context.Context, *Context) error {
+				return fmt.Errorf("log sink down")
+			},
+		},
+		{
+			name: "metrics panic",
+			typ:  TypeMetrics,
+			execFn: func(context.Context, *Context) error {
+				panic("metrics sink down")
+			},
+		},
+		{
+			name: "transform reject",
+			typ:  TypeTransform,
+			execFn: func(_ context.Context, pctx *Context) error {
+				pctx.Reject = true
+				pctx.Reason = "cache backend unavailable"
+				return nil
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := NewManager()
+			_ = m.Register(StageBeforeRequest, &mockPlugin{name: "fail-open", typ: tt.typ, execFn: tt.execFn})
+			nextCalled := false
+			_ = m.Register(StageBeforeRequest, &mockPlugin{
+				name: "next",
+				typ:  TypeGuardrail,
+				execFn: func(context.Context, *Context) error {
+					nextCalled = true
+					return nil
+				},
+			})
+
+			pctx := NewContext(&providers.Request{Model: "gpt-4o"})
+			if err := m.RunBefore(context.Background(), pctx); err != nil {
+				t.Fatalf("RunBefore() error = %v, want nil", err)
+			}
+			if !nextCalled {
+				t.Fatal("fail-open plugin failure should not skip later plugins")
+			}
+			if pctx.Reject || pctx.Reason != "" {
+				t.Fatalf("fail-open rejection leaked: reject=%v reason=%q", pctx.Reject, pctx.Reason)
+			}
+		})
 	}
 }
 
@@ -258,6 +324,166 @@ func TestManager_RunAfter_RejectWithErrorAndEmptyReason_UsesErrorMessage(t *test
 	}
 	if rejection.Reason != "schema mismatch" {
 		t.Fatalf("reason = %q, want %q", rejection.Reason, "schema mismatch")
+	}
+}
+
+func TestManager_RunAfter_FailClosedErrorWithoutRejectReturnsRejection(t *testing.T) {
+	tests := []struct {
+		name string
+		typ  PluginType
+	}{
+		{name: "guardrail", typ: TypeGuardrail},
+		{name: "auth", typ: TypeAuth},
+		{name: "ratelimit", typ: TypeRateLimit},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := NewManager()
+			_ = m.Register(StageAfterRequest, &mockPlugin{
+				name: "schema-guard",
+				typ:  tt.typ,
+				execFn: func(context.Context, *Context) error {
+					return fmt.Errorf("schema guard unavailable")
+				},
+			})
+
+			pctx := NewContext(&providers.Request{})
+			pctx.Response = &providers.Response{ID: "r1"}
+			err := m.RunAfter(context.Background(), pctx)
+			if err == nil {
+				t.Fatal("expected rejection error")
+			}
+			var rejection *RejectionError
+			if !errors.As(err, &rejection) {
+				t.Fatalf("expected RejectionError, got %T", err)
+			}
+			if rejection.PluginType != tt.typ {
+				t.Fatalf("plugin type = %q, want %q", rejection.PluginType, tt.typ)
+			}
+			if rejection.Stage != StageAfterRequest {
+				t.Fatalf("stage = %q, want %q", rejection.Stage, StageAfterRequest)
+			}
+			if rejection.Reason != "schema guard unavailable" {
+				t.Fatalf("reason = %q, want %q", rejection.Reason, "schema guard unavailable")
+			}
+		})
+	}
+}
+
+func TestManager_RunAfter_FailClosedPanicReturnsRejection(t *testing.T) {
+	m := NewManager()
+	_ = m.Register(StageAfterRequest, &mockPlugin{
+		name: "panic-guard",
+		typ:  TypeGuardrail,
+		execFn: func(context.Context, *Context) error {
+			panic("boom")
+		},
+	})
+
+	pctx := NewContext(&providers.Request{})
+	pctx.Response = &providers.Response{ID: "r1"}
+	err := m.RunAfter(context.Background(), pctx)
+	if err == nil {
+		t.Fatal("expected rejection error")
+	}
+	var rejection *RejectionError
+	if !errors.As(err, &rejection) {
+		t.Fatalf("expected RejectionError, got %T", err)
+	}
+	if !strings.Contains(rejection.Reason, "plugin panic-guard panicked") {
+		t.Fatalf("reason = %q, want panic context", rejection.Reason)
+	}
+	if strings.Contains(err.Error(), "runtime/debug.Stack") {
+		t.Fatalf("error = %q, should not expose panic stack", err.Error())
+	}
+}
+
+func TestManager_RunAfter_FailOpenPluginFailureDoesNotAbort(t *testing.T) {
+	tests := []struct {
+		name   string
+		typ    PluginType
+		execFn func(context.Context, *Context) error
+	}{
+		{
+			name: "logging error",
+			typ:  TypeLogging,
+			execFn: func(context.Context, *Context) error {
+				return fmt.Errorf("log sink down")
+			},
+		},
+		{
+			name: "metrics panic",
+			typ:  TypeMetrics,
+			execFn: func(context.Context, *Context) error {
+				panic("metrics sink down")
+			},
+		},
+		{
+			name: "transform reject",
+			typ:  TypeTransform,
+			execFn: func(_ context.Context, pctx *Context) error {
+				pctx.Reject = true
+				pctx.Reason = "cache store unavailable"
+				return nil
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := NewManager()
+			_ = m.Register(StageAfterRequest, &mockPlugin{name: "fail-open", typ: tt.typ, execFn: tt.execFn})
+			nextCalled := false
+			_ = m.Register(StageAfterRequest, &mockPlugin{
+				name: "next",
+				typ:  TypeGuardrail,
+				execFn: func(context.Context, *Context) error {
+					nextCalled = true
+					return nil
+				},
+			})
+
+			pctx := NewContext(&providers.Request{})
+			pctx.Response = &providers.Response{ID: "r1"}
+			if err := m.RunAfter(context.Background(), pctx); err != nil {
+				t.Fatalf("RunAfter() error = %v, want nil", err)
+			}
+			if !nextCalled {
+				t.Fatal("fail-open plugin failure should not skip later plugins")
+			}
+			if pctx.Reject || pctx.Reason != "" {
+				t.Fatalf("fail-open rejection leaked: reject=%v reason=%q", pctx.Reject, pctx.Reason)
+			}
+		})
+	}
+}
+
+func TestManager_RunAfter_DefaultPluginTypeFailsClosed(t *testing.T) {
+	m := NewManager()
+	_ = m.Register(StageAfterRequest, &mockPlugin{
+		name: "custom-policy",
+		typ:  PluginType("custom"),
+		execFn: func(context.Context, *Context) error {
+			return fmt.Errorf("custom plugin failed")
+		},
+	})
+
+	pctx := NewContext(&providers.Request{})
+	pctx.Response = &providers.Response{ID: "r1"}
+	err := m.RunAfter(context.Background(), pctx)
+	if err == nil {
+		t.Fatal("expected rejection error")
+	}
+	var rejection *RejectionError
+	if !errors.As(err, &rejection) {
+		t.Fatalf("expected RejectionError, got %T", err)
+	}
+	if rejection.PluginType != PluginType("custom") {
+		t.Fatalf("plugin type = %q, want custom", rejection.PluginType)
+	}
+	if rejection.Reason != "custom plugin failed" {
+		t.Fatalf("reason = %q, want %q", rejection.Reason, "custom plugin failed")
 	}
 }
 


### PR DESCRIPTION
## Summary

Enforce plugin failure behavior by `PluginType` so safety/control plugins fail closed while observability and transform plugins fail open. This prevents post-response guardrail failures or panics from silently allowing unsafe responses.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] New provider
- [ ] New plugin
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Performance improvement
- [ ] Refactor / code quality
- [ ] Documentation / comments only
- [ ] CI / tooling

## Related issues

Fixes #288

## Changes

- Derive fail-open/fail-closed policy from `PluginType` in the plugin manager.
- Treat `guardrail`, `auth`, `ratelimit`, and unknown plugin types as fail-closed.
- Treat `logging`, `metrics`, and `transform` plugin failures as fail-open.
- Convert fail-closed plugin errors, rejections, and recovered panics into `RejectionError`.
- Add unit and gateway coverage for fail-closed guardrails and fail-open observability/transform behavior.

## Testing

- [x] Existing tests pass (`go test ./...`)
- [x] New unit tests added (if applicable)
- [ ] Manually tested against a live provider (if provider change)

Additional checks run:

```sh
go test ./plugin .
go test ./...
go test -race ./plugin .
```
