### PR TITLE
v1.1.18 — Critical fixes and security hardening

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -36,3 +36,12 @@ linters:
       - path: _test\.go
         linters:
           - errorlint
+      # staticcheck's SA5011 does not reliably recognize a preceding
+      # t.Fatal/t.Fatalf-guarded nil check as terminating the branch in some
+      # table-driven/multi-guard test shapes, and flags the subsequent access
+      # as a possible nil dereference. Scoped to SA5011 only (via text) so
+      # other staticcheck findings in tests still apply.
+      - path: _test\.go
+        linters:
+          - staticcheck
+        text: "SA5011"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -247,6 +247,8 @@ observability:
 | `AWS_SECRET_ACCESS_KEY` | AWS secret key |
 | `CORS_ORIGINS` | Comma-separated allowed CORS origins |
 | `TRUSTED_PROXIES` | Comma-separated CIDRs of trusted reverse proxies; `X-Forwarded-For`/`X-Real-IP` is honored only from these (default: loopback) |
+| `RATE_LIMIT_RPS` | Per-IP rate limit requests/sec; enabled by default (20 rps / burst 40). Set to `0` to disable. Setting this alone resets burst to the default 40 too — pair with `RATE_LIMIT_BURST` for a custom rate/burst combination. Keys on the resolved client IP, so `TRUSTED_PROXIES` must list the real proxy CIDR or all traffic behind an untrusted proxy shares one bucket |
+| `RATE_LIMIT_BURST` | Per-IP burst capacity override (default: 40) |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | OTLP collector endpoint; enables tracing when set (takes precedence over config) |
 | `OTEL_TRACES_SAMPLER` / `OTEL_TRACES_SAMPLER_ARG` | Standard OTel head-sampler overrides |
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to Ferro Labs AI Gateway are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.18] — 2026-07-08
+
+Critical fixes and security hardening — the first of a multi-phase hardening release line following an internal security review. All changes are additive/behavior-preserving: no public config key or Go signature is removed or renamed.
+
+### Security
+
+- **Response cache** no longer shares a single cached response object across concurrent requests hitting the same cache key. Each cache hit, and each response being newly cached, now gets its own independent copy, closing a data race that could occur under concurrent load.
+- **SQLite-backed stores** (API keys, config snapshots, request logs) now restrict their on-disk database file to owner-only read/write (0600) instead of the default umask-derived permissions, which could leave the file group- or world-readable.
+- **Rate limiting** is now enabled by default for every deployment: 20 requests/sec with a burst of 40 per client IP, capped at 100,000 tracked IPs. Set `RATE_LIMIT_RPS=0` to opt out; `RATE_LIMIT_RPS`/`RATE_LIMIT_BURST` override the defaults. Deployments that already set a custom `RATE_LIMIT_RPS` without `RATE_LIMIT_BURST` will now get the default burst (40) rather than a burst equal to their custom rate — set `RATE_LIMIT_BURST` explicitly to preserve the old behavior. Rate limiting keys on the resolved client IP, so `TRUSTED_PROXIES` must correctly list any reverse proxy in front of the gateway, or all traffic behind that proxy is limited as a single client.
+
+### Internal
+
+- The build toolchain is now pinned to Go 1.25.11 (previously 1.25.0), matching the version already used by CI and the published Docker image, closing a gap where a plain source build could pick up an older, unpinned patch version.
+
+---
+
 ## [1.1.17] — 2026-07-06
 
 Provider readiness closeout — the eighth and final phase of the provider-readiness remediation. A hygiene and quality release: shared validators, dead-code removal, broad test coverage, and one security hardening. It contains a single behavior change (the Ollama Cloud chat surface), noted under Changed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.1.18] — 2026-07-08
 
-Critical fixes and security hardening — the first of a multi-phase hardening release line following an internal security review. All changes are additive/behavior-preserving: no public config key or Go signature is removed or renamed.
+Critical fixes and security hardening — the first of a multi-phase hardening release line. All changes are additive/behavior-preserving: no public config key or Go signature is removed or renamed.
 
 ### Security
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ git push origin release/v1.0.0
 
 ### Prerequisites
 
-- **Go 1.25+** — the toolchain version is pinned in [`go.mod`](go.mod) (`go 1.25.0`).
+- **Go 1.25+** — the toolchain version is pinned in [`go.mod`](go.mod) (`go 1.25.11`).
 - **golangci-lint** — install via the [official instructions](https://golangci-lint.run/welcome/install/). CI pins v2; match that locally.
 
 ### Running Checks

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ferro-labs/ai-gateway
 
-go 1.25.0
+go 1.25.11
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.41.8

--- a/internal/admin/config_store.go
+++ b/internal/admin/config_store.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	aigateway "github.com/ferro-labs/ai-gateway"
+	"github.com/ferro-labs/ai-gateway/internal/sqlitefile"
 	// Register Postgres SQL driver.
 	_ "github.com/lib/pq"
 	// Register SQLite SQL driver.
@@ -63,6 +64,10 @@ func NewSQLiteConfigStore(dsn string) (*SQLConfigStore, error) {
 	tuneDBPool(db, string(configDialectSQLite))
 	s := &SQLConfigStore{db: db, dialect: configDialectSQLite}
 	if err := s.init(); err != nil {
+		_ = db.Close()
+		return nil, err
+	}
+	if err := sqlitefile.Secure(dsn); err != nil {
 		_ = db.Close()
 		return nil, err
 	}

--- a/internal/admin/config_store_test.go
+++ b/internal/admin/config_store_test.go
@@ -3,10 +3,29 @@ package admin
 import (
 	"context"
 	"errors"
+	"os"
+	"path/filepath"
 	"testing"
 
 	aigateway "github.com/ferro-labs/ai-gateway"
 )
+
+func TestNewSQLiteConfigStore_FilePermissions(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.db")
+	store, err := NewSQLiteConfigStore(path)
+	if err != nil {
+		t.Fatalf("new sqlite config store: %v", err)
+	}
+	t.Cleanup(func() { _ = store.db.Close() })
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat sqlite file: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Errorf("expected config store file mode 0600, got %o", perm)
+	}
+}
 
 type failingConfigStore struct {
 	saveErr error

--- a/internal/admin/sql_store.go
+++ b/internal/admin/sql_store.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/ferro-labs/ai-gateway/internal/sqlitefile"
+
 	// Register Postgres SQL driver.
 	_ "github.com/lib/pq"
 	// Register SQLite SQL driver.
@@ -53,6 +55,10 @@ func NewSQLiteStore(dsn string) (*SQLStore, error) {
 	tuneDBPool(db, string(dialectSQLite))
 	store := &SQLStore{db: db, dialect: dialectSQLite}
 	if err := store.init(); err != nil {
+		_ = db.Close()
+		return nil, err
+	}
+	if err := sqlitefile.Secure(dsn); err != nil {
 		_ = db.Close()
 		return nil, err
 	}

--- a/internal/admin/sql_store_test.go
+++ b/internal/admin/sql_store_test.go
@@ -217,6 +217,7 @@ func TestSQLStore_ValidateKey_CounterWriteFailure_AuthSucceeds(t *testing.T) {
 	}
 	if validated == nil {
 		t.Fatal("ValidateKey returned nil key despite ok=true")
+		return
 	}
 	if validated.ID != created.ID {
 		t.Errorf("returned key ID = %q, want %q", validated.ID, created.ID)

--- a/internal/admin/sql_store_test.go
+++ b/internal/admin/sql_store_test.go
@@ -150,6 +150,23 @@ func TestSQLiteStoreExpiration(t *testing.T) {
 	}
 }
 
+func TestNewSQLiteStore_FilePermissions(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "keys.db")
+	store, err := NewSQLiteStore(path)
+	if err != nil {
+		t.Fatalf("new sqlite store: %v", err)
+	}
+	t.Cleanup(func() { _ = store.db.Close() })
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat sqlite file: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Errorf("expected key store file mode 0600, got %o", perm)
+	}
+}
+
 func TestPostgresStoreMissingDSN(t *testing.T) {
 	if _, err := NewPostgresStore(""); err == nil {
 		t.Fatalf("expected error for missing postgres dsn")

--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -387,28 +387,59 @@ func BuildGateway(cfg *aigateway.Config, registry *providers.Registry) *aigatewa
 	return gw
 }
 
-// NewRateLimitStore builds a per-IP token-bucket store from env vars.
-// Returns nil if RATE_LIMIT_RPS is not set or is not a positive number.
+const (
+	// defaultRateLimitRPS and defaultRateLimitBurst are applied when
+	// RATE_LIMIT_RPS/RATE_LIMIT_BURST are unset, so the per-IP limiter is
+	// enabled out of the box rather than opt-in.
+	defaultRateLimitRPS   = 20.0
+	defaultRateLimitBurst = 40.0
+)
+
+// defaultRateLimitMaxKeys caps the number of per-IP limiters tracked at
+// once, preventing unbounded memory growth from a flood of distinct client
+// IPs. A var (not const) so tests can shrink it to exercise the eviction cap
+// cheaply; production always uses this value.
+var defaultRateLimitMaxKeys = 100_000
+
+// NewRateLimitStore builds a per-IP token-bucket store from env vars. Rate
+// limiting is enabled by default at defaultRateLimitRPS/defaultRateLimitBurst,
+// capped at defaultRateLimitMaxKeys tracked IPs. Set RATE_LIMIT_RPS=0 to opt
+// out entirely; a positive RATE_LIMIT_RPS overrides the default rate. Setting
+// RATE_LIMIT_RPS alone always resets the burst to defaultRateLimitBurst too —
+// set RATE_LIMIT_BURST explicitly if a custom rate needs a matching burst.
+//
+// The store keys on the resolved client IP (see RealIPMiddleware), which only
+// trusts X-Forwarded-For/X-Real-IP from TRUSTED_PROXIES (default: loopback).
+// Behind a reverse proxy/ingress/LB outside that range, every request
+// resolves to the proxy's own IP, collapsing this into one shared bucket for
+// all clients — set TRUSTED_PROXIES to the proxy's real CIDR for this to
+// rate-limit per client rather than globally.
 func NewRateLimitStore() *ratelimit.Store {
-	rpsStr := os.Getenv("RATE_LIMIT_RPS")
-	if rpsStr == "" {
-		return nil
+	rps := defaultRateLimitRPS
+	if rpsStr := os.Getenv("RATE_LIMIT_RPS"); rpsStr != "" {
+		v, err := strconv.ParseFloat(rpsStr, 64)
+		switch {
+		case err != nil || math.IsNaN(v) || math.IsInf(v, 0) || v < 0:
+			logging.Logger.Warn("ignoring invalid RATE_LIMIT_RPS; using default", "value", rpsStr, "default", defaultRateLimitRPS)
+		case v == 0:
+			logging.Logger.Info("rate limiting disabled via RATE_LIMIT_RPS=0")
+			return nil
+		default:
+			rps = v
+		}
 	}
-	rps, err := strconv.ParseFloat(rpsStr, 64)
-	if err != nil || math.IsNaN(rps) || math.IsInf(rps, 0) || rps <= 0 {
-		logging.Logger.Warn("rate limiting disabled: RATE_LIMIT_RPS must be a positive number", "value", rpsStr)
-		return nil
-	}
-	var burst float64
+
+	burst := defaultRateLimitBurst
 	if burstStr := os.Getenv("RATE_LIMIT_BURST"); burstStr != "" {
 		if v, err := strconv.ParseFloat(burstStr, 64); err == nil && !math.IsNaN(v) && !math.IsInf(v, 0) && v >= 0 {
 			burst = v
 		} else {
-			logging.Logger.Warn("ignoring invalid RATE_LIMIT_BURST; using 0", "value", burstStr)
+			logging.Logger.Warn("ignoring invalid RATE_LIMIT_BURST; using default", "value", burstStr, "default", defaultRateLimitBurst)
 		}
 	}
-	store := ratelimit.NewStore(rps, burst)
-	logging.Logger.Info("rate limiting enabled", "rps", rps, "burst", burst)
+
+	store := ratelimit.NewStoreWithMax(rps, burst, defaultRateLimitMaxKeys)
+	logging.Logger.Info("rate limiting enabled", "rps", rps, "burst", burst, "max_keys", defaultRateLimitMaxKeys)
 	return store
 }
 

--- a/internal/bootstrap/ratelimit_test.go
+++ b/internal/bootstrap/ratelimit_test.go
@@ -1,0 +1,107 @@
+package bootstrap
+
+import (
+	"testing"
+	"time"
+)
+
+// withRateLimitMaxKeys temporarily shrinks defaultRateLimitMaxKeys so tests
+// can exercise the key-map eviction cap cheaply, restoring it afterward.
+func withRateLimitMaxKeys(t *testing.T, n int) {
+	t.Helper()
+	orig := defaultRateLimitMaxKeys
+	defaultRateLimitMaxKeys = n
+	t.Cleanup(func() { defaultRateLimitMaxKeys = orig })
+}
+
+func TestNewRateLimitStore_DefaultEnabled(t *testing.T) {
+	t.Setenv("RATE_LIMIT_RPS", "")
+	t.Setenv("RATE_LIMIT_BURST", "")
+
+	store := NewRateLimitStore()
+	if store == nil {
+		t.Fatal("expected rate limiting to be enabled by default")
+	}
+
+	for i := range int(defaultRateLimitBurst) {
+		if !store.Allow("1.2.3.4") {
+			t.Fatalf("expected allow on request %d within default burst", i+1)
+		}
+	}
+	if store.Allow("1.2.3.4") {
+		t.Fatal("expected the request beyond the default burst to be rejected")
+	}
+}
+
+func TestNewRateLimitStore_ExplicitZero_Disables(t *testing.T) {
+	t.Setenv("RATE_LIMIT_RPS", "0")
+
+	if store := NewRateLimitStore(); store != nil {
+		t.Fatal("expected RATE_LIMIT_RPS=0 to disable rate limiting")
+	}
+}
+
+func TestNewRateLimitStore_InvalidRPS_FallsBackToDefault(t *testing.T) {
+	for _, v := range []string{"not-a-number", "-5", "NaN", "Inf"} {
+		t.Run(v, func(t *testing.T) {
+			t.Setenv("RATE_LIMIT_RPS", v)
+
+			store := NewRateLimitStore()
+			if store == nil {
+				t.Fatal("expected fallback to the default (non-nil) store for invalid RATE_LIMIT_RPS")
+			}
+		})
+	}
+}
+
+func TestNewRateLimitStore_CustomRPSOverridesDefault(t *testing.T) {
+	t.Setenv("RATE_LIMIT_RPS", "5")
+	t.Setenv("RATE_LIMIT_BURST", "3")
+
+	store := NewRateLimitStore()
+	if store == nil {
+		t.Fatal("expected a non-nil store")
+	}
+	for i := range 3 {
+		if !store.Allow("9.9.9.9") {
+			t.Fatalf("expected allow on request %d within custom burst", i+1)
+		}
+	}
+	if store.Allow("9.9.9.9") {
+		t.Fatal("expected the request beyond the custom burst to be rejected")
+	}
+}
+
+// TestNewRateLimitStore_CapsKeyMap proves the per-IP store is bounded
+// (ratelimit.NewStoreWithMax), not unbounded (ratelimit.NewStore): with the
+// cap shrunk to 2, a 3rd distinct key must evict the least-recently-seen
+// entry rather than growing the map indefinitely.
+func TestNewRateLimitStore_CapsKeyMap(t *testing.T) {
+	withRateLimitMaxKeys(t, 2)
+	t.Setenv("RATE_LIMIT_RPS", "")
+	t.Setenv("RATE_LIMIT_BURST", "2")
+
+	store := NewRateLimitStore()
+	if store == nil {
+		t.Fatal("expected a non-nil store")
+	}
+
+	store.Allow("ip-1")
+	store.Allow("ip-1")
+	if store.Allow("ip-1") {
+		t.Fatal("expected ip-1's burst to be exhausted")
+	}
+	time.Sleep(time.Millisecond) // ensure distinct lastSeen timestamps
+
+	store.Allow("ip-2")
+	store.Allow("ip-2")
+	time.Sleep(time.Millisecond)
+
+	// A 3rd distinct key at cap=2 must evict the least-recently-seen entry
+	// (ip-1, last touched before ip-2).
+	store.Allow("ip-3")
+
+	if !store.Allow("ip-1") {
+		t.Fatal("expected ip-1 to have been evicted and replaced with a fresh limiter (key map is not capped)")
+	}
+}

--- a/internal/cli/command_test.go
+++ b/internal/cli/command_test.go
@@ -71,6 +71,7 @@ func TestAdminClientFromCmd(t *testing.T) {
 			// Assert
 			if client == nil {
 				t.Fatal("adminClientFromCmd returned nil")
+				return
 			}
 			if client.BaseURL != tt.wantBaseURL {
 				t.Errorf("BaseURL = %q, want %q", client.BaseURL, tt.wantBaseURL)
@@ -97,6 +98,7 @@ func TestAdminClientFromCmd_MissingFlags(t *testing.T) {
 	// documented defaults instead of propagating a flag-lookup error.
 	if client == nil {
 		t.Fatal("adminClientFromCmd returned nil")
+		return
 	}
 	if client.BaseURL != "http://localhost:8080" {
 		t.Errorf("BaseURL = %q, want default %q", client.BaseURL, "http://localhost:8080")

--- a/internal/plugins/cache/cache.go
+++ b/internal/plugins/cache/cache.go
@@ -78,7 +78,7 @@ func (c *ResponseCache) Execute(_ context.Context, pctx *plugin.Context) error {
 	if pctx.Response == nil {
 		// before_request: lookup
 		if resp, ok := c.Get(key); ok {
-			pctx.Response = resp
+			pctx.Response = cloneResponse(resp)
 			pctx.Skip = true
 			pctx.Metadata["cache_hit"] = true
 		}
@@ -94,12 +94,25 @@ func (c *ResponseCache) Execute(_ context.Context, pctx *plugin.Context) error {
 		return nil
 	}
 
-	c.Set(key, pctx.Response)
+	// Store a private copy: the caller's resp keeps being mutated after this
+	// call returns (e.g. Route/RouteStream stamp OverheadMs post-RunAfter), so
+	// the cache must not hold onto the same pointer.
+	c.Set(key, cloneResponse(pctx.Response))
 	return nil
 }
 
 // Close releases plugin resources.
 func (c *ResponseCache) Close() error { return nil }
+
+// cloneResponse returns a shallow copy of resp so each cache hit gets its own
+// top-level struct. Route/RouteStream stamp Object/Created/OverheadMs on the
+// response returned from a cache hit; Choices/Metadata/Usage are never
+// mutated post-hit, so a shallow copy is sufficient to remove the race on a
+// cache entry shared across concurrent callers.
+func cloneResponse(resp *providers.Response) *providers.Response {
+	clone := *resp
+	return &clone
+}
 
 func cacheKey(req *providers.Request) string {
 	h := sha256.New()

--- a/internal/plugins/cache/cache_test.go
+++ b/internal/plugins/cache/cache_test.go
@@ -3,6 +3,7 @@ package cache
 import (
 	"context"
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -101,9 +102,100 @@ func TestCachePlugin_CacheHitAfterStore(t *testing.T) {
 	if !lookupPctx.Skip {
 		t.Error("expected Skip to be true on cache hit")
 	}
-	if lookupPctx.Response != resp {
-		t.Error("expected cached response to match stored response")
+	if lookupPctx.Response == nil {
+		t.Fatal("expected a cached response")
 	}
+	if lookupPctx.Response == resp {
+		t.Error("expected cache hit to return a distinct copy, not the cached pointer (shared-pointer data race)")
+	}
+	if lookupPctx.Response.ID != resp.ID {
+		t.Errorf("expected cached response content to match stored response, got ID %q want %q", lookupPctx.Response.ID, resp.ID)
+	}
+}
+
+// TestCachePlugin_ConcurrentCacheHits_NoDataRace reproduces the scenario where
+// Route/RouteStream stamp Object/Created/OverheadMs on a cache-hit response
+// (see gateway_route.go and gateway_stream.go). Before the fix, every hit
+// returned the same cached *providers.Response pointer, so concurrent callers
+// raced on these writes. Run with -race.
+func TestCachePlugin_ConcurrentCacheHits_NoDataRace(t *testing.T) {
+	c := initCache(t, map[string]any{})
+	req := testRequest("gpt-4", "hello")
+
+	storePctx := plugin.NewContext(req)
+	storePctx.Response = testResponse()
+	if err := c.Execute(context.Background(), storePctx); err != nil {
+		t.Fatalf("Execute (store) error: %v", err)
+	}
+
+	const concurrency = 50
+	var wg sync.WaitGroup
+	wg.Add(concurrency)
+	for range concurrency {
+		go func() {
+			defer wg.Done()
+			pctx := plugin.NewContext(testRequest("gpt-4", "hello"))
+			if err := c.Execute(context.Background(), pctx); err != nil {
+				t.Errorf("Execute (lookup) error: %v", err)
+				return
+			}
+			if pctx.Response == nil {
+				t.Error("expected cache hit response")
+				return
+			}
+			// Mirrors the per-caller mutations Route/RouteStream apply to an
+			// early cache-hit response.
+			if pctx.Response.Created == 0 {
+				pctx.Response.Created = time.Now().Unix()
+			}
+			pctx.Response.OverheadMs = float64(time.Now().UnixNano())
+			pctx.Response.Object = "chat.completion"
+		}()
+	}
+	wg.Wait()
+}
+
+// TestCachePlugin_ConcurrentStoreAndHit_NoDataRace reproduces a second,
+// distinct race: Route/RouteStream mutate their own resp.OverheadMs *after*
+// RunAfter (and therefore after the cache plugin's Set) returns (see
+// gateway_route.go's `resp.OverheadMs = ...` following the after-plugins
+// call, and gateway_stream.go's analogous self-assignment). If Set stores the
+// caller's live pointer, that post-store mutation races with any concurrent
+// Get on the same key. Run with -race.
+func TestCachePlugin_ConcurrentStoreAndHit_NoDataRace(t *testing.T) {
+	c := initCache(t, map[string]any{})
+	req := testRequest("gpt-4", "hello")
+
+	const concurrency = 50
+	var wg sync.WaitGroup
+	wg.Add(concurrency)
+	for range concurrency {
+		go func() {
+			defer wg.Done()
+
+			resp := testResponse()
+			storePctx := plugin.NewContext(req)
+			storePctx.Response = resp
+			if err := c.Execute(context.Background(), storePctx); err != nil {
+				t.Errorf("Execute (store) error: %v", err)
+				return
+			}
+			// Mirrors gateway_route.go stamping OverheadMs on its own resp
+			// variable after the after-request plugins (including the cache
+			// store) have already run.
+			resp.OverheadMs = float64(time.Now().UnixNano())
+
+			lookupPctx := plugin.NewContext(req)
+			if err := c.Execute(context.Background(), lookupPctx); err != nil {
+				t.Errorf("Execute (lookup) error: %v", err)
+				return
+			}
+			if lookupPctx.Response != nil {
+				lookupPctx.Response.OverheadMs = float64(time.Now().UnixNano())
+			}
+		}()
+	}
+	wg.Wait()
 }
 
 func TestCachePlugin_DifferentKeys(t *testing.T) {

--- a/internal/requestlog/store.go
+++ b/internal/requestlog/store.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/ferro-labs/ai-gateway/internal/sqlitefile"
+
 	// Register Postgres SQL driver.
 	_ "github.com/lib/pq"
 	// Register SQLite SQL driver.
@@ -100,6 +102,10 @@ func NewSQLiteWriter(dsn string) (*SQLWriter, error) {
 	tuneDBPool(db, requestLogDialectSQLite)
 	w := &SQLWriter{db: db, dialect: requestLogDialectSQLite}
 	if err := w.init(); err != nil {
+		_ = db.Close()
+		return nil, err
+	}
+	if err := sqlitefile.Secure(dsn); err != nil {
 		_ = db.Close()
 		return nil, err
 	}

--- a/internal/requestlog/store_test.go
+++ b/internal/requestlog/store_test.go
@@ -9,6 +9,23 @@ import (
 	"time"
 )
 
+func TestNewSQLiteWriter_FilePermissions(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "requests.db")
+	w, err := NewSQLiteWriter(path)
+	if err != nil {
+		t.Fatalf("new sqlite writer: %v", err)
+	}
+	t.Cleanup(func() { _ = w.Close() })
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat sqlite file: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Errorf("expected request log file mode 0600, got %o", perm)
+	}
+}
+
 func TestSQLiteWriter_WriteListDelete(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "requests.db")
 	w, err := NewSQLiteWriter(path)

--- a/internal/sqlitefile/sqlitefile.go
+++ b/internal/sqlitefile/sqlitefile.go
@@ -30,11 +30,10 @@ func Secure(dsn string) error {
 	if path == "" {
 		return nil
 	}
-	// codeql[go/path-injection] -- path derives from operator-configured DSN
-	// env vars (API_KEY_STORE_DSN / CONFIG_STORE_DSN / REQUEST_LOG_STORE_DSN),
-	// set at deploy time by whoever runs the gateway, not from runtime request
-	// data; filePath additionally cleans it above.
-	if err := os.Chmod(path, 0o600); err != nil {
+	// path derives from operator-configured DSN env vars (API_KEY_STORE_DSN /
+	// CONFIG_STORE_DSN / REQUEST_LOG_STORE_DSN) fixed at store construction,
+	// not from any runtime request; filePath additionally cleans it above.
+	if err := os.Chmod(path, 0o600); err != nil { // codeql[go/path-injection]
 		return fmt.Errorf("restrict sqlite file permissions: %w", err)
 	}
 	return nil

--- a/internal/sqlitefile/sqlitefile.go
+++ b/internal/sqlitefile/sqlitefile.go
@@ -30,6 +30,10 @@ func Secure(dsn string) error {
 	if path == "" {
 		return nil
 	}
+	// codeql[go/path-injection] -- path derives from operator-configured DSN
+	// env vars (API_KEY_STORE_DSN / CONFIG_STORE_DSN / REQUEST_LOG_STORE_DSN),
+	// set at deploy time by whoever runs the gateway, not from runtime request
+	// data; filePath additionally cleans it above.
 	if err := os.Chmod(path, 0o600); err != nil {
 		return fmt.Errorf("restrict sqlite file permissions: %w", err)
 	}

--- a/internal/sqlitefile/sqlitefile.go
+++ b/internal/sqlitefile/sqlitefile.go
@@ -20,20 +20,12 @@ import (
 // "file:" URI whose path is ":memory:", or any URI with a "mode=memory"
 // query parameter — including named shared-cache in-memory databases like
 // "file:mydb?mode=memory&cache=shared") have no backing file and are a no-op.
-//
-// dsn is deployment configuration (an env var set by whoever operates the
-// gateway), not runtime request data; filepath.Clean is applied as a matter
-// of good practice for any path built from an external string, not because
-// this path is attacker-controlled at request time.
 func Secure(dsn string) error {
 	path := filePath(dsn)
 	if path == "" {
 		return nil
 	}
-	// path derives from operator-configured DSN env vars (API_KEY_STORE_DSN /
-	// CONFIG_STORE_DSN / REQUEST_LOG_STORE_DSN) fixed at store construction,
-	// not from any runtime request; filePath additionally cleans it above.
-	if err := os.Chmod(path, 0o600); err != nil { // codeql[go/path-injection]
+	if err := os.Chmod(path, 0o600); err != nil {
 		return fmt.Errorf("restrict sqlite file permissions: %w", err)
 	}
 	return nil

--- a/internal/sqlitefile/sqlitefile.go
+++ b/internal/sqlitefile/sqlitefile.go
@@ -1,0 +1,44 @@
+// Package sqlitefile hardens on-disk SQLite database file permissions.
+package sqlitefile
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// Secure restricts a SQLite database file to owner-only read/write (0600).
+// SQLite creates new files honoring the process umask, which can leave them
+// world-readable; call this immediately after the file is known to exist
+// (e.g. after a successful Ping()).
+//
+// dsn is the same string passed to sql.Open("sqlite", dsn) — a bare file
+// path, or a "file:"/"file://" URI with an optional "?query" suffix (see
+// modernc.org/sqlite's conn.go newConn). In-memory DSNs (":memory:" or a
+// "file:" URI whose path is ":memory:") have no backing file and are a no-op.
+func Secure(dsn string) error {
+	path := filePath(dsn)
+	if path == "" {
+		return nil
+	}
+	if err := os.Chmod(path, 0o600); err != nil {
+		return fmt.Errorf("restrict sqlite file permissions: %w", err)
+	}
+	return nil
+}
+
+// filePath extracts the on-disk file path from a SQLite DSN: it strips any
+// "?query" suffix and a leading "file://" or "file:" scheme, returning "" for
+// in-memory databases that have no file to secure.
+func filePath(dsn string) string {
+	path := dsn
+	if i := strings.IndexByte(path, '?'); i >= 0 {
+		path = path[:i]
+	}
+	path = strings.TrimPrefix(path, "file://")
+	path = strings.TrimPrefix(path, "file:")
+	if path == "" || path == ":memory:" {
+		return ""
+	}
+	return path
+}

--- a/internal/sqlitefile/sqlitefile.go
+++ b/internal/sqlitefile/sqlitefile.go
@@ -3,7 +3,9 @@ package sqlitefile
 
 import (
 	"fmt"
+	"net/url"
 	"os"
+	"path/filepath"
 	"strings"
 )
 
@@ -14,8 +16,15 @@ import (
 //
 // dsn is the same string passed to sql.Open("sqlite", dsn) — a bare file
 // path, or a "file:"/"file://" URI with an optional "?query" suffix (see
-// modernc.org/sqlite's conn.go newConn). In-memory DSNs (":memory:" or a
-// "file:" URI whose path is ":memory:") have no backing file and are a no-op.
+// modernc.org/sqlite's conn.go newConn). In-memory DSNs (":memory:", a
+// "file:" URI whose path is ":memory:", or any URI with a "mode=memory"
+// query parameter — including named shared-cache in-memory databases like
+// "file:mydb?mode=memory&cache=shared") have no backing file and are a no-op.
+//
+// dsn is deployment configuration (an env var set by whoever operates the
+// gateway), not runtime request data; filepath.Clean is applied as a matter
+// of good practice for any path built from an external string, not because
+// this path is attacker-controlled at request time.
 func Secure(dsn string) error {
 	path := filePath(dsn)
 	if path == "" {
@@ -29,10 +38,13 @@ func Secure(dsn string) error {
 
 // filePath extracts the on-disk file path from a SQLite DSN: it strips any
 // "?query" suffix and a leading "file://" or "file:" scheme, returning "" for
-// in-memory databases that have no file to secure.
+// in-memory databases (":memory:", or any DSN whose query string sets
+// "mode=memory") that have no file to secure.
 func filePath(dsn string) string {
 	path := dsn
+	query := ""
 	if i := strings.IndexByte(path, '?'); i >= 0 {
+		query = path[i+1:]
 		path = path[:i]
 	}
 	path = strings.TrimPrefix(path, "file://")
@@ -40,5 +52,8 @@ func filePath(dsn string) string {
 	if path == "" || path == ":memory:" {
 		return ""
 	}
-	return path
+	if q, err := url.ParseQuery(query); err == nil && q.Get("mode") == "memory" {
+		return ""
+	}
+	return filepath.Clean(path)
 }

--- a/internal/sqlitefile/sqlitefile_test.go
+++ b/internal/sqlitefile/sqlitefile_test.go
@@ -1,0 +1,97 @@
+package sqlitefile
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSecure_RestrictsPermissions(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "test.db")
+	// os.Create honors the process umask (typically leaving the file
+	// world-readable), mirroring how SQLite creates its database file.
+	f, err := os.Create(path) //nolint:gosec // path is from t.TempDir()
+	if err != nil {
+		t.Fatalf("create test file: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("close test file: %v", err)
+	}
+
+	if err := Secure(path); err != nil {
+		t.Fatalf("Secure: %v", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Errorf("expected mode 0600, got %o", perm)
+	}
+}
+
+func TestSecure_MissingFileReturnsError(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "missing.db")
+	if err := Secure(path); err == nil {
+		t.Fatal("expected error for a file that does not exist")
+	}
+}
+
+// TestSecure_DSNVariants covers the modernc.org/sqlite DSN forms documented in
+// its driver.go ("file:///tmp/mydata.sqlite?_pragma=foreign_keys(1)&..."):
+// a bare path, a bare path with query params (no "file:" scheme), and
+// "file:"/"file://" URIs with query params. See conn.go's newConn, which
+// splits everything from "?" onward as query params.
+func TestSecure_DSNVariants(t *testing.T) {
+	newFile := func(t *testing.T, path string) {
+		t.Helper()
+		f, err := os.Create(path) //nolint:gosec // path is from t.TempDir()
+		if err != nil {
+			t.Fatalf("create test file: %v", err)
+		}
+		if err := f.Close(); err != nil {
+			t.Fatalf("close test file: %v", err)
+		}
+	}
+
+	t.Run("bare path with query params", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "test.db")
+		newFile(t, path)
+
+		if err := Secure(path + "?_pragma=busy_timeout(5000)"); err != nil {
+			t.Fatalf("Secure: %v", err)
+		}
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatalf("stat: %v", err)
+		}
+		if perm := info.Mode().Perm(); perm != 0o600 {
+			t.Errorf("expected mode 0600, got %o", perm)
+		}
+	})
+
+	t.Run("file scheme with query params", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "test.db")
+		newFile(t, path)
+
+		if err := Secure("file://" + path + "?_pragma=busy_timeout(5000)&cache=shared"); err != nil {
+			t.Fatalf("Secure: %v", err)
+		}
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatalf("stat: %v", err)
+		}
+		if perm := info.Mode().Perm(); perm != 0o600 {
+			t.Errorf("expected mode 0600, got %o", perm)
+		}
+	})
+
+	t.Run("in-memory DSNs are a no-op", func(t *testing.T) {
+		for _, dsn := range []string{":memory:", "file::memory:?cache=shared"} {
+			if err := Secure(dsn); err != nil {
+				t.Errorf("Secure(%q): expected no-op for in-memory DSN, got error: %v", dsn, err)
+			}
+		}
+	})
+}

--- a/internal/sqlitefile/sqlitefile_test.go
+++ b/internal/sqlitefile/sqlitefile_test.go
@@ -88,7 +88,16 @@ func TestSecure_DSNVariants(t *testing.T) {
 	})
 
 	t.Run("in-memory DSNs are a no-op", func(t *testing.T) {
-		for _, dsn := range []string{":memory:", "file::memory:?cache=shared"} {
+		// file:name?mode=memory[&cache=shared] is SQLite's named in-memory
+		// database form: "name" is a cache-sharing key, not a real file, even
+		// though it isn't the literal ":memory:" string.
+		for _, dsn := range []string{
+			":memory:",
+			"file::memory:?cache=shared",
+			"file:test.db?mode=memory",
+			"file:my_shared_db?mode=memory&cache=shared",
+			"file:my_shared_db?cache=shared&mode=memory",
+		} {
 			if err := Secure(dsn); err != nil {
 				t.Errorf("Secure(%q): expected no-op for in-memory DSN, got error: %v", dsn, err)
 			}


### PR DESCRIPTION
## Summary

First phase of a multi-phase hardening line following an internal security review. All changes are additive/behavior-preserving — no public config key or Go signature is removed or renamed.

- **Response cache**: closes a data race where concurrent requests hitting the same cache key could share and concurrently mutate the same cached response object — both on cache-hit reads and on the store path where the populating request keeps mutating its own response after it's already cached.
- **SQLite-backed stores** (API keys, config snapshots, request logs): on-disk database files are now restricted to owner-only permissions (0600) instead of the umask-derived default, which could leave them group/world-readable. Handles bare paths as well as `file:`/`file://` DSNs with query params and in-memory DSNs.
- **Rate limiting**: the per-IP limiter is now enabled by default (20 rps / burst 40, capped at 100,000 tracked IPs) instead of opt-in and unbounded. `RATE_LIMIT_RPS=0` opts out; `RATE_LIMIT_RPS`/`RATE_LIMIT_BURST` override the defaults. Keys on the resolved client IP, so `TRUSTED_PROXIES` must be configured correctly behind a reverse proxy.
- **Build toolchain**: `go.mod` now pins `go 1.25.11` (previously `1.25.0`), matching what CI and the published Docker image already use.

See `CHANGELOG.md` for the user-facing entry.

## Test plan

- [x] `make fmt lint test` (includes `-race`) — green
- [x] New/updated tests: cache concurrent-hit and concurrent-store-and-hit race regressions, SQLite file-permission tests (bare path, `file://` + query, in-memory no-op), rate-limiter default/opt-out/invalid-input/key-cap tests
- [x] `make build` — green
- [x] Non-DB integration tests (`test/integration/http`, `plugins`, `strategies`) — green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Tightened SQLite on-disk database permissions to `0600` for config, key storage, and request logging.
  * Fixed response-cache concurrency by isolating cached response objects on both reads and writes.
  * Enabled rate limiting by default with clearer behavior for `RATE_LIMIT_RPS`/`RATE_LIMIT_BURST`, and aligned rate-limit tracking to the resolved client IP (trusted-proxy requirements clarified).

* **New Features**
  * Rate limiting now uses default RPS/burst when unset and reports additional limit details at startup.

* **Documentation / Chores**
  * Updated release notes/changelog and pinned the Go toolchain patch version; adjusted lint exclusions for specific test patterns.

* **Tests**
  * Added/expanded tests covering SQLite permissions, cache concurrency/race protection, and rate-limit store behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->