### PR TITLE
v1.1.19 — Provider Read Bounds & Typed Errors

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,6 +19,7 @@ linters:
     - revive
     - staticcheck
     - unused
+    - noctx
 
   settings:
     gocyclo:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,6 +20,7 @@ linters:
     - staticcheck
     - unused
     - noctx
+    - maintidx
 
   settings:
     gocyclo:
@@ -46,3 +47,19 @@ linters:
         linters:
           - staticcheck
         text: "SA5011"
+      # RouteStream's remaining complexity (after extracting the MCP-loop-
+      # equivalent safe blocks — see resolveStreamOrError and
+      # runBeforePluginsStream) is the streamwrap.MeterMeta closure setup
+      # (CompletionFn/ErrorFn/SpanFinisher), which captures and mutates pctx
+      # (nil-out + sync.Once-guarded release) across three closures.
+      # Extracting it further means passing pctx as **plugin.Context or
+      # restructuring the release semantics — both add real risk of a
+      # double-release or nil-deref in the hottest streaming path. See
+      # gateway_stream.go's test coverage (RunAfterReceivesStreamResponse,
+      # RunOnErrorReceivesStreamError, AfterPluginRejectRunsOnError,
+      # Close_DuringInFlightRouteStreamDoesNotPanic) for what protects this
+      # behavior today.
+      - path: gateway_stream\.go
+        linters:
+          - maintidx
+        text: "RouteStream"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to Ferro Labs AI Gateway are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.19] — 2026-07-09
+
+Provider read bounds and typed errors — the second phase of a multi-phase hardening release line. All changes are additive/behavior-preserving.
+
+### Security
+
+- **Upstream provider responses** are now capped at 50 MiB when read into memory, across every provider, closing a gap where a single oversized upstream response could exhaust gateway memory.
+
+### Fixed
+
+- **DeepSeek streaming responses** now report cache-hit token counts (`cache_read_tokens`) consistently with non-streaming responses; the streaming path was previously dropping this field.
+
+### Internal
+
+- Provider HTTP errors now carry their status code as a typed field, recoverable via `errors.As`, in addition to the existing formatted message, so retry and circuit-breaker classification no longer depends solely on parsing the status out of the error string. Added a cross-provider conformance test covering upstream error-status recovery.
+
+---
+
 ## [1.1.18] — 2026-07-08
 
 Critical fixes and security hardening — the first of a multi-phase hardening release line. All changes are additive/behavior-preserving: no public config key or Go signature is removed or renamed.

--- a/cmd/ferrogw/main_test.go
+++ b/cmd/ferrogw/main_test.go
@@ -75,7 +75,7 @@ func testKeyStore() *admin.KeyStore {
 func TestHealth(t *testing.T) {
 	ks := testKeyStore()
 	r := httpserver.NewRouter(testRegistry(), ks, nil, nil, nil, nil, nil, nil, "", nil)
-	req := httptest.NewRequest("GET", "/health", nil)
+	req := httptest.NewRequestWithContext(t.Context(), "GET", "/health", nil)
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
 
@@ -98,7 +98,7 @@ func TestModels(t *testing.T) {
 	t.Setenv("ALLOW_UNAUTHENTICATED_PROXY", "true")
 	ks := testKeyStore()
 	r := httpserver.NewRouter(testRegistry(), ks, nil, nil, nil, nil, nil, nil, "", nil)
-	req := httptest.NewRequest("GET", "/v1/models", nil)
+	req := httptest.NewRequestWithContext(t.Context(), "GET", "/v1/models", nil)
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
 
@@ -116,7 +116,7 @@ func TestModels(t *testing.T) {
 func TestPprofDisabledByDefault(t *testing.T) {
 	ks := testKeyStore()
 	r := httpserver.NewRouter(testRegistry(), ks, nil, nil, nil, nil, nil, nil, "", nil)
-	req := httptest.NewRequest("GET", "/debug/pprof/", nil)
+	req := httptest.NewRequestWithContext(t.Context(), "GET", "/debug/pprof/", nil)
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
 
@@ -130,7 +130,7 @@ func TestPprofEnabledRequiresAuthEvenWhenUnauthenticatedProxyEnabled(t *testing.
 	t.Setenv("ALLOW_UNAUTHENTICATED_PROXY", "true")
 	ks := testKeyStore()
 	r := httpserver.NewRouter(testRegistry(), ks, nil, nil, nil, nil, nil, nil, "", nil)
-	req := httptest.NewRequest("GET", "/debug/pprof/", nil)
+	req := httptest.NewRequestWithContext(t.Context(), "GET", "/debug/pprof/", nil)
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
 
@@ -144,7 +144,7 @@ func TestPprofEnabledWithAuth(t *testing.T) {
 	t.Setenv("ALLOW_UNAUTHENTICATED_PROXY", "true")
 	ks := testKeyStore()
 	r := httpserver.NewRouter(testRegistry(), ks, nil, nil, nil, nil, nil, nil, "test-master-key", nil)
-	req := httptest.NewRequest("GET", "/debug/pprof/", nil)
+	req := httptest.NewRequestWithContext(t.Context(), "GET", "/debug/pprof/", nil)
 	req.Header.Set("Authorization", "Bearer test-master-key")
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
@@ -161,7 +161,7 @@ func TestDebugVarsRequireAuthEvenWhenUnauthenticatedProxyEnabled(t *testing.T) {
 	t.Setenv("ALLOW_UNAUTHENTICATED_PROXY", "true")
 	ks := testKeyStore()
 	r := httpserver.NewRouter(testRegistry(), ks, nil, nil, nil, nil, nil, nil, "", nil)
-	req := httptest.NewRequest("GET", "/debug/vars", nil)
+	req := httptest.NewRequestWithContext(t.Context(), "GET", "/debug/vars", nil)
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
 
@@ -174,7 +174,7 @@ func TestMetricsRequireAuthEvenWhenUnauthenticatedProxyEnabled(t *testing.T) {
 	t.Setenv("ALLOW_UNAUTHENTICATED_PROXY", "true")
 	ks := testKeyStore()
 	r := httpserver.NewRouter(testRegistry(), ks, nil, nil, nil, nil, nil, nil, "", nil)
-	req := httptest.NewRequest("GET", "/metrics", nil)
+	req := httptest.NewRequestWithContext(t.Context(), "GET", "/metrics", nil)
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
 
@@ -187,7 +187,7 @@ func TestDebugVarsEnabledWithAuth(t *testing.T) {
 	t.Setenv("ALLOW_UNAUTHENTICATED_PROXY", "true")
 	ks := testKeyStore()
 	r := httpserver.NewRouter(testRegistry(), ks, nil, nil, nil, nil, nil, nil, "test-master-key", nil)
-	req := httptest.NewRequest("GET", "/debug/vars", nil)
+	req := httptest.NewRequestWithContext(t.Context(), "GET", "/debug/vars", nil)
 	req.Header.Set("Authorization", "Bearer test-master-key")
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
@@ -218,7 +218,7 @@ func TestDashboardUIPage(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.path, func(t *testing.T) {
-			req := httptest.NewRequest("GET", tt.path, nil)
+			req := httptest.NewRequestWithContext(t.Context(), "GET", tt.path, nil)
 			w := httptest.NewRecorder()
 			r.ServeHTTP(w, req)
 			if w.Code != http.StatusOK {
@@ -237,7 +237,7 @@ func TestDashboardUIPage(t *testing.T) {
 func TestDashboardRedirect(t *testing.T) {
 	ks := testKeyStore()
 	r := httpserver.NewRouter(testRegistry(), ks, nil, nil, nil, nil, nil, nil, "", nil)
-	req := httptest.NewRequest("GET", "/dashboard", nil)
+	req := httptest.NewRequestWithContext(t.Context(), "GET", "/dashboard", nil)
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
 	if w.Code != http.StatusFound {
@@ -260,7 +260,7 @@ func TestDashboardStaticAssets(t *testing.T) {
 	}
 	for _, path := range assets {
 		t.Run(path, func(t *testing.T) {
-			req := httptest.NewRequest("GET", path, nil)
+			req := httptest.NewRequestWithContext(t.Context(), "GET", path, nil)
 			w := httptest.NewRecorder()
 			r.ServeHTTP(w, req)
 			if w.Code != http.StatusOK {
@@ -275,7 +275,7 @@ func TestChatCompletions(t *testing.T) {
 	ks := testKeyStore()
 	r := httpserver.NewRouter(testRegistry(), ks, nil, nil, nil, nil, nil, nil, "", nil)
 	payload := `{"model":"test-model","messages":[{"role":"user","content":"hi"}]}`
-	req := httptest.NewRequest("POST", "/v1/chat/completions", strings.NewReader(payload))
+	req := httptest.NewRequestWithContext(t.Context(), "POST", "/v1/chat/completions", strings.NewReader(payload))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
@@ -338,7 +338,7 @@ func TestChatCompletions_ValidationError(t *testing.T) {
 	ks := testKeyStore()
 	r := httpserver.NewRouter(testRegistry(), ks, nil, nil, nil, nil, nil, nil, "", nil)
 	payload := `{"model":"","messages":[]}`
-	req := httptest.NewRequest("POST", "/v1/chat/completions", strings.NewReader(payload))
+	req := httptest.NewRequestWithContext(t.Context(), "POST", "/v1/chat/completions", strings.NewReader(payload))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
@@ -353,7 +353,7 @@ func TestChatCompletions_UnsupportedModel(t *testing.T) {
 	ks := testKeyStore()
 	r := httpserver.NewRouter(testRegistry(), ks, nil, nil, nil, nil, nil, nil, "", nil)
 	payload := `{"model":"unknown","messages":[{"role":"user","content":"hi"}]}`
-	req := httptest.NewRequest("POST", "/v1/chat/completions", strings.NewReader(payload))
+	req := httptest.NewRequestWithContext(t.Context(), "POST", "/v1/chat/completions", strings.NewReader(payload))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
@@ -401,7 +401,7 @@ func TestChatCompletions_Stream(t *testing.T) {
 	ks := testKeyStore()
 	r := httpserver.NewRouter(testStreamRegistry(), ks, nil, nil, nil, nil, nil, nil, "", nil)
 	payload := `{"model":"test-stream-model","messages":[{"role":"user","content":"hi"}],"stream":true}`
-	req := httptest.NewRequest("POST", "/v1/chat/completions", strings.NewReader(payload))
+	req := httptest.NewRequestWithContext(t.Context(), "POST", "/v1/chat/completions", strings.NewReader(payload))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
@@ -444,7 +444,7 @@ func TestChatCompletions_StreamUnsupported(t *testing.T) {
 	ks := testKeyStore()
 	r := httpserver.NewRouter(testRegistry(), ks, nil, nil, nil, nil, nil, nil, "", nil)
 	payload := `{"model":"test-model","messages":[{"role":"user","content":"hi"}],"stream":true}`
-	req := httptest.NewRequest("POST", "/v1/chat/completions", strings.NewReader(payload))
+	req := httptest.NewRequestWithContext(t.Context(), "POST", "/v1/chat/completions", strings.NewReader(payload))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
@@ -458,7 +458,7 @@ func TestCreateKeyStoreFromEnv_DefaultMemory(t *testing.T) {
 	t.Setenv("API_KEY_STORE_BACKEND", "")
 	t.Setenv("API_KEY_STORE_DSN", "")
 
-	store, backend, err := bootstrap.CreateKeyStoreFromEnv()
+	store, backend, err := bootstrap.CreateKeyStoreFromEnv(t.Context())
 	if err != nil {
 		t.Fatalf("bootstrap.CreateKeyStoreFromEnv returned error: %v", err)
 	}
@@ -578,7 +578,7 @@ func TestCreateKeyStoreFromEnv_SQLite(t *testing.T) {
 	t.Setenv("API_KEY_STORE_BACKEND", "sqlite")
 	t.Setenv("API_KEY_STORE_DSN", dsn)
 
-	store, backend, err := bootstrap.CreateKeyStoreFromEnv()
+	store, backend, err := bootstrap.CreateKeyStoreFromEnv(t.Context())
 	if err != nil {
 		t.Fatalf("bootstrap.CreateKeyStoreFromEnv returned error: %v", err)
 	}
@@ -599,7 +599,7 @@ func TestCreateKeyStoreFromEnv_UnknownBackend(t *testing.T) {
 	t.Setenv("API_KEY_STORE_BACKEND", "unknown")
 	t.Setenv("API_KEY_STORE_DSN", "")
 
-	if _, _, err := bootstrap.CreateKeyStoreFromEnv(); err == nil {
+	if _, _, err := bootstrap.CreateKeyStoreFromEnv(t.Context()); err == nil {
 		t.Fatalf("expected error for unsupported backend")
 	}
 }
@@ -608,7 +608,7 @@ func TestCreateKeyStoreFromEnv_PostgresMissingDSN(t *testing.T) {
 	t.Setenv("API_KEY_STORE_BACKEND", "postgres")
 	t.Setenv("API_KEY_STORE_DSN", "")
 
-	if _, _, err := bootstrap.CreateKeyStoreFromEnv(); err == nil {
+	if _, _, err := bootstrap.CreateKeyStoreFromEnv(t.Context()); err == nil {
 		t.Fatalf("expected error for missing postgres dsn")
 	}
 }
@@ -622,7 +622,7 @@ func TestCreateConfigManagerFromEnv_DefaultMemory(t *testing.T) {
 		Targets:  []aigateway.Target{{VirtualKey: "openai"}},
 	})
 
-	mgr, backend, err := bootstrap.CreateConfigManagerFromEnv(gw)
+	mgr, backend, err := bootstrap.CreateConfigManagerFromEnv(t.Context(), gw)
 	if err != nil {
 		t.Fatalf("bootstrap.CreateConfigManagerFromEnv returned error: %v", err)
 	}
@@ -652,7 +652,7 @@ func TestCreateConfigManagerFromEnv_SQLitePersistence(t *testing.T) {
 	}
 
 	gw1 := newTestGateway(t, initialCfg)
-	mgr1, backend, err := bootstrap.CreateConfigManagerFromEnv(gw1)
+	mgr1, backend, err := bootstrap.CreateConfigManagerFromEnv(t.Context(), gw1)
 	if err != nil {
 		t.Fatalf("bootstrap.CreateConfigManagerFromEnv returned error: %v", err)
 	}
@@ -664,7 +664,7 @@ func TestCreateConfigManagerFromEnv_SQLitePersistence(t *testing.T) {
 	}
 
 	gw2 := newTestGateway(t, initialCfg)
-	mgr2, _, err := bootstrap.CreateConfigManagerFromEnv(gw2)
+	mgr2, _, err := bootstrap.CreateConfigManagerFromEnv(t.Context(), gw2)
 	if err != nil {
 		t.Fatalf("bootstrap.CreateConfigManagerFromEnv (second) returned error: %v", err)
 	}
@@ -686,7 +686,7 @@ func TestCreateConfigManagerFromEnv_UnknownBackend(t *testing.T) {
 		Targets:  []aigateway.Target{{VirtualKey: "openai"}},
 	})
 
-	if _, _, err := bootstrap.CreateConfigManagerFromEnv(gw); err == nil {
+	if _, _, err := bootstrap.CreateConfigManagerFromEnv(t.Context(), gw); err == nil {
 		t.Fatalf("expected error for unsupported backend")
 	}
 }
@@ -700,7 +700,7 @@ func TestCreateConfigManagerFromEnv_PostgresMissingDSN(t *testing.T) {
 		Targets:  []aigateway.Target{{VirtualKey: "openai"}},
 	})
 
-	if _, _, err := bootstrap.CreateConfigManagerFromEnv(gw); err == nil {
+	if _, _, err := bootstrap.CreateConfigManagerFromEnv(t.Context(), gw); err == nil {
 		t.Fatalf("expected error for missing postgres dsn")
 	}
 }

--- a/gateway.go
+++ b/gateway.go
@@ -96,7 +96,10 @@ func New(cfg Config) (*Gateway, error) {
 		return nil, err
 	}
 
-	catalogResult, err := models.LoadWithInfo()
+	// No lifecycle context exists yet at this point in construction (shutdownCtx
+	// is created below); this is a one-time startup fetch bounded by fetchRemote's
+	// own 1s client timeout, so context.Background() is the correct choice here.
+	catalogResult, err := models.LoadWithInfoContext(context.Background())
 	recordCatalogLoad(catalogResult.Source, err)
 	catalog := catalogResult.Catalog
 	if err != nil {
@@ -191,14 +194,17 @@ func (g *Gateway) startCatalogRefresh() {
 			case <-g.shutdownCtx.Done():
 				return
 			case <-ticker.C:
-				g.refreshCatalog()
+				g.refreshCatalog(g.shutdownCtx)
 			}
 		}
 	}()
 }
 
-func (g *Gateway) refreshCatalog() {
-	result, err := models.LoadWithInfo()
+// refreshCatalog fetches the latest model catalog. ctx is g.shutdownCtx, so a
+// fetch already in flight when the gateway shuts down is canceled immediately
+// instead of running to fetchRemote's own 1s timeout.
+func (g *Gateway) refreshCatalog(ctx context.Context) {
+	result, err := models.LoadWithInfoContext(ctx)
 	recordCatalogLoad(result.Source, err)
 	if err != nil {
 		slog.Error("model catalog refresh failed", "url", result.URLForLog(), "error", err)

--- a/gateway_catalog_refresh_test.go
+++ b/gateway_catalog_refresh_test.go
@@ -1,0 +1,41 @@
+package aigateway
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/ferro-labs/ai-gateway/models"
+)
+
+// TestRefreshCatalog_AbortsOnCanceledContext proves refreshCatalog's ctx
+// parameter is actually wired into the fetch (not just accepted and
+// ignored): with a context that expires well before a slow upstream
+// responds, refreshCatalog must return promptly instead of waiting for the
+// server or for fetchRemote's own 1s client timeout. This is the concrete
+// regression test for the shutdown-latency gap that motivated threading
+// g.shutdownCtx through the periodic catalog refresh.
+func TestRefreshCatalog_AbortsOnCanceledContext(t *testing.T) {
+	const serverDelay = 500 * time.Millisecond
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(serverDelay)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"test/remote":{"provider":"test","model_id":"remote","mode":"chat"}}`))
+	}))
+	t.Cleanup(server.Close)
+	t.Setenv(models.CatalogURLEnv, server.URL)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 20*time.Millisecond)
+	defer cancel()
+
+	g := &Gateway{}
+	start := time.Now()
+	g.refreshCatalog(ctx)
+	elapsed := time.Since(start)
+
+	if elapsed >= serverDelay {
+		t.Fatalf("refreshCatalog took %v, want well under the server's %v delay (ctx cancellation must abort the fetch early)", elapsed, serverDelay)
+	}
+}

--- a/gateway_catalog_refresh_test.go
+++ b/gateway_catalog_refresh_test.go
@@ -17,32 +17,19 @@ import (
 // server or for fetchRemote's own 1s client timeout. This is the concrete
 // regression test for the shutdown-latency gap that motivated threading
 // g.shutdownCtx through the periodic catalog refresh.
-//
-// wantUnder is deliberately not "just above the 20ms context timeout" or a
-// large, loose bound — it is calibrated to sit strictly between the two
-// concrete outcomes this test must distinguish:
-//
-//   - ctx honored (correct): the fetch aborts at the ~20ms context timeout,
-//     then every canceled-fetch call falls through to parsing the embedded
-//     catalog_backup.json (3.3 MB, ~2500 entries) plus rebuilding its lookup
-//     index — a constant ~500ms under `go test -race` (measured directly),
-//     independent of the network timing this test cares about. Total: ~520-700ms.
-//   - ctx silently ignored (the regression this test guards against, e.g. a
-//     future refactor that reverts to context.Background()): fetchRemote's
-//     http.Client has its own fixed Timeout: time.Second that applies
-//     regardless of ctx, so the fetch instead runs for the full ~1s before
-//     falling through to the same ~500ms parse. Total: ~1.5-1.7s.
-//
-// wantUnder = 1s sits in the gap between those two ranges with margin on
-// both sides. A larger serverDelay only guards against the (irrelevant, since
-// the client's own 1s Timeout fires first) case of the server responding
-// slower than that; it does not by itself distinguish honored vs. ignored
-// ctx — do not "fix" flakiness here by loosening wantUnder without first
-// checking it still falls strictly below the ~1.5s ignored-ctx floor.
 func TestRefreshCatalog_AbortsOnCanceledContext(t *testing.T) {
 	const (
+		// serverDelay is large enough that the server never actually
+		// responds in time; only fetchRemote's own timing determines elapsed.
 		serverDelay = 5 * time.Second
-		wantUnder   = 1 * time.Second
+		// wantUnder sits strictly between the two outcomes this test
+		// distinguishes: ctx honored aborts at the ~20ms context timeout,
+		// then falls through to parsing the embedded catalog_backup.json
+		// (~500ms under `go test -race`, constant regardless of network
+		// timing) for a ~520-700ms total. ctx silently ignored instead runs
+		// into fetchRemote's own fixed 1s client Timeout before the same
+		// ~500ms parse, for a ~1.5-1.7s total. 1s has margin on both sides.
+		wantUnder = 1 * time.Second
 	)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		time.Sleep(serverDelay)

--- a/gateway_catalog_refresh_test.go
+++ b/gateway_catalog_refresh_test.go
@@ -18,17 +18,31 @@ import (
 // regression test for the shutdown-latency gap that motivated threading
 // g.shutdownCtx through the periodic catalog refresh.
 //
-// The assertion threshold is not "just above the 20ms context timeout":
-// every canceled-fetch call falls through to parsing the embedded
-// catalog_backup.json (3.3 MB, ~2500 entries) plus rebuilding its lookup
-// index, which alone costs ~500ms under `go test -race` (measured directly;
-// this is constant per call, independent of the network timing this test
-// actually cares about). serverDelay and the assertion threshold are set
-// well above that floor so the two are never in the same ballpark.
+// wantUnder is deliberately not "just above the 20ms context timeout" or a
+// large, loose bound — it is calibrated to sit strictly between the two
+// concrete outcomes this test must distinguish:
+//
+//   - ctx honored (correct): the fetch aborts at the ~20ms context timeout,
+//     then every canceled-fetch call falls through to parsing the embedded
+//     catalog_backup.json (3.3 MB, ~2500 entries) plus rebuilding its lookup
+//     index — a constant ~500ms under `go test -race` (measured directly),
+//     independent of the network timing this test cares about. Total: ~520-700ms.
+//   - ctx silently ignored (the regression this test guards against, e.g. a
+//     future refactor that reverts to context.Background()): fetchRemote's
+//     http.Client has its own fixed Timeout: time.Second that applies
+//     regardless of ctx, so the fetch instead runs for the full ~1s before
+//     falling through to the same ~500ms parse. Total: ~1.5-1.7s.
+//
+// wantUnder = 1s sits in the gap between those two ranges with margin on
+// both sides. A larger serverDelay only guards against the (irrelevant, since
+// the client's own 1s Timeout fires first) case of the server responding
+// slower than that; it does not by itself distinguish honored vs. ignored
+// ctx — do not "fix" flakiness here by loosening wantUnder without first
+// checking it still falls strictly below the ~1.5s ignored-ctx floor.
 func TestRefreshCatalog_AbortsOnCanceledContext(t *testing.T) {
 	const (
 		serverDelay = 5 * time.Second
-		wantUnder   = 2 * time.Second
+		wantUnder   = 1 * time.Second
 	)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		time.Sleep(serverDelay)

--- a/gateway_catalog_refresh_test.go
+++ b/gateway_catalog_refresh_test.go
@@ -17,8 +17,19 @@ import (
 // server or for fetchRemote's own 1s client timeout. This is the concrete
 // regression test for the shutdown-latency gap that motivated threading
 // g.shutdownCtx through the periodic catalog refresh.
+//
+// The assertion threshold is not "just above the 20ms context timeout":
+// every canceled-fetch call falls through to parsing the embedded
+// catalog_backup.json (3.3 MB, ~2500 entries) plus rebuilding its lookup
+// index, which alone costs ~500ms under `go test -race` (measured directly;
+// this is constant per call, independent of the network timing this test
+// actually cares about). serverDelay and the assertion threshold are set
+// well above that floor so the two are never in the same ballpark.
 func TestRefreshCatalog_AbortsOnCanceledContext(t *testing.T) {
-	const serverDelay = 500 * time.Millisecond
+	const (
+		serverDelay = 5 * time.Second
+		wantUnder   = 2 * time.Second
+	)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		time.Sleep(serverDelay)
 		w.Header().Set("Content-Type", "application/json")
@@ -35,7 +46,7 @@ func TestRefreshCatalog_AbortsOnCanceledContext(t *testing.T) {
 	g.refreshCatalog(ctx)
 	elapsed := time.Since(start)
 
-	if elapsed >= serverDelay {
-		t.Fatalf("refreshCatalog took %v, want well under the server's %v delay (ctx cancellation must abort the fetch early)", elapsed, serverDelay)
+	if elapsed >= wantUnder {
+		t.Fatalf("refreshCatalog took %v, want under %v (ctx cancellation must abort the fetch early; the %v server delay is never actually waited out)", elapsed, wantUnder, serverDelay)
 	}
 }

--- a/gateway_route.go
+++ b/gateway_route.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ferro-labs/ai-gateway/internal/logging"
 	"github.com/ferro-labs/ai-gateway/internal/mcp"
 	"github.com/ferro-labs/ai-gateway/internal/metrics"
+	"github.com/ferro-labs/ai-gateway/internal/strategies"
 	"github.com/ferro-labs/ai-gateway/models"
 	"github.com/ferro-labs/ai-gateway/observability"
 	"github.com/ferro-labs/ai-gateway/plugin"
@@ -192,33 +193,10 @@ func (g *Gateway) Route(ctx context.Context, req providers.Request) (*providers.
 	// returned tool_calls. Each iteration executes the tools and re-contacts
 	// the LLM until no more tool_calls are present or the depth limit is hit.
 	if mcpExecutorSnapshot != nil && len(mcpTools) > 0 {
-		depth := 0
-		loopProvider := resp.Provider
-		trace.WithRegion(ctx, "gateway.route.mcp.loop", func() {
-			for mcpExecutorSnapshot.ShouldContinueLoop(resp, depth) {
-				depth++
-
-				// ResolvePendingToolCalls returns the assistant message (with tool_calls)
-				// plus one tool-result message per call — append all at once.
-				toolMsgs, toolErr := mcpExecutorSnapshot.ResolvePendingToolCalls(ctx, resp)
-				if toolErr != nil {
-					err = fmt.Errorf("mcp tool execution at depth %d: %w", depth, toolErr)
-					return
-				}
-				req.Messages = append(req.Messages, toolMsgs...)
-
-				// Always non-streaming for intermediate calls.
-				req.Stream = false
-
-				callStart := time.Now()
-				resp, err = s.Execute(ctx, req)
-				providerDuration += time.Since(callStart)
-				if err != nil {
-					return
-				}
-				loopProvider = resp.Provider
-			}
-		})
+		var loopDuration time.Duration
+		var loopProvider string
+		resp, loopDuration, loopProvider, err = g.runMCPLoop(ctx, mcpExecutorSnapshot, s, &req, resp)
+		providerDuration += loopDuration
 		if err != nil {
 			g.routeError(ctx, span, obs, pctx, plugins, loopProvider, req.Model, err, time.Since(start), originalStream, hooksEnabled, obsEventsActive)
 			return nil, err
@@ -255,6 +233,48 @@ func (g *Gateway) Route(ctx context.Context, req providers.Request) (*providers.
 	resp.OverheadMs = float64((latency - providerDuration).Microseconds()) / 1000.0
 
 	return resp, nil
+}
+
+// runMCPLoop drives the agentic MCP tool-call loop: while resp has pending
+// tool_calls, it executes them via the MCP executor, appends the results to
+// req, and re-contacts the provider (always non-streaming for intermediate
+// calls) until no tool_calls remain or the depth limit is hit. req is
+// mutated in place (same aliasing as runBeforePlugins) so the caller's
+// plugin.Context, which was built from &req, still sees the accumulated
+// tool messages. Returns the final response, the accumulated provider-call
+// duration (for OverheadMs accounting), the provider name of the last
+// attempted call (for error reporting), and any error.
+func (g *Gateway) runMCPLoop(ctx context.Context, mcpExecutorSnapshot *mcp.Executor, s strategies.Strategy, req *providers.Request, resp *providers.Response) (*providers.Response, time.Duration, string, error) {
+	var providerDuration time.Duration
+	var err error
+	depth := 0
+	loopProvider := resp.Provider
+	trace.WithRegion(ctx, "gateway.route.mcp.loop", func() {
+		for mcpExecutorSnapshot.ShouldContinueLoop(resp, depth) {
+			depth++
+
+			// ResolvePendingToolCalls returns the assistant message (with tool_calls)
+			// plus one tool-result message per call — append all at once.
+			toolMsgs, toolErr := mcpExecutorSnapshot.ResolvePendingToolCalls(ctx, resp)
+			if toolErr != nil {
+				err = fmt.Errorf("mcp tool execution at depth %d: %w", depth, toolErr)
+				return
+			}
+			req.Messages = append(req.Messages, toolMsgs...)
+
+			// Always non-streaming for intermediate calls.
+			req.Stream = false
+
+			callStart := time.Now()
+			resp, err = s.Execute(ctx, *req)
+			providerDuration += time.Since(callStart)
+			if err != nil {
+				return
+			}
+			loopProvider = resp.Provider
+		}
+	})
+	return resp, providerDuration, loopProvider, err
 }
 
 // dispatchRequestEvent fans a request lifecycle event out to the async hook

--- a/gateway_stream.go
+++ b/gateway_stream.go
@@ -99,69 +99,17 @@ func (g *Gateway) RouteStream(ctx context.Context, req providers.Request) (<-cha
 	}
 
 	// Run before-request plugins (word-filter, max-token, rate-limit, etc.).
-	var pctx *plugin.Context
-	if plugins.HasPlugins() {
-		pctx = plugin.NewContext(&req)
-		// Propagate the opaque key identifier so per-key plugins (rate-limit,
-		// budget) can scope limits to the authenticated caller. The raw bearer
-		// secret is never exposed here — only the stable APIKey.ID.
-		if keyID, ok := authctx.KeyID(ctx); ok {
-			pctx.Metadata["api_key"] = keyID
-		}
-		var early *providers.Response
-		trace.WithRegion(ctx, "gateway.route_stream.plugins.before", func() {
-			early, err = g.runBeforePlugins(ctx, plugins, pctx, &req)
-		})
-		if err != nil {
-			plugin.PutContext(pctx)
-			pctx = nil
-			releasePluginManager()
-			metrics.ForRequest("", req.Model).Rejected.Inc()
-			return nil, err
-		}
-		if early != nil {
-			if early.Created == 0 {
-				early.Created = time.Now().Unix()
-			}
-			g.recordSuccess(ctx, span, obs, early, time.Since(start), true, hooksEnabled, obsEventsActive)
-			plugin.PutContext(pctx)
-			pctx = nil
-			releasePluginManager()
-			return responseStream(early), nil
-		}
-	} else {
-		releasePluginManager()
+	pctx, early, err := g.runBeforePluginsStream(ctx, span, obs, plugins, releasePluginManager, &req, start, hooksEnabled, obsEventsActive)
+	if err != nil {
+		return nil, err
+	}
+	if early != nil {
+		return responseStream(early), nil
 	}
 
 	// Resolve provider according to strategy mode.
-	g.mu.Lock()
-	g.ensureCircuitBreakersLocked()
-	g.mu.Unlock()
-	g.mu.RLock()
-	sp, orderErr := g.resolveStreamingProviderLocked(req)
-	g.mu.RUnlock()
-
-	if orderErr != nil {
-		err = orderErr
-		span.SetError(err)
-		if pctx != nil {
-			pctx.Error = err
-			plugins.RunOnError(ctx, pctx)
-			plugin.PutContext(pctx)
-			releasePluginManager()
-		}
-		return nil, err
-	}
-
-	if sp == nil {
-		err = fmt.Errorf("no streaming-capable provider found for model: %s", req.Model)
-		span.SetError(err)
-		if pctx != nil {
-			pctx.Error = err
-			plugins.RunOnError(ctx, pctx)
-			plugin.PutContext(pctx)
-			releasePluginManager()
-		}
+	sp, err := g.resolveStreamOrError(ctx, span, plugins, pctx, releasePluginManager, req)
+	if err != nil {
 		return nil, err
 	}
 
@@ -319,6 +267,82 @@ func (g *Gateway) RouteStream(ctx context.Context, req providers.Request) (<-cha
 		}
 	})
 	return streamwrap.Meter(ctx, rawCh, start, meta), nil
+}
+
+// runBeforePluginsStream runs before-request plugins for the streaming path
+// and finalizes bookkeeping on every path except "continue routing": a
+// non-nil err means the caller must return (nil, err) immediately (metrics,
+// plugin-context release, and plugin-manager release are already done); a
+// non-nil early means the caller must return (responseStream(early), nil)
+// immediately (success recording and release already done). Otherwise the
+// returned pctx (nil if no plugins are configured, non-nil and still live
+// otherwise) is what the rest of RouteStream continues to use.
+func (g *Gateway) runBeforePluginsStream(ctx context.Context, span observability.Span, obs observability.Provider, plugins *plugin.Manager, releasePluginManager func(), req *providers.Request, start time.Time, hooksEnabled, obsEventsActive bool) (pctx *plugin.Context, early *providers.Response, err error) {
+	if !plugins.HasPlugins() {
+		releasePluginManager()
+		return nil, nil, nil
+	}
+
+	pctx = plugin.NewContext(req)
+	// Propagate the opaque key identifier so per-key plugins (rate-limit,
+	// budget) can scope limits to the authenticated caller. The raw bearer
+	// secret is never exposed here — only the stable APIKey.ID.
+	if keyID, ok := authctx.KeyID(ctx); ok {
+		pctx.Metadata["api_key"] = keyID
+	}
+	trace.WithRegion(ctx, "gateway.route_stream.plugins.before", func() {
+		early, err = g.runBeforePlugins(ctx, plugins, pctx, req)
+	})
+	if err != nil {
+		plugin.PutContext(pctx)
+		releasePluginManager()
+		metrics.ForRequest("", req.Model).Rejected.Inc()
+		return nil, nil, err
+	}
+	if early != nil {
+		if early.Created == 0 {
+			early.Created = time.Now().Unix()
+		}
+		g.recordSuccess(ctx, span, obs, early, time.Since(start), true, hooksEnabled, obsEventsActive)
+		plugin.PutContext(pctx)
+		releasePluginManager()
+		return nil, early, nil
+	}
+	return pctx, nil, nil
+}
+
+// resolveStreamOrError resolves the streaming-capable provider for req under
+// the gateway lock. On failure (resolution error, or no streaming-capable
+// provider found) it finalizes bookkeeping (span error, plugin error hook if
+// pctx is live, plugin-context release, plugin-manager release) and returns
+// a non-nil error — the caller must return (nil, err) immediately, same as
+// every other terminal error path in RouteStream.
+func (g *Gateway) resolveStreamOrError(ctx context.Context, span observability.Span, plugins *plugin.Manager, pctx *plugin.Context, releasePluginManager func(), req providers.Request) (providers.StreamProvider, error) {
+	g.mu.Lock()
+	g.ensureCircuitBreakersLocked()
+	g.mu.Unlock()
+	g.mu.RLock()
+	sp, orderErr := g.resolveStreamingProviderLocked(req)
+	g.mu.RUnlock()
+
+	fail := func(err error) (providers.StreamProvider, error) {
+		span.SetError(err)
+		if pctx != nil {
+			pctx.Error = err
+			plugins.RunOnError(ctx, pctx)
+			plugin.PutContext(pctx)
+			releasePluginManager()
+		}
+		return nil, err
+	}
+
+	if orderErr != nil {
+		return fail(orderErr)
+	}
+	if sp == nil {
+		return fail(fmt.Errorf("no streaming-capable provider found for model: %s", req.Model))
+	}
+	return sp, nil
 }
 
 func responseStream(resp *providers.Response) <-chan providers.StreamChunk {

--- a/internal/admin/config_store.go
+++ b/internal/admin/config_store.go
@@ -12,6 +12,7 @@ import (
 
 	aigateway "github.com/ferro-labs/ai-gateway"
 	"github.com/ferro-labs/ai-gateway/internal/sqlitefile"
+
 	// Register Postgres SQL driver.
 	_ "github.com/lib/pq"
 	// Register SQLite SQL driver.
@@ -52,7 +53,7 @@ type SQLConfigStore struct {
 }
 
 // NewSQLiteConfigStore creates a SQLite-backed config store.
-func NewSQLiteConfigStore(dsn string) (*SQLConfigStore, error) {
+func NewSQLiteConfigStore(ctx context.Context, dsn string) (*SQLConfigStore, error) {
 	dsn = strings.TrimSpace(dsn)
 	if dsn == "" {
 		dsn = "ferrogw-config.db"
@@ -63,7 +64,7 @@ func NewSQLiteConfigStore(dsn string) (*SQLConfigStore, error) {
 	}
 	tuneDBPool(db, string(configDialectSQLite))
 	s := &SQLConfigStore{db: db, dialect: configDialectSQLite}
-	if err := s.init(); err != nil {
+	if err := s.init(ctx); err != nil {
 		_ = db.Close()
 		return nil, err
 	}
@@ -75,7 +76,7 @@ func NewSQLiteConfigStore(dsn string) (*SQLConfigStore, error) {
 }
 
 // NewPostgresConfigStore creates a Postgres-backed config store.
-func NewPostgresConfigStore(dsn string) (*SQLConfigStore, error) {
+func NewPostgresConfigStore(ctx context.Context, dsn string) (*SQLConfigStore, error) {
 	dsn = strings.TrimSpace(dsn)
 	if dsn == "" {
 		return nil, fmt.Errorf("postgres dsn is required")
@@ -86,15 +87,15 @@ func NewPostgresConfigStore(dsn string) (*SQLConfigStore, error) {
 	}
 	tuneDBPool(db, string(configDialectPostgres))
 	s := &SQLConfigStore{db: db, dialect: configDialectPostgres}
-	if err := s.init(); err != nil {
+	if err := s.init(ctx); err != nil {
 		_ = db.Close()
 		return nil, err
 	}
 	return s, nil
 }
 
-func (s *SQLConfigStore) init() error {
-	if err := s.db.Ping(); err != nil {
+func (s *SQLConfigStore) init(ctx context.Context) error {
+	if err := s.db.PingContext(ctx); err != nil {
 		return fmt.Errorf("ping %s config store: %w", s.dialect, err)
 	}
 
@@ -114,7 +115,7 @@ CREATE TABLE IF NOT EXISTS gateway_config (
 );`
 	}
 
-	if _, err := s.db.Exec(ddl); err != nil {
+	if _, err := s.db.ExecContext(ctx, ddl); err != nil {
 		return fmt.Errorf("initialize config schema: %w", err)
 	}
 	return nil

--- a/internal/admin/config_store_test.go
+++ b/internal/admin/config_store_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestNewSQLiteConfigStore_FilePermissions(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "config.db")
-	store, err := NewSQLiteConfigStore(path)
+	store, err := NewSQLiteConfigStore(t.Context(), path)
 	if err != nil {
 		t.Fatalf("new sqlite config store: %v", err)
 	}

--- a/internal/admin/handlers_errors_test.go
+++ b/internal/admin/handlers_errors_test.go
@@ -29,8 +29,10 @@ func (s *dbFailKeyStore) RotateKey(context.Context, string) (*APIKey, error) {
 }
 
 // reqWithID builds a request carrying the chi "id" URL param the key handlers read.
+// No *testing.T is available in this standalone builder; the context is
+// replaced by WithContext below regardless, so context.Background() is fine.
 func reqWithID(method, id string) *http.Request {
-	req := httptest.NewRequest(method, "/", nil)
+	req := httptest.NewRequestWithContext(context.Background(), method, "/", nil)
 	rctx := chi.NewRouteContext()
 	rctx.URLParams.Add("id", id)
 	return req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))

--- a/internal/admin/handlers_test.go
+++ b/internal/admin/handlers_test.go
@@ -203,12 +203,15 @@ func createReadOnlyKey(t *testing.T, h *Handlers) *APIKey {
 	return key
 }
 
+// No *testing.T is available in this standalone builder (74 call sites across
+// this file; threading t through all of them buys nothing since these tests
+// exercise handler auth/routing, not context cancellation).
 func authedRequest(method, url string, body string, apiKey *APIKey) *http.Request {
 	var req *http.Request
 	if body != "" {
-		req = httptest.NewRequest(method, url, bytes.NewBufferString(body))
+		req = httptest.NewRequestWithContext(context.Background(), method, url, bytes.NewBufferString(body))
 	} else {
-		req = httptest.NewRequest(method, url, nil)
+		req = httptest.NewRequestWithContext(context.Background(), method, url, nil)
 	}
 	req.Header.Set("Authorization", "Bearer "+apiKey.Key)
 	return req
@@ -546,7 +549,7 @@ func TestRBACReadOnlyCannotCreateKey(t *testing.T) {
 func TestUnauthorizedRequest(t *testing.T) {
 	_, r := setupTestRouter()
 
-	req := httptest.NewRequest(http.MethodGet, "/admin/keys", nil)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/admin/keys", nil)
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
 
@@ -1056,7 +1059,7 @@ func TestKeyUsageOffsetAndSort(t *testing.T) {
 	time.Sleep(5 * time.Millisecond)
 	_, _ = h.Keys.ValidateKey(context.Background(), keyC.Key)
 
-	req := httptest.NewRequest(http.MethodGet, "/admin/keys/usage?sort=usage&limit=4", nil)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/admin/keys/usage?sort=usage&limit=4", nil)
 	w := httptest.NewRecorder()
 	h.keyUsage(w, req)
 	if w.Code != http.StatusOK {
@@ -1077,7 +1080,7 @@ func TestKeyUsageOffsetAndSort(t *testing.T) {
 	}
 
 	secondExpected := usagePayload.Data[1].ID
-	req = httptest.NewRequest(http.MethodGet, "/admin/keys/usage?sort=usage&limit=1&offset=1", nil)
+	req = httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/admin/keys/usage?sort=usage&limit=1&offset=1", nil)
 	w = httptest.NewRecorder()
 	h.keyUsage(w, req)
 	if w.Code != http.StatusOK {
@@ -1095,7 +1098,7 @@ func TestKeyUsageOffsetAndSort(t *testing.T) {
 		t.Fatalf("offset pagination mismatch: expected id %s got %s", secondExpected, offsetPayload.Data[0].ID)
 	}
 
-	req = httptest.NewRequest(http.MethodGet, "/admin/keys/usage?sort=last_used&limit=4", nil)
+	req = httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/admin/keys/usage?sort=last_used&limit=4", nil)
 	w = httptest.NewRecorder()
 	h.keyUsage(w, req)
 	if w.Code != http.StatusOK {

--- a/internal/admin/middleware_test.go
+++ b/internal/admin/middleware_test.go
@@ -15,7 +15,7 @@ func TestAuthMiddleware_ValidKey(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	}))
 
-	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
 	req.Header.Set("Authorization", "Bearer "+created.Key)
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
@@ -32,7 +32,7 @@ func TestAuthMiddleware_NoAuthHeader(t *testing.T) {
 		t.Error("handler should not be called")
 	}))
 
-	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
 
@@ -48,7 +48,7 @@ func TestAuthMiddleware_InvalidKey(t *testing.T) {
 		t.Error("handler should not be called")
 	}))
 
-	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
 	req.Header.Set("Authorization", "Bearer gw-invalid-key")
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
@@ -67,7 +67,7 @@ func TestAuthMiddleware_RevokedKey(t *testing.T) {
 		t.Error("handler should not be called")
 	}))
 
-	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
 	req.Header.Set("Authorization", "Bearer "+created.Key)
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
@@ -92,7 +92,7 @@ func TestAuthMiddleware_BootstrapKey(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	}))
 
-	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
 	req.Header.Set("Authorization", "Bearer bootstrap-secret")
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
@@ -110,7 +110,7 @@ func TestAuthMiddleware_BootstrapKeyMismatch(t *testing.T) {
 		t.Error("handler should not be called")
 	}))
 
-	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
 	req.Header.Set("Authorization", "Bearer wrong-secret")
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
@@ -135,7 +135,7 @@ func TestAuthMiddleware_BootstrapReadOnlyKey(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	}))
 
-	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
 	req.Header.Set("Authorization", "Bearer readonly-secret")
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
@@ -153,7 +153,7 @@ func TestAuthMiddleware_BootstrapReadOnlyRequiresScope(t *testing.T) {
 		t.Error("handler should not be called")
 	})))
 
-	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
 	req.Header.Set("Authorization", "Bearer readonly-secret")
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
@@ -172,7 +172,7 @@ func TestAuthMiddleware_BootstrapDisabled(t *testing.T) {
 		t.Error("handler should not be called")
 	}))
 
-	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
 	req.Header.Set("Authorization", "Bearer bootstrap-secret")
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
@@ -191,7 +191,7 @@ func TestAuthMiddleware_BootstrapOnlyWhenStoreEmpty(t *testing.T) {
 		t.Error("handler should not be called")
 	}))
 
-	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
 	req.Header.Set("Authorization", "Bearer bootstrap-secret")
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
@@ -214,7 +214,7 @@ func TestAuthMiddleware_MasterKey(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	}))
 
-	req := httptest.NewRequest(http.MethodGet, "/admin/keys", nil)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/admin/keys", nil)
 	req.Header.Set("Authorization", "Bearer test-master-key")
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
@@ -230,7 +230,7 @@ func TestAuthMiddleware_MasterKey_WrongKey(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	}))
 
-	req := httptest.NewRequest(http.MethodGet, "/admin/keys", nil)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/admin/keys", nil)
 	req.Header.Set("Authorization", "Bearer wrong-key")
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
@@ -247,7 +247,7 @@ func TestAuthMiddleware_MasterKey_Empty(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	}))
 
-	req := httptest.NewRequest(http.MethodGet, "/admin/keys", nil)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/admin/keys", nil)
 	req.Header.Set("Authorization", "Bearer some-key")
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)

--- a/internal/admin/sql_store.go
+++ b/internal/admin/sql_store.go
@@ -145,7 +145,11 @@ func (s *SQLStore) prepareStmts(ctx context.Context) error {
 		{&s.stmtRotate, `UPDATE api_keys SET key = ?, rotated_at = ? WHERE id = ?`},
 	}
 	for _, s2 := range stmts {
-		stmt, err := s.db.PrepareContext(ctx, s.bind(s2.query))
+		// These are long-lived prepared statements cached on the SQLStore for
+		// its whole lifetime, not a per-call resource — closed in Close()
+		// (below), which sqlclosecheck's static analysis can't trace through
+		// the *s2.dest indirection.
+		stmt, err := s.db.PrepareContext(ctx, s.bind(s2.query)) //nolint:sqlclosecheck // closed in (*SQLStore).Close
 		if err != nil {
 			return fmt.Errorf("prepare statement: %w", err)
 		}

--- a/internal/admin/sql_store.go
+++ b/internal/admin/sql_store.go
@@ -43,7 +43,7 @@ type SQLStore struct {
 
 // NewSQLiteStore creates a SQLite-backed key store.
 // dsn can be a file path (e.g. /tmp/keys.db) or SQLite DSN.
-func NewSQLiteStore(dsn string) (*SQLStore, error) {
+func NewSQLiteStore(ctx context.Context, dsn string) (*SQLStore, error) {
 	dsn = strings.TrimSpace(dsn)
 	if dsn == "" {
 		dsn = "ferrogw-keys.db"
@@ -54,7 +54,7 @@ func NewSQLiteStore(dsn string) (*SQLStore, error) {
 	}
 	tuneDBPool(db, string(dialectSQLite))
 	store := &SQLStore{db: db, dialect: dialectSQLite}
-	if err := store.init(); err != nil {
+	if err := store.init(ctx); err != nil {
 		_ = db.Close()
 		return nil, err
 	}
@@ -66,7 +66,7 @@ func NewSQLiteStore(dsn string) (*SQLStore, error) {
 }
 
 // NewPostgresStore creates a Postgres-backed key store.
-func NewPostgresStore(dsn string) (*SQLStore, error) {
+func NewPostgresStore(ctx context.Context, dsn string) (*SQLStore, error) {
 	dsn = strings.TrimSpace(dsn)
 	if dsn == "" {
 		return nil, fmt.Errorf("postgres dsn is required")
@@ -77,15 +77,15 @@ func NewPostgresStore(dsn string) (*SQLStore, error) {
 	}
 	tuneDBPool(db, string(dialectPostgres))
 	store := &SQLStore{db: db, dialect: dialectPostgres}
-	if err := store.init(); err != nil {
+	if err := store.init(ctx); err != nil {
 		_ = db.Close()
 		return nil, err
 	}
 	return store, nil
 }
 
-func (s *SQLStore) init() error {
-	if err := s.db.Ping(); err != nil {
+func (s *SQLStore) init(ctx context.Context) error {
+	if err := s.db.PingContext(ctx); err != nil {
 		return fmt.Errorf("ping %s store: %w", s.dialect, err)
 	}
 
@@ -121,16 +121,16 @@ CREATE TABLE IF NOT EXISTS api_keys (
 CREATE INDEX IF NOT EXISTS idx_api_keys_key ON api_keys(key);`
 	}
 
-	if _, err := s.db.Exec(ddl); err != nil {
+	if _, err := s.db.ExecContext(ctx, ddl); err != nil {
 		return fmt.Errorf("initialize %s store schema: %w", s.dialect, err)
 	}
-	if err := s.ensureUsageColumns(); err != nil {
+	if err := s.ensureUsageColumns(ctx); err != nil {
 		return err
 	}
-	return s.prepareStmts()
+	return s.prepareStmts(ctx)
 }
 
-func (s *SQLStore) prepareStmts() error {
+func (s *SQLStore) prepareStmts(ctx context.Context) error {
 	stmts := []struct {
 		dest  **sql.Stmt
 		query string
@@ -145,7 +145,7 @@ func (s *SQLStore) prepareStmts() error {
 		{&s.stmtRotate, `UPDATE api_keys SET key = ?, rotated_at = ? WHERE id = ?`},
 	}
 	for _, s2 := range stmts {
-		stmt, err := s.db.Prepare(s.bind(s2.query))
+		stmt, err := s.db.PrepareContext(ctx, s.bind(s2.query))
 		if err != nil {
 			return fmt.Errorf("prepare statement: %w", err)
 		}
@@ -154,7 +154,7 @@ func (s *SQLStore) prepareStmts() error {
 	return nil
 }
 
-func (s *SQLStore) ensureUsageColumns() error {
+func (s *SQLStore) ensureUsageColumns(ctx context.Context) error {
 	alterStatements := []string{
 		"ALTER TABLE api_keys ADD COLUMN usage_count INTEGER NOT NULL DEFAULT 0",
 	}
@@ -170,7 +170,7 @@ func (s *SQLStore) ensureUsageColumns() error {
 	}
 
 	for _, stmt := range alterStatements {
-		if _, err := s.db.Exec(stmt); err != nil && !isDuplicateColumnError(err) {
+		if _, err := s.db.ExecContext(ctx, stmt); err != nil && !isDuplicateColumnError(err) {
 			return fmt.Errorf("ensure api_keys usage columns: %w", err)
 		}
 	}

--- a/internal/admin/sql_store_test.go
+++ b/internal/admin/sql_store_test.go
@@ -25,18 +25,20 @@ func TestPostgresStoreContract(t *testing.T) {
 		t.Skip("set FERROGW_TEST_POSTGRES_DSN to run Postgres store integration tests")
 	}
 
-	store, err := NewPostgresStore(dsn)
+	store, err := NewPostgresStore(t.Context(), dsn)
 	if err != nil {
 		t.Fatalf("new postgres store: %v", err)
 	}
 	t.Cleanup(func() {
-		_, _ = store.db.Exec("DELETE FROM api_keys")
+		// t.Context() is already canceled by the time Cleanup runs; use a
+		// fresh context for this cleanup query.
+		_, _ = store.db.ExecContext(context.Background(), "DELETE FROM api_keys")
 		if store.db != nil {
 			_ = store.db.Close()
 		}
 	})
 
-	_, _ = store.db.Exec("DELETE FROM api_keys")
+	_, _ = store.db.ExecContext(t.Context(), "DELETE FROM api_keys")
 	runStoreContract(t, store)
 }
 
@@ -152,7 +154,7 @@ func TestSQLiteStoreExpiration(t *testing.T) {
 
 func TestNewSQLiteStore_FilePermissions(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "keys.db")
-	store, err := NewSQLiteStore(path)
+	store, err := NewSQLiteStore(t.Context(), path)
 	if err != nil {
 		t.Fatalf("new sqlite store: %v", err)
 	}
@@ -168,7 +170,7 @@ func TestNewSQLiteStore_FilePermissions(t *testing.T) {
 }
 
 func TestPostgresStoreMissingDSN(t *testing.T) {
-	if _, err := NewPostgresStore(""); err == nil {
+	if _, err := NewPostgresStore(t.Context(), ""); err == nil {
 		t.Fatalf("expected error for missing postgres dsn")
 	}
 }
@@ -177,7 +179,7 @@ func newSQLiteTestStore(t *testing.T) *SQLStore {
 	t.Helper()
 
 	path := filepath.Join(t.TempDir(), "keys.db")
-	store, err := NewSQLiteStore(path)
+	store, err := NewSQLiteStore(t.Context(), path)
 	if err != nil {
 		t.Fatalf("new sqlite store: %v", err)
 	}

--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -110,13 +110,16 @@ func buildServer() (
 	}
 	gw.SetObservability(obsProvider)
 
-	cfgManager, configStoreBackend, err := CreateConfigManagerFromEnv(gw)
+	// No lifecycle context exists yet at this point in startup (signal.NotifyContext
+	// is only set up later, in runUntilShutdown), matching the gwotel.Init call
+	// above — these are one-time store-initialization calls, not per-request work.
+	cfgManager, configStoreBackend, err := CreateConfigManagerFromEnv(context.Background(), gw)
 	if err != nil {
 		logging.Logger.Error("failed to initialize config store", "error", err)
 		os.Exit(1)
 	}
 
-	keyStore, keyStoreBackend, err := CreateKeyStoreFromEnv()
+	keyStore, keyStoreBackend, err := CreateKeyStoreFromEnv(context.Background())
 	if err != nil {
 		logging.Logger.Error("failed to initialize API key store", "error", err)
 		os.Exit(1)
@@ -139,7 +142,7 @@ func buildServer() (
 	}
 
 	rlStore := NewRateLimitStore()
-	logReader, logMaintainer, logReaderBackend, err := CreateRequestLogReaderFromEnv()
+	logReader, logMaintainer, logReaderBackend, err := CreateRequestLogReaderFromEnv(context.Background())
 	if err != nil {
 		logging.Logger.Error("failed to initialize request log reader", "error", err)
 		os.Exit(1)

--- a/internal/bootstrap/stores.go
+++ b/internal/bootstrap/stores.go
@@ -2,6 +2,7 @@
 package bootstrap
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strings"
@@ -20,7 +21,7 @@ const (
 )
 
 // CreateKeyStoreFromEnv builds an admin key store from API_KEY_STORE_BACKEND / API_KEY_STORE_DSN env vars.
-func CreateKeyStoreFromEnv() (admin.Store, string, error) {
+func CreateKeyStoreFromEnv(ctx context.Context) (admin.Store, string, error) {
 	backend := strings.ToLower(strings.TrimSpace(os.Getenv("API_KEY_STORE_BACKEND")))
 	if backend == "" {
 		backend = BackendMemory
@@ -32,13 +33,13 @@ func CreateKeyStoreFromEnv() (admin.Store, string, error) {
 	case BackendMemory, "in-memory", "inmemory":
 		return admin.NewKeyStore(), BackendMemory, nil
 	case BackendSQLite:
-		store, err := admin.NewSQLiteStore(storeDSN)
+		store, err := admin.NewSQLiteStore(ctx, storeDSN)
 		if err != nil {
 			return nil, "", err
 		}
 		return store, BackendSQLite, nil
 	case BackendPostgres, backendPostgresSQL:
-		store, err := admin.NewPostgresStore(storeDSN)
+		store, err := admin.NewPostgresStore(ctx, storeDSN)
 		if err != nil {
 			return nil, "", err
 		}
@@ -49,7 +50,7 @@ func CreateKeyStoreFromEnv() (admin.Store, string, error) {
 }
 
 // CreateRequestLogReaderFromEnv builds a request log reader from REQUEST_LOG_STORE_BACKEND / REQUEST_LOG_STORE_DSN env vars.
-func CreateRequestLogReaderFromEnv() (requestlog.Reader, requestlog.Maintainer, string, error) {
+func CreateRequestLogReaderFromEnv(ctx context.Context) (requestlog.Reader, requestlog.Maintainer, string, error) {
 	backend := strings.ToLower(strings.TrimSpace(os.Getenv("REQUEST_LOG_STORE_BACKEND")))
 	if backend == "" {
 		return nil, nil, "disabled", nil
@@ -59,13 +60,13 @@ func CreateRequestLogReaderFromEnv() (requestlog.Reader, requestlog.Maintainer, 
 
 	switch backend {
 	case BackendSQLite:
-		reader, err := requestlog.NewSQLiteWriter(dsn)
+		reader, err := requestlog.NewSQLiteWriter(ctx, dsn)
 		if err != nil {
 			return nil, nil, "", err
 		}
 		return reader, reader, BackendSQLite, nil
 	case BackendPostgres, backendPostgresSQL:
-		reader, err := requestlog.NewPostgresWriter(dsn)
+		reader, err := requestlog.NewPostgresWriter(ctx, dsn)
 		if err != nil {
 			return nil, nil, "", err
 		}
@@ -76,7 +77,7 @@ func CreateRequestLogReaderFromEnv() (requestlog.Reader, requestlog.Maintainer, 
 }
 
 // CreateConfigManagerFromEnv builds a config manager from CONFIG_STORE_BACKEND / CONFIG_STORE_DSN env vars.
-func CreateConfigManagerFromEnv(gw *aigateway.Gateway) (admin.ConfigManager, string, error) {
+func CreateConfigManagerFromEnv(ctx context.Context, gw *aigateway.Gateway) (admin.ConfigManager, string, error) {
 	backend := strings.ToLower(strings.TrimSpace(os.Getenv("CONFIG_STORE_BACKEND")))
 	if backend == "" {
 		backend = BackendMemory
@@ -92,7 +93,7 @@ func CreateConfigManagerFromEnv(gw *aigateway.Gateway) (admin.ConfigManager, str
 		}
 		return manager, BackendMemory, nil
 	case BackendSQLite:
-		store, err := admin.NewSQLiteConfigStore(dsn)
+		store, err := admin.NewSQLiteConfigStore(ctx, dsn)
 		if err != nil {
 			return nil, "", err
 		}
@@ -103,7 +104,7 @@ func CreateConfigManagerFromEnv(gw *aigateway.Gateway) (admin.ConfigManager, str
 		}
 		return manager, BackendSQLite, nil
 	case BackendPostgres, backendPostgresSQL:
-		store, err := admin.NewPostgresConfigStore(dsn)
+		store, err := admin.NewPostgresConfigStore(ctx, dsn)
 		if err != nil {
 			return nil, "", err
 		}

--- a/internal/bootstrap/stores_test.go
+++ b/internal/bootstrap/stores_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestCreateKeyStoreFromEnv_DefaultsToMemory(t *testing.T) {
 	t.Setenv("API_KEY_STORE_BACKEND", "")
-	store, backend, err := CreateKeyStoreFromEnv()
+	store, backend, err := CreateKeyStoreFromEnv(t.Context())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -26,7 +26,7 @@ func TestCreateKeyStoreFromEnv_MemoryAliases(t *testing.T) {
 	for _, alias := range []string{"memory", "in-memory", "inmemory", "MEMORY", " Memory "} {
 		t.Run(alias, func(t *testing.T) {
 			t.Setenv("API_KEY_STORE_BACKEND", alias)
-			store, backend, err := CreateKeyStoreFromEnv()
+			store, backend, err := CreateKeyStoreFromEnv(t.Context())
 			if err != nil {
 				t.Fatalf("unexpected error for alias %q: %v", alias, err)
 			}
@@ -45,7 +45,7 @@ func TestCreateKeyStoreFromEnv_SQLite(t *testing.T) {
 	t.Setenv("API_KEY_STORE_BACKEND", "sqlite")
 	t.Setenv("API_KEY_STORE_DSN", dbPath)
 
-	store, backend, err := CreateKeyStoreFromEnv()
+	store, backend, err := CreateKeyStoreFromEnv(t.Context())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -59,7 +59,7 @@ func TestCreateKeyStoreFromEnv_SQLite(t *testing.T) {
 
 func TestCreateKeyStoreFromEnv_UnsupportedBackend(t *testing.T) {
 	t.Setenv("API_KEY_STORE_BACKEND", "redis")
-	_, _, err := CreateKeyStoreFromEnv()
+	_, _, err := CreateKeyStoreFromEnv(t.Context())
 	if err == nil {
 		t.Fatal("expected error for unsupported backend")
 	}
@@ -67,7 +67,7 @@ func TestCreateKeyStoreFromEnv_UnsupportedBackend(t *testing.T) {
 
 func TestCreateRequestLogReaderFromEnv_DefaultDisabled(t *testing.T) {
 	t.Setenv("REQUEST_LOG_STORE_BACKEND", "")
-	reader, maintainer, backend, err := CreateRequestLogReaderFromEnv()
+	reader, maintainer, backend, err := CreateRequestLogReaderFromEnv(t.Context())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -84,7 +84,7 @@ func TestCreateRequestLogReaderFromEnv_SQLite(t *testing.T) {
 	t.Setenv("REQUEST_LOG_STORE_BACKEND", "sqlite")
 	t.Setenv("REQUEST_LOG_STORE_DSN", dbPath)
 
-	reader, maintainer, backend, err := CreateRequestLogReaderFromEnv()
+	reader, maintainer, backend, err := CreateRequestLogReaderFromEnv(t.Context())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -98,7 +98,7 @@ func TestCreateRequestLogReaderFromEnv_SQLite(t *testing.T) {
 
 func TestCreateRequestLogReaderFromEnv_UnsupportedBackend(t *testing.T) {
 	t.Setenv("REQUEST_LOG_STORE_BACKEND", "redis")
-	_, _, _, err := CreateRequestLogReaderFromEnv()
+	_, _, _, err := CreateRequestLogReaderFromEnv(t.Context())
 	if err == nil {
 		t.Fatal("expected error for unsupported backend")
 	}
@@ -108,7 +108,7 @@ func TestCreateConfigManagerFromEnv_DefaultsToMemory(t *testing.T) {
 	t.Setenv("CONFIG_STORE_BACKEND", "")
 	gw := newTestGateway(t)
 
-	mgr, backend, err := CreateConfigManagerFromEnv(gw)
+	mgr, backend, err := CreateConfigManagerFromEnv(t.Context(), gw)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -126,7 +126,7 @@ func TestCreateConfigManagerFromEnv_SQLite(t *testing.T) {
 	t.Setenv("CONFIG_STORE_DSN", dbPath)
 	gw := newTestGateway(t)
 
-	mgr, backend, err := CreateConfigManagerFromEnv(gw)
+	mgr, backend, err := CreateConfigManagerFromEnv(t.Context(), gw)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -142,7 +142,7 @@ func TestCreateConfigManagerFromEnv_UnsupportedBackend(t *testing.T) {
 	t.Setenv("CONFIG_STORE_BACKEND", "redis")
 	gw := newTestGateway(t)
 
-	_, _, err := CreateConfigManagerFromEnv(gw)
+	_, _, err := CreateConfigManagerFromEnv(t.Context(), gw)
 	if err == nil {
 		t.Fatal("expected error for unsupported backend")
 	}
@@ -153,7 +153,7 @@ func TestCreateConfigManagerFromEnv_PostgresqlAlias(t *testing.T) {
 	t.Setenv("CONFIG_STORE_DSN", "postgresql://invalid:5432/test")
 	gw := newTestGateway(t)
 
-	_, _, err := CreateConfigManagerFromEnv(gw)
+	_, _, err := CreateConfigManagerFromEnv(t.Context(), gw)
 	if err == nil {
 		t.Skip("postgres not available, but alias was recognized")
 	}

--- a/internal/handler/chat_bodylimit_test.go
+++ b/internal/handler/chat_bodylimit_test.go
@@ -27,7 +27,7 @@ func TestChatCompletions_BodyTooLarge_Returns413(t *testing.T) {
 	// The JSON decoder reads partial content then hits the MaxBytesReader limit.
 	body := `{"model":"test","messages":[{"role":"user","content":"` + strings.Repeat("x", 200) + `"}]}`
 
-	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(body))
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/v1/chat/completions", strings.NewReader(body))
 	w := httptest.NewRecorder()
 
 	// Simulate what the body-limit middleware does: wrap the body with a 10-byte limit.
@@ -47,7 +47,7 @@ func TestDecodeChatCompletionRequest_BodyTooLarge(t *testing.T) {
 	// Use valid-JSON-prefixed body: decoder reads the first few bytes, then hits the limit.
 	body := `{"model":"test","messages":[{"role":"user","content":"` + strings.Repeat("x", 500) + `"}]}`
 
-	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/", strings.NewReader(body))
 	w := httptest.NewRecorder()
 
 	// Wrap with a tiny limit so the reader hits it mid-JSON.

--- a/internal/handler/completions_test.go
+++ b/internal/handler/completions_test.go
@@ -96,7 +96,7 @@ func TestCompletionsHandler_ProxyPath_DoesNotDuplicateV1(t *testing.T) {
 	reg.Register(op)
 
 	h := Completions(reg)
-	req := httptest.NewRequest(http.MethodPost, "/v1/completions", strings.NewReader(`{"model":"gpt-4o","prompt":"hi"}`))
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/v1/completions", strings.NewReader(`{"model":"gpt-4o","prompt":"hi"}`))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
 
@@ -117,7 +117,7 @@ func TestCompletionsHandler_ShimsStreamRequest_ReturnsExplicitError(t *testing.T
 	reg.Register(np)
 
 	h := Completions(reg)
-	req := httptest.NewRequest(http.MethodPost, "/v1/completions", strings.NewReader(`{"model":"non-proxy-model","prompt":"hi","stream":true}`))
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/v1/completions", strings.NewReader(`{"model":"non-proxy-model","prompt":"hi","stream":true}`))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
 

--- a/internal/handler/decode_test.go
+++ b/internal/handler/decode_test.go
@@ -37,7 +37,7 @@ func TestDecodeJSONBody(t *testing.T) {
 		{
 			name: "well-formed body decodes successfully",
 			buildReq: func(_ http.ResponseWriter) *http.Request {
-				return httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"model":"gpt-4o"}`))
+				return httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/", strings.NewReader(`{"model":"gpt-4o"}`))
 			},
 			wantOK:    true,
 			wantModel: "gpt-4o",
@@ -46,7 +46,7 @@ func TestDecodeJSONBody(t *testing.T) {
 			name: "malformed body returns 400",
 			buildReq: func(_ http.ResponseWriter) *http.Request {
 				// Truncated JSON: the decoder fails with a non-MaxBytes error.
-				return httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"model":`))
+				return httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/", strings.NewReader(`{"model":`))
 			},
 			wantOK:     false,
 			wantStatus: http.StatusBadRequest,
@@ -59,7 +59,7 @@ func TestDecodeJSONBody(t *testing.T) {
 				// Valid-JSON-prefixed body far larger than the tiny limit so the
 				// decoder reads partial content, then hits the MaxBytesReader cap.
 				body := `{"model":"` + strings.Repeat("x", 500) + `"}`
-				r := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+				r := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/", strings.NewReader(body))
 				r.Body = http.MaxBytesReader(w, r.Body, 5)
 				return r
 			},

--- a/internal/handler/embeddings_test.go
+++ b/internal/handler/embeddings_test.go
@@ -25,7 +25,7 @@ func TestEmbeddings_NoCapableProvider_Returns404(t *testing.T) {
 	t.Cleanup(func() { _ = gw.Close() })
 
 	body := `{"model":"no-such-embedding-model","input":"hello"}`
-	r := httptest.NewRequest(http.MethodPost, "/v1/embeddings", strings.NewReader(body))
+	r := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/v1/embeddings", strings.NewReader(body))
 	w := httptest.NewRecorder()
 
 	Embeddings(gw)(w, r)

--- a/internal/handler/images_test.go
+++ b/internal/handler/images_test.go
@@ -25,7 +25,7 @@ func TestImages_NoCapableProvider_Returns404(t *testing.T) {
 	t.Cleanup(func() { _ = gw.Close() })
 
 	body := `{"model":"no-such-image-model","prompt":"a cat"}`
-	r := httptest.NewRequest(http.MethodPost, "/v1/images/generations", strings.NewReader(body))
+	r := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/v1/images/generations", strings.NewReader(body))
 	w := httptest.NewRecorder()
 
 	Images(gw)(w, r)

--- a/internal/httpserver/realip_test.go
+++ b/internal/httpserver/realip_test.go
@@ -36,7 +36,7 @@ func applyRealIP(t *testing.T, trustedCIDRs string, req *http.Request) string {
 // is not within any trusted CIDR, X-Forwarded-For is silently discarded and
 // the raw RemoteAddr host is used as the resolved client IP.
 func TestRealIP_UntrustedPeer_IgnoresXFF(t *testing.T) {
-	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
 	req.RemoteAddr = "203.0.113.1:12345" // public IP, not in loopback CIDR
 	req.Header.Set("X-Forwarded-For", "10.0.0.1")
 
@@ -48,7 +48,7 @@ func TestRealIP_UntrustedPeer_IgnoresXFF(t *testing.T) {
 }
 
 func TestRealIP_UntrustedPeer_IgnoresXRealIP(t *testing.T) {
-	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
 	req.RemoteAddr = "198.51.100.5:9999"
 	req.Header.Set("X-Real-IP", "10.0.0.99")
 
@@ -67,7 +67,7 @@ func TestRealIP_UntrustedPeer_IgnoresXRealIP(t *testing.T) {
 // within a trusted CIDR, the leftmost X-Forwarded-For entry is used as the
 // resolved client IP.
 func TestRealIP_TrustedPeer_HonorsXFF(t *testing.T) {
-	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
 	req.RemoteAddr = "127.0.0.1:56789"                           // trusted loopback peer
 	req.Header.Set("X-Forwarded-For", "203.0.113.42, 127.0.0.1") // leftmost = real client
 
@@ -79,7 +79,7 @@ func TestRealIP_TrustedPeer_HonorsXFF(t *testing.T) {
 }
 
 func TestRealIP_TrustedPeer_HonorsXRealIP_WhenNoXFF(t *testing.T) {
-	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
 	req.RemoteAddr = "127.0.0.1:12345"
 	req.Header.Set("X-Real-IP", "198.51.100.7")
 
@@ -91,7 +91,7 @@ func TestRealIP_TrustedPeer_HonorsXRealIP_WhenNoXFF(t *testing.T) {
 }
 
 func TestRealIP_TrustedPeer_IPv6Loopback(t *testing.T) {
-	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
 	req.RemoteAddr = "[::1]:44444"
 	req.Header.Set("X-Forwarded-For", "2001:db8::1")
 
@@ -103,7 +103,7 @@ func TestRealIP_TrustedPeer_IPv6Loopback(t *testing.T) {
 }
 
 func TestRealIP_CustomTrustedCIDR_HonorsXFF(t *testing.T) {
-	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
 	req.RemoteAddr = "10.1.2.3:4567" // inside custom 10.0.0.0/8 range
 	req.Header.Set("X-Forwarded-For", "203.0.113.99")
 
@@ -115,7 +115,7 @@ func TestRealIP_CustomTrustedCIDR_HonorsXFF(t *testing.T) {
 }
 
 func TestRealIP_TrustedPeer_MalformedXFF_FallsBackToPeer(t *testing.T) {
-	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
 	req.RemoteAddr = "127.0.0.1:9999"
 	req.Header.Set("X-Forwarded-For", "not-an-ip")
 
@@ -141,7 +141,7 @@ func TestRateLimit_BucketKey_UsesHostOnly(t *testing.T) {
 	ok := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
 	handler := middleware.RateLimit(store)(ok)
 
-	r1 := httptest.NewRequest(http.MethodGet, "/", nil)
+	r1 := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
 	r1.RemoteAddr = "1.2.3.4:5678"
 	w1 := httptest.NewRecorder()
 	handler.ServeHTTP(w1, r1)
@@ -150,7 +150,7 @@ func TestRateLimit_BucketKey_UsesHostOnly(t *testing.T) {
 	}
 
 	// Different ephemeral port, same host → must hit the same bucket.
-	r2 := httptest.NewRequest(http.MethodGet, "/", nil)
+	r2 := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
 	r2.RemoteAddr = "1.2.3.4:9999"
 	w2 := httptest.NewRecorder()
 	handler.ServeHTTP(w2, r2)

--- a/internal/httpserver/router_bodylimit_test.go
+++ b/internal/httpserver/router_bodylimit_test.go
@@ -66,7 +66,7 @@ func TestBodySizeLimit_TooLarge_Returns413(t *testing.T) {
 
 	// Build a body that is definitely larger than the 64-byte limit.
 	body := `{"model":"stub-model","messages":[{"role":"user","content":"` + strings.Repeat("x", 200) + `"}]}`
-	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(body))
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/v1/chat/completions", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
 
@@ -96,7 +96,7 @@ func TestBodySizeLimit_UnderLimit_NotRejected(t *testing.T) {
 
 	// A minimal valid-looking chat body (under the 10 MiB limit).
 	body := `{"model":"stub-model","messages":[{"role":"user","content":"hi"}]}`
-	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(body))
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/v1/chat/completions", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
 

--- a/internal/logging/logger_test.go
+++ b/internal/logging/logger_test.go
@@ -82,7 +82,7 @@ func TestMiddleware_PropagatesProvidedHeader(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	}))
 
-	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
 	req.Header.Set("X-Request-ID", traceID)
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
@@ -107,7 +107,7 @@ func TestMiddleware_ReusesContextTraceID(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	}))
 
-	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
 	// Both header and context populated; context MUST win.
 	req.Header.Set("X-Request-ID", "header-only-id")
 	req = req.WithContext(WithTraceID(req.Context(), ctxTraceID))
@@ -127,7 +127,7 @@ func TestMiddleware_GeneratesHeaderWhenMissing(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	}))
 
-	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
 

--- a/internal/middleware/bodylimit_test.go
+++ b/internal/middleware/bodylimit_test.go
@@ -25,7 +25,7 @@ func TestMaxRequestBody_UnderLimit(t *testing.T) {
 	h := MaxRequestBody(limit)(inner)
 
 	body := strings.Repeat("x", 50)
-	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/", strings.NewReader(body))
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, req)
 
@@ -53,7 +53,7 @@ func TestMaxRequestBody_OverLimit(t *testing.T) {
 	h := MaxRequestBody(limit)(inner)
 
 	body := strings.Repeat("x", 100) // well over limit
-	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/", strings.NewReader(body))
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, req)
 

--- a/internal/middleware/cors_test.go
+++ b/internal/middleware/cors_test.go
@@ -16,7 +16,7 @@ func TestCORS_NoCORSHeaders_WhenNoOriginsConfigured(t *testing.T) {
 	mw := CORS()
 	handler := mw(dummyHandler)
 
-	r := httptest.NewRequest(http.MethodGet, "/v1/chat/completions", nil)
+	r := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/v1/chat/completions", nil)
 	r.Header.Set("Origin", "https://attacker.example.com")
 	w := httptest.NewRecorder()
 	handler.ServeHTTP(w, r)
@@ -30,7 +30,7 @@ func TestCORS_NoCORSHeaders_WhenOnlyEmptyStrings(t *testing.T) {
 	mw := CORS("", "  ")
 	handler := mw(dummyHandler)
 
-	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
 	r.Header.Set("Origin", "https://attacker.example.com")
 	w := httptest.NewRecorder()
 	handler.ServeHTTP(w, r)
@@ -46,7 +46,7 @@ func TestCORS_NoCORSHeaders_OnAdminPath(t *testing.T) {
 	mw := CORS()
 	handler := mw(dummyHandler)
 
-	r := httptest.NewRequest(http.MethodGet, "/admin/keys", nil)
+	r := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/admin/keys", nil)
 	r.Header.Set("Origin", "https://attacker.example.com")
 	w := httptest.NewRecorder()
 	handler.ServeHTTP(w, r)
@@ -72,7 +72,7 @@ func TestCORS_NoOriginsConfigured_OptionsPassesThrough(t *testing.T) {
 	mw := CORS()
 	handler := mw(next)
 
-	r := httptest.NewRequest(http.MethodOptions, "/v1/chat/completions", nil)
+	r := httptest.NewRequestWithContext(t.Context(), http.MethodOptions, "/v1/chat/completions", nil)
 	r.Header.Set("Origin", "https://attacker.example.com")
 	w := httptest.NewRecorder()
 	handler.ServeHTTP(w, r)
@@ -88,7 +88,7 @@ func TestCORS_AllowedOrigin_SetsHeaderAndVary(t *testing.T) {
 	mw := CORS("https://example.com", "https://other.com")
 	handler := mw(dummyHandler)
 
-	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
 	r.Header.Set("Origin", "https://example.com")
 	w := httptest.NewRecorder()
 	handler.ServeHTTP(w, r)
@@ -105,7 +105,7 @@ func TestCORS_DisallowedOrigin_NoAllowOriginHeader(t *testing.T) {
 	mw := CORS("https://example.com")
 	handler := mw(dummyHandler)
 
-	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
 	r.Header.Set("Origin", "https://evil.com")
 	w := httptest.NewRecorder()
 	handler.ServeHTTP(w, r)
@@ -119,7 +119,7 @@ func TestCORS_PreflightOptions_Returns204(t *testing.T) {
 	mw := CORS("https://example.com")
 	handler := mw(dummyHandler)
 
-	r := httptest.NewRequest(http.MethodOptions, "/", nil)
+	r := httptest.NewRequestWithContext(t.Context(), http.MethodOptions, "/", nil)
 	r.Header.Set("Origin", "https://example.com")
 	w := httptest.NewRecorder()
 	handler.ServeHTTP(w, r)
@@ -137,7 +137,7 @@ func TestCORS_PreflightOptions_DoesNotCallNext(t *testing.T) {
 	mw := CORS("https://example.com")
 	handler := mw(next)
 
-	r := httptest.NewRequest(http.MethodOptions, "/", nil)
+	r := httptest.NewRequestWithContext(t.Context(), http.MethodOptions, "/", nil)
 	r.Header.Set("Origin", "https://example.com")
 	w := httptest.NewRecorder()
 	handler.ServeHTTP(w, r)
@@ -154,7 +154,7 @@ func TestCORS_WithConfiguredOrigin_PreflightGetsAllowHeaders(t *testing.T) {
 	mw := CORS("https://dash.example.com")
 	handler := mw(dummyHandler)
 
-	r := httptest.NewRequest(http.MethodOptions, "/v1/chat/completions", nil)
+	r := httptest.NewRequestWithContext(t.Context(), http.MethodOptions, "/v1/chat/completions", nil)
 	r.Header.Set("Origin", "https://dash.example.com")
 	w := httptest.NewRecorder()
 	handler.ServeHTTP(w, r)
@@ -174,7 +174,7 @@ func TestCORS_StandardHeaders_AlwaysSet(t *testing.T) {
 	mw := CORS("https://example.com")
 	handler := mw(dummyHandler)
 
-	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
 	r.Header.Set("Origin", "https://example.com")
 	w := httptest.NewRecorder()
 	handler.ServeHTTP(w, r)
@@ -199,7 +199,7 @@ func TestCORS_NonOptions_CallsNextHandler(t *testing.T) {
 	mw := CORS()
 	handler := mw(next)
 
-	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
 	w := httptest.NewRecorder()
 	handler.ServeHTTP(w, r)
 
@@ -215,7 +215,7 @@ func TestCORS_TrimsWhitespaceFromOrigins(t *testing.T) {
 	mw := CORS("  https://example.com  ")
 	handler := mw(dummyHandler)
 
-	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
 	r.Header.Set("Origin", "https://example.com")
 	w := httptest.NewRecorder()
 	handler.ServeHTTP(w, r)

--- a/internal/middleware/proxyauth_test.go
+++ b/internal/middleware/proxyauth_test.go
@@ -18,7 +18,7 @@ func TestProxyAuthMiddleware_MasterKeyRequired(t *testing.T) {
 	}))
 
 	// No auth header → 401.
-	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/v1/chat/completions", nil)
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
 	if rr.Code != http.StatusUnauthorized {
@@ -26,7 +26,7 @@ func TestProxyAuthMiddleware_MasterKeyRequired(t *testing.T) {
 	}
 
 	// Master key → 200.
-	req = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	req = httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/v1/chat/completions", nil)
 	req.Header.Set("Authorization", "Bearer test-master-key")
 	rr = httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
@@ -45,7 +45,7 @@ func TestProxyAuthMiddleware_UnauthenticatedProxy(t *testing.T) {
 	}))
 
 	// Unauthenticated proxy explicitly enabled → pass through.
-	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/v1/chat/completions", nil)
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
 	if rr.Code != http.StatusOK {
@@ -62,7 +62,7 @@ func TestProxyAuthMiddleware_DefaultRequiresAuth(t *testing.T) {
 	}))
 
 	// No master key, no ALLOW_UNAUTHENTICATED_PROXY → 401.
-	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/v1/chat/completions", nil)
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
 	if rr.Code != http.StatusUnauthorized {

--- a/internal/middleware/ratelimit_test.go
+++ b/internal/middleware/ratelimit_test.go
@@ -19,7 +19,7 @@ func TestRateLimit_AllowsRequestUnderLimit(t *testing.T) {
 	store := ratelimit.NewStore(10, 10)
 	handler := makeRateLimitHandler(store)
 
-	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
 	r.RemoteAddr = testIP
 	w := httptest.NewRecorder()
 	handler.ServeHTTP(w, r)
@@ -36,7 +36,7 @@ func TestRateLimit_Blocks_WhenBurstExceeded(t *testing.T) {
 
 	ip := testIP
 
-	first := httptest.NewRequest(http.MethodGet, "/", nil)
+	first := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
 	first.RemoteAddr = ip
 	w1 := httptest.NewRecorder()
 	handler.ServeHTTP(w1, first)
@@ -44,7 +44,7 @@ func TestRateLimit_Blocks_WhenBurstExceeded(t *testing.T) {
 		t.Fatalf("first request: expected 200, got %d", w1.Code)
 	}
 
-	second := httptest.NewRequest(http.MethodGet, "/", nil)
+	second := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
 	second.RemoteAddr = ip
 	w2 := httptest.NewRecorder()
 	handler.ServeHTTP(w2, second)
@@ -60,12 +60,12 @@ func TestRateLimit_Returns429WithOpenAIErrorBody(t *testing.T) {
 	ip := testIP
 
 	// Exhaust the bucket.
-	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
 	r.RemoteAddr = ip
 	handler.ServeHTTP(httptest.NewRecorder(), r)
 
 	// Blocked request — check content type and body shape.
-	r2 := httptest.NewRequest(http.MethodGet, "/", nil)
+	r2 := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
 	r2.RemoteAddr = ip
 	w := httptest.NewRecorder()
 	handler.ServeHTTP(w, r2)
@@ -89,7 +89,7 @@ func TestRateLimit_UsesResolvedRemoteAddr(t *testing.T) {
 	handler := makeRateLimitHandler(store)
 
 	makeReq := func() *httptest.ResponseRecorder {
-		r := httptest.NewRequest(http.MethodGet, "/", nil)
+		r := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
 		// Simulate what RealIPMiddleware would produce: bare host, no port.
 		r.RemoteAddr = "203.0.113.5"
 		w := httptest.NewRecorder()
@@ -111,7 +111,7 @@ func TestRateLimit_DifferentIPs_IndependentBuckets(t *testing.T) {
 	handler := makeRateLimitHandler(store)
 
 	for _, ip := range []string{"1.1.1.1:1", "2.2.2.2:2"} {
-		r := httptest.NewRequest(http.MethodGet, "/", nil)
+		r := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
 		r.RemoteAddr = ip
 		w := httptest.NewRecorder()
 		handler.ServeHTTP(w, r)
@@ -131,7 +131,7 @@ func TestRateLimit_NilStore_Passthrough(t *testing.T) {
 	})
 	RateLimit(nil)(next).ServeHTTP(
 		httptest.NewRecorder(),
-		httptest.NewRequest(http.MethodGet, "/", nil),
+		httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil),
 	)
 	if !called {
 		t.Fatal("nil store: expected next handler to be called (passthrough), but it was not")
@@ -147,7 +147,7 @@ func TestRateLimit_NextHandler_NotCalledOnBlock(t *testing.T) {
 	ip := "5.5.5.5:5"
 
 	// First request passes — next is called.
-	r1 := httptest.NewRequest(http.MethodGet, "/", nil)
+	r1 := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
 	r1.RemoteAddr = ip
 	handler.ServeHTTP(httptest.NewRecorder(), r1)
 	if !called {
@@ -156,7 +156,7 @@ func TestRateLimit_NextHandler_NotCalledOnBlock(t *testing.T) {
 
 	// Second request is blocked — next must not be called again.
 	called = false
-	r2 := httptest.NewRequest(http.MethodGet, "/", nil)
+	r2 := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
 	r2.RemoteAddr = ip
 	handler.ServeHTTP(httptest.NewRecorder(), r2)
 	if called {

--- a/internal/middleware/securityheaders_test.go
+++ b/internal/middleware/securityheaders_test.go
@@ -10,7 +10,7 @@ import (
 func TestSecurityHeaders_SetsBaselineHeaders(t *testing.T) {
 	handler := SecurityHeaders(dummyHandler)
 
-	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
 	w := httptest.NewRecorder()
 	handler.ServeHTTP(w, r)
 
@@ -32,7 +32,7 @@ func TestSecurityHeaders_SetsBaselineHeaders(t *testing.T) {
 func TestSecurityHeaders_NoHSTS_WhenNotTLS(t *testing.T) {
 	handler := SecurityHeaders(dummyHandler)
 
-	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
 	// r.TLS is nil by default — plain HTTP
 	w := httptest.NewRecorder()
 	handler.ServeHTTP(w, r)
@@ -45,7 +45,7 @@ func TestSecurityHeaders_NoHSTS_WhenNotTLS(t *testing.T) {
 func TestSecurityHeaders_HSTS_WhenTLS(t *testing.T) {
 	handler := SecurityHeaders(dummyHandler)
 
-	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
 	r.TLS = &tls.ConnectionState{}
 	w := httptest.NewRecorder()
 	handler.ServeHTTP(w, r)
@@ -64,7 +64,7 @@ func TestSecurityHeaders_CallsNextHandler(t *testing.T) {
 	})
 	handler := SecurityHeaders(next)
 
-	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
 	w := httptest.NewRecorder()
 	handler.ServeHTTP(w, r)
 

--- a/internal/otel/middleware_test.go
+++ b/internal/otel/middleware_test.go
@@ -27,7 +27,7 @@ func TestMiddlewareExtractsTraceparent(t *testing.T) {
 	}))
 
 	rr := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/health", nil)
 	req.Header.Set("traceparent", traceparent)
 	h.ServeHTTP(rr, req)
 
@@ -48,7 +48,7 @@ func TestMiddlewareNoTraceparentLeavesContextEmpty(t *testing.T) {
 	}))
 
 	rr := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/health", nil)
 	h.ServeHTTP(rr, req)
 
 	if seen != "" {

--- a/internal/otel/otel_test.go
+++ b/internal/otel/otel_test.go
@@ -288,7 +288,7 @@ func TestMiddlewarePassthrough(t *testing.T) {
 	}))
 
 	rr := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/health", nil)
 	h.ServeHTTP(rr, req)
 
 	if !called {

--- a/internal/plugins/logger/logger.go
+++ b/internal/plugins/logger/logger.go
@@ -57,15 +57,17 @@ func (l *RequestLogger) Init(config map[string]any) error {
 	if persist {
 		backend, _ := config["backend"].(string)
 		dsn, _ := config["dsn"].(string)
+		// plugin.Plugin.Init has no ctx parameter (config-load time, not a
+		// request), so there is no caller context to thread through here.
 		switch strings.ToLower(strings.TrimSpace(backend)) {
 		case "sqlite", "":
-			writer, err := requestlog.NewSQLiteWriter(dsn)
+			writer, err := requestlog.NewSQLiteWriter(context.Background(), dsn)
 			if err != nil {
 				return err
 			}
 			l.writer = writer
 		case "postgres", "postgresql":
-			writer, err := requestlog.NewPostgresWriter(dsn)
+			writer, err := requestlog.NewPostgresWriter(context.Background(), dsn)
 			if err != nil {
 				return err
 			}

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -30,7 +30,7 @@ func buildTestRegistry(upstreamURL string) *providers.Registry {
 func TestResolveProvider_XProviderHeader(t *testing.T) {
 	reg := buildTestRegistry("http://localhost")
 
-	req := httptest.NewRequest(http.MethodPost, "/v1/files", nil)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/v1/files", nil)
 	req.Header.Set("X-Provider", providerOpenAI)
 
 	p, ok := ResolveProvider(req, reg)
@@ -46,7 +46,7 @@ func TestResolveProvider_ModelInBody(t *testing.T) {
 	reg := buildTestRegistry("http://localhost")
 
 	body := `{"model":"gpt-4o","messages":[]}`
-	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(body))
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/v1/chat/completions", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	req.ContentLength = int64(len(body))
 
@@ -62,7 +62,7 @@ func TestResolveProvider_ModelInBody(t *testing.T) {
 func TestResolveProvider_UnknownProvider(t *testing.T) {
 	reg := buildTestRegistry("http://localhost")
 
-	req := httptest.NewRequest(http.MethodPost, "/v1/files", nil)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/v1/files", nil)
 	req.Header.Set("X-Provider", "nonexistent")
 
 	_, ok := ResolveProvider(req, reg)
@@ -74,7 +74,7 @@ func TestResolveProvider_UnknownProvider(t *testing.T) {
 func TestResolveProvider_NoProviderInfo(t *testing.T) {
 	reg := buildTestRegistry("http://localhost")
 
-	req := httptest.NewRequest(http.MethodPost, "/v1/files", nil)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/v1/files", nil)
 
 	_, ok := ResolveProvider(req, reg)
 	if ok {
@@ -86,7 +86,7 @@ func TestResolveProvider_BodyRestoredAfterRead(t *testing.T) {
 	reg := buildTestRegistry("http://localhost")
 
 	body := `{"model":"gpt-4o"}`
-	req := httptest.NewRequest(http.MethodPost, "/v1/test", strings.NewReader(body))
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/v1/test", strings.NewReader(body))
 	req.ContentLength = int64(len(body))
 
 	ResolveProvider(req, reg) //nolint:errcheck
@@ -105,7 +105,7 @@ func TestResolveProvider_ModelAfterLargeNestedField(t *testing.T) {
 	reg := buildTestRegistry("http://localhost")
 
 	body := `{"messages":[{"role":"user","content":"hello"},{"role":"assistant","content":"world"}],"metadata":{"nested":{"a":[1,2,3],"b":{"c":"d"}}},"model":"gpt-4o","stream":true}`
-	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(body))
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/v1/chat/completions", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	req.ContentLength = int64(len(body))
 
@@ -130,7 +130,7 @@ func TestResolveProvider_IgnoresNestedModelField(t *testing.T) {
 	reg := buildTestRegistry("http://localhost")
 
 	body := `{"input":{"model":"gpt-4o"},"messages":[]}`
-	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(body))
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/v1/chat/completions", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	req.ContentLength = int64(len(body))
 
@@ -160,7 +160,7 @@ func TestProxyHandler_ForwardsRequest(t *testing.T) {
 	reg := buildTestRegistry(upstream.URL)
 	handler := Handler(reg)
 
-	req := httptest.NewRequest(http.MethodPost, "/v1/files", strings.NewReader(`{}`))
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/v1/files", strings.NewReader(`{}`))
 	req.Header.Set("X-Provider", providerOpenAI)
 	req.ContentLength = 2
 	w := httptest.NewRecorder()
@@ -185,7 +185,7 @@ func TestProxyHandler_InjectsAuthHeader(t *testing.T) {
 	reg := buildTestRegistry(upstream.URL)
 	handler := Handler(reg)
 
-	req := httptest.NewRequest(http.MethodPost, "/v1/files", nil)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/v1/files", nil)
 	req.Header.Set("X-Provider", providerOpenAI)
 	w := httptest.NewRecorder()
 
@@ -208,7 +208,7 @@ func TestProxyHandler_RemovesGatewayHeaders(t *testing.T) {
 	reg := buildTestRegistry(upstream.URL)
 	handler := Handler(reg)
 
-	req := httptest.NewRequest(http.MethodPost, "/v1/files", nil)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/v1/files", nil)
 	req.Header.Set("X-Provider", providerOpenAI)
 	w := httptest.NewRecorder()
 
@@ -229,7 +229,7 @@ func TestProxyHandler_AddsGatewayProviderHeader(t *testing.T) {
 	reg := buildTestRegistry(upstream.URL)
 	handler := Handler(reg)
 
-	req := httptest.NewRequest(http.MethodPost, "/v1/files", nil)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/v1/files", nil)
 	req.Header.Set("X-Provider", providerOpenAI)
 	w := httptest.NewRecorder()
 
@@ -252,7 +252,7 @@ func TestProxyHandler_RebuildsForwardedHeaders(t *testing.T) {
 	reg := buildTestRegistry(upstream.URL)
 	handler := Handler(reg)
 
-	req := httptest.NewRequest(http.MethodPost, "/v1/files", nil)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/v1/files", nil)
 	req.RemoteAddr = "203.0.113.10:1234"
 	req.Header.Set("X-Provider", providerOpenAI)
 	req.Header.Set("X-Forwarded-For", "1.2.3.4")
@@ -279,7 +279,7 @@ func TestProxyHandler_PassthroughNon200(t *testing.T) {
 	reg := buildTestRegistry(upstream.URL)
 	handler := Handler(reg)
 
-	req := httptest.NewRequest(http.MethodPost, "/v1/files", nil)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/v1/files", nil)
 	req.Header.Set("X-Provider", providerOpenAI)
 	w := httptest.NewRecorder()
 
@@ -294,7 +294,7 @@ func TestProxyHandler_NoProvider_Returns400(t *testing.T) {
 	reg := providers.NewRegistry() // empty registry
 	handler := Handler(reg)
 
-	req := httptest.NewRequest(http.MethodPost, "/v1/audio/transcriptions", nil)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/v1/audio/transcriptions", nil)
 	w := httptest.NewRecorder()
 
 	handler(w, req)
@@ -327,7 +327,7 @@ func TestProxyHandler_DoesNotDoubleV1Prefix(t *testing.T) {
 	reg := buildTestRegistry(upstream.URL + "/v1")
 	handler := Handler(reg)
 
-	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{}`))
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/v1/responses", strings.NewReader(`{}`))
 	req.Header.Set("X-Provider", providerOpenAI)
 	req.ContentLength = 2
 	w := httptest.NewRecorder()
@@ -354,7 +354,7 @@ func TestProxyHandler_PreservesV1PrefixForRootBase(t *testing.T) {
 	reg := buildTestRegistry(upstream.URL) // base has no /v1
 	handler := Handler(reg)
 
-	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{}`))
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/v1/responses", strings.NewReader(`{}`))
 	req.Header.Set("X-Provider", providerOpenAI)
 	req.ContentLength = 2
 	w := httptest.NewRecorder()
@@ -378,7 +378,7 @@ func TestProxyHandler_GatesNonOpenAIWireProvider(t *testing.T) {
 	reg.Register(g)
 	handler := Handler(reg)
 
-	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{}`))
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/v1/responses", strings.NewReader(`{}`))
 	req.Header.Set("X-Provider", g.Name())
 	req.ContentLength = 2
 	w := httptest.NewRecorder()
@@ -437,7 +437,7 @@ func TestProxyHandler_InvokesRequestSigner(t *testing.T) {
 	reg.Register(stubSigningProvider{baseURL: upstream.URL, signed: &signed})
 	handler := Handler(reg)
 
-	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{}`))
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/v1/responses", strings.NewReader(`{}`))
 	req.Header.Set("X-Provider", "stub-signer")
 	req.ContentLength = 2
 	w := httptest.NewRecorder()
@@ -467,7 +467,7 @@ func TestProxyHandler_RequestSignerFailure_Returns502(t *testing.T) {
 	reg.Register(stubSigningProvider{baseURL: upstream.URL, signErr: errors.New("sign failed")})
 	handler := Handler(reg)
 
-	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{}`))
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/v1/responses", strings.NewReader(`{}`))
 	req.Header.Set("X-Provider", "stub-signer")
 	req.ContentLength = 2
 	w := httptest.NewRecorder()
@@ -565,7 +565,7 @@ func TestProxyHandler_ErrorHandler_GenericJSON(t *testing.T) {
 	reg := buildTestRegistry(deadURL)
 	handler := Handler(reg)
 
-	req := httptest.NewRequest(http.MethodPost, "/v1/files", nil)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/v1/files", nil)
 	req.Header.Set("X-Provider", providerOpenAI)
 	w := httptest.NewRecorder()
 	handler(w, req)

--- a/internal/requestlog/store.go
+++ b/internal/requestlog/store.go
@@ -90,7 +90,7 @@ type SQLWriter struct {
 }
 
 // NewSQLiteWriter creates a SQLite-backed request log writer.
-func NewSQLiteWriter(dsn string) (*SQLWriter, error) {
+func NewSQLiteWriter(ctx context.Context, dsn string) (*SQLWriter, error) {
 	dsn = strings.TrimSpace(dsn)
 	if dsn == "" {
 		dsn = "ferrogw-requests.db"
@@ -101,7 +101,7 @@ func NewSQLiteWriter(dsn string) (*SQLWriter, error) {
 	}
 	tuneDBPool(db, requestLogDialectSQLite)
 	w := &SQLWriter{db: db, dialect: requestLogDialectSQLite}
-	if err := w.init(); err != nil {
+	if err := w.init(ctx); err != nil {
 		_ = db.Close()
 		return nil, err
 	}
@@ -113,7 +113,7 @@ func NewSQLiteWriter(dsn string) (*SQLWriter, error) {
 }
 
 // NewPostgresWriter creates a Postgres-backed request log writer.
-func NewPostgresWriter(dsn string) (*SQLWriter, error) {
+func NewPostgresWriter(ctx context.Context, dsn string) (*SQLWriter, error) {
 	dsn = strings.TrimSpace(dsn)
 	if dsn == "" {
 		return nil, fmt.Errorf("postgres dsn is required")
@@ -124,15 +124,15 @@ func NewPostgresWriter(dsn string) (*SQLWriter, error) {
 	}
 	tuneDBPool(db, requestLogDialectPostgres)
 	w := &SQLWriter{db: db, dialect: requestLogDialectPostgres}
-	if err := w.init(); err != nil {
+	if err := w.init(ctx); err != nil {
 		_ = db.Close()
 		return nil, err
 	}
 	return w, nil
 }
 
-func (w *SQLWriter) init() error {
-	if err := w.db.Ping(); err != nil {
+func (w *SQLWriter) init(ctx context.Context) error {
+	if err := w.db.PingContext(ctx); err != nil {
 		return fmt.Errorf("ping %s request log writer: %w", w.dialect, err)
 	}
 
@@ -166,7 +166,7 @@ CREATE TABLE IF NOT EXISTS request_logs (
 );`
 	}
 
-	if _, err := w.db.Exec(ddl); err != nil {
+	if _, err := w.db.ExecContext(ctx, ddl); err != nil {
 		return fmt.Errorf("initialize request log schema: %w", err)
 	}
 	return nil

--- a/internal/requestlog/store_test.go
+++ b/internal/requestlog/store_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestNewSQLiteWriter_FilePermissions(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "requests.db")
-	w, err := NewSQLiteWriter(path)
+	w, err := NewSQLiteWriter(t.Context(), path)
 	if err != nil {
 		t.Fatalf("new sqlite writer: %v", err)
 	}
@@ -28,7 +28,7 @@ func TestNewSQLiteWriter_FilePermissions(t *testing.T) {
 
 func TestSQLiteWriter_WriteListDelete(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "requests.db")
-	w, err := NewSQLiteWriter(path)
+	w, err := NewSQLiteWriter(t.Context(), path)
 	if err != nil {
 		t.Fatalf("new sqlite writer: %v", err)
 	}
@@ -122,16 +122,18 @@ func TestPostgresWriterContract(t *testing.T) {
 		t.Skip("set FERROGW_TEST_POSTGRES_DSN to run Postgres requestlog integration tests")
 	}
 
-	w, err := NewPostgresWriter(dsn)
+	w, err := NewPostgresWriter(t.Context(), dsn)
 	if err != nil {
 		t.Fatalf("new postgres writer: %v", err)
 	}
 	t.Cleanup(func() {
-		_, _ = w.db.Exec("DELETE FROM request_logs")
+		// t.Context() is already canceled by the time Cleanup runs; use a
+		// fresh context for this cleanup query.
+		_, _ = w.db.ExecContext(context.Background(), "DELETE FROM request_logs")
 		_ = w.Close()
 	})
 
-	_, _ = w.db.Exec("DELETE FROM request_logs")
+	_, _ = w.db.ExecContext(t.Context(), "DELETE FROM request_logs")
 
 	entry := Entry{
 		TraceID:          "pg-trace",
@@ -170,7 +172,7 @@ func TestSQLiteWriter_DefaultDSNAndZeroCreatedAt(t *testing.T) {
 		_ = os.Chdir(wd)
 	})
 
-	w, err := NewSQLiteWriter("   ")
+	w, err := NewSQLiteWriter(t.Context(), "   ")
 	if err != nil {
 		t.Fatalf("new sqlite writer with default dsn: %v", err)
 	}
@@ -203,7 +205,7 @@ func TestSQLiteWriter_DefaultDSNAndZeroCreatedAt(t *testing.T) {
 
 func TestSQLiteWriter_ListDefaultsAndSinceFilter(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "requests.db")
-	w, err := NewSQLiteWriter(path)
+	w, err := NewSQLiteWriter(t.Context(), path)
 	if err != nil {
 		t.Fatalf("new sqlite writer: %v", err)
 	}
@@ -256,7 +258,7 @@ func TestSQLiteWriter_ListDefaultsAndSinceFilter(t *testing.T) {
 
 func TestDeleteRequiresBefore(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "requests.db")
-	w, err := NewSQLiteWriter(path)
+	w, err := NewSQLiteWriter(t.Context(), path)
 	if err != nil {
 		t.Fatalf("new sqlite writer: %v", err)
 	}
@@ -271,7 +273,7 @@ func TestDeleteRequiresBefore(t *testing.T) {
 }
 
 func TestNewPostgresWriterRequiresDSN(t *testing.T) {
-	_, err := NewPostgresWriter("   ")
+	_, err := NewPostgresWriter(t.Context(), "   ")
 	if err == nil || !strings.Contains(err.Error(), "postgres dsn is required") {
 		t.Fatalf("expected postgres dsn required error, got %v", err)
 	}

--- a/internal/transport/transport_test.go
+++ b/internal/transport/transport_test.go
@@ -184,9 +184,18 @@ func BenchmarkTransportConcurrent(b *testing.B) {
 	client := m.ForProvider("bench")
 	body := `{"model":"gpt-4o","messages":[{"role":"user","content":"hello"}]}`
 
+	postJSON := func() (*http.Response, error) {
+		req, err := http.NewRequestWithContext(b.Context(), http.MethodPost, srv.URL, strings.NewReader(body))
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("Content-Type", "application/json")
+		return client.Do(req)
+	}
+
 	// Warm up connections.
 	for i := 0; i < 20; i++ {
-		resp, err := client.Post(srv.URL, "application/json", strings.NewReader(body))
+		resp, err := postJSON()
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -198,7 +207,7 @@ func BenchmarkTransportConcurrent(b *testing.B) {
 	b.ReportAllocs()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
-			resp, err := client.Post(srv.URL, "application/json", strings.NewReader(body))
+			resp, err := postJSON()
 			if err != nil {
 				b.Fatal(err)
 			}

--- a/models/catalog.go
+++ b/models/catalog.go
@@ -7,6 +7,7 @@
 package models
 
 import (
+	"context"
 	_ "embed"
 	"encoding/json"
 	"fmt"
@@ -177,20 +178,35 @@ type Lifecycle struct {
 // Load fetches the model catalog from a remote URL (1s timeout).
 // On any failure it falls back to the embedded catalog_backup.json.
 // The gateway never fails to start due to catalog unavailability.
+// Equivalent to LoadContext(context.Background()).
 func Load() (Catalog, error) {
-	result, err := LoadWithInfo()
+	return LoadContext(context.Background())
+}
+
+// LoadContext is Load with a caller-supplied context bounding the remote
+// fetch, so it can be canceled early (e.g. on gateway shutdown) instead of
+// always running to its own internal timeout.
+func LoadContext(ctx context.Context) (Catalog, error) {
+	result, err := LoadWithInfoContext(ctx)
 	return result.Catalog, err
 }
 
 // LoadWithInfo fetches the model catalog and returns metadata about whether
 // the remote source or embedded fallback was used.
+// Equivalent to LoadWithInfoContext(context.Background()).
 func LoadWithInfo() (LoadResult, error) {
+	return LoadWithInfoContext(context.Background())
+}
+
+// LoadWithInfoContext is LoadWithInfo with a caller-supplied context bounding
+// the remote fetch.
+func LoadWithInfoContext(ctx context.Context) (LoadResult, error) {
 	catalogURL := os.Getenv(CatalogURLEnv)
 	if catalogURL == "" {
 		catalogURL = defaultCatalogURL
 	}
 
-	if data, err := fetchRemote(catalogURL); err == nil {
+	if data, err := fetchRemote(ctx, catalogURL); err == nil {
 		c, parseErr := parse(data)
 		if parseErr == nil {
 			return LoadResult{Catalog: c, Source: LoadSourceRemote, URL: catalogURL}, nil
@@ -251,13 +267,17 @@ func catalogLoadErrorForLog(err error, catalogURL string) string {
 // larger than any realistic catalog file.
 const maxCatalogResponseBytes = 8 * 1024 * 1024
 
-func fetchRemote(rawURL string) ([]byte, error) {
+func fetchRemote(ctx context.Context, rawURL string) ([]byte, error) {
 	u, err := url.Parse(rawURL)
 	if err != nil || (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
 		return nil, fmt.Errorf("invalid catalog URL %q: must be http or https with a host", rawURL)
 	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil) //nolint:gosec // URL scheme and host validated above
+	if err != nil {
+		return nil, err
+	}
 	client := &http.Client{Timeout: time.Second}
-	resp, err := client.Get(rawURL) //nolint:gosec // URL scheme and host validated above
+	resp, err := client.Do(req) //nolint:gosec // URL scheme and host validated above
 	if err != nil {
 		return nil, err
 	}

--- a/models/catalog_test.go
+++ b/models/catalog_test.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"bytes"
+	"context"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -158,6 +159,36 @@ func TestLoadWithInfoUsesRemoteCatalog(t *testing.T) {
 	}
 	if model.ModelID != "remote" {
 		t.Fatalf("ModelID = %q, want remote", model.ModelID)
+	}
+}
+
+// TestLoadWithInfoContext_HonorsCanceledContext proves the ctx passed to
+// LoadWithInfoContext is actually wired into the outbound HTTP request (not
+// just accepted and ignored): with an already-canceled context, the request
+// must never reach the server at all, and the result must fall back to the
+// embedded catalog exactly like any other remote-fetch failure.
+func TestLoadWithInfoContext_HonorsCanceledContext(t *testing.T) {
+	var reached bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		reached = true
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"test/remote":{"provider":"test","model_id":"remote","mode":"chat"}}`))
+	}))
+	t.Cleanup(server.Close)
+	t.Setenv(CatalogURLEnv, server.URL)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	result, err := LoadWithInfoContext(ctx)
+	if err != nil {
+		t.Fatalf("LoadWithInfoContext returned error: %v", err)
+	}
+	if result.Source != LoadSourceFallback {
+		t.Fatalf("Source = %q, want %q (canceled context must not reach the server)", result.Source, LoadSourceFallback)
+	}
+	if reached {
+		t.Fatal("server was reached despite an already-canceled context")
 	}
 }
 

--- a/models/catalog_test.go
+++ b/models/catalog_test.go
@@ -10,6 +10,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 )
 
@@ -168,9 +169,9 @@ func TestLoadWithInfoUsesRemoteCatalog(t *testing.T) {
 // must never reach the server at all, and the result must fall back to the
 // embedded catalog exactly like any other remote-fetch failure.
 func TestLoadWithInfoContext_HonorsCanceledContext(t *testing.T) {
-	var reached bool
+	var reached atomic.Bool
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		reached = true
+		reached.Store(true)
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"test/remote":{"provider":"test","model_id":"remote","mode":"chat"}}`))
 	}))
@@ -187,7 +188,7 @@ func TestLoadWithInfoContext_HonorsCanceledContext(t *testing.T) {
 	if result.Source != LoadSourceFallback {
 		t.Fatalf("Source = %q, want %q (canceled context must not reach the server)", result.Source, LoadSourceFallback)
 	}
-	if reached {
+	if reached.Load() {
 		t.Fatal("server was reached despite an already-canceled context")
 	}
 }

--- a/providers/ai21/ai21.go
+++ b/providers/ai21/ai21.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"strings"
 
@@ -182,7 +181,7 @@ func (p *Provider) completeJurassic(ctx context.Context, req core.Request) (*cor
 	}
 	defer func() { _ = httpResp.Body.Close() }()
 
-	respBody, err := io.ReadAll(httpResp.Body)
+	respBody, err := core.ReadResponseBody(httpResp.Body, core.MaxProviderResponseBytes)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response: %w", err)
 	}

--- a/providers/anthropic/anthropic.go
+++ b/providers/anthropic/anthropic.go
@@ -296,8 +296,9 @@ func (p *Provider) Complete(ctx context.Context, req core.Request) (*core.Respon
 	defer func() { _ = httpResp.Body.Close() }()
 
 	if httpResp.StatusCode != http.StatusOK {
-		// Error branch keeps ReadAll: the raw body is needed verbatim for the
-		// fallback error message when it is not valid Anthropic error JSON.
+		// Error branch reads the full (capped) body via core.ReadResponseBody:
+		// the raw body is needed verbatim for the fallback error message when
+		// it is not valid Anthropic error JSON.
 		respBody, err := core.ReadResponseBody(httpResp.Body, core.MaxProviderResponseBytes)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read response: %w", err)

--- a/providers/anthropic/anthropic.go
+++ b/providers/anthropic/anthropic.go
@@ -298,7 +298,7 @@ func (p *Provider) Complete(ctx context.Context, req core.Request) (*core.Respon
 	if httpResp.StatusCode != http.StatusOK {
 		// Error branch keeps ReadAll: the raw body is needed verbatim for the
 		// fallback error message when it is not valid Anthropic error JSON.
-		respBody, err := io.ReadAll(httpResp.Body)
+		respBody, err := core.ReadResponseBody(httpResp.Body, core.MaxProviderResponseBytes)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read response: %w", err)
 		}
@@ -307,8 +307,10 @@ func (p *Provider) Complete(ctx context.Context, req core.Request) (*core.Respon
 
 	// Success path streams the decode straight off the response body, avoiding
 	// the extra full-body copy that io.ReadAll + Unmarshal incurs per request.
+	// The body is still capped so an oversized upstream response can't exhaust
+	// memory via the decoder's internal buffering.
 	var aResp anthropicwire.Response
-	if err := json.NewDecoder(httpResp.Body).Decode(&aResp); err != nil {
+	if err := json.NewDecoder(io.LimitReader(httpResp.Body, core.MaxProviderResponseBytes)).Decode(&aResp); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
 	}
 

--- a/providers/anthropic/anthropic_stream.go
+++ b/providers/anthropic/anthropic_stream.go
@@ -2,7 +2,6 @@ package anthropic
 
 import (
 	"context"
-	"io"
 	"net/http"
 
 	"github.com/ferro-labs/ai-gateway/providers/core"
@@ -30,7 +29,7 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 
 	if httpResp.StatusCode != http.StatusOK {
 		defer func() { _ = httpResp.Body.Close() }()
-		respBody, _ := io.ReadAll(httpResp.Body)
+		respBody, _ := core.ReadResponseBody(httpResp.Body, core.MaxProviderResponseBytes)
 		return nil, core.APIError("anthropic", httpResp.StatusCode, respBody)
 	}
 

--- a/providers/anthropic/anthropic_stream.go
+++ b/providers/anthropic/anthropic_stream.go
@@ -2,6 +2,7 @@ package anthropic
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 
 	"github.com/ferro-labs/ai-gateway/providers/core"
@@ -29,7 +30,10 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 
 	if httpResp.StatusCode != http.StatusOK {
 		defer func() { _ = httpResp.Body.Close() }()
-		respBody, _ := core.ReadResponseBody(httpResp.Body, core.MaxProviderResponseBytes)
+		respBody, err := core.ReadResponseBody(httpResp.Body, core.MaxProviderResponseBytes)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read response: %w", err)
+		}
 		return nil, core.APIError("anthropic", httpResp.StatusCode, respBody)
 	}
 

--- a/providers/anthropic/anthropic_test.go
+++ b/providers/anthropic/anthropic_test.go
@@ -3,6 +3,7 @@ package anthropic
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -525,5 +526,35 @@ func TestComplete_ErrorPathReturnsAPIError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "overloaded") || !strings.Contains(err.Error(), "429") {
 		t.Fatalf("error = %v, want status + upstream message", err)
+	}
+}
+
+// TestComplete_OversizedResponseTruncatedNotBuffered verifies the native
+// (non-openaicompat) chat path's streaming decode is capped via
+// io.LimitReader: a well-formed JSON body whose content exceeds the cap gets
+// truncated mid-value rather than fully buffered and decoded, proving the
+// decoder never reads past core.MaxProviderResponseBytes. Unlike the
+// openaicompat path (which reads the full body up front via
+// core.ReadResponseBody and can report an explicit "byte limit" error), this
+// path fails with a JSON truncation error — the important property is that it
+// fails fast instead of buffering an unbounded body.
+func TestComplete_OversizedResponseTruncatedNotBuffered(t *testing.T) {
+	padding := strings.Repeat("a", core.MaxProviderResponseBytes)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"id":"x","model":"m","content":[{"type":"text","text":"`+padding+`"}]}`)
+	}))
+	defer srv.Close()
+
+	p, err := New("sk-test-key", srv.URL)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	_, err = p.Complete(context.Background(), core.Request{
+		Model:    "claude-sonnet-5",
+		Messages: []core.Message{{Role: core.RoleUser, Content: "hi"}},
+	})
+	if err == nil {
+		t.Fatal("expected a decode error: the well-formed body exceeds the cap and must be truncated, not fully buffered")
 	}
 }

--- a/providers/anthropic/anthropic_test.go
+++ b/providers/anthropic/anthropic_test.go
@@ -3,6 +3,7 @@ package anthropic
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -556,5 +557,42 @@ func TestComplete_OversizedResponseTruncatedNotBuffered(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("expected a decode error: the well-formed body exceeds the cap and must be truncated, not fully buffered")
+	}
+	if !strings.Contains(err.Error(), "failed to unmarshal response") {
+		t.Errorf("error = %q, want the JSON-decode failure wrapper, proving this failed at Decode() and not somewhere earlier", err.Error())
+	}
+	var statusErr *core.HTTPStatusError
+	if errors.As(err, &statusErr) {
+		t.Errorf("error unexpectedly carries a typed HTTPStatusError (%+v); this is a 200 response truncated mid-decode, not an upstream error status", statusErr)
+	}
+}
+
+// TestCompleteStream_UpstreamErrorBodyExceedsCap verifies that when a non-200
+// stream response body itself exceeds the read cap, the resulting read error
+// is surfaced to the caller instead of being silently discarded (which would
+// otherwise produce a misleading empty-message error).
+func TestCompleteStream_UpstreamErrorBodyExceedsCap(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write(make([]byte, core.MaxProviderResponseBytes+1))
+	}))
+	defer srv.Close()
+
+	p, err := New("sk-test-key", srv.URL)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	ch, err := p.CompleteStream(context.Background(), core.Request{
+		Model:    "claude-sonnet-5",
+		Messages: []core.Message{{Role: core.RoleUser, Content: "hi"}},
+	})
+	if err == nil {
+		t.Fatal("expected an error for an oversized non-200 stream response body")
+	}
+	if ch != nil {
+		t.Errorf("expected nil channel on error, got %#v", ch)
+	}
+	if !strings.Contains(err.Error(), "byte limit") {
+		t.Errorf("error = %q, want it to mention the byte limit (read error must not be discarded)", err.Error())
 	}
 }

--- a/providers/azure_openai/embedding.go
+++ b/providers/azure_openai/embedding.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 
 	"github.com/ferro-labs/ai-gateway/providers/core"
@@ -70,7 +69,7 @@ func (p *Provider) Embed(ctx context.Context, req core.EmbeddingRequest) (*core.
 	}
 	defer func() { _ = httpResp.Body.Close() }()
 
-	respBody, err := io.ReadAll(httpResp.Body)
+	respBody, err := core.ReadResponseBody(httpResp.Body, core.MaxProviderResponseBytes)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response: %w", err)
 	}

--- a/providers/azure_openai/image.go
+++ b/providers/azure_openai/image.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 
 	"github.com/ferro-labs/ai-gateway/providers/core"
@@ -62,7 +61,7 @@ func (p *Provider) GenerateImage(ctx context.Context, req core.ImageRequest) (*c
 	}
 	defer func() { _ = httpResp.Body.Close() }()
 
-	respBody, err := io.ReadAll(httpResp.Body)
+	respBody, err := core.ReadResponseBody(httpResp.Body, core.MaxProviderResponseBytes)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response: %w", err)
 	}

--- a/providers/cohere/cohere.go
+++ b/providers/cohere/cohere.go
@@ -251,13 +251,19 @@ func cohereContentParts(parts []core.ContentPart) []any {
 // cohereAPIError builds a provider error from a non-2xx Cohere response, whose
 // error envelope is a flat {"message":…} (not the OpenAI {"error":{…}} shape),
 // so core.APIError cannot decode it. prefix is the full message prefix (e.g.
-// "cohere API error"), unlike core.APIError's bare provider-name label.
+// "cohere API error"), unlike core.APIError's bare provider-name label. The
+// returned *core.HTTPStatusError lets core.ParseStatusCode recover the status
+// via errors.As, same as core.APIError.
 func cohereAPIError(prefix string, status int, body []byte) error {
+	msg := string(body)
 	var errResp cohereErrorResponse
 	if json.Unmarshal(body, &errResp) == nil && errResp.Message != "" {
-		return fmt.Errorf("%s (%d): %s", prefix, status, errResp.Message)
+		msg = errResp.Message
 	}
-	return fmt.Errorf("%s (%d): %s", prefix, status, string(body))
+	return &core.HTTPStatusError{
+		StatusCode: status,
+		Message:    fmt.Sprintf("%s (%d): %s", prefix, status, msg),
+	}
 }
 
 // Complete sends a chat completion request to Cohere.

--- a/providers/cohere/cohere.go
+++ b/providers/cohere/cohere.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"strings"
 
@@ -298,7 +297,7 @@ func (p *Provider) Complete(ctx context.Context, req core.Request) (*core.Respon
 	}
 	defer func() { _ = httpResp.Body.Close() }()
 
-	respBody, err := io.ReadAll(httpResp.Body)
+	respBody, err := core.ReadResponseBody(httpResp.Body, core.MaxProviderResponseBytes)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response: %w", err)
 	}
@@ -453,7 +452,7 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 
 	if httpResp.StatusCode != http.StatusOK {
 		defer func() { _ = httpResp.Body.Close() }()
-		respBody, _ := io.ReadAll(httpResp.Body)
+		respBody, _ := core.ReadResponseBody(httpResp.Body, core.MaxProviderResponseBytes)
 		return nil, cohereAPIError("cohere API error", httpResp.StatusCode, respBody)
 	}
 
@@ -665,7 +664,7 @@ func (p *Provider) Embed(ctx context.Context, req core.EmbeddingRequest) (*core.
 	}
 	defer func() { _ = httpResp.Body.Close() }()
 
-	respBody, err := io.ReadAll(httpResp.Body)
+	respBody, err := core.ReadResponseBody(httpResp.Body, core.MaxProviderResponseBytes)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read embed response: %w", err)
 	}

--- a/providers/cohere/cohere.go
+++ b/providers/cohere/cohere.go
@@ -458,7 +458,10 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 
 	if httpResp.StatusCode != http.StatusOK {
 		defer func() { _ = httpResp.Body.Close() }()
-		respBody, _ := core.ReadResponseBody(httpResp.Body, core.MaxProviderResponseBytes)
+		respBody, err := core.ReadResponseBody(httpResp.Body, core.MaxProviderResponseBytes)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read response: %w", err)
+		}
 		return nil, cohereAPIError("cohere API error", httpResp.StatusCode, respBody)
 	}
 

--- a/providers/cohere/cohere_test.go
+++ b/providers/cohere/cohere_test.go
@@ -667,6 +667,34 @@ func TestCohereProvider_CompleteStream_UpstreamNon2xxError(t *testing.T) {
 	}
 }
 
+// TestCohereProvider_CompleteStream_UpstreamErrorBodyExceedsCap verifies that
+// when a non-200 stream response body itself exceeds the read cap, the
+// resulting read error is surfaced to the caller instead of being silently
+// discarded (which would otherwise produce a misleading empty-message error).
+func TestCohereProvider_CompleteStream_UpstreamErrorBodyExceedsCap(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write(make([]byte, core.MaxProviderResponseBytes+1))
+	}))
+	defer srv.Close()
+
+	p, _ := New("test-key", srv.URL)
+	ch, err := p.CompleteStream(context.Background(), core.Request{
+		Model:    "command-r-plus",
+		Messages: []core.Message{{Role: core.RoleUser, Content: "Hi"}},
+	})
+	if err == nil {
+		t.Fatal("expected an error for an oversized non-200 stream response body")
+	}
+	if ch != nil {
+		t.Errorf("expected nil channel on pre-goroutine error, got %#v", ch)
+	}
+	if !strings.Contains(err.Error(), "byte limit") {
+		t.Errorf("error = %q, want it to mention the byte limit (read error must not be discarded)", err.Error())
+	}
+}
+
 // TestCohereProvider_CompleteStream_TruncatedStream verifies that a stream cut
 // short mid-body (declared Content-Length longer than the bytes written) surfaces
 // the scanner read error as a StreamChunk.Error, exercising the mid-stream

--- a/providers/core/api_error.go
+++ b/providers/core/api_error.go
@@ -15,20 +15,34 @@ type apiErrorEnvelope struct {
 	Detail string `json:"detail"`
 }
 
+// HTTPStatusError is a provider error carrying the upstream HTTP status code
+// as a typed field, so callers can classify errors via errors.As instead of
+// parsing the code back out of the formatted message.
+type HTTPStatusError struct {
+	StatusCode int
+	Message    string // fully formatted message, e.g. "groq API error (429): rate limited"
+}
+
+func (e *HTTPStatusError) Error() string { return e.Message }
+
 // APIError builds a provider error from a non-success HTTP response body. It
 // extracts the message from the OpenAI {"error":{"message":…}} envelope, then the
 // {"detail":"…"} envelope, and otherwise falls back to the raw body. label is the
-// human-facing provider name (e.g. "groq"); status is embedded in parentheses so
-// ParseStatusCode can recover it.
+// human-facing provider name (e.g. "groq"). The returned error is a
+// *HTTPStatusError: status is both embedded in the message in parentheses (for
+// display/logging) and available as a typed field via errors.As.
 func APIError(label string, status int, body []byte) error {
+	msg := string(body)
 	var e apiErrorEnvelope
 	if json.Unmarshal(body, &e) == nil {
 		if e.Error.Message != "" {
-			return fmt.Errorf("%s API error (%d): %s", label, status, e.Error.Message)
-		}
-		if e.Detail != "" {
-			return fmt.Errorf("%s API error (%d): %s", label, status, e.Detail)
+			msg = e.Error.Message
+		} else if e.Detail != "" {
+			msg = e.Detail
 		}
 	}
-	return fmt.Errorf("%s API error (%d): %s", label, status, string(body))
+	return &HTTPStatusError{
+		StatusCode: status,
+		Message:    fmt.Sprintf("%s API error (%d): %s", label, status, msg),
+	}
 }

--- a/providers/core/api_error_test.go
+++ b/providers/core/api_error_test.go
@@ -1,6 +1,8 @@
 package core
 
 import (
+	"errors"
+	"fmt"
 	"strings"
 	"testing"
 )
@@ -31,5 +33,39 @@ func TestAPIError_Envelopes(t *testing.T) {
 				t.Errorf("error = %q, want it to embed the status", err.Error())
 			}
 		})
+	}
+}
+
+// TestAPIError_TypedStatusRecoverable verifies APIError returns an error that
+// errors.As can recover a typed *HTTPStatusError from, so callers no longer
+// need to regex-parse the status out of the formatted message.
+func TestAPIError_TypedStatusRecoverable(t *testing.T) {
+	err := APIError("groq", 429, []byte(`{"error":{"message":"rate limited"}}`))
+
+	var statusErr *HTTPStatusError
+	if !errors.As(err, &statusErr) {
+		t.Fatalf("errors.As failed to recover *HTTPStatusError from %v", err)
+	}
+	if statusErr.StatusCode != 429 {
+		t.Errorf("StatusCode = %d, want 429", statusErr.StatusCode)
+	}
+	if statusErr.Error() != err.Error() {
+		t.Errorf("HTTPStatusError.Error() = %q, want it to match the top-level error message %q", statusErr.Error(), err.Error())
+	}
+}
+
+// TestAPIError_TypedStatusSurvivesWrapping verifies errors.As still recovers
+// the typed status after the error is wrapped with %w, matching how
+// internal/strategies/fallback.go wraps provider errors with retry-attempt
+// context.
+func TestAPIError_TypedStatusSurvivesWrapping(t *testing.T) {
+	err := fmt.Errorf("provider groq attempt 1: %w", APIError("groq", 503, []byte("down")))
+
+	var statusErr *HTTPStatusError
+	if !errors.As(err, &statusErr) {
+		t.Fatalf("errors.As failed to recover *HTTPStatusError from wrapped error %v", err)
+	}
+	if statusErr.StatusCode != 503 {
+		t.Errorf("StatusCode = %d, want 503", statusErr.StatusCode)
 	}
 }

--- a/providers/core/chat.go
+++ b/providers/core/chat.go
@@ -299,10 +299,11 @@ type Usage struct {
 }
 
 // UnmarshalJSON decodes the OpenAI usage object, folding the nested
-// prompt_tokens_details.cached_tokens and completion_tokens_details.reasoning_tokens
-// into the flat CacheReadTokens/ReasoningTokens fields so providers that report
-// usage in the nested form (OpenRouter, xAI, …) surface it consistently. A
-// nonzero flat field takes precedence over the nested value.
+// prompt_tokens_details.cached_tokens and completion_tokens_details.reasoning_tokens,
+// and DeepSeek's flat prompt_cache_hit_tokens, into the flat
+// CacheReadTokens/ReasoningTokens fields so providers that report usage in
+// these alternate forms (OpenRouter, xAI, DeepSeek's streaming path, …)
+// surface it consistently. A nonzero flat field takes precedence.
 func (u *Usage) UnmarshalJSON(data []byte) error {
 	type usageAlias Usage // avoid recursing into this method
 	var raw struct {
@@ -313,6 +314,7 @@ func (u *Usage) UnmarshalJSON(data []byte) error {
 		CompletionTokensDetails *struct {
 			ReasoningTokens int `json:"reasoning_tokens"`
 		} `json:"completion_tokens_details"`
+		PromptCacheHitTokens int `json:"prompt_cache_hit_tokens"`
 	}
 	if err := json.Unmarshal(data, &raw); err != nil {
 		return err
@@ -320,6 +322,9 @@ func (u *Usage) UnmarshalJSON(data []byte) error {
 	*u = Usage(raw.usageAlias)
 	if u.CacheReadTokens == 0 && raw.PromptTokensDetails != nil {
 		u.CacheReadTokens = raw.PromptTokensDetails.CachedTokens
+	}
+	if u.CacheReadTokens == 0 && raw.PromptCacheHitTokens != 0 {
+		u.CacheReadTokens = raw.PromptCacheHitTokens
 	}
 	if u.ReasoningTokens == 0 && raw.CompletionTokensDetails != nil {
 		u.ReasoningTokens = raw.CompletionTokensDetails.ReasoningTokens

--- a/providers/core/errors.go
+++ b/providers/core/errors.go
@@ -16,13 +16,19 @@ var ErrNoCapableProvider = errors.New("no capable provider for model")
 // provider error messages (e.g. "provider API error (429): ...").
 var statusCodePattern = regexp.MustCompile(`\((\d{3})\)`)
 
-// ParseStatusCode extracts the HTTP status code embedded in a provider error
-// message. Returns 0 if no 3-digit parenthesised code can be found.
-// All built-in providers embed a 3-digit HTTP status code in parentheses inside
-// their error messages (e.g. "... API error (NNN): message").
+// ParseStatusCode recovers the HTTP status code from a provider error. It
+// first tries errors.As for a typed *HTTPStatusError (as returned by
+// APIError), unwrapping through any %w wrapping; if the error was never
+// constructed via APIError, it falls back to regexing a 3-digit parenthesised
+// code out of the message (e.g. "... API error (NNN): message"). Returns 0 if
+// neither recovers a code.
 func ParseStatusCode(err error) int {
 	if err == nil {
 		return 0
+	}
+	var statusErr *HTTPStatusError
+	if errors.As(err, &statusErr) {
+		return statusErr.StatusCode
 	}
 	m := statusCodePattern.FindStringSubmatch(err.Error())
 	if len(m) < 2 {

--- a/providers/core/errors_test.go
+++ b/providers/core/errors_test.go
@@ -1,0 +1,39 @@
+package core
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestParseStatusCode_TypedError(t *testing.T) {
+	err := &HTTPStatusError{StatusCode: 429, Message: "no parenthesised code here"}
+	if got := ParseStatusCode(err); got != 429 {
+		t.Errorf("ParseStatusCode = %d, want 429 (from typed error, not regex)", got)
+	}
+}
+
+func TestParseStatusCode_TypedErrorWrapped(t *testing.T) {
+	err := fmt.Errorf("provider x attempt 1: %w", &HTTPStatusError{StatusCode: 500, Message: "boom"})
+	if got := ParseStatusCode(err); got != 500 {
+		t.Errorf("ParseStatusCode = %d, want 500 (recovered through %%w wrapping)", got)
+	}
+}
+
+func TestParseStatusCode_RegexFallback(t *testing.T) {
+	err := fmt.Errorf("legacy provider error (418): teapot")
+	if got := ParseStatusCode(err); got != 418 {
+		t.Errorf("ParseStatusCode = %d, want 418 (regex fallback for non-typed errors)", got)
+	}
+}
+
+func TestParseStatusCode_NoCode(t *testing.T) {
+	if got := ParseStatusCode(fmt.Errorf("no code here")); got != 0 {
+		t.Errorf("ParseStatusCode = %d, want 0", got)
+	}
+}
+
+func TestParseStatusCode_Nil(t *testing.T) {
+	if got := ParseStatusCode(nil); got != 0 {
+		t.Errorf("ParseStatusCode = %d, want 0", got)
+	}
+}

--- a/providers/core/response_body.go
+++ b/providers/core/response_body.go
@@ -7,12 +7,23 @@ import (
 
 // MaxProviderResponseBytes bounds how much of an upstream provider HTTP
 // response body is read into memory, so a single oversized response cannot
-// exhaust gateway memory.
+// exhaust gateway memory. Applies uniformly to chat, embedding, and image
+// responses; a legitimate response larger than this (e.g. a very large
+// batch-embedding call) is rejected rather than allowed through uncapped.
 const MaxProviderResponseBytes = 50 << 20 // 50 MiB
 
-// ReadResponseBody reads up to maxBytes from r and returns an error if the
-// body exceeds that limit, rather than silently truncating it. It reads one
-// byte past maxBytes to detect the overflow.
+// ReadResponseBody reads up to maxBytes from r and returns an explicit
+// "exceeds N byte limit" error if the body exceeds that limit, rather than
+// silently truncating it. It reads one byte past maxBytes to detect the
+// overflow.
+//
+// A few providers (anthropic, openai) instead wrap httpResp.Body directly in
+// io.LimitReader(body, MaxProviderResponseBytes) around a streaming
+// json.Decoder, to avoid this function's extra full-body copy. That path
+// still bounds memory the same way, but an oversized body there surfaces as
+// a generic JSON truncation/decode error rather than this function's
+// explicit byte-limit message — expect a less clear error on those two
+// success paths specifically.
 func ReadResponseBody(r io.Reader, maxBytes int64) ([]byte, error) {
 	body, err := io.ReadAll(io.LimitReader(r, maxBytes+1))
 	if err != nil {

--- a/providers/core/response_body.go
+++ b/providers/core/response_body.go
@@ -16,14 +16,6 @@ const MaxProviderResponseBytes = 50 << 20 // 50 MiB
 // "exceeds N byte limit" error if the body exceeds that limit, rather than
 // silently truncating it. It reads one byte past maxBytes to detect the
 // overflow.
-//
-// A few providers (anthropic, openai) instead wrap httpResp.Body directly in
-// io.LimitReader(body, MaxProviderResponseBytes) around a streaming
-// json.Decoder, to avoid this function's extra full-body copy. That path
-// still bounds memory the same way, but an oversized body there surfaces as
-// a generic JSON truncation/decode error rather than this function's
-// explicit byte-limit message — expect a less clear error on those two
-// success paths specifically.
 func ReadResponseBody(r io.Reader, maxBytes int64) ([]byte, error) {
 	body, err := io.ReadAll(io.LimitReader(r, maxBytes+1))
 	if err != nil {

--- a/providers/core/response_body.go
+++ b/providers/core/response_body.go
@@ -1,0 +1,25 @@
+package core
+
+import (
+	"fmt"
+	"io"
+)
+
+// MaxProviderResponseBytes bounds how much of an upstream provider HTTP
+// response body is read into memory, so a single oversized response cannot
+// exhaust gateway memory.
+const MaxProviderResponseBytes = 50 << 20 // 50 MiB
+
+// ReadResponseBody reads up to maxBytes from r and returns an error if the
+// body exceeds that limit, rather than silently truncating it. It reads one
+// byte past maxBytes to detect the overflow.
+func ReadResponseBody(r io.Reader, maxBytes int64) ([]byte, error) {
+	body, err := io.ReadAll(io.LimitReader(r, maxBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(body)) > maxBytes {
+		return nil, fmt.Errorf("response body exceeds %d byte limit", maxBytes)
+	}
+	return body, nil
+}

--- a/providers/core/response_body_test.go
+++ b/providers/core/response_body_test.go
@@ -1,0 +1,47 @@
+package core
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestReadResponseBody_UnderCap(t *testing.T) {
+	body, err := ReadResponseBody(bytes.NewReader([]byte("hello")), 10)
+	if err != nil {
+		t.Fatalf("ReadResponseBody: %v", err)
+	}
+	if string(body) != "hello" {
+		t.Errorf("body = %q, want %q", body, "hello")
+	}
+}
+
+func TestReadResponseBody_ExactlyAtCap(t *testing.T) {
+	body, err := ReadResponseBody(bytes.NewReader([]byte("hello")), 5)
+	if err != nil {
+		t.Fatalf("ReadResponseBody: %v", err)
+	}
+	if string(body) != "hello" {
+		t.Errorf("body = %q, want %q", body, "hello")
+	}
+}
+
+func TestReadResponseBody_OverCap(t *testing.T) {
+	_, err := ReadResponseBody(bytes.NewReader([]byte("hello world")), 5)
+	if err == nil {
+		t.Fatal("expected error for a body exceeding the cap")
+	}
+	if !strings.Contains(err.Error(), "5 byte limit") {
+		t.Errorf("error = %q, want it to mention the byte limit", err.Error())
+	}
+}
+
+func TestReadResponseBody_Empty(t *testing.T) {
+	body, err := ReadResponseBody(bytes.NewReader(nil), 10)
+	if err != nil {
+		t.Fatalf("ReadResponseBody: %v", err)
+	}
+	if len(body) != 0 {
+		t.Errorf("body = %q, want empty", body)
+	}
+}

--- a/providers/core/usage_test.go
+++ b/providers/core/usage_test.go
@@ -34,3 +34,32 @@ func TestUsage_FlatFieldTakesPrecedence(t *testing.T) {
 		t.Errorf("CacheReadTokens = %d, want 9 (flat precedence)", u.CacheReadTokens)
 	}
 }
+
+// TestUsage_UnmarshalDeepSeekPromptCacheHitTokens verifies DeepSeek's flat
+// (non-nested) prompt_cache_hit_tokens field folds into CacheReadTokens, same
+// as OpenAI's nested prompt_tokens_details.cached_tokens. This is what makes
+// DeepSeek's streaming path (which decodes usage straight into core.Usage via
+// this method) surface cache-hit tokens; the non-streaming path already
+// captures it through DeepSeek's own hand-rolled usage struct.
+func TestUsage_UnmarshalDeepSeekPromptCacheHitTokens(t *testing.T) {
+	var u Usage
+	if err := json.Unmarshal([]byte(`{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15,"prompt_cache_hit_tokens":6,"prompt_cache_miss_tokens":4}`), &u); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if u.CacheReadTokens != 6 {
+		t.Errorf("CacheReadTokens = %d, want 6 (from prompt_cache_hit_tokens)", u.CacheReadTokens)
+	}
+}
+
+// TestUsage_FlatCacheReadTokensBeatsPromptCacheHitTokens verifies the
+// existing flat field still wins over DeepSeek's field, same precedence rule
+// as the nested OpenAI detail.
+func TestUsage_FlatCacheReadTokensBeatsPromptCacheHitTokens(t *testing.T) {
+	var u Usage
+	if err := json.Unmarshal([]byte(`{"cache_read_tokens":9,"prompt_cache_hit_tokens":6}`), &u); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if u.CacheReadTokens != 9 {
+		t.Errorf("CacheReadTokens = %d, want 9 (flat precedence)", u.CacheReadTokens)
+	}
+}

--- a/providers/deepseek/deepseek.go
+++ b/providers/deepseek/deepseek.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"strings"
 
@@ -151,7 +150,7 @@ func (p *Provider) Complete(ctx context.Context, req core.Request) (*core.Respon
 	}
 	defer func() { _ = httpResp.Body.Close() }()
 
-	respBody, err := io.ReadAll(httpResp.Body)
+	respBody, err := core.ReadResponseBody(httpResp.Body, core.MaxProviderResponseBytes)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response: %w", err)
 	}

--- a/providers/deepseek/deepseek_test.go
+++ b/providers/deepseek/deepseek_test.go
@@ -122,6 +122,46 @@ func TestDeepSeekProvider_CompleteStream_MockSSE(t *testing.T) {
 	}
 }
 
+// TestDeepSeekProvider_CompleteStream_SurfacesCacheReadTokens verifies the
+// streaming path (which decodes straight into core.StreamChunk via the shared
+// openaicompat decoder, unlike Complete's hand-rolled usage struct) still
+// surfaces DeepSeek's flat prompt_cache_hit_tokens as CacheReadTokens on the
+// terminal usage chunk.
+func TestDeepSeekProvider_CompleteStream_SurfacesCacheReadTokens(t *testing.T) {
+	sseData := "data: {\"id\":\"chatcmpl-1\",\"model\":\"deepseek-chat\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"Hi\"},\"finish_reason\":\"stop\"}]}\n\n" +
+		"data: {\"id\":\"chatcmpl-1\",\"model\":\"deepseek-chat\",\"choices\":[],\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":2,\"total_tokens\":12,\"prompt_cache_hit_tokens\":6,\"prompt_cache_miss_tokens\":4}}\n\n" +
+		"data: [DONE]\n\n"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(sseData))
+	}))
+	defer srv.Close()
+
+	p, _ := New("test-key", srv.URL)
+	ch, err := p.CompleteStream(context.Background(), core.Request{
+		Model:    "deepseek-chat",
+		Messages: []core.Message{{Role: "user", Content: "Hi"}},
+	})
+	if err != nil {
+		t.Fatalf("CompleteStream() error: %v", err)
+	}
+
+	var usageChunk *core.StreamChunk
+	for c := range ch {
+		if c.Usage != nil {
+			usageChunk = &c
+		}
+	}
+	if usageChunk == nil {
+		t.Fatal("expected a chunk carrying usage")
+	}
+	if usageChunk.Usage.CacheReadTokens != 6 {
+		t.Errorf("CacheReadTokens = %d, want 6 (from prompt_cache_hit_tokens)", usageChunk.Usage.CacheReadTokens)
+	}
+}
+
 func TestDeepSeekProvider_Complete_Integration(t *testing.T) {
 	apiKey := os.Getenv("DEEPSEEK_API_KEY")
 	if apiKey == "" {

--- a/providers/gemini/embed.go
+++ b/providers/gemini/embed.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -72,7 +71,7 @@ func (p *Provider) Embed(ctx context.Context, req core.EmbeddingRequest) (*core.
 	defer release()
 	defer func() { _ = httpResp.Body.Close() }()
 
-	respBody, err := io.ReadAll(httpResp.Body)
+	respBody, err := core.ReadResponseBody(httpResp.Body, core.MaxProviderResponseBytes)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read embed response: %w", err)
 	}

--- a/providers/gemini/gemini.go
+++ b/providers/gemini/gemini.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"slices"
@@ -598,7 +597,7 @@ func (p *Provider) Complete(ctx context.Context, req core.Request) (*core.Respon
 	defer release()
 	defer func() { _ = httpResp.Body.Close() }()
 
-	respBody, err := io.ReadAll(httpResp.Body)
+	respBody, err := core.ReadResponseBody(httpResp.Body, core.MaxProviderResponseBytes)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response: %w", err)
 	}
@@ -660,7 +659,7 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 
 	if httpResp.StatusCode != http.StatusOK {
 		defer func() { _ = httpResp.Body.Close() }()
-		respBody, _ := io.ReadAll(httpResp.Body)
+		respBody, _ := core.ReadResponseBody(httpResp.Body, core.MaxProviderResponseBytes)
 		return nil, core.APIError("gemini", httpResp.StatusCode, respBody)
 	}
 

--- a/providers/gemini/gemini.go
+++ b/providers/gemini/gemini.go
@@ -659,7 +659,10 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 
 	if httpResp.StatusCode != http.StatusOK {
 		defer func() { _ = httpResp.Body.Close() }()
-		respBody, _ := core.ReadResponseBody(httpResp.Body, core.MaxProviderResponseBytes)
+		respBody, err := core.ReadResponseBody(httpResp.Body, core.MaxProviderResponseBytes)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read response: %w", err)
+		}
 		return nil, core.APIError("gemini", httpResp.StatusCode, respBody)
 	}
 

--- a/providers/gemini/gemini_test.go
+++ b/providers/gemini/gemini_test.go
@@ -272,6 +272,33 @@ func TestGeminiProvider_CompleteStream_MockSSE(t *testing.T) {
 	}
 }
 
+// TestGeminiProvider_CompleteStream_UpstreamErrorBodyExceedsCap verifies that
+// when a non-200 stream response body itself exceeds the read cap, the
+// resulting read error is surfaced to the caller instead of being silently
+// discarded (which would otherwise produce a misleading empty-message error).
+func TestGeminiProvider_CompleteStream_UpstreamErrorBodyExceedsCap(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write(make([]byte, core.MaxProviderResponseBytes+1))
+	}))
+	defer srv.Close()
+
+	p, _ := New("test-key", srv.URL)
+	ch, err := p.CompleteStream(context.Background(), core.Request{
+		Model:    "gemini-2.0-flash",
+		Messages: []core.Message{{Role: "user", Content: "Hi"}},
+	})
+	if err == nil {
+		t.Fatal("expected an error for an oversized non-200 stream response body")
+	}
+	if ch != nil {
+		t.Errorf("expected nil channel on error, got %#v", ch)
+	}
+	if !strings.Contains(err.Error(), "byte limit") {
+		t.Errorf("error = %q, want it to mention the byte limit (read error must not be discarded)", err.Error())
+	}
+}
+
 func TestGeminiProvider_CompleteStream_IndexesFunctionCalls(t *testing.T) {
 	sseData := `data: {"candidates":[{"content":{"role":"model","parts":[{"functionCall":{"id":"call_1","name":"lookup_weather","args":{"city":"SF"}}},{"functionCall":{"id":"call_2","name":"lookup_time","args":{"city":"SF"}}}]},"finishReason":"STOP"}]}
 

--- a/providers/gemini/image.go
+++ b/providers/gemini/image.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -114,7 +113,7 @@ func (p *Provider) GenerateImage(ctx context.Context, req core.ImageRequest) (*c
 	defer release()
 	defer func() { _ = httpResp.Body.Close() }()
 
-	respBody, err := io.ReadAll(httpResp.Body)
+	respBody, err := core.ReadResponseBody(httpResp.Body, core.MaxProviderResponseBytes)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read image response: %w", err)
 	}

--- a/providers/hugging_face/hugging_face.go
+++ b/providers/hugging_face/hugging_face.go
@@ -157,7 +157,7 @@ func (p *Provider) postTask(ctx context.Context, url string, body io.Reader) ([]
 	}
 	defer func() { _ = httpResp.Body.Close() }()
 
-	respBody, err := io.ReadAll(httpResp.Body)
+	respBody, err := core.ReadResponseBody(httpResp.Body, core.MaxProviderResponseBytes)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response: %w", err)
 	}

--- a/providers/internal/openaicompat/complete.go
+++ b/providers/internal/openaicompat/complete.go
@@ -87,7 +87,7 @@ func PostChat(ctx context.Context, p ChatParams, req core.Request) (*core.Respon
 	defer release()
 	defer func() { _ = httpResp.Body.Close() }()
 
-	respBody, err := io.ReadAll(httpResp.Body)
+	respBody, err := core.ReadResponseBody(httpResp.Body, core.MaxProviderResponseBytes)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response: %w", err)
 	}
@@ -162,7 +162,7 @@ func PostStream(ctx context.Context, p ChatParams, req core.Request) (<-chan cor
 
 	if httpResp.StatusCode != http.StatusOK {
 		defer func() { _ = httpResp.Body.Close() }()
-		respBody, _ := io.ReadAll(httpResp.Body)
+		respBody, _ := core.ReadResponseBody(httpResp.Body, core.MaxProviderResponseBytes)
 		return nil, APIError(p.Label, httpResp.StatusCode, respBody)
 	}
 	return StreamSSE(httpResp.Body), nil

--- a/providers/internal/openaicompat/complete.go
+++ b/providers/internal/openaicompat/complete.go
@@ -162,7 +162,10 @@ func PostStream(ctx context.Context, p ChatParams, req core.Request) (<-chan cor
 
 	if httpResp.StatusCode != http.StatusOK {
 		defer func() { _ = httpResp.Body.Close() }()
-		respBody, _ := core.ReadResponseBody(httpResp.Body, core.MaxProviderResponseBytes)
+		respBody, err := core.ReadResponseBody(httpResp.Body, core.MaxProviderResponseBytes)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read response: %w", err)
+		}
 		return nil, APIError(p.Label, httpResp.StatusCode, respBody)
 	}
 	return StreamSSE(httpResp.Body), nil

--- a/providers/internal/openaicompat/complete_test.go
+++ b/providers/internal/openaicompat/complete_test.go
@@ -178,3 +178,28 @@ func TestPostEmbeddings_ForwardsInputType(t *testing.T) {
 		t.Errorf("input_type = %s, want \"query\"", got)
 	}
 }
+
+// TestPostChat_OversizedResponseRejected verifies the shared chat path bounds
+// the response read via core.ReadResponseBody instead of buffering an
+// unbounded upstream body.
+func TestPostChat_OversizedResponseRejected(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(make([]byte, core.MaxProviderResponseBytes+1))
+	}))
+	defer srv.Close()
+
+	_, err := PostChat(context.Background(), ChatParams{
+		HTTPClient: srv.Client(),
+		URL:        srv.URL,
+		Headers:    map[string]string{"Content-Type": "application/json"},
+		Provider:   "test",
+		Label:      "test",
+	}, core.Request{Model: "m", Messages: []core.Message{{Role: core.RoleUser, Content: "hi"}}})
+	if err == nil {
+		t.Fatal("expected an error for a response exceeding the byte limit")
+	}
+	if !strings.Contains(err.Error(), "byte limit") {
+		t.Errorf("error = %q, want it to mention the byte limit", err.Error())
+	}
+}

--- a/providers/internal/openaicompat/complete_test.go
+++ b/providers/internal/openaicompat/complete_test.go
@@ -88,6 +88,37 @@ func TestPostStream_UpstreamError(t *testing.T) {
 	}
 }
 
+// TestPostStream_UpstreamErrorBodyExceedsCap verifies that when a non-200
+// stream response body itself exceeds the read cap, the resulting read error
+// is surfaced to the caller instead of being silently discarded (which would
+// otherwise produce a misleading empty-message error).
+func TestPostStream_UpstreamErrorBodyExceedsCap(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write(make([]byte, core.MaxProviderResponseBytes+1))
+	}))
+	defer srv.Close()
+
+	ch, err := PostStream(context.Background(), ChatParams{
+		HTTPClient: srv.Client(),
+		URL:        srv.URL,
+		Headers:    map[string]string{"Content-Type": "application/json"},
+		Provider:   "test",
+		Label:      "test",
+	}, core.Request{Model: "m", Messages: []core.Message{{Role: core.RoleUser, Content: "hi"}}})
+
+	if err == nil {
+		t.Fatal("expected an error for an oversized non-200 stream response body")
+	}
+	if ch != nil {
+		t.Errorf("PostStream() channel = %v, want nil on error", ch)
+	}
+	if !strings.Contains(err.Error(), "byte limit") {
+		t.Errorf("error = %q, want it to mention the byte limit (read error must not be discarded)", err.Error())
+	}
+}
+
 // TestPostChat_NormalizesFinishReason verifies a provider-specific finish reason
 // (Mistral's model_length) is normalized to the canonical OpenAI value.
 func TestPostChat_NormalizesFinishReason(t *testing.T) {

--- a/providers/internal/openaicompat/embedding.go
+++ b/providers/internal/openaicompat/embedding.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 
 	"github.com/ferro-labs/ai-gateway/providers/core"
@@ -84,7 +83,7 @@ func PostEmbeddings(ctx context.Context, p EmbeddingParams, req core.EmbeddingRe
 	}
 	defer func() { _ = httpResp.Body.Close() }()
 
-	respBody, err := io.ReadAll(httpResp.Body)
+	respBody, err := core.ReadResponseBody(httpResp.Body, core.MaxProviderResponseBytes)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response: %w", err)
 	}

--- a/providers/ollama/embedding.go
+++ b/providers/ollama/embedding.go
@@ -64,11 +64,7 @@ func (p *Provider) Embed(ctx context.Context, req core.EmbeddingRequest) (*core.
 		return nil, fmt.Errorf("failed to read response: %w", err)
 	}
 	if httpResp.StatusCode != http.StatusOK {
-		var errResp ollamaErrorResponse
-		if json.Unmarshal(respBody, &errResp) == nil && errResp.Error.Message != "" {
-			return nil, fmt.Errorf("ollama API error (%d): %s", httpResp.StatusCode, errResp.Error.Message)
-		}
-		return nil, fmt.Errorf("ollama API error (%d): %s", httpResp.StatusCode, string(respBody))
+		return nil, core.APIError("ollama", httpResp.StatusCode, respBody)
 	}
 
 	var oResp ollamaEmbedResponse

--- a/providers/ollama/embedding.go
+++ b/providers/ollama/embedding.go
@@ -64,7 +64,7 @@ func (p *Provider) Embed(ctx context.Context, req core.EmbeddingRequest) (*core.
 		return nil, fmt.Errorf("failed to read response: %w", err)
 	}
 	if httpResp.StatusCode != http.StatusOK {
-		return nil, core.APIError("ollama", httpResp.StatusCode, respBody)
+		return nil, ollamaAPIError(httpResp.StatusCode, respBody)
 	}
 
 	var oResp ollamaEmbedResponse

--- a/providers/ollama/embedding.go
+++ b/providers/ollama/embedding.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 
 	"github.com/ferro-labs/ai-gateway/providers/core"
@@ -60,7 +59,7 @@ func (p *Provider) Embed(ctx context.Context, req core.EmbeddingRequest) (*core.
 	}
 	defer func() { _ = httpResp.Body.Close() }()
 
-	respBody, err := io.ReadAll(httpResp.Body)
+	respBody, err := core.ReadResponseBody(httpResp.Body, core.MaxProviderResponseBytes)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response: %w", err)
 	}

--- a/providers/ollama/ollama.go
+++ b/providers/ollama/ollama.go
@@ -112,6 +112,28 @@ type tagsResponse struct {
 	} `json:"models"`
 }
 
+// ollamaAPIError builds a provider error from a non-2xx response on one of
+// Ollama's native endpoints (/api/tags, /api/embed). Ollama documents its
+// error body as a flat {"error":"..."} string (see
+// https://docs.ollama.com/api/errors), not the OpenAI-nested
+// {"error":{"message":...}} shape core.APIError expects, so core.APIError
+// cannot decode it. The OpenAI-compat surface (/v1/chat/completions, used by
+// Complete/CompleteStream) is a different endpoint that genuinely does return
+// OpenAI-shaped errors and keeps using core.APIError via openaicompat.
+func ollamaAPIError(statusCode int, body []byte) error {
+	msg := string(body)
+	var envelope struct {
+		Error string `json:"error"`
+	}
+	if json.Unmarshal(body, &envelope) == nil && envelope.Error != "" {
+		msg = envelope.Error
+	}
+	return &core.HTTPStatusError{
+		StatusCode: statusCode,
+		Message:    fmt.Sprintf("ollama API error (%d): %s", statusCode, msg),
+	}
+}
+
 // DiscoverModels fetches the live model list from the self-hosted Ollama
 // server's /api/tags endpoint. Ollama is unauthenticated, so no Authorization
 // header is sent.
@@ -138,7 +160,7 @@ func (p *Provider) DiscoverModels(ctx context.Context) ([]core.ModelInfo, error)
 	}
 
 	if httpResp.StatusCode != http.StatusOK {
-		return nil, core.APIError("ollama", httpResp.StatusCode, respBody)
+		return nil, ollamaAPIError(httpResp.StatusCode, respBody)
 	}
 
 	var tags tagsResponse

--- a/providers/ollama/ollama.go
+++ b/providers/ollama/ollama.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -141,7 +140,7 @@ func (p *Provider) DiscoverModels(ctx context.Context) ([]core.ModelInfo, error)
 	}
 	defer func() { _ = httpResp.Body.Close() }()
 
-	respBody, err := io.ReadAll(httpResp.Body)
+	respBody, err := core.ReadResponseBody(httpResp.Body, core.MaxProviderResponseBytes)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response: %w", err)
 	}

--- a/providers/ollama/ollama.go
+++ b/providers/ollama/ollama.go
@@ -80,14 +80,6 @@ func (p *Provider) Models() []core.ModelInfo {
 	return core.ModelsFromList(p.name, p.SupportedModels())
 }
 
-type ollamaErrorDetail struct {
-	Message string `json:"message"`
-}
-
-type ollamaErrorResponse struct {
-	Error ollamaErrorDetail `json:"error"`
-}
-
 // Complete sends a chat completion request and returns the full response. It
 // speaks Ollama's OpenAI-compatible /v1/chat/completions endpoint via the shared
 // helper, which sets core.Response.Provider and normalizes finish reasons.
@@ -146,11 +138,7 @@ func (p *Provider) DiscoverModels(ctx context.Context) ([]core.ModelInfo, error)
 	}
 
 	if httpResp.StatusCode != http.StatusOK {
-		var errResp ollamaErrorResponse
-		if json.Unmarshal(respBody, &errResp) == nil && errResp.Error.Message != "" {
-			return nil, fmt.Errorf("ollama API error (%d): %s", httpResp.StatusCode, errResp.Error.Message)
-		}
-		return nil, fmt.Errorf("ollama API error (%d): %s", httpResp.StatusCode, string(respBody))
+		return nil, core.APIError("ollama", httpResp.StatusCode, respBody)
 	}
 
 	var tags tagsResponse

--- a/providers/ollama/ollama_test.go
+++ b/providers/ollama/ollama_test.go
@@ -248,6 +248,32 @@ func TestOllamaProvider_Embed_MockHTTP(t *testing.T) {
 	}
 }
 
+// TestOllamaProvider_Embed_Non200Error verifies the native /api/embed error
+// path decodes Ollama's actual documented error shape — a flat
+// {"error":"..."} string — not the OpenAI-nested shape core.APIError expects.
+func TestOllamaProvider_Embed_Non200Error(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":"model not found"}`))
+	}))
+	defer srv.Close()
+
+	p, _ := New(srv.URL, nil)
+	_, err := p.Embed(context.Background(), core.EmbeddingRequest{
+		Model: "nomic-embed-text",
+		Input: "hello",
+	})
+	if err == nil {
+		t.Fatal("Embed() error = nil, want error on non-200")
+	}
+	if !strings.Contains(err.Error(), "model not found") || strings.Contains(err.Error(), `{"error"`) {
+		t.Errorf("error = %q, want the cleanly extracted message \"model not found\", not the raw JSON blob", err.Error())
+	}
+	if got := core.ParseStatusCode(err); got != http.StatusBadRequest {
+		t.Errorf("ParseStatusCode(err) = %d, want %d", got, http.StatusBadRequest)
+	}
+}
+
 func TestOllamaProvider_Embed_ForwardsDimensions(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var body map[string]any
@@ -347,16 +373,29 @@ func TestOllamaProvider_DiscoverModels_ParsesTagsNoAuth(t *testing.T) {
 	}
 }
 
+// TestOllamaProvider_DiscoverModels_Non200Error verifies the native /api/tags
+// error path decodes Ollama's actual documented error shape — a flat
+// {"error":"..."} string (see https://docs.ollama.com/api/errors), not the
+// OpenAI-nested {"error":{"message":...}} shape core.APIError expects. The
+// OpenAI-compat surface (Complete/CompleteStream, /v1/chat/completions) is a
+// different endpoint that genuinely does return OpenAI-shaped errors and is
+// covered separately; this test is specific to Ollama's native endpoints.
 func TestOllamaProvider_DiscoverModels_Non200Error(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
-		_, _ = w.Write([]byte(`{"error":{"message":"boom"}}`))
+		_, _ = w.Write([]byte(`{"error":"boom"}`))
 	}))
 	defer srv.Close()
 
 	p, _ := New(srv.URL, nil)
-	if _, err := p.DiscoverModels(context.Background()); err == nil {
+	_, err := p.DiscoverModels(context.Background())
+	if err == nil {
 		t.Fatal("DiscoverModels() error = nil, want error on non-200")
+	}
+	// "boom" alone is a substring of the raw JSON blob too, so also assert the
+	// message is NOT the undecoded blob, ruling out the raw-body fallback path.
+	if !strings.Contains(err.Error(), "boom") || strings.Contains(err.Error(), `{"error"`) {
+		t.Errorf("error = %q, want the cleanly extracted message \"boom\", not the raw JSON blob", err.Error())
 	}
 }
 

--- a/providers/ollama_cloud/embedding.go
+++ b/providers/ollama_cloud/embedding.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 
 	"github.com/ferro-labs/ai-gateway/providers/core"
@@ -59,7 +58,7 @@ func (p *Provider) Embed(ctx context.Context, req core.EmbeddingRequest) (*core.
 	}
 	defer func() { _ = httpResp.Body.Close() }()
 
-	respBody, err := io.ReadAll(httpResp.Body)
+	respBody, err := core.ReadResponseBody(httpResp.Body, core.MaxProviderResponseBytes)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response: %w", err)
 	}

--- a/providers/ollama_cloud/ollama_cloud.go
+++ b/providers/ollama_cloud/ollama_cloud.go
@@ -189,7 +189,10 @@ func apiError(statusCode int, body []byte) error {
 	if msg == "" {
 		msg = "unexpected response"
 	}
-	return fmt.Errorf("ollama-cloud API error (%d): %s", statusCode, msg)
+	return &core.HTTPStatusError{
+		StatusCode: statusCode,
+		Message:    fmt.Sprintf("ollama-cloud API error (%d): %s", statusCode, msg),
+	}
 }
 
 func parseErrorMessage(body []byte) string {

--- a/providers/openai/openai.go
+++ b/providers/openai/openai.go
@@ -278,18 +278,21 @@ func (p *Provider) Complete(ctx context.Context, req core.Request) (*core.Respon
 	defer func() { _ = httpResp.Body.Close() }()
 
 	if httpResp.StatusCode != http.StatusOK {
-		respBody, err := io.ReadAll(httpResp.Body)
+		respBody, err := core.ReadResponseBody(httpResp.Body, core.MaxProviderResponseBytes)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read response: %w", err)
 		}
 		return nil, core.APIError(p.name, httpResp.StatusCode, respBody)
 	}
 
+	// Bound decode + drain together so an oversized upstream response can't
+	// exhaust memory via the decoder's internal buffering or the drain copy.
+	limited := io.LimitReader(httpResp.Body, core.MaxProviderResponseBytes)
 	var completion openAIChatCompletionResponse
-	if err := json.NewDecoder(httpResp.Body).Decode(&completion); err != nil {
+	if err := json.NewDecoder(limited).Decode(&completion); err != nil {
 		return nil, fmt.Errorf("failed to decode response: %w", err)
 	}
-	if _, err := io.Copy(io.Discard, httpResp.Body); err != nil {
+	if _, err := io.Copy(io.Discard, limited); err != nil {
 		return nil, fmt.Errorf("failed to drain response: %w", err)
 	}
 
@@ -357,7 +360,7 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 
 	if httpResp.StatusCode != http.StatusOK {
 		defer func() { _ = httpResp.Body.Close() }()
-		respBody, err := io.ReadAll(httpResp.Body)
+		respBody, err := core.ReadResponseBody(httpResp.Body, core.MaxProviderResponseBytes)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read response: %w", err)
 		}

--- a/providers/openai/openai_test.go
+++ b/providers/openai/openai_test.go
@@ -276,6 +276,54 @@ func TestOpenAIProvider_Complete_DrainsSuccessfulResponseBody(t *testing.T) {
 	}
 }
 
+// TestOpenAIProvider_Complete_OversizedTrailingPaddingBounded verifies the
+// decode+drain reads on the success path are capped at
+// core.MaxProviderResponseBytes combined: a well-formed, small JSON body
+// followed by padding that pushes the total past the cap must still decode
+// successfully and return promptly, proving the drain does not attempt to
+// consume an unbounded amount of trailing data.
+func TestOpenAIProvider_Complete_OversizedTrailingPaddingBounded(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"id":"chatcmpl-1",
+			"object":"chat.completion",
+			"created":1234567890,
+			"model":"gpt-4o-mini",
+			"choices":[{"index":0,"message":{"role":"assistant","content":"hello"},"finish_reason":"stop"}],
+			"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}
+		}`))
+		_, _ = w.Write([]byte(strings.Repeat(" ", core.MaxProviderResponseBytes)))
+	}))
+	defer srv.Close()
+
+	provider, err := New("sk-test-key", srv.URL)
+	if err != nil {
+		t.Fatalf("New() returned error: %v", err)
+	}
+
+	done := make(chan struct{})
+	var resp *core.Response
+	go func() {
+		resp, err = provider.Complete(context.Background(), core.Request{
+			Model:    "gpt-4o-mini",
+			Messages: []core.Message{{Role: "user", Content: "hi"}},
+		})
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("Complete() did not return within 10s; drain may be unbounded")
+	}
+	if err != nil {
+		t.Fatalf("Complete() error: %v", err)
+	}
+	if resp == nil || resp.ID != "chatcmpl-1" {
+		t.Fatalf("unexpected response: %+v", resp)
+	}
+}
+
 func TestOpenAIProvider_Complete_MockHTTPError(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusTooManyRequests)

--- a/providers/replicate/replicate.go
+++ b/providers/replicate/replicate.go
@@ -393,7 +393,10 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 	}
 	if httpResp.StatusCode != http.StatusOK {
 		defer func() { _ = httpResp.Body.Close() }()
-		respBody, _ := core.ReadResponseBody(httpResp.Body, core.MaxProviderResponseBytes)
+		respBody, err := core.ReadResponseBody(httpResp.Body, core.MaxProviderResponseBytes)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read response: %w", err)
+		}
 		return nil, core.APIError(Name, httpResp.StatusCode, respBody)
 	}
 

--- a/providers/replicate/replicate.go
+++ b/providers/replicate/replicate.go
@@ -393,7 +393,7 @@ func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan
 	}
 	if httpResp.StatusCode != http.StatusOK {
 		defer func() { _ = httpResp.Body.Close() }()
-		respBody, _ := io.ReadAll(httpResp.Body)
+		respBody, _ := core.ReadResponseBody(httpResp.Body, core.MaxProviderResponseBytes)
 		return nil, core.APIError(Name, httpResp.StatusCode, respBody)
 	}
 
@@ -491,7 +491,7 @@ func (p *Provider) submit(ctx context.Context, url string, body io.Reader, wait 
 	}
 	defer func() { _ = httpResp.Body.Close() }()
 
-	respBody, err := io.ReadAll(httpResp.Body)
+	respBody, err := core.ReadResponseBody(httpResp.Body, core.MaxProviderResponseBytes)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response: %w", err)
 	}
@@ -576,7 +576,7 @@ func (p *Provider) pollOnce(ctx context.Context, pollURL string) (*Prediction, e
 	if err != nil {
 		return nil, fmt.Errorf("poll request failed: %w", err)
 	}
-	pollBody, readErr := io.ReadAll(pollResp.Body)
+	pollBody, readErr := core.ReadResponseBody(pollResp.Body, core.MaxProviderResponseBytes)
 	_ = pollResp.Body.Close()
 	if readErr != nil {
 		return nil, fmt.Errorf("failed to read poll response body: %w", readErr)

--- a/providers/replicate/replicate_test.go
+++ b/providers/replicate/replicate_test.go
@@ -543,6 +543,40 @@ func TestReplicateProvider_CompleteStream_SubmitError(t *testing.T) {
 	}
 }
 
+// TestReplicateProvider_CompleteStream_StreamFetchErrorBodyExceedsCap verifies
+// that when the submit succeeds but the subsequent GET to the stream URL
+// returns a non-200 response whose body itself exceeds the read cap, the
+// resulting read error is surfaced to the caller instead of being silently
+// discarded (which would otherwise produce a misleading empty-message error).
+func TestReplicateProvider_CompleteStream_StreamFetchErrorBodyExceedsCap(t *testing.T) {
+	var streamURL string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/models/", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"id":"pred-1","status":"starting","urls":{"stream":"` + streamURL + `"}}`))
+	})
+	mux.HandleFunc("/stream", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write(make([]byte, core.MaxProviderResponseBytes+1))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	streamURL = srv.URL + "/stream"
+
+	p, _ := New("test-token", srv.URL, []string{"test/model"}, nil)
+	_, err := p.CompleteStream(context.Background(), core.Request{
+		Model:    "test/model",
+		Messages: []core.Message{{Role: "user", Content: "Hi"}},
+	})
+	if err == nil {
+		t.Fatal("expected an error for an oversized non-200 stream-fetch response body")
+	}
+	if !strings.Contains(err.Error(), "byte limit") {
+		t.Errorf("error = %q, want it to mention the byte limit (read error must not be discarded)", err.Error())
+	}
+}
+
 // ── Usage + finish_reason ──────────────────────────────────────────────────────
 
 func TestReplicateProvider_Complete_UsageAndFinishReason(t *testing.T) {

--- a/providers/status_conformance_test.go
+++ b/providers/status_conformance_test.go
@@ -1,0 +1,325 @@
+package providers
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	ai21pkg "github.com/ferro-labs/ai-gateway/providers/ai21"
+	anthropicpkg "github.com/ferro-labs/ai-gateway/providers/anthropic"
+	azurefoundrypkg "github.com/ferro-labs/ai-gateway/providers/azure_foundry"
+	azureopenaipkg "github.com/ferro-labs/ai-gateway/providers/azure_openai"
+	cerebraspkg "github.com/ferro-labs/ai-gateway/providers/cerebras"
+	cloudflarepkg "github.com/ferro-labs/ai-gateway/providers/cloudflare"
+	coherepkg "github.com/ferro-labs/ai-gateway/providers/cohere"
+	"github.com/ferro-labs/ai-gateway/providers/core"
+	databrickspkg "github.com/ferro-labs/ai-gateway/providers/databricks"
+	deepinfrapkg "github.com/ferro-labs/ai-gateway/providers/deepinfra"
+	deepseekpkg "github.com/ferro-labs/ai-gateway/providers/deepseek"
+	fireworkspkg "github.com/ferro-labs/ai-gateway/providers/fireworks"
+	geminipkg "github.com/ferro-labs/ai-gateway/providers/gemini"
+	groqpkg "github.com/ferro-labs/ai-gateway/providers/groq"
+	huggingfacepkg "github.com/ferro-labs/ai-gateway/providers/hugging_face"
+	mistralpkg "github.com/ferro-labs/ai-gateway/providers/mistral"
+	moonshotpkg "github.com/ferro-labs/ai-gateway/providers/moonshot"
+	novitapkg "github.com/ferro-labs/ai-gateway/providers/novita"
+	nvidianimpkg "github.com/ferro-labs/ai-gateway/providers/nvidia_nim"
+	ollamapkg "github.com/ferro-labs/ai-gateway/providers/ollama"
+	ollamacloudpkg "github.com/ferro-labs/ai-gateway/providers/ollama_cloud"
+	openaipkg "github.com/ferro-labs/ai-gateway/providers/openai"
+	openrouterpkg "github.com/ferro-labs/ai-gateway/providers/openrouter"
+	perplexitypkg "github.com/ferro-labs/ai-gateway/providers/perplexity"
+	qwenpkg "github.com/ferro-labs/ai-gateway/providers/qwen"
+	replicatepkg "github.com/ferro-labs/ai-gateway/providers/replicate"
+	sambanovapkg "github.com/ferro-labs/ai-gateway/providers/sambanova"
+	togetherpkg "github.com/ferro-labs/ai-gateway/providers/together"
+	xaipkg "github.com/ferro-labs/ai-gateway/providers/xai"
+)
+
+// statusConformanceCase builds a provider pointed at a caller-supplied base
+// URL, so it can be redirected to a local stub server.
+type statusConformanceCase struct {
+	name  string
+	model string // model ID sent in the request; defaults to "test-model" if empty
+	build func(t *testing.T, baseURL string) Provider
+}
+
+// statusConformanceCases covers every provider whose constructor accepts a
+// base-URL override. Bedrock (AWS-SDK-signed transport) and Vertex AI
+// (GCP-SDK auth) are intentionally excluded — neither takes a simple baseURL
+// override, so they can't be pointed at a local stub without deeper
+// credential/transport stubbing than this conformance test is worth.
+func statusConformanceCases() []statusConformanceCase {
+	return []statusConformanceCase{
+		{name: "ai21", build: func(t *testing.T, baseURL string) Provider {
+			t.Helper()
+			p, err := ai21pkg.New(testAPIKey, baseURL)
+			if err != nil {
+				t.Fatalf("New: %v", err)
+			}
+			return p
+		}},
+		{name: "anthropic", build: func(t *testing.T, baseURL string) Provider {
+			t.Helper()
+			p, err := anthropicpkg.New(testAPIKey, baseURL)
+			if err != nil {
+				t.Fatalf("New: %v", err)
+			}
+			return p
+		}},
+		{name: "azure_foundry", build: func(t *testing.T, baseURL string) Provider {
+			t.Helper()
+			p, err := azurefoundrypkg.New(testAPIKey, baseURL, "")
+			if err != nil {
+				t.Fatalf("New: %v", err)
+			}
+			return p
+		}},
+		{name: "azure_openai", build: func(t *testing.T, baseURL string) Provider {
+			t.Helper()
+			p, err := azureopenaipkg.New(testAPIKey, baseURL, "gpt-4o", "")
+			if err != nil {
+				t.Fatalf("New: %v", err)
+			}
+			return p
+		}},
+		{name: "cerebras", build: func(t *testing.T, baseURL string) Provider {
+			t.Helper()
+			p, err := cerebraspkg.New(testAPIKey, baseURL)
+			if err != nil {
+				t.Fatalf("New: %v", err)
+			}
+			return p
+		}},
+		{name: "cloudflare", build: func(t *testing.T, baseURL string) Provider {
+			t.Helper()
+			p, err := cloudflarepkg.New(testAPIKey, "acct-123", baseURL)
+			if err != nil {
+				t.Fatalf("New: %v", err)
+			}
+			return p
+		}},
+		{name: "cohere", build: func(t *testing.T, baseURL string) Provider {
+			t.Helper()
+			p, err := coherepkg.New(testAPIKey, baseURL)
+			if err != nil {
+				t.Fatalf("New: %v", err)
+			}
+			return p
+		}},
+		{name: "databricks", build: func(t *testing.T, baseURL string) Provider {
+			t.Helper()
+			p, err := databrickspkg.New(testAPIKey, baseURL)
+			if err != nil {
+				t.Fatalf("New: %v", err)
+			}
+			return p
+		}},
+		{name: "deepinfra", build: func(t *testing.T, baseURL string) Provider {
+			t.Helper()
+			p, err := deepinfrapkg.New(testAPIKey, baseURL)
+			if err != nil {
+				t.Fatalf("New: %v", err)
+			}
+			return p
+		}},
+		{name: "deepseek", build: func(t *testing.T, baseURL string) Provider {
+			t.Helper()
+			p, err := deepseekpkg.New(testAPIKey, baseURL)
+			if err != nil {
+				t.Fatalf("New: %v", err)
+			}
+			return p
+		}},
+		{name: "fireworks", build: func(t *testing.T, baseURL string) Provider {
+			t.Helper()
+			p, err := fireworkspkg.New(testAPIKey, baseURL)
+			if err != nil {
+				t.Fatalf("New: %v", err)
+			}
+			return p
+		}},
+		{name: "gemini", build: func(t *testing.T, baseURL string) Provider {
+			t.Helper()
+			p, err := geminipkg.New(testAPIKey, baseURL)
+			if err != nil {
+				t.Fatalf("New: %v", err)
+			}
+			return p
+		}},
+		{name: "groq", build: func(t *testing.T, baseURL string) Provider {
+			t.Helper()
+			p, err := groqpkg.New(testAPIKey, baseURL)
+			if err != nil {
+				t.Fatalf("New: %v", err)
+			}
+			return p
+		}},
+		{name: "hugging_face", build: func(t *testing.T, baseURL string) Provider {
+			t.Helper()
+			p, err := huggingfacepkg.New(testAPIKey, baseURL)
+			if err != nil {
+				t.Fatalf("New: %v", err)
+			}
+			return p
+		}},
+		{name: "mistral", build: func(t *testing.T, baseURL string) Provider {
+			t.Helper()
+			p, err := mistralpkg.New(testAPIKey, baseURL)
+			if err != nil {
+				t.Fatalf("New: %v", err)
+			}
+			return p
+		}},
+		{name: "moonshot", build: func(t *testing.T, baseURL string) Provider {
+			t.Helper()
+			p, err := moonshotpkg.New(testAPIKey, baseURL)
+			if err != nil {
+				t.Fatalf("New: %v", err)
+			}
+			return p
+		}},
+		{name: "novita", build: func(t *testing.T, baseURL string) Provider {
+			t.Helper()
+			p, err := novitapkg.New(testAPIKey, baseURL)
+			if err != nil {
+				t.Fatalf("New: %v", err)
+			}
+			return p
+		}},
+		{name: "nvidia_nim", build: func(t *testing.T, baseURL string) Provider {
+			t.Helper()
+			p, err := nvidianimpkg.New(testAPIKey, baseURL)
+			if err != nil {
+				t.Fatalf("New: %v", err)
+			}
+			return p
+		}},
+		{name: "ollama", build: func(t *testing.T, baseURL string) Provider {
+			t.Helper()
+			p, err := ollamapkg.New(baseURL, nil)
+			if err != nil {
+				t.Fatalf("New: %v", err)
+			}
+			return p
+		}},
+		{name: "ollama_cloud", build: func(t *testing.T, baseURL string) Provider {
+			t.Helper()
+			p, err := ollamacloudpkg.New(testAPIKey, baseURL, []string{"gpt-oss:20b"})
+			if err != nil {
+				t.Fatalf("New: %v", err)
+			}
+			return p
+		}},
+		{name: "openai", build: func(t *testing.T, baseURL string) Provider {
+			t.Helper()
+			p, err := openaipkg.New(testAPIKey, baseURL)
+			if err != nil {
+				t.Fatalf("New: %v", err)
+			}
+			return p
+		}},
+		{name: "openrouter", build: func(t *testing.T, baseURL string) Provider {
+			t.Helper()
+			p, err := openrouterpkg.New(testAPIKey, baseURL)
+			if err != nil {
+				t.Fatalf("New: %v", err)
+			}
+			return p
+		}},
+		{name: "perplexity", build: func(t *testing.T, baseURL string) Provider {
+			t.Helper()
+			p, err := perplexitypkg.New(testAPIKey, baseURL)
+			if err != nil {
+				t.Fatalf("New: %v", err)
+			}
+			return p
+		}},
+		{name: "qwen", build: func(t *testing.T, baseURL string) Provider {
+			t.Helper()
+			p, err := qwenpkg.New(testAPIKey, baseURL)
+			if err != nil {
+				t.Fatalf("New: %v", err)
+			}
+			return p
+		}},
+		{name: "replicate", model: "test-owner/test-model", build: func(t *testing.T, baseURL string) Provider {
+			t.Helper()
+			p, err := replicatepkg.New(testAPIKey, baseURL, nil, nil)
+			if err != nil {
+				t.Fatalf("New: %v", err)
+			}
+			return p
+		}},
+		{name: "sambanova", build: func(t *testing.T, baseURL string) Provider {
+			t.Helper()
+			p, err := sambanovapkg.New(testAPIKey, baseURL)
+			if err != nil {
+				t.Fatalf("New: %v", err)
+			}
+			return p
+		}},
+		{name: "together", build: func(t *testing.T, baseURL string) Provider {
+			t.Helper()
+			p, err := togetherpkg.New(testAPIKey, baseURL)
+			if err != nil {
+				t.Fatalf("New: %v", err)
+			}
+			return p
+		}},
+		{name: "xai", build: func(t *testing.T, baseURL string) Provider {
+			t.Helper()
+			p, err := xaipkg.New(testAPIKey, baseURL)
+			if err != nil {
+				t.Fatalf("New: %v", err)
+			}
+			return p
+		}},
+	}
+}
+
+// newStatusStub starts a stub HTTP server that always responds with status
+// and an OpenAI-shaped {"error":{"message":…}} body, regardless of path.
+func newStatusStub(status int) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(`{"error":{"message":"stub error"}}`))
+	}))
+}
+
+// TestProviderStatusConformance verifies core.ParseStatusCode recovers the
+// upstream HTTP status from every provider's Complete() error, for both a
+// retryable (429) and a non-retryable (500) canned upstream response. This is
+// the cross-provider regression test for H2-2 (typed HTTPStatusError): a
+// provider that stops embedding a parseable status in its error breaks
+// gateway_circuitbreaker.go's isRateLimitError and
+// internal/strategies/fallback.go's onStatusCodes retry gate silently.
+func TestProviderStatusConformance(t *testing.T) {
+	for _, status := range []int{http.StatusTooManyRequests, http.StatusInternalServerError} {
+		for _, tc := range statusConformanceCases() {
+			t.Run(fmt.Sprintf("%s/%d", tc.name, status), func(t *testing.T) {
+				srv := newStatusStub(status)
+				defer srv.Close()
+
+				model := tc.model
+				if model == "" {
+					model = "test-model"
+				}
+				p := tc.build(t, srv.URL)
+				_, err := p.Complete(context.Background(), core.Request{
+					Model:    model,
+					Messages: []core.Message{{Role: core.RoleUser, Content: "hi"}},
+				})
+				if err == nil {
+					t.Fatalf("Complete() returned no error for a %d upstream response", status)
+				}
+				if got := core.ParseStatusCode(err); got != status {
+					t.Errorf("ParseStatusCode(err) = %d, want %d; err = %v", got, status, err)
+				}
+			})
+		}
+	}
+}

--- a/providers/status_conformance_test.go
+++ b/providers/status_conformance_test.go
@@ -46,6 +46,23 @@ type statusConformanceCase struct {
 	build func(t *testing.T, baseURL string) Provider
 }
 
+// simpleBuild adapts a provider constructor shaped func(apiKey, baseURL string)
+// (P, error) — the shape shared by most providers — into a
+// statusConformanceCase build func, so each such provider needs only a
+// one-line case instead of repeating the same construct-and-check-error
+// closure. Providers with a differently-shaped constructor (extra
+// parameters, different argument order) still write their own closure below.
+func simpleBuild[P Provider](newFn func(apiKey, baseURL string) (P, error)) func(t *testing.T, baseURL string) Provider {
+	return func(t *testing.T, baseURL string) Provider {
+		t.Helper()
+		p, err := newFn(testAPIKey, baseURL)
+		if err != nil {
+			t.Fatalf("New: %v", err)
+		}
+		return p
+	}
+}
+
 // statusConformanceCases covers every provider whose constructor accepts a
 // base-URL override. Bedrock (AWS-SDK-signed transport) and Vertex AI
 // (GCP-SDK auth) are intentionally excluded — neither takes a simple baseURL
@@ -53,22 +70,8 @@ type statusConformanceCase struct {
 // credential/transport stubbing than this conformance test is worth.
 func statusConformanceCases() []statusConformanceCase {
 	return []statusConformanceCase{
-		{name: "ai21", model: "jamba-mini-1.7", build: func(t *testing.T, baseURL string) Provider {
-			t.Helper()
-			p, err := ai21pkg.New(testAPIKey, baseURL)
-			if err != nil {
-				t.Fatalf("New: %v", err)
-			}
-			return p
-		}},
-		{name: "anthropic", build: func(t *testing.T, baseURL string) Provider {
-			t.Helper()
-			p, err := anthropicpkg.New(testAPIKey, baseURL)
-			if err != nil {
-				t.Fatalf("New: %v", err)
-			}
-			return p
-		}},
+		{name: "ai21", model: "jamba-mini-1.7", build: simpleBuild(ai21pkg.New)},
+		{name: "anthropic", build: simpleBuild(anthropicpkg.New)},
 		{name: "azure_foundry", build: func(t *testing.T, baseURL string) Provider {
 			t.Helper()
 			p, err := azurefoundrypkg.New(testAPIKey, baseURL, "")
@@ -85,14 +88,7 @@ func statusConformanceCases() []statusConformanceCase {
 			}
 			return p
 		}},
-		{name: "cerebras", build: func(t *testing.T, baseURL string) Provider {
-			t.Helper()
-			p, err := cerebraspkg.New(testAPIKey, baseURL)
-			if err != nil {
-				t.Fatalf("New: %v", err)
-			}
-			return p
-		}},
+		{name: "cerebras", build: simpleBuild(cerebraspkg.New)},
 		{name: "cloudflare", build: func(t *testing.T, baseURL string) Provider {
 			t.Helper()
 			p, err := cloudflarepkg.New(testAPIKey, "acct-123", baseURL)
@@ -101,102 +97,18 @@ func statusConformanceCases() []statusConformanceCase {
 			}
 			return p
 		}},
-		{name: "cohere", build: func(t *testing.T, baseURL string) Provider {
-			t.Helper()
-			p, err := coherepkg.New(testAPIKey, baseURL)
-			if err != nil {
-				t.Fatalf("New: %v", err)
-			}
-			return p
-		}},
-		{name: "databricks", build: func(t *testing.T, baseURL string) Provider {
-			t.Helper()
-			p, err := databrickspkg.New(testAPIKey, baseURL)
-			if err != nil {
-				t.Fatalf("New: %v", err)
-			}
-			return p
-		}},
-		{name: "deepinfra", build: func(t *testing.T, baseURL string) Provider {
-			t.Helper()
-			p, err := deepinfrapkg.New(testAPIKey, baseURL)
-			if err != nil {
-				t.Fatalf("New: %v", err)
-			}
-			return p
-		}},
-		{name: "deepseek", build: func(t *testing.T, baseURL string) Provider {
-			t.Helper()
-			p, err := deepseekpkg.New(testAPIKey, baseURL)
-			if err != nil {
-				t.Fatalf("New: %v", err)
-			}
-			return p
-		}},
-		{name: "fireworks", build: func(t *testing.T, baseURL string) Provider {
-			t.Helper()
-			p, err := fireworkspkg.New(testAPIKey, baseURL)
-			if err != nil {
-				t.Fatalf("New: %v", err)
-			}
-			return p
-		}},
-		{name: "gemini", build: func(t *testing.T, baseURL string) Provider {
-			t.Helper()
-			p, err := geminipkg.New(testAPIKey, baseURL)
-			if err != nil {
-				t.Fatalf("New: %v", err)
-			}
-			return p
-		}},
-		{name: "groq", build: func(t *testing.T, baseURL string) Provider {
-			t.Helper()
-			p, err := groqpkg.New(testAPIKey, baseURL)
-			if err != nil {
-				t.Fatalf("New: %v", err)
-			}
-			return p
-		}},
-		{name: "hugging_face", build: func(t *testing.T, baseURL string) Provider {
-			t.Helper()
-			p, err := huggingfacepkg.New(testAPIKey, baseURL)
-			if err != nil {
-				t.Fatalf("New: %v", err)
-			}
-			return p
-		}},
-		{name: "mistral", build: func(t *testing.T, baseURL string) Provider {
-			t.Helper()
-			p, err := mistralpkg.New(testAPIKey, baseURL)
-			if err != nil {
-				t.Fatalf("New: %v", err)
-			}
-			return p
-		}},
-		{name: "moonshot", build: func(t *testing.T, baseURL string) Provider {
-			t.Helper()
-			p, err := moonshotpkg.New(testAPIKey, baseURL)
-			if err != nil {
-				t.Fatalf("New: %v", err)
-			}
-			return p
-		}},
-		{name: "novita", build: func(t *testing.T, baseURL string) Provider {
-			t.Helper()
-			p, err := novitapkg.New(testAPIKey, baseURL)
-			if err != nil {
-				t.Fatalf("New: %v", err)
-			}
-			return p
-		}},
-		{name: "nvidia_nim", build: func(t *testing.T, baseURL string) Provider {
-			t.Helper()
-			p, err := nvidianimpkg.New(testAPIKey, baseURL)
-			if err != nil {
-				t.Fatalf("New: %v", err)
-			}
-			return p
-		}},
+		{name: "cohere", build: simpleBuild(coherepkg.New)},
+		{name: "databricks", build: simpleBuild(databrickspkg.New)},
+		{name: "deepinfra", build: simpleBuild(deepinfrapkg.New)},
+		{name: "deepseek", build: simpleBuild(deepseekpkg.New)},
+		{name: "fireworks", build: simpleBuild(fireworkspkg.New)},
+		{name: "gemini", build: simpleBuild(geminipkg.New)},
+		{name: "groq", build: simpleBuild(groqpkg.New)},
+		{name: "hugging_face", build: simpleBuild(huggingfacepkg.New)},
+		{name: "mistral", build: simpleBuild(mistralpkg.New)},
+		{name: "moonshot", build: simpleBuild(moonshotpkg.New)},
+		{name: "novita", build: simpleBuild(novitapkg.New)},
+		{name: "nvidia_nim", build: simpleBuild(nvidianimpkg.New)},
 		{name: "ollama", build: func(t *testing.T, baseURL string) Provider {
 			t.Helper()
 			p, err := ollamapkg.New(baseURL, nil)
@@ -213,38 +125,10 @@ func statusConformanceCases() []statusConformanceCase {
 			}
 			return p
 		}},
-		{name: "openai", build: func(t *testing.T, baseURL string) Provider {
-			t.Helper()
-			p, err := openaipkg.New(testAPIKey, baseURL)
-			if err != nil {
-				t.Fatalf("New: %v", err)
-			}
-			return p
-		}},
-		{name: "openrouter", build: func(t *testing.T, baseURL string) Provider {
-			t.Helper()
-			p, err := openrouterpkg.New(testAPIKey, baseURL)
-			if err != nil {
-				t.Fatalf("New: %v", err)
-			}
-			return p
-		}},
-		{name: "perplexity", build: func(t *testing.T, baseURL string) Provider {
-			t.Helper()
-			p, err := perplexitypkg.New(testAPIKey, baseURL)
-			if err != nil {
-				t.Fatalf("New: %v", err)
-			}
-			return p
-		}},
-		{name: "qwen", build: func(t *testing.T, baseURL string) Provider {
-			t.Helper()
-			p, err := qwenpkg.New(testAPIKey, baseURL)
-			if err != nil {
-				t.Fatalf("New: %v", err)
-			}
-			return p
-		}},
+		{name: "openai", build: simpleBuild(openaipkg.New)},
+		{name: "openrouter", build: simpleBuild(openrouterpkg.New)},
+		{name: "perplexity", build: simpleBuild(perplexitypkg.New)},
+		{name: "qwen", build: simpleBuild(qwenpkg.New)},
 		{name: "replicate", model: "test-owner/test-model", build: func(t *testing.T, baseURL string) Provider {
 			t.Helper()
 			p, err := replicatepkg.New(testAPIKey, baseURL, nil, nil)
@@ -253,30 +137,9 @@ func statusConformanceCases() []statusConformanceCase {
 			}
 			return p
 		}},
-		{name: "sambanova", build: func(t *testing.T, baseURL string) Provider {
-			t.Helper()
-			p, err := sambanovapkg.New(testAPIKey, baseURL)
-			if err != nil {
-				t.Fatalf("New: %v", err)
-			}
-			return p
-		}},
-		{name: "together", build: func(t *testing.T, baseURL string) Provider {
-			t.Helper()
-			p, err := togetherpkg.New(testAPIKey, baseURL)
-			if err != nil {
-				t.Fatalf("New: %v", err)
-			}
-			return p
-		}},
-		{name: "xai", build: func(t *testing.T, baseURL string) Provider {
-			t.Helper()
-			p, err := xaipkg.New(testAPIKey, baseURL)
-			if err != nil {
-				t.Fatalf("New: %v", err)
-			}
-			return p
-		}},
+		{name: "sambanova", build: simpleBuild(sambanovapkg.New)},
+		{name: "together", build: simpleBuild(togetherpkg.New)},
+		{name: "xai", build: simpleBuild(xaipkg.New)},
 	}
 }
 

--- a/providers/status_conformance_test.go
+++ b/providers/status_conformance_test.go
@@ -53,7 +53,7 @@ type statusConformanceCase struct {
 // credential/transport stubbing than this conformance test is worth.
 func statusConformanceCases() []statusConformanceCase {
 	return []statusConformanceCase{
-		{name: "ai21", build: func(t *testing.T, baseURL string) Provider {
+		{name: "ai21", model: "jamba-mini-1.7", build: func(t *testing.T, baseURL string) Provider {
 			t.Helper()
 			p, err := ai21pkg.New(testAPIKey, baseURL)
 			if err != nil {
@@ -291,12 +291,19 @@ func newStatusStub(status int) *httptest.Server {
 }
 
 // TestProviderStatusConformance verifies core.ParseStatusCode recovers the
-// upstream HTTP status from every provider's Complete() error, for both a
-// retryable (429) and a non-retryable (500) canned upstream response. This is
-// the cross-provider regression test for H2-2 (typed HTTPStatusError): a
-// provider that stops embedding a parseable status in its error breaks
+// upstream HTTP status from every provider's Complete() (and, where
+// implemented, CompleteStream()) error, for both a retryable (429) and a
+// non-retryable (500) canned upstream response. This is the cross-provider
+// regression test for H2-2 (typed HTTPStatusError): a provider that stops
+// embedding a parseable status in its error breaks
 // gateway_circuitbreaker.go's isRateLimitError and
-// internal/strategies/fallback.go's onStatusCodes retry gate silently.
+// internal/strategies/fallback.go's onStatusCodes retry gate silently. The
+// streaming half also guards the H2-1 regression class found in review: a
+// provider that discards ReadResponseBody's error on a non-200 stream
+// response loses the status/message entirely rather than just the byte-limit
+// detail, since a discarded read error still leaves the status code intact —
+// so this specifically exercises the "does CompleteStream even return an
+// error at all, with a recoverable status" contract, not the message detail.
 func TestProviderStatusConformance(t *testing.T) {
 	for _, status := range []int{http.StatusTooManyRequests, http.StatusInternalServerError} {
 		for _, tc := range statusConformanceCases() {
@@ -308,16 +315,35 @@ func TestProviderStatusConformance(t *testing.T) {
 				if model == "" {
 					model = "test-model"
 				}
-				p := tc.build(t, srv.URL)
-				_, err := p.Complete(context.Background(), core.Request{
+				req := core.Request{
 					Model:    model,
 					Messages: []core.Message{{Role: core.RoleUser, Content: "hi"}},
-				})
+				}
+
+				p := tc.build(t, srv.URL)
+				_, err := p.Complete(context.Background(), req)
 				if err == nil {
 					t.Fatalf("Complete() returned no error for a %d upstream response", status)
 				}
 				if got := core.ParseStatusCode(err); got != status {
-					t.Errorf("ParseStatusCode(err) = %d, want %d; err = %v", got, status, err)
+					t.Errorf("Complete(): ParseStatusCode(err) = %d, want %d; err = %v", got, status, err)
+				}
+
+				sp, ok := p.(StreamProvider)
+				if !ok {
+					return
+				}
+				ch, err := sp.CompleteStream(context.Background(), req)
+				if err == nil {
+					for range ch { //nolint:revive // drain to avoid a goroutine leak if a provider unexpectedly starts one
+					}
+					t.Fatalf("CompleteStream() returned no error for a %d upstream response", status)
+				}
+				if ch != nil {
+					t.Errorf("CompleteStream() channel = %v, want nil on a pre-stream error", ch)
+				}
+				if got := core.ParseStatusCode(err); got != status {
+					t.Errorf("CompleteStream(): ParseStatusCode(err) = %d, want %d; err = %v", got, status, err)
 				}
 			})
 		}

--- a/providers/status_conformance_test.go
+++ b/providers/status_conformance_test.go
@@ -293,17 +293,12 @@ func newStatusStub(status int) *httptest.Server {
 // TestProviderStatusConformance verifies core.ParseStatusCode recovers the
 // upstream HTTP status from every provider's Complete() (and, where
 // implemented, CompleteStream()) error, for both a retryable (429) and a
-// non-retryable (500) canned upstream response. This is the cross-provider
-// regression test for H2-2 (typed HTTPStatusError): a provider that stops
-// embedding a parseable status in its error breaks
-// gateway_circuitbreaker.go's isRateLimitError and
-// internal/strategies/fallback.go's onStatusCodes retry gate silently. The
-// streaming half also guards the H2-1 regression class found in review: a
-// provider that discards ReadResponseBody's error on a non-200 stream
-// response loses the status/message entirely rather than just the byte-limit
-// detail, since a discarded read error still leaves the status code intact —
-// so this specifically exercises the "does CompleteStream even return an
-// error at all, with a recoverable status" contract, not the message detail.
+// non-retryable (500) canned upstream response. Status-code recoverability is
+// relied on by gateway_circuitbreaker.go's isRateLimitError and
+// internal/strategies/fallback.go's onStatusCodes retry gate, so a provider
+// that stops surfacing a parseable status breaks that gating silently. The
+// streaming assertions only check that an error with a recoverable status is
+// returned at all, not the message detail.
 func TestProviderStatusConformance(t *testing.T) {
 	for _, status := range []int{http.StatusTooManyRequests, http.StatusInternalServerError} {
 		for _, tc := range statusConformanceCases() {

--- a/providers/vertex_ai/vertex_ai.go
+++ b/providers/vertex_ai/vertex_ai.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -310,7 +309,7 @@ func (p *Provider) doPredict(ctx context.Context, model string, body any, label 
 	}
 	defer func() { _ = httpResp.Body.Close() }()
 
-	respBody, err := io.ReadAll(httpResp.Body)
+	respBody, err := core.ReadResponseBody(httpResp.Body, core.MaxProviderResponseBytes)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read %s response: %w", label, err)
 	}

--- a/providers/xai/image.go
+++ b/providers/xai/image.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"time"
 
@@ -65,7 +64,7 @@ func (p *Provider) GenerateImage(ctx context.Context, req core.ImageRequest) (*c
 	}
 	defer func() { _ = httpResp.Body.Close() }()
 
-	respBody, err := io.ReadAll(httpResp.Body)
+	respBody, err := core.ReadResponseBody(httpResp.Body, core.MaxProviderResponseBytes)
 	if err != nil {
 		return nil, fmt.Errorf("xai: failed to read image response: %w", err)
 	}

--- a/test/integration/admin_store_test.go
+++ b/test/integration/admin_store_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestPostgresStore_CRUD(t *testing.T) {
-	store, err := admin.NewPostgresStore(testDSN)
+	store, err := admin.NewPostgresStore(t.Context(), testDSN)
 	if err != nil {
 		t.Fatalf("new postgres store: %v", err)
 	}
@@ -52,7 +52,7 @@ func TestPostgresStore_CRUD(t *testing.T) {
 }
 
 func TestPostgresStore_ValidateAndUsage(t *testing.T) {
-	store, err := admin.NewPostgresStore(testDSN)
+	store, err := admin.NewPostgresStore(t.Context(), testDSN)
 	if err != nil {
 		t.Fatalf("new postgres store: %v", err)
 	}
@@ -76,7 +76,7 @@ func TestPostgresStore_ValidateAndUsage(t *testing.T) {
 }
 
 func TestPostgresStore_Expiration(t *testing.T) {
-	store, err := admin.NewPostgresStore(testDSN)
+	store, err := admin.NewPostgresStore(t.Context(), testDSN)
 	if err != nil {
 		t.Fatalf("new postgres store: %v", err)
 	}
@@ -100,7 +100,7 @@ func TestPostgresStore_Expiration(t *testing.T) {
 }
 
 func TestPostgresStore_RevokeAndRotate(t *testing.T) {
-	store, err := admin.NewPostgresStore(testDSN)
+	store, err := admin.NewPostgresStore(t.Context(), testDSN)
 	if err != nil {
 		t.Fatalf("new postgres store: %v", err)
 	}
@@ -134,7 +134,7 @@ func TestPostgresStore_RevokeAndRotate(t *testing.T) {
 }
 
 func TestPostgresStore_ListMasked(t *testing.T) {
-	store, err := admin.NewPostgresStore(testDSN)
+	store, err := admin.NewPostgresStore(t.Context(), testDSN)
 	if err != nil {
 		t.Fatalf("new postgres store: %v", err)
 	}

--- a/test/integration/bootstrap_test.go
+++ b/test/integration/bootstrap_test.go
@@ -14,7 +14,7 @@ func TestBootstrap_KeyStore_Postgres(t *testing.T) {
 	t.Setenv("API_KEY_STORE_BACKEND", "postgres")
 	t.Setenv("API_KEY_STORE_DSN", testDSN)
 
-	store, backend, err := bootstrap.CreateKeyStoreFromEnv()
+	store, backend, err := bootstrap.CreateKeyStoreFromEnv(t.Context())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -30,7 +30,7 @@ func TestBootstrap_KeyStore_PostgreSQLAlias(t *testing.T) {
 	t.Setenv("API_KEY_STORE_BACKEND", "postgresql")
 	t.Setenv("API_KEY_STORE_DSN", testDSN)
 
-	store, backend, err := bootstrap.CreateKeyStoreFromEnv()
+	store, backend, err := bootstrap.CreateKeyStoreFromEnv(t.Context())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -46,7 +46,7 @@ func TestBootstrap_RequestLogReader_Postgres(t *testing.T) {
 	t.Setenv("REQUEST_LOG_STORE_BACKEND", "postgres")
 	t.Setenv("REQUEST_LOG_STORE_DSN", testDSN)
 
-	reader, maintainer, backend, err := bootstrap.CreateRequestLogReaderFromEnv()
+	reader, maintainer, backend, err := bootstrap.CreateRequestLogReaderFromEnv(t.Context())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -70,7 +70,7 @@ func TestBootstrap_ConfigManager_Postgres(t *testing.T) {
 		t.Fatalf("new gateway: %v", err)
 	}
 
-	mgr, backend, err := bootstrap.CreateConfigManagerFromEnv(gw)
+	mgr, backend, err := bootstrap.CreateConfigManagerFromEnv(t.Context(), gw)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/test/integration/config_store_test.go
+++ b/test/integration/config_store_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestPostgresConfigStore_SaveLoadRoundtrip(t *testing.T) {
-	store, err := admin.NewPostgresConfigStore(testDSN)
+	store, err := admin.NewPostgresConfigStore(t.Context(), testDSN)
 	if err != nil {
 		t.Fatalf("new config store: %v", err)
 	}
@@ -45,7 +45,7 @@ func TestPostgresConfigStore_SaveLoadRoundtrip(t *testing.T) {
 }
 
 func TestPostgresConfigStore_Delete(t *testing.T) {
-	store, err := admin.NewPostgresConfigStore(testDSN)
+	store, err := admin.NewPostgresConfigStore(t.Context(), testDSN)
 	if err != nil {
 		t.Fatalf("new config store: %v", err)
 	}
@@ -72,7 +72,7 @@ func TestPostgresConfigStore_Delete(t *testing.T) {
 }
 
 func TestPostgresConfigManager_ReloadPersists(t *testing.T) {
-	store, err := admin.NewPostgresConfigStore(testDSN)
+	store, err := admin.NewPostgresConfigStore(t.Context(), testDSN)
 	if err != nil {
 		t.Fatalf("new config store: %v", err)
 	}

--- a/test/integration/requestlog_test.go
+++ b/test/integration/requestlog_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestPostgresRequestLog_WriteAndList(t *testing.T) {
-	w, err := requestlog.NewPostgresWriter(testDSN)
+	w, err := requestlog.NewPostgresWriter(t.Context(), testDSN)
 	if err != nil {
 		t.Fatalf("new writer: %v", err)
 	}
@@ -46,7 +46,7 @@ func TestPostgresRequestLog_WriteAndList(t *testing.T) {
 }
 
 func TestPostgresRequestLog_Pagination(t *testing.T) {
-	w, err := requestlog.NewPostgresWriter(testDSN)
+	w, err := requestlog.NewPostgresWriter(t.Context(), testDSN)
 	if err != nil {
 		t.Fatalf("new writer: %v", err)
 	}
@@ -87,7 +87,7 @@ func TestPostgresRequestLog_Pagination(t *testing.T) {
 }
 
 func TestPostgresRequestLog_Delete(t *testing.T) {
-	w, err := requestlog.NewPostgresWriter(testDSN)
+	w, err := requestlog.NewPostgresWriter(t.Context(), testDSN)
 	if err != nil {
 		t.Fatalf("new writer: %v", err)
 	}


### PR DESCRIPTION
## Summary

Second phase of the post-audit hardening line, following v1.1.18 (#331). All changes are additive/behavior-preserving — no public config key or Go signature is removed or renamed.

- **Bounded upstream reads**: every provider's HTTP response read (`io.ReadAll` and two previously-unbounded `json.Decoder`-on-body streaming-decode paths in anthropic/openai) is now capped at 50 MiB via `core.ReadResponseBody`/`io.LimitReader`, so a single oversized upstream response can no longer exhaust gateway memory.
- **Typed HTTP status errors**: `core.APIError` now returns `*core.HTTPStatusError`, recoverable via `errors.As`. `core.ParseStatusCode` tries the typed error first and falls back to its previous regex-on-message approach. No call-site changes were needed in `gateway_circuitbreaker.go` or `internal/strategies/fallback.go` — `errors.As` correctly unwraps through their existing retry-wrapping. Three providers (cohere, ollama, ollama_cloud) that previously hand-rolled status-in-message errors were migrated to the typed error.
- **DeepSeek streaming fix**: streaming responses now report cache-hit token counts (`prompt_cache_hit_tokens` → `CacheReadTokens`), matching what the non-streaming path already captured.
- **Cross-provider conformance test**: new test asserting all 28 baseURL-configurable providers (Bedrock/Vertex AI excluded — SDK-signed transports) correctly recover a 429/500 upstream status through both `Complete()` and `CompleteStream()`.
- **Fixed 5 discarded-read-error sites**: a CodeRabbit review of this branch found that the mechanical `io.ReadAll` → `core.ReadResponseBody` swap left several streaming error-paths (`cohere`, `openaicompat`, `anthropic`, `replicate`, `gemini`) silently discarding the new read error on a non-200 stream response — previously harmless since `io.ReadAll` couldn't fail that way, but `ReadResponseBody` legitimately can (size exceeded). All five now propagate the read error instead of returning an empty-message error.
- **`noctx` lint hardening**: added the `noctx` linter (flags outbound HTTP/DB calls made without a `context.Context`) and threaded `ctx` through every finding — DB store constructors (`internal/admin`, `internal/requestlog`), bootstrap factory functions, and the model-catalog fetch path. `models.Load()`/`models.LoadWithInfo()` (public API) keep their exact signatures unchanged, delegating to new `LoadContext`/`LoadWithInfoContext` variants, so this is non-breaking for external consumers of the module. One real behavior improvement: the periodic catalog refresh now cancels immediately on gateway shutdown instead of waiting up to its 1s internal timeout. ~100 test call sites updated to pass `t.Context()`.
- **Ollama native-endpoint error parsing fix**: found while addressing CodeRabbit feedback — `DiscoverModels` (`/api/tags`) and `Embed` (`/api/embed`) were passing Ollama's flat `{"error":"..."}` error body into a decoder that only understands the OpenAI-nested `{"error":{"message":...}}`/`{"detail":"..."}` shapes, so upstream error messages surfaced as a raw JSON blob instead of the actual text. Fixed with a small local `ollamaAPIError` helper, mirroring the existing cohere/ollama_cloud pattern for non-OpenAI envelopes. (The OpenAI-compat surface used by `Complete`/`CompleteStream` is unaffected — it genuinely returns OpenAI-shaped errors.)

See `CHANGELOG.md` for the user-facing entry.

## Test plan

- [x] `make fmt lint test` (includes `-race`) — green
- [x] `make build` — green
- [x] `golangci-lint run ./...` with `noctx` enabled — 0 issues, verified stable across repeated clean-cache runs
- [x] TDD throughout: every fix (including the 5 discarded-read-error sites, the ctx-cancellation behavior, and the Ollama error-parsing bug) was reproduced RED before being fixed
- [x] New/updated tests: bounded-read tests, typed-error tests (`errors.As` recovery, wrapped and unwrapped), DeepSeek streaming cache-token test, cross-provider status conformance suite (`Complete` + `CompleteStream`, 28 providers × 2 statuses = 84 subtests), catalog-fetch cancellation tests, Ollama flat-error-shape tests
- [x] Reviewed by `go-reviewer` and `code-reviewer` agents across three rounds (H2 implementation, discarded-error fixes, noctx hardening) — all APPROVE, 0 CRITICAL/HIGH — and CodeRabbit; all actionable findings fixed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Added a 50 MiB cap on upstream response bodies across providers (including error payloads) to reduce risk of oversized responses stressing gateway memory.

* **Bug Fixes**
  * Fixed DeepSeek streaming usage reporting so `cache_read_tokens` is consistently populated.
  * Improved upstream error handling with typed, status-aware errors and better recovery of HTTP status codes; oversized upstream error-body read failures are now surfaced instead of being dropped.

* **Reliability**
  * Updated catalog/model loading and refresh to respect cancellation during shutdown, improving timely aborts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->