### PR TITLE
v1.1.20 — Streaming Deadlines & Serving Robustness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ["1.25.11"]
+        go: ["1.25.12"]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -65,7 +65,7 @@ jobs:
         run: go test -v -short -race -timeout 180s ./...
 
       - name: Test coverage
-        if: matrix.go == '1.25.11'
+        if: matrix.go == '1.25.12'
         id: coverage
         run: |
           go test -short -race -coverprofile=coverage.out -covermode=atomic ./...
@@ -80,7 +80,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload coverage artifact
-        if: matrix.go == '1.25.11'
+        if: matrix.go == '1.25.12'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: coverage-go-${{ matrix.go }}
@@ -88,7 +88,7 @@ jobs:
           if-no-files-found: error
 
       - name: Upload coverage to Codecov
-        if: matrix.go == '1.25.11'
+        if: matrix.go == '1.25.12'
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -109,7 +109,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
-          go-version: "1.25.11"
+          go-version: "1.25.12"
           check-latest: true
           cache: true
 
@@ -130,7 +130,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
-          go-version: "1.25.11"
+          go-version: "1.25.12"
           check-latest: true
           cache: true
 
@@ -153,7 +153,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
       with:
-        go-version: '1.25.11'
+        go-version: '1.25.12'
         check-latest: true
 
     - name: Run golangci-lint (v2)

--- a/.github/workflows/code-scanning.yml
+++ b/.github/workflows/code-scanning.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
-          go-version: "1.25.11"
+          go-version: "1.25.12"
           check-latest: true
           cache: true
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
-          go-version: "1.25.11"
+          go-version: "1.25.12"
           cache: true
 
       - name: Set up QEMU (for cross-platform Docker builds)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to Ferro Labs AI Gateway are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.20] — 2026-07-10
+
+Streaming deadlines and serving robustness — the third phase of the v1.1.x hardening release line. All changes are additive/behavior-preserving for the public API.
+
+### Security
+
+- **Streaming response writes** on pass-through proxy routes and legacy completions streaming now use short per-write deadlines that are cleared after each successful write, reducing the chance that slow or disconnected clients can tie up server resources indefinitely.
+- **Browser-facing responses** now include Content-Security-Policy and Permissions-Policy headers in addition to the existing baseline security headers.
+
+### Changed
+
+- **Provider auto-registration** now warns and skips a single configured provider when its factory fails, allowing the gateway to continue serving with other valid providers. Fatal startup behavior is unchanged for invalid config, store initialization, plugin loading, and other process-level failures.
+- **Health endpoints** now return HTTP 503 for degraded or no-provider states while preserving the existing JSON response body shape for `/health` and `/admin/health`.
+
+### Fixed
+
+- **Panic recovery** now returns the gateway's JSON error envelope from the outer HTTP middleware layer, so recovered panics are shaped consistently with other server errors.
+- **Rejected-request metrics** now bucket unknown or arbitrary model names under the bounded `unknown` model label, avoiding high-cardinality Prometheus series from user-supplied model strings.
+
+---
+
 ## [1.1.19] — 2026-07-09
 
 Provider read bounds and typed errors — the second phase of a multi-phase hardening release line. All changes are additive/behavior-preserving.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,24 +5,26 @@ All notable changes to Ferro Labs AI Gateway are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.1.20] — 2026-07-10
+## [1.1.20] — 2026-07-09
 
 Streaming deadlines and serving robustness — the third phase of the v1.1.x hardening release line. All changes are additive/behavior-preserving for the public API.
 
 ### Security
 
-- **Streaming response writes** on pass-through proxy routes and legacy completions streaming now use short per-write deadlines that are cleared after each successful write, reducing the chance that slow or disconnected clients can tie up server resources indefinitely.
-- **Browser-facing responses** now include Content-Security-Policy and Permissions-Policy headers in addition to the existing baseline security headers.
+- **Long-lived streaming responses** on pass-through proxy routes and legacy completions streaming are no longer truncated after 120 seconds. Each client-facing write now carries its own short deadline, and a slow client that stops reading is disconnected instead of blocking a request goroutine.
+- **Upstream idle bound.** Because per-write deadlines take the server's overall write timeout out of play, both streaming paths now cancel the upstream request when it produces no data for 5 minutes. A stalled or trickling provider can no longer hold a connection open indefinitely.
+- **Browser-facing responses** now include Content-Security-Policy and Permissions-Policy headers in addition to the existing baseline security headers. The policy sets `script-src 'self'`, so the admin dashboard no longer relies on inline scripts or inline event handlers.
 
 ### Changed
 
-- **Provider auto-registration** now warns and skips a single configured provider when its factory fails, allowing the gateway to continue serving with other valid providers. Fatal startup behavior is unchanged for invalid config, store initialization, plugin loading, and other process-level failures.
-- **Health endpoints** now return HTTP 503 for degraded or no-provider states while preserving the existing JSON response body shape for `/health` and `/admin/health`.
+- **Provider auto-registration** now warns and skips a single configured provider when its factory fails, allowing the gateway to continue serving with other valid providers. Fatal startup behavior is unchanged for invalid config, store initialization, plugin loading, and other process-level failures. Each skip increments the new `gateway_provider_init_failures_total{provider}` counter — alert on it, since the gateway stays healthy with the provider missing.
+- **`/health`** now returns HTTP 503 for degraded or no-provider states while preserving its JSON response body, so load balancer and Kubernetes probes can act on it. `/admin/health` is bearer-authenticated rather than a probe target and continues to return 200, reporting state in the body.
+- **`ferrogw status` and `ferrogw doctor`** distinguish a degraded gateway from an unreachable one and print the reported status.
 
 ### Fixed
 
-- **Panic recovery** now returns the gateway's JSON error envelope from the outer HTTP middleware layer, so recovered panics are shaped consistently with other server errors.
-- **Rejected-request metrics** now bucket unknown or arbitrary model names under the bounded `unknown` model label, avoiding high-cardinality Prometheus series from user-supplied model strings.
+- **Panic recovery** now returns the gateway's JSON error envelope from the outermost HTTP middleware layer, so panics raised inside the tracing and logging middleware are recovered too. Recovered panics are logged with a stack trace and the request's trace ID.
+- **Request metrics** now bucket unknown or arbitrary model names under the bounded `unknown` model label on both the rejected and error paths. Previously any request naming an unroutable model minted a new Prometheus series and a permanent metric-handle cache entry.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Streaming deadlines and serving robustness — the third phase of the v1.1.x har
 - **Long-lived streaming responses** on pass-through proxy routes and legacy completions streaming are no longer truncated after 120 seconds. Each client-facing write now carries its own short deadline, and a slow client that stops reading is disconnected instead of blocking a request goroutine.
 - **Upstream idle bound.** Because per-write deadlines take the server's overall write timeout out of play, both streaming paths now cancel the upstream request when it produces no data for 5 minutes. A stalled or trickling provider can no longer hold a connection open indefinitely.
 - **Browser-facing responses** now include Content-Security-Policy and Permissions-Policy headers in addition to the existing baseline security headers. The policy sets `script-src 'self'`, so the admin dashboard no longer relies on inline scripts or inline event handlers.
+- **Build toolchain pinned to Go 1.25.12**, picking up the fix for [GO-2026-5856](https://pkg.go.dev/vuln/GO-2026-5856) — an Encrypted Client Hello privacy leak in `crypto/tls`.
 
 ### Changed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ git push origin release/v1.0.0
 
 ### Prerequisites
 
-- **Go 1.25+** — the toolchain version is pinned in [`go.mod`](go.mod) (`go 1.25.11`).
+- **Go 1.25+** — the toolchain version is pinned in [`go.mod`](go.mod) (`go 1.25.12`).
 - **golangci-lint** — install via the [official instructions](https://golangci-lint.run/welcome/install/). CI pins v2; match that locally.
 
 ### Running Checks

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.25.11-alpine AS builder
+FROM golang:1.25.12-alpine AS builder
 
 RUN apk add --no-cache git ca-certificates
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -77,7 +77,7 @@ Weekly patch line. Each release is backward-compatible bug-fixing on a single th
 
 ### Next patch
 
-- **v1.1.20** — Streaming deadlines and serving robustness: long-lived proxy and legacy-completions streams, recoverable provider initialization failures, degraded health status codes, CSP/Permissions-Policy headers, panic recovery order, and metrics-cardinality hardening.
+- **v1.1.20** — Streaming deadlines and serving robustness: long-lived proxy and legacy-completions streams with an upstream idle bound, recoverable provider initialization failures, degraded health status codes, CSP/Permissions-Policy headers, panic recovery order, and metrics-cardinality hardening.
 
 ## v1.2.0 — Provider Parameter Capability Matrix
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -71,6 +71,13 @@ Weekly patch line. Each release is backward-compatible bug-fixing on a single th
 - **v1.1.7** — Small enhancements: end-to-end `context.Context` propagation, plugin-registry concurrency, hot-path allocation reductions, git-hook gating.
 - **v1.1.8** — Security & trust hardening: baseline HTTP security headers, request body-size limit, trusted-proxy client-IP resolution, expanded secret redaction, config-validation and admin-key safety.
 - **v1.1.9** — Quality & maintainability hardening: per-key rate-limit / budget scoping, atomic budget soft cap, internal package restructuring (no API or behaviour changes), and CI supply-chain hardening (SHA-pinned actions).
+- **v1.1.10–v1.1.17** — Provider readiness remediation: proxy governance, native provider fidelity, enterprise endpoints, OpenAI-compatible provider coverage, local/prediction API providers, and provider-readiness closeout.
+- **v1.1.18** — Critical fixes and security hardening: concurrent cache-hit race fix, SQLite file permissions restricted to `0600`, safe default per-IP rate limiting, and Go 1.25.11 toolchain pin.
+- **v1.1.19** — Provider read bounds and typed errors: upstream provider response reads capped at 50 MiB, typed provider HTTP status errors for retry/circuit-breaker classification, DeepSeek streaming token accounting, and cross-provider status conformance.
+
+### Next patch
+
+- **v1.1.20** — Streaming deadlines and serving robustness: long-lived proxy and legacy-completions streams, recoverable provider initialization failures, degraded health status codes, CSP/Permissions-Policy headers, panic recovery order, and metrics-cardinality hardening.
 
 ## v1.2.0 — Provider Parameter Capability Matrix
 

--- a/gateway_route.go
+++ b/gateway_route.go
@@ -109,7 +109,7 @@ func (g *Gateway) Route(ctx context.Context, req providers.Request) (*providers.
 			early, err = g.runBeforePlugins(ctx, plugins, pctx, &req)
 		})
 		if err != nil {
-			metrics.ForRequest("", req.Model).Rejected.Inc()
+			metrics.ForRequest("", g.rejectedMetricModel(req.Model)).Rejected.Inc()
 			return nil, err
 		}
 		if early != nil {
@@ -233,6 +233,18 @@ func (g *Gateway) Route(ctx context.Context, req providers.Request) (*providers.
 	resp.OverheadMs = float64((latency - providerDuration).Microseconds()) / 1000.0
 
 	return resp, nil
+}
+
+func (g *Gateway) rejectedMetricModel(model string) string {
+	if model == "" {
+		return metrics.UnknownModelLabel
+	}
+	for _, known := range g.AllModels() {
+		if known.ID == model {
+			return model
+		}
+	}
+	return metrics.UnknownModelLabel
 }
 
 // runMCPLoop drives the agentic MCP tool-call loop: while resp has pending

--- a/gateway_route.go
+++ b/gateway_route.go
@@ -109,7 +109,7 @@ func (g *Gateway) Route(ctx context.Context, req providers.Request) (*providers.
 			early, err = g.runBeforePlugins(ctx, plugins, pctx, &req)
 		})
 		if err != nil {
-			metrics.ForRequest("", g.rejectedMetricModel(req.Model)).Rejected.Inc()
+			metrics.ForRequest("", g.metricModel(req.Model)).Rejected.Inc()
 			return nil, err
 		}
 		if early != nil {
@@ -235,14 +235,20 @@ func (g *Gateway) Route(ctx context.Context, req providers.Request) (*providers.
 	return resp, nil
 }
 
-func (g *Gateway) rejectedMetricModel(model string) string {
+// metricModel bounds the Prometheus "model" label. Client-supplied model names
+// reach the reject and error paths verbatim, so any name the gateway cannot
+// route is collapsed to metrics.UnknownModelLabel rather than minting a new
+// time series. The exact-match routing index is the authoritative set of known
+// model IDs and is already rebuilt whenever providers or discovery change.
+func (g *Gateway) metricModel(model string) string {
 	if model == "" {
 		return metrics.UnknownModelLabel
 	}
-	for _, known := range g.AllModels() {
-		if known.ID == model {
-			return model
-		}
+	g.mu.RLock()
+	_, known := g.modelIndex.exactProviders[model]
+	g.mu.RUnlock()
+	if known {
+		return model
 	}
 	return metrics.UnknownModelLabel
 }
@@ -317,7 +323,9 @@ func (g *Gateway) routeError(ctx context.Context, span observability.Span, obs o
 	if errors.Is(err, circuitbreaker.ErrCircuitOpen) {
 		errType = "circuit_open"
 	}
-	metrics.ForRequest(provider, model).Error.Inc()
+	// Bucket the label, not the log/span: model here is still the raw client
+	// value on the "no provider supports this model" path.
+	metrics.ForRequest(provider, g.metricModel(model)).Error.Inc()
 	metrics.ForProviderError(provider, errType).Inc()
 
 	span.SetError(err)

--- a/gateway_stream.go
+++ b/gateway_stream.go
@@ -164,8 +164,12 @@ func (g *Gateway) RouteStream(ctx context.Context, req providers.Request) (<-cha
 	g.mu.RUnlock()
 
 	meta := streamwrap.MeterMeta{
-		Provider:        providerName,
-		Model:           req.Model,
+		Provider: providerName,
+		Model:    req.Model,
+		// Model stays raw for cost lookup and event payloads; only the metric
+		// label is bounded, mirroring the non-streaming path's use of the
+		// provider-reported model.
+		MetricModel:     g.metricModel(req.Model),
 		Catalog:         catalog,
 		TraceID:         logging.TraceIDFromContext(ctx),
 		LatencyRecorder: g.latencyTracker.Record,

--- a/gateway_stream.go
+++ b/gateway_stream.go
@@ -296,7 +296,7 @@ func (g *Gateway) runBeforePluginsStream(ctx context.Context, span observability
 	if err != nil {
 		plugin.PutContext(pctx)
 		releasePluginManager()
-		metrics.ForRequest("", req.Model).Rejected.Inc()
+		metrics.ForRequest("", g.rejectedMetricModel(req.Model)).Rejected.Inc()
 		return nil, nil, err
 	}
 	if early != nil {

--- a/gateway_stream.go
+++ b/gateway_stream.go
@@ -138,7 +138,9 @@ func (g *Gateway) RouteStream(ctx context.Context, req providers.Request) (<-cha
 			plugin.PutContext(pctx)
 			releasePluginManager()
 		}
-		metrics.ForRequest(providerName, req.Model).Error.Inc()
+		// Providers that accept any model ID (openrouter, ollama, azure_openai, …)
+		// let a raw client model reach this counter, so bound it.
+		metrics.ForRequest(providerName, g.metricModel(req.Model)).Error.Inc()
 		metrics.ForProviderError(providerName, errType).Inc()
 		span.SetError(err)
 		if hooksEnabled || obsEventsActive {
@@ -296,7 +298,7 @@ func (g *Gateway) runBeforePluginsStream(ctx context.Context, span observability
 	if err != nil {
 		plugin.PutContext(pctx)
 		releasePluginManager()
-		metrics.ForRequest("", g.rejectedMetricModel(req.Model)).Rejected.Inc()
+		metrics.ForRequest("", g.metricModel(req.Model)).Rejected.Inc()
 		return nil, nil, err
 	}
 	if early != nil {

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -2699,21 +2699,9 @@ func TestGateway_Route_PluginRejectsRequest(t *testing.T) {
 	}
 }
 
-type wildcardMetricProvider struct {
-	mockProvider
-}
-
-func (p *wildcardMetricProvider) SupportsModel(string) bool { return true }
-func (p *wildcardMetricProvider) Models() []providers.ModelInfo {
-	return []providers.ModelInfo{{ID: "known-model", Object: "model", OwnedBy: p.name}}
-}
-
-func TestGateway_Route_PluginRejectsUnknownModelBucketsMetricLabel(t *testing.T) {
-	rawModel := "user-supplied-high-cardinality-" + strings.NewReplacer("/", "_", " ", "_").Replace(t.Name())
-	if requestMetricLabelExists(t, "", rawModel, "rejected") {
-		t.Fatalf("raw model label %q already exists before test", rawModel)
-	}
-
+// newMetricLabelGateway returns a gateway serving exactly "known-model".
+func newMetricLabelGateway(t *testing.T) *Gateway {
+	t.Helper()
 	gw, err := New(Config{
 		Strategy: StrategyConfig{Mode: ModeSingle},
 		Targets:  []Target{{VirtualKey: mockProviderName}},
@@ -2721,12 +2709,43 @@ func TestGateway_Route_PluginRejectsUnknownModelBucketsMetricLabel(t *testing.T)
 	if err != nil {
 		t.Fatalf("New gateway: %v", err)
 	}
-	gw.RegisterProvider(&wildcardMetricProvider{mockProvider: mockProvider{
+	gw.RegisterProvider(&mockProvider{
 		name:   mockProviderName,
 		models: []string{"known-model"},
 		resp:   &providers.Response{ID: "should-not-reach"},
-	}})
+	})
+	return gw
+}
 
+func TestGateway_metricModel(t *testing.T) {
+	gw := newMetricLabelGateway(t)
+
+	tests := []struct {
+		name  string
+		model string
+		want  string
+	}{
+		{name: "known model passes through", model: "known-model", want: "known-model"},
+		{name: "empty model buckets", model: "", want: metrics.UnknownModelLabel},
+		{name: "arbitrary model buckets", model: "totally-made-up-model", want: metrics.UnknownModelLabel},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := gw.metricModel(tt.model); got != tt.want {
+				t.Fatalf("metricModel(%q) = %q, want %q", tt.model, got, tt.want)
+			}
+		})
+	}
+}
+
+// A plugin rejection carries the raw client model to the "rejected" counter.
+func TestGateway_Route_PluginRejectsUnknownModelBucketsMetricLabel(t *testing.T) {
+	const rawModel = "user-supplied-high-cardinality-rejected"
+	if requestMetricLabelExists(t, "", rawModel, "rejected") {
+		t.Fatalf("raw model label %q already exists before test", rawModel)
+	}
+
+	gw := newMetricLabelGateway(t)
 	_ = gw.RegisterPlugin(plugin.StageBeforeRequest, &testPlugin{
 		name: "blocker",
 		typ:  plugin.TypeGuardrail,
@@ -2739,7 +2758,7 @@ func TestGateway_Route_PluginRejectsUnknownModelBucketsMetricLabel(t *testing.T)
 
 	unknownCounter := metrics.ForRequest("", metrics.UnknownModelLabel).Rejected
 	before := counterValue(t, unknownCounter)
-	_, err = gw.Route(context.Background(), providers.Request{
+	_, err := gw.Route(context.Background(), providers.Request{
 		Model:    rawModel,
 		Messages: []providers.Message{{Role: "user", Content: "hi"}},
 	})
@@ -2752,8 +2771,77 @@ func TestGateway_Route_PluginRejectsUnknownModelBucketsMetricLabel(t *testing.T)
 	if requestMetricLabelExists(t, "", rawModel, "rejected") {
 		t.Fatalf("raw rejected model label %q should not be created", rawModel)
 	}
-	if got := gw.rejectedMetricModel("known-model"); got != "known-model" {
-		t.Fatalf("known rejected metric model = %q, want known-model", got)
+}
+
+// The error path needs no plugin at all: any unroutable model reaches it, which
+// makes it the cardinality vector a client can trigger against a stock gateway.
+func TestGateway_Route_UnroutableModelBucketsErrorMetricLabel(t *testing.T) {
+	const rawModel = "user-supplied-high-cardinality-error"
+	if requestMetricLabelExists(t, "", rawModel, "error") {
+		t.Fatalf("raw model label %q already exists before test", rawModel)
+	}
+
+	gw := newMetricLabelGateway(t)
+	unknownCounter := metrics.ForRequest("", metrics.UnknownModelLabel).Error
+	before := counterValue(t, unknownCounter)
+
+	_, err := gw.Route(context.Background(), providers.Request{
+		Model:    rawModel,
+		Messages: []providers.Message{{Role: "user", Content: "hi"}},
+	})
+	if err == nil {
+		t.Fatal("expected routing error for unsupported model")
+	}
+	if delta := counterValue(t, unknownCounter) - before; delta != 1 {
+		t.Fatalf("unknown error counter delta = %v, want 1", delta)
+	}
+	if requestMetricLabelExists(t, "", rawModel, "error") {
+		t.Fatalf("raw error model label %q should not be created", rawModel)
+	}
+}
+
+// wildcardStreamProvider mirrors the 14 providers that accept any model ID
+// (openrouter, ollama, azure_openai, …). They route a raw client model all the
+// way to a provider call, so a CompleteStream failure lands on the error counter
+// with that raw value.
+type wildcardStreamProvider struct {
+	mockStreamProvider
+}
+
+func (p *wildcardStreamProvider) SupportsModel(string) bool { return true }
+
+func TestGateway_RouteStream_WildcardProviderBucketsErrorMetricLabel(t *testing.T) {
+	const rawModel = "user-supplied-high-cardinality-stream"
+	if requestMetricLabelExists(t, mockProviderName, rawModel, "error") {
+		t.Fatalf("raw model label %q already exists before test", rawModel)
+	}
+
+	gw, err := New(Config{
+		Strategy: StrategyConfig{Mode: ModeSingle},
+		Targets:  []Target{{VirtualKey: mockProviderName}},
+	})
+	if err != nil {
+		t.Fatalf("New gateway: %v", err)
+	}
+	gw.RegisterProvider(&wildcardStreamProvider{mockStreamProvider: mockStreamProvider{
+		mockProvider: mockProvider{name: mockProviderName, models: []string{"known-model"}},
+		streamErr:    errors.New("upstream rejected model"),
+	}})
+
+	unknownCounter := metrics.ForRequest(mockProviderName, metrics.UnknownModelLabel).Error
+	before := counterValue(t, unknownCounter)
+
+	if _, err := gw.RouteStream(context.Background(), providers.Request{
+		Model:    rawModel,
+		Messages: []providers.Message{{Role: "user", Content: "hi"}},
+	}); err == nil {
+		t.Fatal("expected streaming error")
+	}
+	if delta := counterValue(t, unknownCounter) - before; delta != 1 {
+		t.Fatalf("unknown stream error counter delta = %v, want 1", delta)
+	}
+	if requestMetricLabelExists(t, mockProviderName, rawModel, "error") {
+		t.Fatalf("raw stream error model label %q should not be created", rawModel)
 	}
 }
 

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -94,6 +94,29 @@ func counterValue(t *testing.T, c prometheus.Counter) float64 {
 	return m.GetCounter().GetValue()
 }
 
+func requestMetricLabelExists(t *testing.T, provider, model, status string) bool {
+	t.Helper()
+	mfs, err := prometheus.DefaultGatherer.Gather()
+	if err != nil {
+		t.Fatalf("gather metrics: %v", err)
+	}
+	for _, mf := range mfs {
+		if mf.GetName() != "gateway_requests_total" {
+			continue
+		}
+		for _, m := range mf.GetMetric() {
+			labels := map[string]string{}
+			for _, label := range m.GetLabel() {
+				labels[label.GetName()] = label.GetValue()
+			}
+			if labels["provider"] == provider && labels["model"] == model && labels["status"] == status {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func ptrFloat64(v float64) *float64 { return &v }
 
 func drainStream(t *testing.T, ch <-chan providers.StreamChunk) {
@@ -2673,6 +2696,64 @@ func TestGateway_Route_PluginRejectsRequest(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("expected rejection error")
+	}
+}
+
+type wildcardMetricProvider struct {
+	mockProvider
+}
+
+func (p *wildcardMetricProvider) SupportsModel(string) bool { return true }
+func (p *wildcardMetricProvider) Models() []providers.ModelInfo {
+	return []providers.ModelInfo{{ID: "known-model", Object: "model", OwnedBy: p.name}}
+}
+
+func TestGateway_Route_PluginRejectsUnknownModelBucketsMetricLabel(t *testing.T) {
+	rawModel := "user-supplied-high-cardinality-" + strings.NewReplacer("/", "_", " ", "_").Replace(t.Name())
+	if requestMetricLabelExists(t, "", rawModel, "rejected") {
+		t.Fatalf("raw model label %q already exists before test", rawModel)
+	}
+
+	gw, err := New(Config{
+		Strategy: StrategyConfig{Mode: ModeSingle},
+		Targets:  []Target{{VirtualKey: mockProviderName}},
+	})
+	if err != nil {
+		t.Fatalf("New gateway: %v", err)
+	}
+	gw.RegisterProvider(&wildcardMetricProvider{mockProvider: mockProvider{
+		name:   mockProviderName,
+		models: []string{"known-model"},
+		resp:   &providers.Response{ID: "should-not-reach"},
+	}})
+
+	_ = gw.RegisterPlugin(plugin.StageBeforeRequest, &testPlugin{
+		name: "blocker",
+		typ:  plugin.TypeGuardrail,
+		execFn: func(_ context.Context, pctx *plugin.Context) error {
+			pctx.Reject = true
+			pctx.Reason = "blocked"
+			return nil
+		},
+	})
+
+	unknownCounter := metrics.ForRequest("", metrics.UnknownModelLabel).Rejected
+	before := counterValue(t, unknownCounter)
+	_, err = gw.Route(context.Background(), providers.Request{
+		Model:    rawModel,
+		Messages: []providers.Message{{Role: "user", Content: "hi"}},
+	})
+	if err == nil {
+		t.Fatal("expected rejection error")
+	}
+	if delta := counterValue(t, unknownCounter) - before; delta != 1 {
+		t.Fatalf("unknown rejected counter delta = %v, want 1", delta)
+	}
+	if requestMetricLabelExists(t, "", rawModel, "rejected") {
+		t.Fatalf("raw rejected model label %q should not be created", rawModel)
+	}
+	if got := gw.rejectedMetricModel("known-model"); got != "known-model" {
+		t.Fatalf("known rejected metric model = %q, want known-model", got)
 	}
 }
 

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -2810,6 +2810,46 @@ type wildcardStreamProvider struct {
 
 func (p *wildcardStreamProvider) SupportsModel(string) bool { return true }
 
+// A wildcard provider can accept an arbitrary model and stream successfully, so
+// the success/token/duration labels emitted by streamwrap must be bounded too —
+// not just the error label. The raw model still reaches cost lookup and events.
+func TestGateway_RouteStream_SuccessBucketsMetricLabel(t *testing.T) {
+	const rawModel = "user-supplied-high-cardinality-stream-success"
+	if requestMetricLabelExists(t, mockProviderName, rawModel, "success") {
+		t.Fatalf("raw model label %q already exists before test", rawModel)
+	}
+
+	gw, err := New(Config{
+		Strategy: StrategyConfig{Mode: ModeSingle},
+		Targets:  []Target{{VirtualKey: mockProviderName}},
+	})
+	if err != nil {
+		t.Fatalf("New gateway: %v", err)
+	}
+	gw.RegisterProvider(&wildcardStreamProvider{mockStreamProvider: mockStreamProvider{
+		mockProvider: mockProvider{name: mockProviderName, models: []string{"known-model"}},
+	}})
+
+	unknownCounter := metrics.ForRequest(mockProviderName, metrics.UnknownModelLabel).Success
+	before := counterValue(t, unknownCounter)
+
+	ch, err := gw.RouteStream(context.Background(), providers.Request{
+		Model:    rawModel,
+		Messages: []providers.Message{{Role: "user", Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("RouteStream: %v", err)
+	}
+	drainStream(t, ch) // streamwrap emits metrics before closing the channel
+
+	if delta := counterValue(t, unknownCounter) - before; delta != 1 {
+		t.Fatalf("unknown success counter delta = %v, want 1", delta)
+	}
+	if requestMetricLabelExists(t, mockProviderName, rawModel, "success") {
+		t.Fatalf("raw success model label %q should not be created", rawModel)
+	}
+}
+
 func TestGateway_RouteStream_WildcardProviderBucketsErrorMetricLabel(t *testing.T) {
 	const rawModel = "user-supplied-high-cardinality-stream"
 	if requestMetricLabelExists(t, mockProviderName, rawModel, "error") {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ferro-labs/ai-gateway
 
-go 1.25.11
+go 1.25.12
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.41.8

--- a/internal/admin/admin_dashboard_handlers.go
+++ b/internal/admin/admin_dashboard_handlers.go
@@ -180,5 +180,8 @@ func (h *Handlers) healthCheck(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("Cache-Control", "no-store")
+	if overallStatus != "healthy" {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}
 	_ = json.NewEncoder(w).Encode(resp)
 }

--- a/internal/admin/admin_dashboard_handlers.go
+++ b/internal/admin/admin_dashboard_handlers.go
@@ -178,10 +178,12 @@ func (h *Handlers) healthCheck(w http.ResponseWriter, r *http.Request) {
 		resp["scopes"] = apiKey.Scopes
 	}
 
+	// Deliberately always 200: this endpoint is bearer-authenticated, so it is
+	// never an LB or k8s probe target, and three clients read a non-2xx here as
+	// "auth failed" or "gateway down" — the dashboard login probe, the dashboard
+	// providers page, and `ferrogw admin health`. Degradation is reported in the
+	// body. Probes should use the unauthenticated /health, which does return 503.
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("Cache-Control", "no-store")
-	if overallStatus != "healthy" {
-		w.WriteHeader(http.StatusServiceUnavailable)
-	}
 	_ = json.NewEncoder(w).Encode(resp)
 }

--- a/internal/admin/handlers_test.go
+++ b/internal/admin/handlers_test.go
@@ -500,8 +500,10 @@ func TestHealthCheck(t *testing.T) {
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
 
-	if w.Code != http.StatusServiceUnavailable {
-		t.Fatalf("expected 503, got %d: %s", w.Code, w.Body.String())
+	// 200 even while degraded: the dashboard login probe and providers page read
+	// any non-2xx here as an auth failure. The body carries the real status.
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
 	}
 
 	var result map[string]any

--- a/internal/admin/handlers_test.go
+++ b/internal/admin/handlers_test.go
@@ -500,14 +500,14 @@ func TestHealthCheck(t *testing.T) {
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
 
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d: %s", w.Code, w.Body.String())
 	}
 
 	var result map[string]any
 	_ = json.NewDecoder(w.Body).Decode(&result)
-	if _, ok := result["status"]; !ok {
-		t.Error("expected status field")
+	if result["status"] != "no_providers" {
+		t.Fatalf("expected status no_providers, got %v", result["status"])
 	}
 	if _, ok := result["providers"]; !ok {
 		t.Error("expected providers field")

--- a/internal/admin/health_status_test.go
+++ b/internal/admin/health_status_test.go
@@ -1,0 +1,44 @@
+package admin
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/ferro-labs/ai-gateway/providers"
+	"github.com/go-chi/chi/v5"
+)
+
+func TestHealthCheckHealthyProvidersReturns200(t *testing.T) {
+	store := NewKeyStore()
+	registry := providers.NewRegistry()
+	registry.Register(adminHealthProvider{})
+	h := &Handlers{Keys: store, Providers: registry}
+	r := chi.NewRouter()
+	r.Use(AuthMiddleware(store, ""))
+	r.Mount("/admin", h.Routes())
+	key := createAdminKey(t, h)
+
+	req := authedRequest(http.MethodGet, "/admin/health", "", key)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+type adminHealthProvider struct{}
+
+func (adminHealthProvider) Name() string              { return "admin-health" }
+func (adminHealthProvider) SupportedModels() []string { return []string{"admin-health-model"} }
+func (adminHealthProvider) SupportsModel(model string) bool {
+	return model == "admin-health-model"
+}
+func (adminHealthProvider) Models() []providers.ModelInfo {
+	return []providers.ModelInfo{{ID: "admin-health-model", Object: "model", OwnedBy: "admin-health"}}
+}
+func (adminHealthProvider) Complete(context.Context, providers.Request) (*providers.Response, error) {
+	return nil, nil
+}

--- a/internal/admin/health_status_test.go
+++ b/internal/admin/health_status_test.go
@@ -2,6 +2,7 @@ package admin
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -10,23 +11,64 @@ import (
 	"github.com/go-chi/chi/v5"
 )
 
-func TestHealthCheckHealthyProvidersReturns200(t *testing.T) {
-	store := NewKeyStore()
-	registry := providers.NewRegistry()
-	registry.Register(adminHealthProvider{})
-	h := &Handlers{Keys: store, Providers: registry}
-	r := chi.NewRouter()
-	r.Use(AuthMiddleware(store, ""))
-	r.Mount("/admin", h.Routes())
-	key := createAdminKey(t, h)
-
-	req := authedRequest(http.MethodGet, "/admin/health", "", key)
-	w := httptest.NewRecorder()
-	r.ServeHTTP(w, req)
-
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+// /admin/health is bearer-authenticated and is read by the dashboard login probe,
+// the providers page, and `ferrogw admin health` — all of which treat a non-2xx
+// as a failure. It therefore always answers 200 and reports state in the body.
+func TestHealthCheckAlwaysReturns200AndReportsStatusInBody(t *testing.T) {
+	tests := []struct {
+		name       string
+		providers  providers.ProviderSource
+		wantStatus string
+	}{
+		{name: "healthy", providers: registryWith(adminHealthProvider{}), wantStatus: "healthy"},
+		{name: "no providers", providers: providers.NewRegistry(), wantStatus: "no_providers"},
+		{name: "degraded", providers: ghostProviderSource{}, wantStatus: "degraded"},
 	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := NewKeyStore()
+			h := &Handlers{Keys: store, Providers: tt.providers}
+			r := chi.NewRouter()
+			r.Use(AuthMiddleware(store, ""))
+			r.Mount("/admin", h.Routes())
+			key := createAdminKey(t, h)
+
+			req := authedRequest(http.MethodGet, "/admin/health", "", key)
+			w := httptest.NewRecorder()
+			r.ServeHTTP(w, req)
+
+			if w.Code != http.StatusOK {
+				t.Fatalf("status code = %d, want 200: %s", w.Code, w.Body.String())
+			}
+			var payload struct {
+				Status string `json:"status"`
+			}
+			if err := json.NewDecoder(w.Body).Decode(&payload); err != nil {
+				t.Fatalf("decode health response: %v", err)
+			}
+			if payload.Status != tt.wantStatus {
+				t.Fatalf("status = %q, want %q", payload.Status, tt.wantStatus)
+			}
+		})
+	}
+}
+
+func registryWith(p providers.Provider) *providers.Registry {
+	registry := providers.NewRegistry()
+	registry.Register(p)
+	return registry
+}
+
+// ghostProviderSource names a provider that cannot be resolved, the state the
+// health handler reports as "degraded".
+type ghostProviderSource struct{}
+
+func (ghostProviderSource) List() []string                        { return []string{"ghost"} }
+func (ghostProviderSource) Get(string) (providers.Provider, bool) { return nil, false }
+func (ghostProviderSource) AllModels() []providers.ModelInfo      { return nil }
+func (ghostProviderSource) FindByModel(string) (providers.Provider, bool) {
+	return nil, false
 }
 
 type adminHealthProvider struct{}

--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -353,7 +353,10 @@ func registerBedrockProvider(registry *providers.Registry) {
 			SessionToken:    os.Getenv("AWS_SESSION_TOKEN"),
 		})
 		if err != nil {
+			// Same warn-and-skip contract as registerProviderEntries: the counter
+			// is the only machine-readable signal that this provider is missing.
 			logging.Logger.Error("provider init failed", "provider", providers.NameBedrock, "error", err)
+			metrics.ProviderInitFailures.WithLabelValues(providers.NameBedrock).Inc()
 		} else {
 			registry.Register(p)
 			logging.Logger.Info("provider registered", "provider", providers.NameBedrock, "region", p.Region())

--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -308,9 +308,13 @@ func LoadConfig() *aigateway.Config {
 // RegisterProviders auto-registers all providers found via environment variables.
 func RegisterProviders() *providers.Registry {
 	registry := providers.NewRegistry()
+	registerProviderEntries(registry, providers.AllProviders())
+	registerBedrockProvider(registry)
+	return registry
+}
 
-	// Register all providers whose required environment variables are set.
-	for _, entry := range providers.AllProviders() {
+func registerProviderEntries(registry *providers.Registry, entries []providers.ProviderEntry) {
+	for _, entry := range entries {
 		if entry.ID == providers.NameBedrock {
 			continue // handled below with its dual-key detection
 		}
@@ -322,13 +326,15 @@ func RegisterProviders() *providers.Registry {
 
 		p, err := entry.Build(cfg)
 		if err != nil {
-			logging.Logger.Error("provider init failed", "provider", entry.ID, "error", err)
-			os.Exit(1)
+			logging.Logger.Warn("provider init skipped", "provider", entry.ID, "error", err)
+			continue
 		}
 		registry.Register(p)
 		logging.Logger.Info("provider registered", "provider", entry.ID)
 	}
+}
 
+func registerBedrockProvider(registry *providers.Registry) {
 	// AWS Bedrock: register if AWS_REGION, AWS_ACCESS_KEY_ID, or
 	// AWS_BEARER_TOKEN_BEDROCK is set.
 	if region := os.Getenv("AWS_REGION"); region != "" ||
@@ -348,8 +354,6 @@ func RegisterProviders() *providers.Registry {
 			logging.Logger.Info("provider registered", "provider", providers.NameBedrock, "region", p.Region())
 		}
 	}
-
-	return registry
 }
 
 // BuildGateway constructs the Gateway, wires providers, and loads plugins.

--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ferro-labs/ai-gateway/internal/admin"
 	"github.com/ferro-labs/ai-gateway/internal/httpserver"
 	"github.com/ferro-labs/ai-gateway/internal/logging"
+	"github.com/ferro-labs/ai-gateway/internal/metrics"
 	gwotel "github.com/ferro-labs/ai-gateway/internal/otel"
 	"github.com/ferro-labs/ai-gateway/internal/ratelimit"
 	"github.com/ferro-labs/ai-gateway/internal/requestlog"
@@ -326,7 +327,11 @@ func registerProviderEntries(registry *providers.Registry, entries []providers.P
 
 		p, err := entry.Build(cfg)
 		if err != nil {
+			// Warn-and-skip so one bad credential cannot stop the whole gateway.
+			// The counter is what keeps that from being a silent partial outage:
+			// /health only counts registered providers, so it stays 200 here.
 			logging.Logger.Warn("provider init skipped", "provider", entry.ID, "error", err)
+			metrics.ProviderInitFailures.WithLabelValues(entry.ID).Inc()
 			continue
 		}
 		registry.Register(p)

--- a/internal/bootstrap/provider_registration_test.go
+++ b/internal/bootstrap/provider_registration_test.go
@@ -56,6 +56,28 @@ func TestRegisterProviderEntriesSkipsBrokenProviderAndKeepsGoodProvider(t *testi
 	}
 }
 
+// Bedrock is registered by its own dual-key branch rather than the generic loop,
+// so it needs the same failure signal: an access key without a secret builds no
+// provider, the gateway still starts, and /health still reports it as serving.
+func TestRegisterBedrockProviderCountsInitFailure(t *testing.T) {
+	t.Setenv("AWS_REGION", "us-east-1")
+	t.Setenv("AWS_ACCESS_KEY_ID", "AKIAEXAMPLE")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "") // static credentials require both
+	t.Setenv("AWS_BEARER_TOKEN_BEDROCK", "")
+
+	before := initFailureCount(t, providers.NameBedrock)
+
+	registry := providers.NewRegistry()
+	registerBedrockProvider(registry)
+
+	if _, ok := registry.Get(providers.NameBedrock); ok {
+		t.Fatal("bedrock should not register with incomplete static credentials")
+	}
+	if delta := initFailureCount(t, providers.NameBedrock) - before; delta != 1 {
+		t.Fatalf("bedrock init failure counter delta = %v, want 1", delta)
+	}
+}
+
 // initFailureCount reads gateway_provider_init_failures_total for one provider.
 func initFailureCount(t *testing.T, provider string) float64 {
 	t.Helper()

--- a/internal/bootstrap/provider_registration_test.go
+++ b/internal/bootstrap/provider_registration_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/ferro-labs/ai-gateway/providers"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 func TestRegisterProviderEntriesSkipsBrokenProviderAndKeepsGoodProvider(t *testing.T) {
@@ -44,6 +45,37 @@ func TestRegisterProviderEntriesSkipsBrokenProviderAndKeepsGoodProvider(t *testi
 	if _, ok := registry.Get("good-provider"); !ok {
 		t.Fatal("good provider should be registered")
 	}
+
+	// Skipping must not be silent: /health still answers 200 because it only
+	// counts registered providers, so this counter is the operator's only signal.
+	if got := initFailureCount(t, "broken-provider"); got != 1 {
+		t.Fatalf("provider init failure counter = %v, want 1", got)
+	}
+	if got := initFailureCount(t, "good-provider"); got != 0 {
+		t.Fatalf("good provider recorded %v init failures, want 0", got)
+	}
+}
+
+// initFailureCount reads gateway_provider_init_failures_total for one provider.
+func initFailureCount(t *testing.T, provider string) float64 {
+	t.Helper()
+	mfs, err := prometheus.DefaultGatherer.Gather()
+	if err != nil {
+		t.Fatalf("gather metrics: %v", err)
+	}
+	for _, mf := range mfs {
+		if mf.GetName() != "gateway_provider_init_failures_total" {
+			continue
+		}
+		for _, m := range mf.GetMetric() {
+			for _, label := range m.GetLabel() {
+				if label.GetName() == "provider" && label.GetValue() == provider {
+					return m.GetCounter().GetValue()
+				}
+			}
+		}
+	}
+	return 0
 }
 
 type bootstrapProvider struct {

--- a/internal/bootstrap/provider_registration_test.go
+++ b/internal/bootstrap/provider_registration_test.go
@@ -1,0 +1,67 @@
+package bootstrap
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/ferro-labs/ai-gateway/providers"
+)
+
+func TestRegisterProviderEntriesSkipsBrokenProviderAndKeepsGoodProvider(t *testing.T) {
+	t.Setenv("BROKEN_PROVIDER_KEY", "set")
+	t.Setenv("GOOD_PROVIDER_KEY", "set")
+
+	registry := providers.NewRegistry()
+	registerProviderEntries(registry, []providers.ProviderEntry{
+		{
+			ID: "broken-provider",
+			EnvMappings: []providers.EnvMapping{{
+				ConfigKey: providers.CfgKeyAPIKey,
+				EnvVar:    "BROKEN_PROVIDER_KEY",
+				Required:  true,
+			}},
+			Build: func(providers.ProviderConfig) (providers.Provider, error) {
+				return nil, errors.New("build failed")
+			},
+		},
+		{
+			ID: "good-provider",
+			EnvMappings: []providers.EnvMapping{{
+				ConfigKey: providers.CfgKeyAPIKey,
+				EnvVar:    "GOOD_PROVIDER_KEY",
+				Required:  true,
+			}},
+			Build: func(providers.ProviderConfig) (providers.Provider, error) {
+				return bootstrapProvider{name: "good-provider", models: []string{"good-model"}}, nil
+			},
+		},
+	})
+
+	if _, ok := registry.Get("broken-provider"); ok {
+		t.Fatal("broken provider should be skipped")
+	}
+	if _, ok := registry.Get("good-provider"); !ok {
+		t.Fatal("good provider should be registered")
+	}
+}
+
+type bootstrapProvider struct {
+	name   string
+	models []string
+}
+
+func (p bootstrapProvider) Name() string                  { return p.name }
+func (p bootstrapProvider) SupportedModels() []string     { return p.models }
+func (p bootstrapProvider) Models() []providers.ModelInfo { return nil }
+func (p bootstrapProvider) SupportsModel(model string) bool {
+	for _, m := range p.models {
+		if m == model {
+			return true
+		}
+	}
+	return false
+}
+func (bootstrapProvider) Complete(context.Context, providers.Request) (*providers.Response, error) {
+	return nil, nil
+}

--- a/internal/cli/client.go
+++ b/internal/cli/client.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"slices"
 	"time"
 )
 
@@ -51,6 +52,13 @@ func (c *AdminClient) Get(ctx context.Context, path string, dest any) error {
 	return c.do(ctx, http.MethodGet, path, nil, dest)
 }
 
+// GetHealth performs a GET request against a health endpoint, decoding a 503
+// "degraded" body rather than reporting it as a failed request. A gateway that
+// answers with 503 is reachable — that distinction is the whole point of asking.
+func (c *AdminClient) GetHealth(ctx context.Context, path string, dest any) error {
+	return c.do(ctx, http.MethodGet, path, nil, dest, http.StatusServiceUnavailable)
+}
+
 // Post performs a POST request with a JSON body.
 func (c *AdminClient) Post(ctx context.Context, path string, body, dest any) error {
 	return c.do(ctx, http.MethodPost, path, body, dest)
@@ -61,7 +69,9 @@ func (c *AdminClient) Put(ctx context.Context, path string, body, dest any) erro
 	return c.do(ctx, http.MethodPut, path, body, dest)
 }
 
-func (c *AdminClient) do(ctx context.Context, method, path string, body, dest any) error {
+// do issues the request and decodes dest. Status codes in tolerate are decoded
+// instead of being turned into an error.
+func (c *AdminClient) do(ctx context.Context, method, path string, body, dest any, tolerate ...int) error {
 	var bodyReader io.Reader
 	if body != nil {
 		data, err := json.Marshal(body)
@@ -91,7 +101,7 @@ func (c *AdminClient) do(ctx context.Context, method, path string, body, dest an
 		return fmt.Errorf("read response: %w", err)
 	}
 
-	if resp.StatusCode >= 400 {
+	if resp.StatusCode >= 400 && !slices.Contains(tolerate, resp.StatusCode) {
 		var apiErr struct {
 			Error struct {
 				Message string `json:"message"`

--- a/internal/cli/client_health_test.go
+++ b/internal/cli/client_health_test.go
@@ -1,0 +1,56 @@
+package cli
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// /health answers 503 while degraded. Get must still treat that as a failed
+// request, but GetHealth has to decode the body — a gateway that answers at all
+// is reachable, and that distinction is the point of `ferrogw status`/`doctor`.
+func TestGetHealthDecodesDegradedResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte(`{"status":"no_providers","providers":[]}`))
+	}))
+	defer server.Close()
+
+	client := NewAdminClient(server.URL, "")
+
+	var viaGet map[string]any
+	if err := client.Get(t.Context(), "/health", &viaGet); err == nil {
+		t.Fatal("Get should surface a 503 as an error")
+	}
+
+	var health map[string]any
+	if err := client.GetHealth(t.Context(), "/health", &health); err != nil {
+		t.Fatalf("GetHealth should tolerate a 503: %v", err)
+	}
+	if health["status"] != "no_providers" {
+		t.Fatalf("status = %v, want no_providers", health["status"])
+	}
+}
+
+// Tolerating 503 must not swallow the codes that mean the request itself failed.
+func TestGetHealthStillFailsOnUnauthorized(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":{"message":"invalid api key"}}`))
+	}))
+	defer server.Close()
+
+	client := NewAdminClient(server.URL, "")
+
+	var health map[string]any
+	err := client.GetHealth(t.Context(), "/health", &health)
+	if err == nil {
+		t.Fatal("GetHealth should surface a 401")
+	}
+	if !strings.Contains(err.Error(), "invalid api key") {
+		t.Fatalf("error = %v, want it to carry the upstream message", err)
+	}
+}

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -82,11 +82,16 @@ func runDoctor(cmd *cobra.Command, _ []string) error {
 		Status string `json:"status"`
 	}
 	start := time.Now()
-	err := c.Get(cmd.Context(), "/health", &h)
+	// GetHealth, not Get: /health answers 503 while degraded, and a degraded
+	// gateway is exactly what doctor exists to diagnose.
+	err := c.GetHealth(cmd.Context(), "/health", &h)
 	latency := time.Since(start)
-	if err != nil {
+	switch {
+	case err != nil:
 		fmt.Printf("    %s %s: %v\n", Clr(ColorRed, SymFAIL), c.BaseURL, err)
-	} else {
+	case h.Status != "ok":
+		fmt.Printf("    %s %s -- %s (%dms)\n", Clr(ColorYellow, SymWARN), c.BaseURL, h.Status, latency.Milliseconds())
+	default:
 		fmt.Printf("    %s %s -- healthy (%dms)\n", Clr(ColorGreen, SymOK), c.BaseURL, latency.Milliseconds())
 	}
 

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -19,16 +19,22 @@ func runStatus(cmd *cobra.Command, _ []string) error {
 
 	start := time.Now()
 	var health map[string]any
-	if err := c.Get(cmd.Context(), "/health", &health); err != nil {
+	if err := c.GetHealth(cmd.Context(), "/health", &health); err != nil {
 		fmt.Printf("  %s Gateway unreachable: %v\n", Clr(ColorRed, SymFAIL), err)
 		return nil
 	}
 	latency := time.Since(start)
 
+	// /health answers 503 while degraded (e.g. no providers configured). The
+	// gateway is up; say what is actually wrong instead of "unreachable".
+	status, symbol, color := "healthy", SymOK, ColorGreen
+	if s, ok := health["status"].(string); ok && s != "ok" {
+		status, symbol, color = s, SymWARN, ColorYellow
+	}
 	fmt.Printf("  %s %s -- %s (%s)\n",
-		Clr(ColorGreen, SymOK),
+		Clr(color, symbol),
 		c.BaseURL,
-		Clr(ColorBold+ColorGreen, "healthy"),
+		Clr(ColorBold+color, status),
 		latency.Round(time.Millisecond),
 	)
 

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -27,9 +27,14 @@ func runStatus(cmd *cobra.Command, _ []string) error {
 
 	// /health answers 503 while degraded (e.g. no providers configured). The
 	// gateway is up; say what is actually wrong instead of "unreachable".
-	status, symbol, color := "healthy", SymOK, ColorGreen
-	if s, ok := health["status"].(string); ok && s != "ok" {
-		status, symbol, color = s, SymWARN, ColorYellow
+	// A body with no usable status is reported as such rather than as healthy.
+	status, symbol, color := "unknown", SymWARN, ColorYellow
+	if s, ok := health["status"].(string); ok {
+		if s == "ok" {
+			status, symbol, color = "healthy", SymOK, ColorGreen
+		} else {
+			status = s
+		}
 	}
 	fmt.Printf("  %s %s -- %s (%s)\n",
 		Clr(color, symbol),

--- a/internal/handler/chat.go
+++ b/internal/handler/chat.go
@@ -100,6 +100,9 @@ func Health(gw *aigateway.Gateway) http.HandlerFunc {
 			status = "no_providers"
 		}
 		w.Header().Set("Content-Type", "application/json")
+		if status != "ok" {
+			w.WriteHeader(http.StatusServiceUnavailable)
+		}
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"status":    status,
 			"providers": providerStatuses,

--- a/internal/handler/completions.go
+++ b/internal/handler/completions.go
@@ -3,6 +3,7 @@ package handler
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -83,7 +84,12 @@ func Completions(registry *providers.Registry) http.HandlerFunc {
 				apierror.WriteOpenAI(w, http.StatusInternalServerError, err.Error(), "server_error", "internal_error")
 				return
 			}
-			outReq, err := http.NewRequestWithContext(r.Context(), http.MethodPost, target, bytes.NewReader(body))
+			// Streaming clears http.Server's WriteTimeout per write, so an idle
+			// upstream is bounded by cancelling this context instead.
+			upstreamCtx, cancelUpstream := context.WithCancel(r.Context())
+			defer cancelUpstream()
+
+			outReq, err := http.NewRequestWithContext(upstreamCtx, http.MethodPost, target, bytes.NewReader(body))
 			if err != nil {
 				apierror.WriteOpenAI(w, http.StatusInternalServerError, "failed to create upstream request: "+err.Error(), "server_error", "internal_error")
 				return
@@ -107,6 +113,15 @@ func Completions(registry *providers.Registry) http.HandlerFunc {
 			}
 			defer func() { _ = resp.Body.Close() }()
 
+			upstreamBody := io.Reader(resp.Body)
+			if legacyReq.Stream {
+				// Closing the wrapper stops its idle timer; it also closes
+				// resp.Body, which net/http makes idempotent.
+				idle := streamio.NewIdleReadCloser(resp.Body, streamio.IdleTimeout(), cancelUpstream)
+				defer func() { _ = idle.Close() }()
+				upstreamBody = idle
+			}
+
 			// Mirror status + content-type and stream the body back.
 			for k, vs := range resp.Header {
 				for _, v := range vs {
@@ -116,9 +131,9 @@ func Completions(registry *providers.Registry) http.HandlerFunc {
 			w.Header().Set("X-Gateway-Provider", p.Name())
 			w.WriteHeader(resp.StatusCode)
 			if legacyReq.Stream {
-				_, _ = streamio.Copy(r.Context(), w, resp.Body)
+				_, _ = streamio.Copy(r.Context(), w, upstreamBody)
 			} else {
-				_, _ = io.Copy(w, resp.Body) //nolint:gosec
+				_, _ = io.Copy(w, upstreamBody) //nolint:gosec
 			}
 			return
 		}

--- a/internal/handler/completions.go
+++ b/internal/handler/completions.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/ferro-labs/ai-gateway/internal/apierror"
 	"github.com/ferro-labs/ai-gateway/internal/httpclient"
+	"github.com/ferro-labs/ai-gateway/internal/logging"
 	"github.com/ferro-labs/ai-gateway/internal/streamio"
 	"github.com/ferro-labs/ai-gateway/providers"
 )
@@ -130,10 +131,19 @@ func Completions(registry *providers.Registry) http.HandlerFunc {
 			}
 			w.Header().Set("X-Gateway-Provider", p.Name())
 			w.WriteHeader(resp.StatusCode)
+
+			var copyErr error
 			if legacyReq.Stream {
-				_, _ = streamio.Copy(r.Context(), w, upstreamBody)
+				_, copyErr = streamio.Copy(r.Context(), w, upstreamBody)
 			} else {
-				_, _ = io.Copy(w, upstreamBody) //nolint:gosec
+				_, copyErr = io.Copy(w, upstreamBody) //nolint:gosec
+			}
+			// Headers are already out, so this cannot become an error response —
+			// but an idle-timeout cut of a stalled upstream would otherwise be
+			// invisible. A client that hung up is not worth reporting.
+			if copyErr != nil && r.Context().Err() == nil {
+				logging.FromContext(r.Context()).Warn("completions response copy failed",
+					"provider", p.Name(), "stream", legacyReq.Stream, "error", copyErr)
 			}
 			return
 		}

--- a/internal/handler/completions.go
+++ b/internal/handler/completions.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/ferro-labs/ai-gateway/internal/apierror"
 	"github.com/ferro-labs/ai-gateway/internal/httpclient"
+	"github.com/ferro-labs/ai-gateway/internal/streamio"
 	"github.com/ferro-labs/ai-gateway/providers"
 )
 
@@ -114,7 +115,11 @@ func Completions(registry *providers.Registry) http.HandlerFunc {
 			}
 			w.Header().Set("X-Gateway-Provider", p.Name())
 			w.WriteHeader(resp.StatusCode)
-			io.Copy(w, resp.Body) //nolint:errcheck,gosec
+			if legacyReq.Stream {
+				_, _ = streamio.Copy(r.Context(), w, resp.Body)
+			} else {
+				_, _ = io.Copy(w, resp.Body) //nolint:gosec
+			}
 			return
 		}
 

--- a/internal/handler/completions_test.go
+++ b/internal/handler/completions_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/ferro-labs/ai-gateway/providers"
 	openaipkg "github.com/ferro-labs/ai-gateway/providers/openai"
@@ -141,4 +142,66 @@ func TestCompletionsHandler_ShimsStreamRequest_ReturnsExplicitError(t *testing.T
 	if np.calls != 0 {
 		t.Fatalf("provider should not be called for unsupported stream shim, got %d calls", np.calls)
 	}
+}
+
+func TestCompletionsHandler_ProxyStreamPathUsesWriteDeadlines(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("data: {\"id\":\"chunk-1\"}\n\n"))
+	}))
+	defer upstream.Close()
+
+	reg := providers.NewRegistry()
+	op, err := openaipkg.New("sk-test", upstream.URL)
+	if err != nil {
+		t.Fatalf("failed to build openai provider: %v", err)
+	}
+	reg.Register(op)
+
+	h := Completions(reg)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/v1/completions", strings.NewReader(`{"model":"gpt-4o","prompt":"hi","stream":true}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := newCompletionDeadlineRecorder()
+
+	h(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "data:") {
+		t.Fatalf("expected streamed body, got %q", w.Body.String())
+	}
+	if len(w.deadlines) < 2 {
+		t.Fatalf("expected write deadline set and clear, got %d entries", len(w.deadlines))
+	}
+	if w.deadlines[0].IsZero() {
+		t.Fatal("first deadline should set a timeout")
+	}
+	if !w.deadlines[len(w.deadlines)-1].IsZero() {
+		t.Fatalf("last deadline should clear timeout, got %v", w.deadlines[len(w.deadlines)-1])
+	}
+	if w.flushes == 0 {
+		t.Fatal("expected streaming response flush")
+	}
+}
+
+type completionDeadlineRecorder struct {
+	*httptest.ResponseRecorder
+	deadlines []time.Time
+	flushes   int
+}
+
+func newCompletionDeadlineRecorder() *completionDeadlineRecorder {
+	return &completionDeadlineRecorder{ResponseRecorder: httptest.NewRecorder()}
+}
+
+func (r *completionDeadlineRecorder) Flush() {
+	r.flushes++
+	r.ResponseRecorder.Flush()
+}
+
+func (r *completionDeadlineRecorder) SetWriteDeadline(deadline time.Time) error {
+	r.deadlines = append(r.deadlines, deadline)
+	return nil
 }

--- a/internal/handler/completions_test.go
+++ b/internal/handler/completions_test.go
@@ -1,14 +1,18 @@
 package handler
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/ferro-labs/ai-gateway/internal/logging"
+	"github.com/ferro-labs/ai-gateway/internal/streamio"
 	"github.com/ferro-labs/ai-gateway/providers"
 	openaipkg "github.com/ferro-labs/ai-gateway/providers/openai"
 )
@@ -183,6 +187,54 @@ func TestCompletionsHandler_ProxyStreamPathUsesWriteDeadlines(t *testing.T) {
 	}
 	if w.flushes == 0 {
 		t.Fatal("expected streaming response flush")
+	}
+}
+
+// Cutting a stalled upstream must not be silent: the copy error is the only
+// evidence the idle bound fired, and a client that hung up is not an error.
+func TestCompletionsHandler_StalledUpstreamCutIsLogged(t *testing.T) {
+	defer streamio.SetIdleTimeoutForTest(50 * time.Millisecond)()
+
+	var logs bytes.Buffer
+	prevLogger := logging.Logger
+	logging.Logger = slog.New(slog.NewTextHandler(&logs, nil))
+	defer func() { logging.Logger = prevLogger }()
+
+	upstreamDone := make(chan struct{})
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("data: {\"id\":\"chunk-1\"}\n\n"))
+		if flusher, ok := w.(http.Flusher); ok {
+			flusher.Flush()
+		}
+		<-r.Context().Done() // stall until the gateway gives up
+		close(upstreamDone)
+	}))
+	defer upstream.Close()
+
+	reg := providers.NewRegistry()
+	op, err := openaipkg.New("sk-test", upstream.URL)
+	if err != nil {
+		t.Fatalf("failed to build openai provider: %v", err)
+	}
+	reg.Register(op)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/v1/completions",
+		strings.NewReader(`{"model":"gpt-4o","prompt":"hi","stream":true}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := newCompletionDeadlineRecorder()
+
+	Completions(reg)(w, req)
+
+	select {
+	case <-upstreamDone:
+	case <-time.After(10 * time.Second):
+		t.Fatal("upstream request was never cancelled by the idle bound")
+	}
+
+	if got := logs.String(); !strings.Contains(got, "completions response copy failed") {
+		t.Fatalf("idle-timeout cut was not logged: %s", got)
 	}
 }
 

--- a/internal/handler/health_test.go
+++ b/internal/handler/health_test.go
@@ -1,0 +1,70 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	aigateway "github.com/ferro-labs/ai-gateway"
+	"github.com/ferro-labs/ai-gateway/providers"
+)
+
+func TestHealthStatusCodes(t *testing.T) {
+	tests := []struct {
+		name       string
+		register   bool
+		wantStatus string
+		wantCode   int
+	}{
+		{name: "healthy", register: true, wantStatus: "ok", wantCode: http.StatusOK},
+		{name: "no providers", register: false, wantStatus: "no_providers", wantCode: http.StatusServiceUnavailable},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gw, err := aigateway.New(aigateway.Config{
+				Strategy: aigateway.StrategyConfig{Mode: aigateway.ModeSingle},
+				Targets:  []aigateway.Target{{VirtualKey: "health-provider"}},
+			})
+			if err != nil {
+				t.Fatalf("New gateway: %v", err)
+			}
+			if tt.register {
+				gw.RegisterProvider(healthProvider{})
+			}
+
+			req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/health", nil)
+			w := httptest.NewRecorder()
+			Health(gw).ServeHTTP(w, req)
+
+			if w.Code != tt.wantCode {
+				t.Fatalf("status code = %d, want %d: %s", w.Code, tt.wantCode, w.Body.String())
+			}
+			var payload struct {
+				Status string `json:"status"`
+			}
+			if err := json.NewDecoder(w.Body).Decode(&payload); err != nil {
+				t.Fatalf("decode health response: %v", err)
+			}
+			if payload.Status != tt.wantStatus {
+				t.Fatalf("status = %q, want %q", payload.Status, tt.wantStatus)
+			}
+		})
+	}
+}
+
+type healthProvider struct{}
+
+func (healthProvider) Name() string              { return "health-provider" }
+func (healthProvider) SupportedModels() []string { return []string{"health-model"} }
+func (healthProvider) SupportsModel(model string) bool {
+	return model == "health-model"
+}
+func (healthProvider) Models() []providers.ModelInfo {
+	return []providers.ModelInfo{{ID: "health-model", Object: "model", OwnedBy: "health-provider"}}
+}
+func (healthProvider) Complete(context.Context, providers.Request) (*providers.Response, error) {
+	return nil, nil
+}

--- a/internal/httpserver/router.go
+++ b/internal/httpserver/router.go
@@ -22,7 +22,6 @@ import (
 	"github.com/ferro-labs/ai-gateway/providers"
 	webassets "github.com/ferro-labs/ai-gateway/web"
 	"github.com/go-chi/chi/v5"
-	chimw "github.com/go-chi/chi/v5/middleware"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
@@ -64,6 +63,9 @@ func NewRouter(
 	}
 
 	// Core middleware stack.
+	// RecoverJSON is outermost so panics anywhere below this point still return
+	// the gateway's JSON error envelope while inner middleware defers can run.
+	r.Use(middleware.RecoverJSON)
 	// OTel middleware MUST come before logging.Middleware so any inbound
 	// W3C traceparent is extracted into the request context, then the
 	// logging layer reuses that trace ID for X-Request-ID. When no OTel
@@ -71,7 +73,6 @@ func NewRouter(
 	// global propagator is the default no-op propagator).
 	r.Use(gwotel.Middleware)
 	r.Use(logging.Middleware) // inject trace ID + X-Request-ID header
-	r.Use(chimw.Recoverer)
 	// SecurityHeaders applies baseline browser-hardening headers (X-Content-Type-Options,
 	// X-Frame-Options, Referrer-Policy, and HSTS on TLS connections) to every response.
 	// It must come before CORS so that security headers are present on all responses,

--- a/internal/httpserver/router_dashboard_test.go
+++ b/internal/httpserver/router_dashboard_test.go
@@ -1,0 +1,57 @@
+package httpserver_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	aigateway "github.com/ferro-labs/ai-gateway"
+)
+
+// The login page is the entry point to the whole dashboard, and it is served
+// with the same strict CSP as every other response. Its script must therefore be
+// an external file the policy allows, not an inline block the policy kills.
+func TestDashboardLoginPageIsServableUnderCSP(t *testing.T) {
+	gw, err := aigateway.New(aigateway.Config{
+		Strategy: aigateway.StrategyConfig{Mode: aigateway.ModeSingle},
+		Targets:  []aigateway.Target{{VirtualKey: "stub"}},
+	})
+	if err != nil {
+		t.Fatalf("New gateway: %v", err)
+	}
+	router := buildTestRouter(t, gw)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/dashboard/login", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("login page status = %d, want 200", w.Code)
+	}
+	csp := w.Header().Get("Content-Security-Policy")
+	if !strings.Contains(csp, "script-src 'self'") {
+		t.Fatalf("login page CSP = %q, want a strict script-src", csp)
+	}
+
+	page := w.Body.String()
+	if strings.Contains(page, "<script>") {
+		t.Fatal("login page carries an inline <script>, which script-src 'self' blocks")
+	}
+	const scriptPath = "/dashboard/static/pages/login.js"
+	if !strings.Contains(page, scriptPath) {
+		t.Fatalf("login page does not reference %s", scriptPath)
+	}
+
+	// And that script must actually be served, or the form never wires up.
+	scriptReq := httptest.NewRequestWithContext(t.Context(), http.MethodGet, scriptPath, nil)
+	scriptW := httptest.NewRecorder()
+	router.ServeHTTP(scriptW, scriptReq)
+
+	if scriptW.Code != http.StatusOK {
+		t.Fatalf("%s status = %d, want 200", scriptPath, scriptW.Code)
+	}
+	if !strings.Contains(scriptW.Body.String(), "login-form") {
+		t.Fatalf("%s does not contain the login form handler", scriptPath)
+	}
+}

--- a/internal/httpserver/router_recover_test.go
+++ b/internal/httpserver/router_recover_test.go
@@ -1,0 +1,81 @@
+package httpserver_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	aigateway "github.com/ferro-labs/ai-gateway"
+	"github.com/ferro-labs/ai-gateway/providers"
+)
+
+// panicProvider panics inside the provider call, i.e. below every middleware.
+type panicProvider struct{}
+
+func (panicProvider) Name() string              { return "panic-provider" }
+func (panicProvider) SupportedModels() []string { return []string{"panic-model"} }
+func (panicProvider) SupportsModel(m string) bool {
+	return m == "panic-model"
+}
+func (panicProvider) Models() []providers.ModelInfo {
+	return []providers.ModelInfo{{ID: "panic-model", Object: "model", OwnedBy: "panic-provider"}}
+}
+func (panicProvider) Complete(context.Context, providers.Request) (*providers.Response, error) {
+	panic("provider exploded")
+}
+
+// A panic anywhere under the middleware stack must surface as the gateway's JSON
+// error envelope, with the trace ID that logging.Middleware assigned still on the
+// response. This pins RecoverJSON's position at the outside of the chain.
+func TestRouter_PanicReturnsJSONEnvelopeWithTraceID(t *testing.T) {
+	gw, err := aigateway.New(aigateway.Config{
+		Strategy: aigateway.StrategyConfig{Mode: aigateway.ModeSingle},
+		Targets:  []aigateway.Target{{VirtualKey: "panic-provider"}},
+	})
+	if err != nil {
+		t.Fatalf("New gateway: %v", err)
+	}
+	gw.RegisterProvider(panicProvider{})
+
+	router := buildTestRouter(t, gw)
+	body := `{"model":"panic-model","messages":[{"role":"user","content":"hi"}]}`
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/v1/chat/completions", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.ContentLength = int64(len(body))
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500: %s", w.Code, w.Body.String())
+	}
+	if ct := w.Header().Get("Content-Type"); !strings.Contains(ct, "application/json") {
+		t.Fatalf("Content-Type = %q, want application/json", ct)
+	}
+	if w.Header().Get("X-Request-ID") == "" {
+		t.Fatal("X-Request-ID missing: logging.Middleware ran but its header did not survive recovery")
+	}
+	if w.Header().Get("Content-Security-Policy") == "" {
+		t.Fatal("Content-Security-Policy missing from the recovered error response")
+	}
+
+	var payload struct {
+		Error struct {
+			Message string `json:"message"`
+			Type    string `json:"type"`
+			Code    string `json:"code"`
+		} `json:"error"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if payload.Error.Type != "server_error" || payload.Error.Code != "internal_error" {
+		t.Fatalf("error = %#v, want server_error/internal_error", payload.Error)
+	}
+	if strings.Contains(payload.Error.Message, "exploded") {
+		t.Fatalf("panic detail leaked to the client: %q", payload.Error.Message)
+	}
+}

--- a/internal/httpserver/router_streaming_test.go
+++ b/internal/httpserver/router_streaming_test.go
@@ -1,0 +1,171 @@
+package httpserver_test
+
+import (
+	"bufio"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	aigateway "github.com/ferro-labs/ai-gateway"
+	"github.com/ferro-labs/ai-gateway/internal/admin"
+	"github.com/ferro-labs/ai-gateway/internal/httpserver"
+	"github.com/ferro-labs/ai-gateway/providers"
+	openaipkg "github.com/ferro-labs/ai-gateway/providers/openai"
+)
+
+// middleware.RecoverJSON wraps every request's ResponseWriter to track whether
+// the response has been committed. That wrapper does not satisfy http.Flusher or
+// http.Hijacker itself — the stack reaches them through Unwrap and
+// http.NewResponseController. These tests pin that contract through the real
+// router, where a broken Unwrap chain would silently stop flushing or turn every
+// protocol upgrade into a 502.
+
+// buildProxyTestRouter wires the full router with a proxiable provider aimed at
+// upstreamURL, reachable as "X-Provider: openai".
+func buildProxyTestRouter(t *testing.T, upstreamURL string) http.Handler {
+	t.Helper()
+	t.Setenv("ALLOW_UNAUTHENTICATED_PROXY", "true")
+
+	gw, err := aigateway.New(aigateway.Config{
+		Strategy: aigateway.StrategyConfig{Mode: aigateway.ModeSingle},
+		Targets:  []aigateway.Target{{VirtualKey: "stub"}},
+	})
+	if err != nil {
+		t.Fatalf("New gateway: %v", err)
+	}
+
+	reg := providers.NewRegistry()
+	p, err := openaipkg.New("sk-test-key", upstreamURL)
+	if err != nil {
+		t.Fatalf("build openai provider: %v", err)
+	}
+	reg.Register(p)
+
+	return httpserver.NewRouter(reg, admin.NewKeyStore(), nil, gw, nil, nil, nil, nil, "", nil)
+}
+
+func TestRouter_ProxyUpgradeSurvivesResponseWriterWrapping(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		conn, buf, err := http.NewResponseController(w).Hijack()
+		if err != nil {
+			t.Errorf("upstream hijack: %v", err)
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		_, _ = buf.WriteString("HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n\r\n")
+		_ = buf.Flush()
+
+		line, err := buf.ReadString('\n')
+		if err != nil {
+			return
+		}
+		_, _ = buf.WriteString("echo:" + line)
+		_ = buf.Flush()
+	}))
+	defer upstream.Close()
+
+	gateway := httptest.NewServer(buildProxyTestRouter(t, upstream.URL))
+	defer gateway.Close()
+
+	var dialer net.Dialer
+	conn, err := dialer.DialContext(t.Context(), "tcp", strings.TrimPrefix(gateway.URL, "http://"))
+	if err != nil {
+		t.Fatalf("dial gateway: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+	_ = conn.SetDeadline(time.Now().Add(10 * time.Second))
+
+	if _, err := conn.Write([]byte("GET /v1/realtime HTTP/1.1\r\nHost: gateway\r\n" +
+		"X-Provider: openai\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n\r\n")); err != nil {
+		t.Fatalf("write upgrade request: %v", err)
+	}
+
+	br := bufio.NewReader(conn)
+	status, err := br.ReadString('\n')
+	if err != nil {
+		t.Fatalf("read status line: %v", err)
+	}
+	if !strings.Contains(status, "101") {
+		t.Fatalf("status = %q, want 101 Switching Protocols", strings.TrimSpace(status))
+	}
+	for { // drain headers
+		line, err := br.ReadString('\n')
+		if err != nil {
+			t.Fatalf("read headers: %v", err)
+		}
+		if strings.TrimSpace(line) == "" {
+			break
+		}
+	}
+
+	if _, err := conn.Write([]byte("ping\n")); err != nil {
+		t.Fatalf("write through tunnel: %v", err)
+	}
+	echo, err := br.ReadString('\n')
+	if err != nil {
+		t.Fatalf("read through tunnel: %v", err)
+	}
+	if strings.TrimSpace(echo) != "echo:ping" {
+		t.Fatalf("tunnel echo = %q, want echo:ping", strings.TrimSpace(echo))
+	}
+}
+
+func TestRouter_ProxyStreamReachesClientIncrementally(t *testing.T) {
+	release := make(chan struct{})
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("data: first\n\n"))
+		_ = http.NewResponseController(w).Flush()
+		<-release // hold the response open: the first chunk must already be out
+		_, _ = w.Write([]byte("data: second\n\n"))
+	}))
+	defer upstream.Close()
+	defer close(release)
+
+	gateway := httptest.NewServer(buildProxyTestRouter(t, upstream.URL))
+	defer gateway.Close()
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, gateway.URL+"/v1/responses", nil)
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	req.Header.Set("X-Provider", "openai")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request gateway: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+
+	// If flushing did not survive the wrapper chain, this read blocks until the
+	// upstream handler returns — which it cannot do until release is closed.
+	type readResult struct {
+		data string
+		err  error
+	}
+	got := make(chan readResult, 1)
+	go func() {
+		buf := make([]byte, 64)
+		n, readErr := resp.Body.Read(buf)
+		got <- readResult{data: string(buf[:n]), err: readErr}
+	}()
+
+	select {
+	case r := <-got:
+		if r.err != nil {
+			t.Fatalf("read first chunk: %v", r.err)
+		}
+		if !strings.Contains(r.data, "first") {
+			t.Fatalf("first chunk = %q, want it to contain \"first\"", r.data)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("first chunk never arrived: flushing was lost through the ResponseWriter wrapper chain")
+	}
+}

--- a/internal/logging/logger.go
+++ b/internal/logging/logger.go
@@ -81,6 +81,11 @@ func Enabled(ctx context.Context, level slog.Level) bool {
 	return Logger.Enabled(ctx, level)
 }
 
+// RequestIDHeader carries the request's trace ID on the way in and back out.
+// Middleware sets it on the response; middleware.RecoverJSON reads it back off
+// because it runs above the layer that puts the trace ID on the context.
+const RequestIDHeader = "X-Request-ID"
+
 // Middleware injects a trace ID into every request context and echoes it in
 // the X-Request-ID response header. Resolution precedence:
 //  1. A trace ID already present on the request context (e.g. seeded by
@@ -95,13 +100,13 @@ func Middleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		traceID := TraceIDFromContext(r.Context())
 		if traceID == "" {
-			traceID = r.Header.Get("X-Request-ID")
+			traceID = r.Header.Get(RequestIDHeader)
 		}
 		if traceID == "" {
 			traceID = NewTraceID()
 		}
 		ctx := WithTraceID(r.Context(), traceID)
-		w.Header().Set("X-Request-ID", traceID)
+		w.Header().Set(RequestIDHeader, traceID)
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
 }

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -10,6 +10,9 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
+// UnknownModelLabel is the bounded label used for rejected requests whose model is unknown.
+const UnknownModelLabel = "unknown"
+
 // Request-level counters and histograms.
 var (
 	// RequestsTotal counts completed requests labelled by provider, model, and

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -63,6 +63,18 @@ var (
 		[]string{"provider", "error_type"},
 	)
 
+	// ProviderInitFailures counts providers whose factory failed at startup. A
+	// failure is warned-and-skipped so one bad credential cannot stop the
+	// gateway, which makes this counter the only machine-readable signal that a
+	// configured provider is missing. Alert on any non-zero value.
+	ProviderInitFailures = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "gateway_provider_init_failures_total",
+			Help: "Total providers skipped because their factory failed at startup.",
+		},
+		[]string{"provider"},
+	)
+
 	// CircuitBreakerState tracks per-provider circuit breaker state as a gauge:
 	// 0 = closed, 1 = open, 2 = half_open.
 	CircuitBreakerState = promauto.NewGaugeVec(

--- a/internal/middleware/recover.go
+++ b/internal/middleware/recover.go
@@ -64,8 +64,14 @@ type committedWriter struct {
 
 func (w *committedWriter) Unwrap() http.ResponseWriter { return w.ResponseWriter }
 
+// WriteHeader commits only on a final status. net/http allows any number of 1xx
+// informational headers before the single 2xx-5xx one, and httputil.ReverseProxy
+// forwards an upstream 1xx (e.g. 103 Early Hints) straight through — treating
+// that as committed would leave a panicking request with no response at all.
 func (w *committedWriter) WriteHeader(status int) {
-	w.committed = true
+	if status >= 200 {
+		w.committed = true
+	}
 	w.ResponseWriter.WriteHeader(status)
 }
 

--- a/internal/middleware/recover.go
+++ b/internal/middleware/recover.go
@@ -15,6 +15,7 @@ import (
 // still recovered and every inner deferred span is closed on the way out.
 func RecoverJSON(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		cw := &committedWriter{ResponseWriter: w}
 		defer func() {
 			recovered := recover()
 			if recovered == nil {
@@ -30,14 +31,45 @@ func RecoverJSON(next http.Handler) http.Handler {
 			// derived request that never reaches this closure. The header it sets
 			// on the shared ResponseWriter is the only handle we have on it.
 			logger := logging.Logger
-			if traceID := w.Header().Get("X-Request-ID"); traceID != "" {
+			if traceID := cw.Header().Get(logging.RequestIDHeader); traceID != "" {
 				logger = logger.With("trace_id", traceID)
 			}
 			// debug.Stack() inside the deferred function still unwinds through
 			// runtime.gopanic to the frame that panicked.
-			logger.Error("panic recovered", "panic", recovered, "stack", string(debug.Stack()))
-			apierror.WriteOpenAI(w, http.StatusInternalServerError, "internal server error", "server_error", "internal_error")
+			logger.Error("panic recovered",
+				"panic", recovered,
+				"response_committed", cw.committed,
+				"stack", string(debug.Stack()),
+			)
+			// Once the status line or any body byte has gone out — a streamed
+			// response, say — an error envelope would append garbage to what the
+			// client already has. Log it and let the truncated response stand.
+			if !cw.committed {
+				apierror.WriteOpenAI(w, http.StatusInternalServerError, "internal server error", "server_error", "internal_error")
+			}
 		}()
-		next.ServeHTTP(w, r)
+		next.ServeHTTP(cw, r)
 	})
+}
+
+// committedWriter records whether any response bytes have reached the client.
+//
+// It implements Unwrap so http.NewResponseController still reaches the real
+// writer's Flush, Hijack, and SetWriteDeadline; no gateway code type-asserts a
+// request ResponseWriter to http.Flusher or http.Hijacker directly.
+type committedWriter struct {
+	http.ResponseWriter
+	committed bool
+}
+
+func (w *committedWriter) Unwrap() http.ResponseWriter { return w.ResponseWriter }
+
+func (w *committedWriter) WriteHeader(status int) {
+	w.committed = true
+	w.ResponseWriter.WriteHeader(status)
+}
+
+func (w *committedWriter) Write(p []byte) (int, error) {
+	w.committed = true
+	return w.ResponseWriter.Write(p)
 }

--- a/internal/middleware/recover.go
+++ b/internal/middleware/recover.go
@@ -1,0 +1,21 @@
+package middleware
+
+import (
+	"net/http"
+
+	"github.com/ferro-labs/ai-gateway/internal/apierror"
+	"github.com/ferro-labs/ai-gateway/internal/logging"
+)
+
+// RecoverJSON recovers panics and returns the gateway's JSON error envelope.
+func RecoverJSON(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer func() {
+			if recovered := recover(); recovered != nil {
+				logging.FromContext(r.Context()).Error("panic recovered", "panic", recovered)
+				apierror.WriteOpenAI(w, http.StatusInternalServerError, "internal server error", "server_error", "internal_error")
+			}
+		}()
+		next.ServeHTTP(w, r)
+	})
+}

--- a/internal/middleware/recover.go
+++ b/internal/middleware/recover.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"errors"
 	"net/http"
 
 	"github.com/ferro-labs/ai-gateway/internal/apierror"
@@ -12,6 +13,9 @@ func RecoverJSON(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		defer func() {
 			if recovered := recover(); recovered != nil {
+				if recoveredErr, ok := recovered.(error); ok && errors.Is(recoveredErr, http.ErrAbortHandler) {
+					panic(recovered)
+				}
 				logging.FromContext(r.Context()).Error("panic recovered", "panic", recovered)
 				apierror.WriteOpenAI(w, http.StatusInternalServerError, "internal server error", "server_error", "internal_error")
 			}

--- a/internal/middleware/recover.go
+++ b/internal/middleware/recover.go
@@ -3,22 +3,40 @@ package middleware
 import (
 	"errors"
 	"net/http"
+	"runtime/debug"
 
 	"github.com/ferro-labs/ai-gateway/internal/apierror"
 	"github.com/ferro-labs/ai-gateway/internal/logging"
 )
 
 // RecoverJSON recovers panics and returns the gateway's JSON error envelope.
+//
+// It is registered outermost so a panic in the tracing or logging middleware is
+// still recovered and every inner deferred span is closed on the way out.
 func RecoverJSON(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		defer func() {
-			if recovered := recover(); recovered != nil {
-				if recoveredErr, ok := recovered.(error); ok && errors.Is(recoveredErr, http.ErrAbortHandler) {
-					panic(recovered)
-				}
-				logging.FromContext(r.Context()).Error("panic recovered", "panic", recovered)
-				apierror.WriteOpenAI(w, http.StatusInternalServerError, "internal server error", "server_error", "internal_error")
+			recovered := recover()
+			if recovered == nil {
+				return
 			}
+			// http.ErrAbortHandler is the documented way for a handler (notably
+			// httputil.ReverseProxy) to drop a connection. Let it reach net/http.
+			if recoveredErr, ok := recovered.(error); ok && errors.Is(recoveredErr, http.ErrAbortHandler) {
+				panic(recovered)
+			}
+			// Deliberately not logging.FromContext(r.Context()): this middleware
+			// runs above logging.Middleware, which injects the trace ID into a
+			// derived request that never reaches this closure. The header it sets
+			// on the shared ResponseWriter is the only handle we have on it.
+			logger := logging.Logger
+			if traceID := w.Header().Get("X-Request-ID"); traceID != "" {
+				logger = logger.With("trace_id", traceID)
+			}
+			// debug.Stack() inside the deferred function still unwinds through
+			// runtime.gopanic to the frame that panicked.
+			logger.Error("panic recovered", "panic", recovered, "stack", string(debug.Stack()))
+			apierror.WriteOpenAI(w, http.StatusInternalServerError, "internal server error", "server_error", "internal_error")
 		}()
 		next.ServeHTTP(w, r)
 	})

--- a/internal/middleware/recover_test.go
+++ b/internal/middleware/recover_test.go
@@ -40,3 +40,23 @@ func TestRecoverJSONReturnsErrorEnvelope(t *testing.T) {
 		t.Fatalf("panic detail leaked in response message: %q", payload.Error.Message)
 	}
 }
+
+func TestRecoverJSONRepanicsAbortHandler(t *testing.T) {
+	handler := RecoverJSON(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		panic(http.ErrAbortHandler)
+	}))
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/abort", nil)
+	w := httptest.NewRecorder()
+
+	defer func() {
+		recovered := recover()
+		if recovered != http.ErrAbortHandler {
+			t.Fatalf("recovered = %v, want http.ErrAbortHandler", recovered)
+		}
+		if w.Body.Len() != 0 {
+			t.Fatalf("response body should stay empty, got %q", w.Body.String())
+		}
+	}()
+	handler.ServeHTTP(w, req)
+}

--- a/internal/middleware/recover_test.go
+++ b/internal/middleware/recover_test.go
@@ -1,0 +1,42 @@
+package middleware
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestRecoverJSONReturnsErrorEnvelope(t *testing.T) {
+	handler := RecoverJSON(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		panic("boom")
+	}))
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/panic", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500: %s", w.Code, w.Body.String())
+	}
+	if ct := w.Header().Get("Content-Type"); !strings.Contains(ct, "application/json") {
+		t.Fatalf("Content-Type = %q, want application/json", ct)
+	}
+	var payload struct {
+		Error struct {
+			Message string `json:"message"`
+			Type    string `json:"type"`
+			Code    string `json:"code"`
+		} `json:"error"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if payload.Error.Code != "internal_error" || payload.Error.Type != "server_error" {
+		t.Fatalf("error = %#v, want internal_error/server_error", payload.Error)
+	}
+	if strings.Contains(payload.Error.Message, "boom") {
+		t.Fatalf("panic detail leaked in response message: %q", payload.Error.Message)
+	}
+}

--- a/internal/middleware/recover_test.go
+++ b/internal/middleware/recover_test.go
@@ -79,6 +79,63 @@ func TestRecoverJSONDoesNotCorruptCommittedResponse(t *testing.T) {
 	}
 }
 
+// net/http allows any number of 1xx informational headers before the single
+// 2xx-5xx one, so only a final status commits the response.
+func TestCommittedWriterIgnoresInformationalStatus(t *testing.T) {
+	cw := &committedWriter{ResponseWriter: httptest.NewRecorder()}
+
+	cw.WriteHeader(http.StatusEarlyHints) // 103
+	if cw.committed {
+		t.Fatal("a 1xx informational response must not commit the response")
+	}
+	cw.WriteHeader(http.StatusOK)
+	if !cw.committed {
+		t.Fatal("a final status must commit the response")
+	}
+}
+
+// httputil.ReverseProxy forwards an upstream 1xx straight through WriteHeader.
+// Treating it as committed would leave a panicking request with no final
+// response at all — the client would hang on a bare 103.
+//
+// httptest.ResponseRecorder latches Code on the first WriteHeader and cannot
+// model 1xx, so this runs against a real server.
+func TestRecoverJSONWritesEnvelopeAfterInformationalResponse(t *testing.T) {
+	captureLogs(t)
+
+	server := httptest.NewServer(RecoverJSON(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Link", "</style.css>; rel=preload; as=style")
+		w.WriteHeader(http.StatusEarlyHints) // 103, informational only
+		panic("exploded after early hints")
+	})))
+	defer server.Close()
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, server.URL, nil)
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500 after a 103", resp.StatusCode)
+	}
+	var payload struct {
+		Error struct {
+			Code string `json:"code"`
+		} `json:"error"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if payload.Error.Code != "internal_error" {
+		t.Fatalf("error code = %q, want internal_error", payload.Error.Code)
+	}
+}
+
 // The ordering contract: RecoverJSON sits above logging (and tracing), so a
 // panic raised inside those layers still produces the JSON envelope.
 func TestRecoverJSONRecoversPanicRaisedInsideLoggingLayer(t *testing.T) {

--- a/internal/middleware/recover_test.go
+++ b/internal/middleware/recover_test.go
@@ -1,12 +1,80 @@
 package middleware
 
 import (
+	"bytes"
 	"encoding/json"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/ferro-labs/ai-gateway/internal/logging"
 )
+
+// captureLogs redirects the package logger for the duration of a test.
+func captureLogs(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	prev := logging.Logger
+	logging.Logger = slog.New(slog.NewTextHandler(&buf, nil))
+	t.Cleanup(func() { logging.Logger = prev })
+	return &buf
+}
+
+func panicsAt(http.ResponseWriter, *http.Request) { panic("boom") }
+
+func TestRecoverJSONLogsStackAndTraceID(t *testing.T) {
+	logs := captureLogs(t)
+
+	// logging.Middleware sets X-Request-ID on the shared ResponseWriter; that is
+	// the only way the outermost recover can correlate the panic to the request.
+	handler := RecoverJSON(logging.Middleware(http.HandlerFunc(panicsAt)))
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/panic", nil)
+	req.Header.Set("X-Request-ID", "trace-abc123")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500", w.Code)
+	}
+	out := logs.String()
+	if !strings.Contains(out, "trace_id=trace-abc123") {
+		t.Fatalf("panic log is missing the request trace_id: %s", out)
+	}
+	if !strings.Contains(out, "panicsAt") {
+		t.Fatalf("panic log is missing a stack trace through the panicking frame: %s", out)
+	}
+	if got := w.Header().Get("X-Request-ID"); got != "trace-abc123" {
+		t.Fatalf("X-Request-ID = %q, want trace-abc123", got)
+	}
+}
+
+// The ordering contract: RecoverJSON sits above logging (and tracing), so a
+// panic raised inside those layers still produces the JSON envelope.
+func TestRecoverJSONRecoversPanicRaisedInsideLoggingLayer(t *testing.T) {
+	captureLogs(t)
+
+	panicInLoggingLayer := func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+			_ = next
+			panic("middleware exploded")
+		})
+	}
+	handler := RecoverJSON(panicInLoggingLayer(logging.Middleware(http.HandlerFunc(panicsAt))))
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/panic", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500: %s", w.Code, w.Body.String())
+	}
+	if ct := w.Header().Get("Content-Type"); !strings.Contains(ct, "application/json") {
+		t.Fatalf("Content-Type = %q, want application/json", ct)
+	}
+}
 
 func TestRecoverJSONReturnsErrorEnvelope(t *testing.T) {
 	handler := RecoverJSON(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {

--- a/internal/middleware/recover_test.go
+++ b/internal/middleware/recover_test.go
@@ -51,6 +51,34 @@ func TestRecoverJSONLogsStackAndTraceID(t *testing.T) {
 	}
 }
 
+// A panic partway through a streamed response must not append an error envelope
+// to bytes the client has already received.
+func TestRecoverJSONDoesNotCorruptCommittedResponse(t *testing.T) {
+	captureLogs(t)
+
+	handler := RecoverJSON(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("data: {\"id\":\"chunk-1\"}\n\n"))
+		panic("exploded mid-stream")
+	}))
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/stream", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want the already-sent 200", w.Code)
+	}
+	body := w.Body.String()
+	if body != "data: {\"id\":\"chunk-1\"}\n\n" {
+		t.Fatalf("recovery appended bytes to a committed response: %q", body)
+	}
+	if strings.Contains(body, "internal_error") {
+		t.Fatal("error envelope was appended to an in-flight stream")
+	}
+}
+
 // The ordering contract: RecoverJSON sits above logging (and tracing), so a
 // panic raised inside those layers still produces the JSON envelope.
 func TestRecoverJSONRecoversPanicRaisedInsideLoggingLayer(t *testing.T) {

--- a/internal/middleware/securityheaders.go
+++ b/internal/middleware/securityheaders.go
@@ -9,6 +9,8 @@ import "net/http"
 // (i.e. r.TLS != nil) to avoid breaking plain-HTTP deployments.
 //
 // Headers applied:
+//   - Content-Security-Policy: default-src 'self'; object-src 'none'; frame-ancestors 'none'
+//   - Permissions-Policy: camera=(), microphone=(), geolocation=()
 //   - X-Content-Type-Options: nosniff
 //   - X-Frame-Options: DENY
 //   - Referrer-Policy: strict-origin-when-cross-origin
@@ -16,6 +18,8 @@ import "net/http"
 func SecurityHeaders(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		h := w.Header()
+		h.Set("Content-Security-Policy", "default-src 'self'; object-src 'none'; frame-ancestors 'none'")
+		h.Set("Permissions-Policy", "camera=(), microphone=(), geolocation=()")
 		h.Set("X-Content-Type-Options", "nosniff")
 		h.Set("X-Frame-Options", "DENY")
 		h.Set("Referrer-Policy", "strict-origin-when-cross-origin")

--- a/internal/middleware/securityheaders.go
+++ b/internal/middleware/securityheaders.go
@@ -3,14 +3,40 @@ package middleware
 
 import "net/http"
 
+// ContentSecurityPolicy is the policy served with every response.
+//
+// script-src is strict: the admin token lives in localStorage, so blocking
+// injected and inline script is the one directive that matters here. The
+// dashboard therefore carries no inline <script> and no on*= attributes —
+// handlers are registered against data-action in web/static/dashboard.js, and
+// TestTemplatesCarryNoInlineScript keeps it that way.
+//
+// style-src keeps 'unsafe-inline': the templates still use style="…" attributes
+// and login.html an inline <style> block. Inline style is a far weaker vector
+// than inline script, and tightening it would buy little for a large diff.
+// cdn.jsdelivr.net serves the Geist font stylesheet imported by style.css.
+const ContentSecurityPolicy = "default-src 'self'; " +
+	"base-uri 'self'; " +
+	"form-action 'self'; " +
+	"frame-ancestors 'none'; " +
+	"object-src 'none'; " +
+	"script-src 'self'; " +
+	"style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; " +
+	"font-src 'self' https://cdn.jsdelivr.net; " +
+	"img-src 'self' data:; " +
+	"connect-src 'self'"
+
+// PermissionsPolicy denies browser features the dashboard never uses.
+const PermissionsPolicy = "camera=(), microphone=(), geolocation=()"
+
 // SecurityHeaders returns middleware that sets baseline browser-hardening
 // headers on every response. These headers are unconditional except for
 // Strict-Transport-Security, which is only emitted when the connection is TLS
 // (i.e. r.TLS != nil) to avoid breaking plain-HTTP deployments.
 //
 // Headers applied:
-//   - Content-Security-Policy: default-src 'self'; object-src 'none'; frame-ancestors 'none'
-//   - Permissions-Policy: camera=(), microphone=(), geolocation=()
+//   - Content-Security-Policy: see ContentSecurityPolicy
+//   - Permissions-Policy: see PermissionsPolicy
 //   - X-Content-Type-Options: nosniff
 //   - X-Frame-Options: DENY
 //   - Referrer-Policy: strict-origin-when-cross-origin
@@ -18,8 +44,8 @@ import "net/http"
 func SecurityHeaders(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		h := w.Header()
-		h.Set("Content-Security-Policy", "default-src 'self'; object-src 'none'; frame-ancestors 'none'")
-		h.Set("Permissions-Policy", "camera=(), microphone=(), geolocation=()")
+		h.Set("Content-Security-Policy", ContentSecurityPolicy)
+		h.Set("Permissions-Policy", PermissionsPolicy)
 		h.Set("X-Content-Type-Options", "nosniff")
 		h.Set("X-Frame-Options", "DENY")
 		h.Set("Referrer-Policy", "strict-origin-when-cross-origin")

--- a/internal/middleware/securityheaders_test.go
+++ b/internal/middleware/securityheaders_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto/tls"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -21,11 +22,41 @@ func TestSecurityHeaders_SetsBaselineHeaders(t *testing.T) {
 		{"X-Content-Type-Options", "nosniff"},
 		{"X-Frame-Options", "DENY"},
 		{"Referrer-Policy", "strict-origin-when-cross-origin"},
+		{"Content-Security-Policy", ContentSecurityPolicy},
+		{"Permissions-Policy", PermissionsPolicy},
 	}
 	for _, tt := range tests {
 		if got := w.Header().Get(tt.header); got != tt.want {
 			t.Errorf("header %s = %q, want %q", tt.header, got, tt.want)
 		}
+	}
+}
+
+// The policy protects an admin token held in localStorage. These are the
+// directives that do that work; a future edit must not quietly relax them.
+func TestSecurityHeaders_ContentSecurityPolicyBlocksInjectedScript(t *testing.T) {
+	mustContain := []string{
+		"script-src 'self'",
+		"object-src 'none'",
+		"frame-ancestors 'none'",
+		"base-uri 'self'",
+	}
+	for _, directive := range mustContain {
+		if !strings.Contains(ContentSecurityPolicy, directive) {
+			t.Errorf("CSP is missing %q: %s", directive, ContentSecurityPolicy)
+		}
+	}
+
+	// 'unsafe-inline'/'unsafe-eval' in script-src would defeat the whole policy.
+	// It is allowed in style-src, so check the script-src directive alone.
+	scriptSrc := ""
+	for _, directive := range strings.Split(ContentSecurityPolicy, ";") {
+		if strings.HasPrefix(strings.TrimSpace(directive), "script-src") {
+			scriptSrc = directive
+		}
+	}
+	if strings.Contains(scriptSrc, "unsafe-inline") || strings.Contains(scriptSrc, "unsafe-eval") {
+		t.Fatalf("script-src must not allow unsafe script execution: %q", scriptSrc)
 	}
 }
 

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -5,6 +5,7 @@ package proxy
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -112,6 +113,13 @@ func Handler(registry *providers.Registry) http.HandlerFunc {
 			transport = signingRoundTripper{base: transport, signer: signer}
 		}
 
+		// WrapResponseWriter clears http.Server's WriteTimeout after the first
+		// write so long streams are not truncated. Cancelling this context on an
+		// idle upstream is what replaces the bound that removal gives up.
+		upstreamCtx, cancelUpstream := context.WithCancel(r.Context())
+		defer cancelUpstream()
+		r = r.WithContext(upstreamCtx)
+
 		proxy := &httputil.ReverseProxy{
 			Transport:     transport,
 			FlushInterval: proxyFlushInterval,
@@ -126,6 +134,12 @@ func Handler(registry *providers.Registry) http.HandlerFunc {
 			},
 			ModifyResponse: func(resp *http.Response) error {
 				resp.Header.Set("X-Gateway-Provider", providerName)
+				// A 101 hands resp.Body to handleUpgradeResponse, which requires an
+				// io.ReadWriteCloser, and a tunnelled connection (e.g. /v1/realtime)
+				// is legitimately idle. Bound only ordinary response bodies.
+				if resp.StatusCode != http.StatusSwitchingProtocols {
+					resp.Body = streamio.NewIdleReadCloser(resp.Body, streamio.IdleTimeout(), cancelUpstream)
+				}
 				return nil
 			},
 			ErrorHandler: func(w http.ResponseWriter, _ *http.Request, err error) {

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/ferro-labs/ai-gateway/internal/apierror"
 	"github.com/ferro-labs/ai-gateway/internal/httpclient"
+	"github.com/ferro-labs/ai-gateway/internal/streamio"
 	"github.com/ferro-labs/ai-gateway/providers"
 )
 
@@ -143,7 +144,7 @@ func Handler(registry *providers.Registry) http.HandlerFunc {
 			},
 		}
 
-		proxy.ServeHTTP(w, r)
+		proxy.ServeHTTP(streamio.WrapResponseWriter(w), r)
 	}
 }
 

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -1,11 +1,13 @@
 package proxy
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -13,6 +15,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ferro-labs/ai-gateway/internal/streamio"
 	"github.com/ferro-labs/ai-gateway/providers"
 	geminipkg "github.com/ferro-labs/ai-gateway/providers/gemini"
 	openaipkg "github.com/ferro-labs/ai-gateway/providers/openai"
@@ -637,15 +640,139 @@ func TestProxyHandler_StreamingResponseUsesWriteDeadlines(t *testing.T) {
 	if !w.deadlines[len(w.deadlines)-1].IsZero() {
 		t.Fatalf("last deadline should clear timeout, got %v", w.deadlines[len(w.deadlines)-1])
 	}
+	if w.flushes == 0 {
+		t.Fatal("expected the reverse proxy to flush through the wrapped ResponseWriter")
+	}
+}
+
+// Clearing the write deadline after each write also disables http.Server's
+// WriteTimeout, so an upstream that sends a chunk and then stalls forever must
+// be cut by the idle bound rather than pinning the handler.
+func TestProxyHandler_StalledUpstreamIsCutByIdleTimeout(t *testing.T) {
+	defer streamio.SetIdleTimeoutForTest(50 * time.Millisecond)()
+
+	upstreamBlocked := make(chan struct{})
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("data: {\"id\":\"chunk-1\"}\n\n"))
+		if flusher, ok := w.(http.Flusher); ok {
+			flusher.Flush()
+		}
+		// Stall until the gateway gives up on us and cancels the request.
+		<-r.Context().Done()
+		close(upstreamBlocked)
+	}))
+	defer upstream.Close()
+
+	handler := Handler(buildTestRegistry(upstream.URL))
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/v1/responses", strings.NewReader(`{"model":"gpt-4o","stream":true}`))
+	req.Header.Set("X-Provider", providerOpenAI)
+	req.ContentLength = int64(len(`{"model":"gpt-4o","stream":true}`))
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		handler(newProxyDeadlineRecorder(), req)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("handler never returned: a stalled upstream pinned the connection")
+	}
+
+	select {
+	case <-upstreamBlocked:
+	case <-time.After(10 * time.Second):
+		t.Fatal("upstream request context was never cancelled")
+	}
+}
+
+// httputil.ReverseProxy runs ModifyResponse before handleUpgradeResponse, which
+// requires res.Body to be an io.ReadWriteCloser. Wrapping the body of a 101
+// would break every upgrade endpoint (e.g. /v1/realtime).
+func TestProxyHandler_SwitchingProtocolsUpgradeStillWorks(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		conn, buf, err := http.NewResponseController(w).Hijack()
+		if err != nil {
+			t.Errorf("upstream hijack: %v", err)
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		_, _ = buf.WriteString("HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n\r\n")
+		_ = buf.Flush()
+
+		line, err := buf.ReadString('\n')
+		if err != nil {
+			return
+		}
+		_, _ = buf.WriteString("echo:" + line)
+		_ = buf.Flush()
+	}))
+	defer upstream.Close()
+
+	gateway := httptest.NewServer(Handler(buildTestRegistry(upstream.URL)))
+	defer gateway.Close()
+
+	var dialer net.Dialer
+	conn, err := dialer.DialContext(t.Context(), "tcp", strings.TrimPrefix(gateway.URL, "http://"))
+	if err != nil {
+		t.Fatalf("dial gateway: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+	_ = conn.SetDeadline(time.Now().Add(10 * time.Second))
+
+	_, err = conn.Write([]byte("GET /v1/realtime HTTP/1.1\r\nHost: gateway\r\n" +
+		"X-Provider: " + providerOpenAI + "\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n\r\n"))
+	if err != nil {
+		t.Fatalf("write upgrade request: %v", err)
+	}
+
+	br := bufio.NewReader(conn)
+	status, err := br.ReadString('\n')
+	if err != nil {
+		t.Fatalf("read status line: %v", err)
+	}
+	if !strings.Contains(status, "101") {
+		t.Fatalf("status = %q, want 101 Switching Protocols", strings.TrimSpace(status))
+	}
+	for { // drain headers
+		line, err := br.ReadString('\n')
+		if err != nil {
+			t.Fatalf("read headers: %v", err)
+		}
+		if strings.TrimSpace(line) == "" {
+			break
+		}
+	}
+
+	// The tunnel must carry bytes both ways.
+	if _, err := conn.Write([]byte("ping\n")); err != nil {
+		t.Fatalf("write through tunnel: %v", err)
+	}
+	echo, err := br.ReadString('\n')
+	if err != nil {
+		t.Fatalf("read through tunnel: %v", err)
+	}
+	if strings.TrimSpace(echo) != "echo:ping" {
+		t.Fatalf("tunnel echo = %q, want echo:ping", strings.TrimSpace(echo))
+	}
 }
 
 type proxyDeadlineRecorder struct {
 	*httptest.ResponseRecorder
 	deadlines []time.Time
+	flushes   int
 }
 
 func newProxyDeadlineRecorder() *proxyDeadlineRecorder {
 	return &proxyDeadlineRecorder{ResponseRecorder: httptest.NewRecorder()}
+}
+
+func (r *proxyDeadlineRecorder) Flush() {
+	r.flushes++
+	r.ResponseRecorder.Flush()
 }
 
 func (r *proxyDeadlineRecorder) SetWriteDeadline(deadline time.Time) error {

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/ferro-labs/ai-gateway/providers"
 	geminipkg "github.com/ferro-labs/ai-gateway/providers/gemini"
@@ -598,4 +599,56 @@ func TestProxyHandler_ErrorHandler_GenericJSON(t *testing.T) {
 	if msg == "" {
 		t.Error("response 'error.message' is empty")
 	}
+}
+
+func TestProxyHandler_StreamingResponseUsesWriteDeadlines(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("data: {\"id\":\"chunk-1\"}\n\n"))
+		if flusher, ok := w.(http.Flusher); ok {
+			flusher.Flush()
+		}
+	}))
+	defer upstream.Close()
+
+	reg := buildTestRegistry(upstream.URL)
+	handler := Handler(reg)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/v1/responses", strings.NewReader(`{"model":"gpt-4o","stream":true}`))
+	req.Header.Set("X-Provider", providerOpenAI)
+	req.ContentLength = int64(len(`{"model":"gpt-4o","stream":true}`))
+	w := newProxyDeadlineRecorder()
+
+	handler(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "data:") {
+		t.Fatalf("expected streamed body, got %q", w.Body.String())
+	}
+	if len(w.deadlines) < 2 {
+		t.Fatalf("expected write deadline set and clear, got %d entries", len(w.deadlines))
+	}
+	if w.deadlines[0].IsZero() {
+		t.Fatal("first deadline should set a timeout")
+	}
+	if !w.deadlines[len(w.deadlines)-1].IsZero() {
+		t.Fatalf("last deadline should clear timeout, got %v", w.deadlines[len(w.deadlines)-1])
+	}
+}
+
+type proxyDeadlineRecorder struct {
+	*httptest.ResponseRecorder
+	deadlines []time.Time
+}
+
+func newProxyDeadlineRecorder() *proxyDeadlineRecorder {
+	return &proxyDeadlineRecorder{ResponseRecorder: httptest.NewRecorder()}
+}
+
+func (r *proxyDeadlineRecorder) SetWriteDeadline(deadline time.Time) error {
+	r.deadlines = append(r.deadlines, deadline)
+	return nil
 }

--- a/internal/sse/sse.go
+++ b/internal/sse/sse.go
@@ -14,9 +14,10 @@ import (
 	"github.com/ferro-labs/ai-gateway/providers"
 )
 
-var (
-	idleTimeout = 2 * time.Minute
-)
+// idleTimeout bounds the gap between two chunks arriving on the provider
+// channel. The proxy and legacy-completions paths bound their upstream reads
+// with streamio.IdleTimeout instead.
+var idleTimeout = 2 * time.Minute
 
 // SetIdleTimeoutForTest overrides the idle timeout for testing and returns a restore function.
 func SetIdleTimeoutForTest(d time.Duration) func() {

--- a/internal/sse/sse.go
+++ b/internal/sse/sse.go
@@ -10,12 +10,12 @@ import (
 	"time"
 
 	"github.com/ferro-labs/ai-gateway/internal/logging"
+	"github.com/ferro-labs/ai-gateway/internal/streamio"
 	"github.com/ferro-labs/ai-gateway/providers"
 )
 
 var (
-	writeDeadline = 15 * time.Second
-	idleTimeout   = 2 * time.Minute
+	idleTimeout = 2 * time.Minute
 )
 
 // SetIdleTimeoutForTest overrides the idle timeout for testing and returns a restore function.
@@ -32,7 +32,7 @@ func Write(ctx context.Context, w http.ResponseWriter, ch <-chan providers.Strea
 	w.Header().Set("Connection", "keep-alive")
 
 	controller := http.NewResponseController(w)
-	_ = clearWriteDeadline(controller)
+	_ = streamio.ClearWriteDeadline(controller)
 
 	bw := bufio.NewWriterSize(w, 4096)
 	enc := json.NewEncoder(bw)
@@ -105,26 +105,7 @@ func Write(ctx context.Context, w http.ResponseWriter, ch <-chan providers.Strea
 }
 
 func writeAndFlush(ctx context.Context, controller *http.ResponseController, bw *bufio.Writer, writeFn func() error) error {
-	if err := setWriteDeadline(controller, time.Now().Add(writeDeadline)); err != nil {
-		return err
-	}
-	defer func() {
-		_ = clearWriteDeadline(controller)
-	}()
-
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	default:
-	}
-
-	if err := writeFn(); err != nil {
-		return err
-	}
-	if err := bw.Flush(); err != nil {
-		return err
-	}
-	return flush(controller)
+	return streamio.WriteAndFlush(ctx, controller, bw.Flush, writeFn)
 }
 
 // writeChunk writes a single stream chunk as an SSE event using a
@@ -152,22 +133,4 @@ func writeEvent(bw *bufio.Writer, enc *json.Encoder, payload any) error {
 		return err
 	}
 	return bw.WriteByte('\n')
-}
-
-func flush(controller *http.ResponseController) error {
-	if err := controller.Flush(); err != nil && !errors.Is(err, http.ErrNotSupported) {
-		return err
-	}
-	return nil
-}
-
-func setWriteDeadline(controller *http.ResponseController, deadline time.Time) error {
-	if err := controller.SetWriteDeadline(deadline); err != nil && !errors.Is(err, http.ErrNotSupported) {
-		return err
-	}
-	return nil
-}
-
-func clearWriteDeadline(controller *http.ResponseController) error {
-	return setWriteDeadline(controller, time.Time{})
 }

--- a/internal/streamio/streamio.go
+++ b/internal/streamio/streamio.go
@@ -12,8 +12,57 @@ import (
 const (
 	// DefaultWriteDeadline bounds each client-facing streaming write.
 	DefaultWriteDeadline = 15 * time.Second
-	copyBufferSize       = 32 * 1024
+
+	copyBufferSize = 32 * 1024
 )
+
+// idleTimeout bounds the gap between two upstream reads. Clearing the write
+// deadline after every write also clears http.Server's WriteTimeout for the
+// connection, so without this a trickling upstream would hold a goroutine and a
+// connection open indefinitely. Generous enough for a reasoning model's
+// time-to-first-chunk; every real provider heartbeats well inside it.
+var idleTimeout = 5 * time.Minute
+
+// IdleTimeout returns the active upstream idle bound.
+func IdleTimeout() time.Duration { return idleTimeout }
+
+// SetIdleTimeoutForTest overrides the idle bound and returns a restore function.
+func SetIdleTimeoutForTest(d time.Duration) func() {
+	prev := idleTimeout
+	idleTimeout = d
+	return func() { idleTimeout = prev }
+}
+
+// NewIdleReadCloser wraps rc so onIdle fires when no read completes within idle.
+// Pass the CancelFunc of the context driving the upstream request: cancelling it
+// unblocks the in-flight Read instead of leaving it parked forever. Closing the
+// returned ReadCloser stops the timer and closes rc. A non-positive idle
+// disables the bound and returns rc unchanged.
+func NewIdleReadCloser(rc io.ReadCloser, idle time.Duration, onIdle func()) io.ReadCloser {
+	if idle <= 0 {
+		return rc
+	}
+	return &idleReadCloser{rc: rc, idle: idle, timer: time.AfterFunc(idle, onIdle)}
+}
+
+type idleReadCloser struct {
+	rc    io.ReadCloser
+	timer *time.Timer
+	idle  time.Duration
+}
+
+// Read re-arms the timer after each read returns, so the timer that is running
+// while Read blocks is always the one armed by the previous read.
+func (r *idleReadCloser) Read(p []byte) (int, error) {
+	n, err := r.rc.Read(p)
+	r.timer.Reset(r.idle)
+	return n, err
+}
+
+func (r *idleReadCloser) Close() error {
+	r.timer.Stop()
+	return r.rc.Close()
+}
 
 // WrapResponseWriter returns a ResponseWriter that sets a short write deadline
 // around every Write call. Unsupported deadline operations are ignored.
@@ -40,14 +89,11 @@ func (w *deadlineResponseWriter) Write(p []byte) (int, error) {
 		return 0, err
 	}
 	n, err := w.ResponseWriter.Write(p)
-	clearErr := ClearWriteDeadline(w.controller)
-	if err != nil {
-		return n, err
-	}
-	if clearErr != nil {
-		return n, clearErr
-	}
-	return n, nil
+	// The write already happened; a failure to clear the deadline is not a write
+	// error. Clearing it matters so the gap until the next write stays unbounded
+	// by http.Server's WriteTimeout — the idle bound is the reader's job.
+	_ = ClearWriteDeadline(w.controller)
+	return n, err
 }
 
 // Copy streams src to w, applying the default write deadline to each write and

--- a/internal/streamio/streamio.go
+++ b/internal/streamio/streamio.go
@@ -1,0 +1,142 @@
+// Package streamio contains shared helpers for bounded streaming response writes.
+package streamio
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"time"
+)
+
+const (
+	// DefaultWriteDeadline bounds each client-facing streaming write.
+	DefaultWriteDeadline = 15 * time.Second
+	copyBufferSize       = 32 * 1024
+)
+
+// WrapResponseWriter returns a ResponseWriter that sets a short write deadline
+// around every Write call. Unsupported deadline operations are ignored.
+func WrapResponseWriter(w http.ResponseWriter) http.ResponseWriter {
+	return &deadlineResponseWriter{
+		ResponseWriter: w,
+		controller:     http.NewResponseController(w),
+		timeout:        DefaultWriteDeadline,
+	}
+}
+
+type deadlineResponseWriter struct {
+	http.ResponseWriter
+	controller *http.ResponseController
+	timeout    time.Duration
+}
+
+func (w *deadlineResponseWriter) Unwrap() http.ResponseWriter {
+	return w.ResponseWriter
+}
+
+func (w *deadlineResponseWriter) Write(p []byte) (int, error) {
+	if err := SetWriteDeadline(w.controller, time.Now().Add(w.timeout)); err != nil {
+		return 0, err
+	}
+	n, err := w.ResponseWriter.Write(p)
+	clearErr := ClearWriteDeadline(w.controller)
+	if err != nil {
+		return n, err
+	}
+	if clearErr != nil {
+		return n, clearErr
+	}
+	return n, nil
+}
+
+// Copy streams src to w, applying the default write deadline to each write and
+// flushing after every chunk.
+func Copy(ctx context.Context, w http.ResponseWriter, src io.Reader) (int64, error) {
+	controller := http.NewResponseController(w)
+	buf := make([]byte, copyBufferSize)
+	var written int64
+
+	for {
+		select {
+		case <-ctx.Done():
+			return written, ctx.Err()
+		default:
+		}
+
+		nr, readErr := src.Read(buf)
+		if nr > 0 {
+			chunk := buf[:nr]
+			if err := WriteAndFlush(ctx, controller, nil, func() error {
+				nw, writeErr := w.Write(chunk)
+				if nw > 0 {
+					written += int64(nw)
+				}
+				if writeErr != nil {
+					return writeErr
+				}
+				if nw != nr {
+					return io.ErrShortWrite
+				}
+				return nil
+			}); err != nil {
+				return written, err
+			}
+		}
+
+		if readErr != nil {
+			if errors.Is(readErr, io.EOF) {
+				return written, nil
+			}
+			return written, readErr
+		}
+	}
+}
+
+// WriteAndFlush sets the default write deadline, runs writeFn, flushes the
+// optional buffered writer, flushes the response, then clears the deadline.
+func WriteAndFlush(ctx context.Context, controller *http.ResponseController, flushBuffer func() error, writeFn func() error) error {
+	if err := SetWriteDeadline(controller, time.Now().Add(DefaultWriteDeadline)); err != nil {
+		return err
+	}
+	defer func() {
+		_ = ClearWriteDeadline(controller)
+	}()
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
+	if err := writeFn(); err != nil {
+		return err
+	}
+	if flushBuffer != nil {
+		if err := flushBuffer(); err != nil {
+			return err
+		}
+	}
+	return Flush(controller)
+}
+
+// Flush flushes the response when supported.
+func Flush(controller *http.ResponseController) error {
+	if err := controller.Flush(); err != nil && !errors.Is(err, http.ErrNotSupported) {
+		return err
+	}
+	return nil
+}
+
+// SetWriteDeadline applies deadline when supported.
+func SetWriteDeadline(controller *http.ResponseController, deadline time.Time) error {
+	if err := controller.SetWriteDeadline(deadline); err != nil && !errors.Is(err, http.ErrNotSupported) {
+		return err
+	}
+	return nil
+}
+
+// ClearWriteDeadline removes any active write deadline when supported.
+func ClearWriteDeadline(controller *http.ResponseController) error {
+	return SetWriteDeadline(controller, time.Time{})
+}

--- a/internal/streamio/streamio_test.go
+++ b/internal/streamio/streamio_test.go
@@ -3,9 +3,11 @@ package streamio
 import (
 	"context"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -101,6 +103,122 @@ func TestCopyReturnsCanceledContextBeforeWrite(t *testing.T) {
 	if rw.Body.Len() != 0 {
 		t.Fatalf("body should be empty, got %q", rw.Body.String())
 	}
+}
+
+func TestNewIdleReadCloser_FiresWhenUpstreamStalls(t *testing.T) {
+	fired := make(chan struct{})
+	rc := NewIdleReadCloser(io.NopCloser(blockingReader{}), 10*time.Millisecond, func() { close(fired) })
+	defer func() { _ = rc.Close() }()
+
+	select {
+	case <-fired:
+	case <-time.After(2 * time.Second):
+		t.Fatal("idle callback never fired while the upstream stalled")
+	}
+}
+
+func TestNewIdleReadCloser_CloseStopsTimer(t *testing.T) {
+	var fired atomic.Bool
+	rc := NewIdleReadCloser(io.NopCloser(blockingReader{}), 10*time.Millisecond, func() { fired.Store(true) })
+	if err := rc.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	time.Sleep(50 * time.Millisecond)
+	if fired.Load() {
+		t.Fatal("idle callback fired after Close")
+	}
+}
+
+func TestNewIdleReadCloser_ReadRearmsTimer(t *testing.T) {
+	var fired atomic.Bool
+	src := io.NopCloser(strings.NewReader("abcdef"))
+	rc := NewIdleReadCloser(src, 40*time.Millisecond, func() { fired.Store(true) })
+	defer func() { _ = rc.Close() }()
+
+	// Six reads spaced under the bound must never trip it, even though their
+	// total duration exceeds it.
+	buf := make([]byte, 1)
+	for range 6 {
+		if _, err := rc.Read(buf); err != nil {
+			t.Fatalf("Read: %v", err)
+		}
+		time.Sleep(10 * time.Millisecond)
+		if fired.Load() {
+			t.Fatal("idle callback fired while reads were still completing")
+		}
+	}
+}
+
+func TestNewIdleReadCloser_NonPositiveIdleDisablesBound(t *testing.T) {
+	src := io.NopCloser(strings.NewReader("x"))
+	if got := NewIdleReadCloser(src, 0, func() { t.Fatal("must not fire") }); got != src {
+		t.Fatalf("zero idle should return the source unchanged, got %T", got)
+	}
+}
+
+func TestWrapResponseWriter_SetsAndClearsDeadlinePerWrite(t *testing.T) {
+	rw := newDeadlineRecorder()
+	w := WrapResponseWriter(rw)
+
+	for range 2 {
+		if _, err := w.Write([]byte("chunk")); err != nil {
+			t.Fatalf("Write: %v", err)
+		}
+	}
+
+	// Each write must set a deadline then clear it, so the gap between writes is
+	// unbounded by http.Server's WriteTimeout.
+	if len(rw.deadlines) != 4 {
+		t.Fatalf("deadlines = %v, want set/clear per write (4 entries)", rw.deadlines)
+	}
+	for i, d := range rw.deadlines {
+		if wantZero := i%2 == 1; d.IsZero() != wantZero {
+			t.Fatalf("deadlines[%d].IsZero() = %v, want %v", i, d.IsZero(), wantZero)
+		}
+	}
+}
+
+func TestWrapResponseWriter_DeadlineFailureAbortsWrite(t *testing.T) {
+	wantErr := errors.New("deadline failed")
+	rw := newDeadlineRecorder()
+	rw.deadlineErr = wantErr
+	w := WrapResponseWriter(rw)
+
+	n, err := w.Write([]byte("chunk"))
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("error = %v, want %v", err, wantErr)
+	}
+	if n != 0 {
+		t.Fatalf("written = %d, want 0", n)
+	}
+	if rw.Body.Len() != 0 {
+		t.Fatalf("body should be empty, got %q", rw.Body.String())
+	}
+}
+
+// The wrapper embeds the http.ResponseWriter interface, so it does not itself
+// satisfy http.Flusher. ReverseProxy reaches Flush through ResponseController,
+// which walks Unwrap — this pins that contract.
+func TestWrapResponseWriter_UnwrapExposesFlusher(t *testing.T) {
+	rw := newDeadlineRecorder()
+	w := WrapResponseWriter(rw)
+
+	if _, ok := w.(http.Flusher); ok {
+		t.Fatal("wrapper unexpectedly satisfies http.Flusher directly; test no longer covers the Unwrap path")
+	}
+	if err := http.NewResponseController(w).Flush(); err != nil {
+		t.Fatalf("Flush through ResponseController: %v", err)
+	}
+	if rw.flushes != 1 {
+		t.Fatalf("flushes = %d, want 1", rw.flushes)
+	}
+}
+
+type blockingReader struct{}
+
+func (blockingReader) Read([]byte) (int, error) {
+	select {} // never returns; stands in for a stalled upstream
 }
 
 type deadlineRecorder struct {

--- a/internal/streamio/streamio_test.go
+++ b/internal/streamio/streamio_test.go
@@ -1,0 +1,125 @@
+package streamio
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestWriteAndFlushSetsAndClearsDeadline(t *testing.T) {
+	rw := newDeadlineRecorder()
+	controller := http.NewResponseController(rw)
+
+	err := WriteAndFlush(context.Background(), controller, nil, func() error {
+		_, writeErr := rw.Write([]byte("data: {}\n\n"))
+		return writeErr
+	})
+	if err != nil {
+		t.Fatalf("WriteAndFlush returned error: %v", err)
+	}
+	if len(rw.deadlines) < 2 {
+		t.Fatalf("expected set and clear deadlines, got %d entries", len(rw.deadlines))
+	}
+	if rw.deadlines[0].IsZero() {
+		t.Fatal("first deadline should set a timeout")
+	}
+	if !rw.deadlines[len(rw.deadlines)-1].IsZero() {
+		t.Fatalf("last deadline should clear timeout, got %v", rw.deadlines[len(rw.deadlines)-1])
+	}
+	if rw.flushes == 0 {
+		t.Fatal("expected response flush")
+	}
+}
+
+func TestWriteAndFlushIgnoresUnsupportedDeadline(t *testing.T) {
+	rw := httptest.NewRecorder()
+	controller := http.NewResponseController(rw)
+
+	err := WriteAndFlush(context.Background(), controller, nil, func() error {
+		_, writeErr := rw.Write([]byte("ok"))
+		return writeErr
+	})
+	if err != nil {
+		t.Fatalf("WriteAndFlush returned error for unsupported deadline: %v", err)
+	}
+	if rw.Body.String() != "ok" {
+		t.Fatalf("body = %q, want ok", rw.Body.String())
+	}
+}
+
+func TestWriteAndFlushPropagatesDeadlineError(t *testing.T) {
+	wantErr := errors.New("deadline failed")
+	rw := newDeadlineRecorder()
+	rw.deadlineErr = wantErr
+	controller := http.NewResponseController(rw)
+
+	err := WriteAndFlush(context.Background(), controller, nil, func() error {
+		t.Fatal("writeFn should not run when setting deadline fails")
+		return nil
+	})
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("error = %v, want %v", err, wantErr)
+	}
+}
+
+func TestCopyWritesWithDeadlinesAndFlushes(t *testing.T) {
+	rw := newDeadlineRecorder()
+	written, err := Copy(context.Background(), rw, strings.NewReader("hello"))
+	if err != nil {
+		t.Fatalf("Copy returned error: %v", err)
+	}
+	if written != 5 {
+		t.Fatalf("written = %d, want 5", written)
+	}
+	if rw.Body.String() != "hello" {
+		t.Fatalf("body = %q, want hello", rw.Body.String())
+	}
+	if len(rw.deadlines) < 2 {
+		t.Fatalf("expected set and clear deadlines, got %d entries", len(rw.deadlines))
+	}
+	if rw.flushes == 0 {
+		t.Fatal("expected response flush")
+	}
+}
+
+func TestCopyReturnsCanceledContextBeforeWrite(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	rw := newDeadlineRecorder()
+	written, err := Copy(ctx, rw, strings.NewReader("hello"))
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("error = %v, want context.Canceled", err)
+	}
+	if written != 0 {
+		t.Fatalf("written = %d, want 0", written)
+	}
+	if rw.Body.Len() != 0 {
+		t.Fatalf("body should be empty, got %q", rw.Body.String())
+	}
+}
+
+type deadlineRecorder struct {
+	*httptest.ResponseRecorder
+	deadlines   []time.Time
+	deadlineErr error
+	flushes     int
+}
+
+func newDeadlineRecorder() *deadlineRecorder {
+	return &deadlineRecorder{ResponseRecorder: httptest.NewRecorder()}
+}
+
+func (r *deadlineRecorder) Flush() {
+	r.flushes++
+	r.ResponseRecorder.Flush()
+}
+
+func (r *deadlineRecorder) SetWriteDeadline(deadline time.Time) error {
+	r.deadlines = append(r.deadlines, deadline)
+	return r.deadlineErr
+}

--- a/internal/streamwrap/wrap.go
+++ b/internal/streamwrap/wrap.go
@@ -51,7 +51,9 @@ type MeterMeta struct {
 	Model string
 	// MetricModel is the bounded form of Model used for Prometheus labels: a
 	// model the gateway cannot route collapses to metrics.UnknownModelLabel so a
-	// client cannot mint unbounded time series. Empty falls back to Model.
+	// client cannot mint unbounded time series. Required whenever Model can carry
+	// a client-supplied value — leaving it empty degrades every label for the
+	// request to "unknown" rather than falling back to the raw model.
 	MetricModel string
 	// Catalog is a snapshot of the gateway's model catalog used for cost calculation.
 	Catalog models.Catalog
@@ -80,13 +82,16 @@ type MeterMeta struct {
 	CircuitBreakerOutcome func(err error)
 }
 
-// metricLabelModel returns the bounded Prometheus label for this request,
-// falling back to the raw model when the caller did not bucket it.
+// metricLabelModel returns the bounded Prometheus label for this request.
+//
+// An unset MetricModel fails closed to UnknownModelLabel rather than falling
+// back to the raw, client-supplied Model. Losing one label's precision is
+// strictly better than letting a caller mint unbounded time series by omission.
 func (m MeterMeta) metricLabelModel() string {
-	if m.MetricModel != "" {
-		return m.MetricModel
+	if m.MetricModel == "" {
+		return metrics.UnknownModelLabel
 	}
-	return m.Model
+	return m.MetricModel
 }
 
 // StreamOutcome bundles the values stamped onto the observability span

--- a/internal/streamwrap/wrap.go
+++ b/internal/streamwrap/wrap.go
@@ -45,8 +45,14 @@ import (
 type MeterMeta struct {
 	// Provider is the name of the provider that handled the request (e.g. "openai").
 	Provider string
-	// Model is the model ID after alias resolution.
+	// Model is the model ID after alias resolution. It reaches this struct as the
+	// client supplied it, so it is used for cost lookup and event payloads but
+	// never as a Prometheus label — see MetricModel.
 	Model string
+	// MetricModel is the bounded form of Model used for Prometheus labels: a
+	// model the gateway cannot route collapses to metrics.UnknownModelLabel so a
+	// client cannot mint unbounded time series. Empty falls back to Model.
+	MetricModel string
 	// Catalog is a snapshot of the gateway's model catalog used for cost calculation.
 	Catalog models.Catalog
 	// PublishFn is the gateway's event-hook dispatcher. Called asynchronously on
@@ -72,6 +78,15 @@ type MeterMeta struct {
 	// CircuitBreakerOutcome, if non-nil, is invoked once when the stream
 	// finishes. err is nil on success; non-nil on provider/stream failure.
 	CircuitBreakerOutcome func(err error)
+}
+
+// metricLabelModel returns the bounded Prometheus label for this request,
+// falling back to the raw model when the caller did not bucket it.
+func (m MeterMeta) metricLabelModel() string {
+	if m.MetricModel != "" {
+		return m.MetricModel
+	}
+	return m.Model
 }
 
 // StreamOutcome bundles the values stamped onto the observability span
@@ -257,7 +272,7 @@ func finishStreamOnError(
 	case errors.Is(streamErr, circuitbreaker.ErrCircuitOpen):
 		errType = "circuit_open"
 	}
-	requestMetrics := metrics.ForRequest(meta.Provider, meta.Model)
+	requestMetrics := metrics.ForRequest(meta.Provider, meta.metricLabelModel())
 	requestMetrics.Error.Inc()
 	metrics.ForProviderError(meta.Provider, errType).Inc()
 	if meta.PublishFn != nil {
@@ -308,7 +323,7 @@ func handleCompletionFn(
 	if err == nil {
 		return false
 	}
-	requestMetrics := metrics.ForRequest(meta.Provider, meta.Model)
+	requestMetrics := metrics.ForRequest(meta.Provider, meta.metricLabelModel())
 	requestMetrics.Error.Inc()
 	metrics.ForProviderError(meta.Provider, "plugin_error").Inc()
 	select {
@@ -341,7 +356,7 @@ func finishStreamOnSuccess(
 	ttftMs, ttltMs float64,
 	latency time.Duration,
 ) {
-	requestMetrics := metrics.ForRequest(meta.Provider, meta.Model)
+	requestMetrics := metrics.ForRequest(meta.Provider, meta.metricLabelModel())
 	requestMetrics.Duration.Observe(latency.Seconds())
 	requestMetrics.Success.Inc()
 

--- a/internal/streamwrap/wrap_leak_test.go
+++ b/internal/streamwrap/wrap_leak_test.go
@@ -60,11 +60,12 @@ func TestMeter_ClientDisconnect_NoGoroutineLeak(t *testing.T) {
 	}
 
 	out := Meter(ctx, src, time.Now(), MeterMeta{
-		Provider:  "openai",
-		Model:     "gpt-4o",
-		Catalog:   models.Catalog{},
-		PublishFn: publishFn,
-		TraceID:   "trace-disconnect",
+		Provider:    "openai",
+		Model:       "gpt-4o",
+		MetricModel: "gpt-4o",
+		Catalog:     models.Catalog{},
+		PublishFn:   publishFn,
+		TraceID:     "trace-disconnect",
 	})
 
 	// Consume 1 chunk, then disconnect.
@@ -121,9 +122,10 @@ func TestMeter_ConsumerStopsReading_NoLeak(t *testing.T) {
 	)
 
 	out := Meter(context.Background(), src, time.Now(), MeterMeta{
-		Provider: "openai",
-		Model:    "gpt-4o",
-		Catalog:  models.Catalog{},
+		Provider:    "openai",
+		Model:       "gpt-4o",
+		MetricModel: "gpt-4o",
+		Catalog:     models.Catalog{},
 	})
 
 	// Read one, then stop. Meter's per-chunk send is buffered through the

--- a/internal/streamwrap/wrap_test.go
+++ b/internal/streamwrap/wrap_test.go
@@ -44,9 +44,10 @@ func TestMeter_ForwardsAllChunks(t *testing.T) {
 	}
 	src := feed(chunks...)
 	out := Meter(context.Background(), src, time.Now(), MeterMeta{
-		Provider: "openai",
-		Model:    "gpt-4o",
-		Catalog:  models.Catalog{},
+		Provider:    "openai",
+		Model:       "gpt-4o",
+		MetricModel: "gpt-4o",
+		Catalog:     models.Catalog{},
 	})
 
 	var got []providers.StreamChunk
@@ -78,11 +79,12 @@ func TestMeter_CallsPublishFn_OnSuccess(t *testing.T) {
 	)
 
 	out := Meter(context.Background(), src, time.Now(), MeterMeta{
-		Provider:  "openai",
-		Model:     "gpt-4o",
-		Catalog:   models.Catalog{},
-		PublishFn: publishFn,
-		TraceID:   "trace-123",
+		Provider:    "openai",
+		Model:       "gpt-4o",
+		MetricModel: "gpt-4o",
+		Catalog:     models.Catalog{},
+		PublishFn:   publishFn,
+		TraceID:     "trace-123",
 	})
 
 	// Drain. PublishFn is called synchronously inside the Meter goroutine
@@ -127,10 +129,11 @@ func TestMeter_CallsPublishFn_OnError(t *testing.T) {
 	)
 
 	out := Meter(context.Background(), src, time.Now(), MeterMeta{
-		Provider:  "groq",
-		Model:     "llama-3",
-		Catalog:   models.Catalog{},
-		PublishFn: publishFn,
+		Provider:    "groq",
+		Model:       "llama-3",
+		MetricModel: "llama-3",
+		Catalog:     models.Catalog{},
+		PublishFn:   publishFn,
 	})
 	// PublishFn is called synchronously before close(out); no sleep needed.
 	for range out { //nolint:revive
@@ -157,9 +160,10 @@ func TestMeter_IncrementsProviderErrors_OnError(t *testing.T) {
 	beforeProvErr := counterValue(t, metrics.ProviderErrors.WithLabelValues("groq", "provider_error"))
 
 	out := Meter(context.Background(), src, time.Now(), MeterMeta{
-		Provider: "groq",
-		Model:    "llama-3",
-		Catalog:  models.Catalog{},
+		Provider:    "groq",
+		Model:       "llama-3",
+		MetricModel: "llama-3",
+		Catalog:     models.Catalog{},
 	})
 	for range out { //nolint:revive
 	}
@@ -184,9 +188,10 @@ func TestMeter_IncrementsProviderErrors_CircuitOpen(t *testing.T) {
 	beforeProvErr := counterValue(t, metrics.ProviderErrors.WithLabelValues("groq", "circuit_open"))
 
 	out := Meter(context.Background(), src, time.Now(), MeterMeta{
-		Provider: "groq",
-		Model:    "llama-3",
-		Catalog:  models.Catalog{},
+		Provider:    "groq",
+		Model:       "llama-3",
+		MetricModel: "llama-3",
+		Catalog:     models.Catalog{},
 	})
 	for range out { //nolint:revive
 	}
@@ -230,6 +235,7 @@ func TestMeter_CircuitBreakerOutcome_PreservesProviderErrorOnClientCancel(t *tes
 	out := Meter(ctx, src, time.Now(), MeterMeta{
 		Provider:              "openai",
 		Model:                 "gpt-4o",
+		MetricModel:           "gpt-4o",
 		Catalog:               models.Catalog{},
 		CircuitBreakerOutcome: outcomeFn,
 	})
@@ -272,6 +278,7 @@ func TestMeter_CallsCircuitBreakerOutcome_OnSuccessAndError(t *testing.T) {
 		out := Meter(context.Background(), src, time.Now(), MeterMeta{
 			Provider:              "openai",
 			Model:                 "gpt-4o",
+			MetricModel:           "gpt-4o",
 			Catalog:               models.Catalog{},
 			CircuitBreakerOutcome: outcomeFn,
 		})
@@ -298,6 +305,7 @@ func TestMeter_CallsCircuitBreakerOutcome_OnSuccessAndError(t *testing.T) {
 		out := Meter(context.Background(), src, time.Now(), MeterMeta{
 			Provider:              "openai",
 			Model:                 "gpt-4o",
+			MetricModel:           "gpt-4o",
 			Catalog:               models.Catalog{},
 			CircuitBreakerOutcome: outcomeFn,
 		})
@@ -325,9 +333,10 @@ func TestMeter_CallsCircuitBreakerOutcome_OnAfterPluginError(t *testing.T) {
 	)
 
 	out := Meter(context.Background(), src, time.Now(), MeterMeta{
-		Provider: "openai",
-		Model:    "gpt-4o",
-		Catalog:  models.Catalog{},
+		Provider:    "openai",
+		Model:       "gpt-4o",
+		MetricModel: "gpt-4o",
+		Catalog:     models.Catalog{},
 		CompletionFn: func(context.Context, *providers.Response) error {
 			return pluginErr
 		},
@@ -347,11 +356,81 @@ func TestMeter_NilPublishFn_NoPanic(t *testing.T) {
 	t.Helper()
 	src := feed(providers.StreamChunk{ID: "1"})
 	out := Meter(context.Background(), src, time.Now(), MeterMeta{
-		Provider:  "openai",
-		Model:     "gpt-4o",
-		Catalog:   models.Catalog{},
-		PublishFn: nil,
+		Provider:    "openai",
+		Model:       "gpt-4o",
+		MetricModel: "gpt-4o",
+		Catalog:     models.Catalog{},
+		PublishFn:   nil,
 	})
 	for range out { //nolint:revive
+	}
+}
+
+// A caller that forgets MetricModel must not silently reintroduce unbounded
+// cardinality: the label fails closed to "unknown" instead of echoing the raw,
+// client-supplied model. Model itself stays raw for cost lookup and events.
+func TestMeterMeta_MetricLabelModelFailsClosed(t *testing.T) {
+	tests := []struct {
+		name string
+		meta MeterMeta
+		want string
+	}{
+		{
+			name: "bucketed label is used",
+			meta: MeterMeta{Model: "raw-client-model", MetricModel: metrics.UnknownModelLabel},
+			want: metrics.UnknownModelLabel,
+		},
+		{
+			name: "known model passes through",
+			meta: MeterMeta{Model: "gpt-4o", MetricModel: "gpt-4o"},
+			want: "gpt-4o",
+		},
+		{
+			name: "unset MetricModel never leaks the raw model",
+			meta: MeterMeta{Model: "raw-client-model"},
+			want: metrics.UnknownModelLabel,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.meta.metricLabelModel(); got != tt.want {
+				t.Fatalf("metricLabelModel() = %q, want %q", got, tt.want)
+			}
+			if tt.meta.Model == "" {
+				t.Fatal("Model must remain available for cost lookup")
+			}
+		})
+	}
+}
+
+// The unset case must not merely default — it must also keep the raw model out
+// of the emitted series.
+func TestMeter_UnsetMetricModelDoesNotEmitRawModelLabel(t *testing.T) {
+	const rawModel = "streamwrap-raw-model-must-not-appear"
+
+	src := feed(providers.StreamChunk{Usage: &providers.Usage{PromptTokens: 1, CompletionTokens: 1}})
+	out := Meter(context.Background(), src, time.Now(), MeterMeta{
+		Provider: "openai",
+		Model:    rawModel, // MetricModel deliberately unset
+		Catalog:  models.Catalog{},
+	})
+	for range out { //nolint:revive // drain
+	}
+
+	mfs, err := prometheus.DefaultGatherer.Gather()
+	if err != nil {
+		t.Fatalf("gather metrics: %v", err)
+	}
+	for _, mf := range mfs {
+		if mf.GetName() != "gateway_requests_total" {
+			continue
+		}
+		for _, m := range mf.GetMetric() {
+			for _, label := range m.GetLabel() {
+				if label.GetName() == "model" && label.GetValue() == rawModel {
+					t.Fatalf("raw model %q leaked into a metric series", rawModel)
+				}
+			}
+		}
 	}
 }

--- a/web/assets_test.go
+++ b/web/assets_test.go
@@ -1,0 +1,45 @@
+package web
+
+import (
+	"io/fs"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// The gateway serves Content-Security-Policy: script-src 'self'. Under that
+// policy an inline <script> block or an on*="…" attribute silently stops
+// running, which is exactly how a broken login page ships unnoticed. Event
+// handlers belong in web/static as data-action registrations.
+var (
+	inlineScript  = regexp.MustCompile(`(?i)<script(?:\s[^>]*)?>\s*[^<\s]`)
+	inlineHandler = regexp.MustCompile(`(?i)\son[a-z]+\s*=\s*["']`)
+)
+
+func TestTemplatesCarryNoInlineScript(t *testing.T) {
+	err := fs.WalkDir(Assets, "templates", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || filepath.Ext(path) != ".html" {
+			return nil
+		}
+		body, readErr := fs.ReadFile(Assets, path)
+		if readErr != nil {
+			return readErr
+		}
+		markup := string(body)
+
+		if loc := inlineScript.FindString(markup); loc != "" {
+			t.Errorf("%s: inline <script> is blocked by script-src 'self'; move it into web/static (found %q)", path, strings.TrimSpace(loc))
+		}
+		if loc := inlineHandler.FindString(markup); loc != "" {
+			t.Errorf("%s: inline %q handler is blocked by script-src 'self'; use data-action + registerActions", path, strings.TrimSpace(loc))
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk templates: %v", err)
+	}
+}

--- a/web/static/dashboard.js
+++ b/web/static/dashboard.js
@@ -126,6 +126,31 @@ function logout() {
   window.location.href = '/dashboard/login';
 }
 
+// Click delegation. The Content-Security-Policy sets script-src 'self', which
+// blocks inline onclick="..." attributes, so markup declares data-action="name"
+// and pages register the handler here. Handlers receive (element, event).
+//
+// Only the nearest ancestor with data-action runs, so a data-action on a modal
+// body shadows the overlay's close action the way stopPropagation used to.
+var actionHandlers = {};
+
+function registerActions(handlers) {
+  Object.keys(handlers).forEach(function(name) { actionHandlers[name] = handlers[name]; });
+}
+
+document.addEventListener('click', function(event) {
+  var target = event.target;
+  var el = target && target.closest ? target.closest('[data-action]') : null;
+  if (!el) return;
+  var handler = actionHandlers[el.getAttribute('data-action')];
+  if (handler) handler(el, event);
+});
+
+registerActions({
+  'toggle-theme': toggleDarkMode,
+  'logout': logout
+});
+
 document.addEventListener('DOMContentLoaded', function() {
   initDarkMode();
   if (checkAuth()) {

--- a/web/static/pages/analytics.js
+++ b/web/static/pages/analytics.js
@@ -10,6 +10,10 @@ function setRange(btn, hours) {
   loadAnalytics();
 }
 
+registerActions({
+  'set-range': function(el) { setRange(el, Number(el.getAttribute('data-hours'))); }
+});
+
 function loadAnalytics() {
   var since = new Date(Date.now() - _currentRangeHours * 3600 * 1000).toISOString();
   apiRequest('/admin/logs/stats?since=' + encodeURIComponent(since))

--- a/web/static/pages/config.js
+++ b/web/static/pages/config.js
@@ -1,5 +1,12 @@
 'use strict';
 
+registerActions({
+  'switch-tab': function(el) { switchTab(el.getAttribute('data-tab')); },
+  'start-edit': startEdit,
+  'cancel-edit': cancelEdit,
+  'save-config': saveConfig
+});
+
 function switchTab(tab) {
   var panelCurrent = document.getElementById('panel-current');
   var panelHistory = document.getElementById('panel-history');

--- a/web/static/pages/keys.js
+++ b/web/static/pages/keys.js
@@ -2,6 +2,16 @@
 
 var _createdKeyValue = '';
 
+registerActions({
+  'show-create-key': showCreateKeyModal,
+  'submit-create-key': submitCreateKey,
+  'copy-created-key': copyCreatedKey,
+  'close-modal': function(el) { closeModal(el.getAttribute('data-modal')); },
+  // Swallows clicks inside the modal card so they never reach the overlay's
+  // close action — data-action resolves to the nearest ancestor only.
+  'modal-body': function() {}
+});
+
 document.addEventListener('DOMContentLoaded', function() {
   loadKeys();
 });
@@ -135,10 +145,6 @@ function showCreateKeyModal() {
 function closeModal(id) {
   var modal = document.getElementById(id);
   if (modal) modal.style.display = 'none';
-}
-
-function handleOverlayClick(event, id) {
-  if (event.target === event.currentTarget) closeModal(id);
 }
 
 async function submitCreateKey() {

--- a/web/static/pages/login.js
+++ b/web/static/pages/login.js
@@ -1,0 +1,51 @@
+'use strict';
+
+// Served as a file rather than an inline <script> so the dashboard can run under
+// Content-Security-Policy: script-src 'self'.
+
+document.addEventListener('DOMContentLoaded', function() {
+  // Already authenticated — skip the form.
+  if (localStorage.getItem('gw-admin-key')) {
+    window.location.href = '/dashboard/overview';
+    return;
+  }
+
+  var form = document.getElementById('login-form');
+  if (!form) return;
+
+  form.addEventListener('submit', async function(e) {
+    e.preventDefault();
+    var key = document.getElementById('login-key').value.trim();
+    var errEl = document.getElementById('login-error');
+    errEl.style.display = 'none';
+
+    if (!key) {
+      errEl.textContent = 'Please enter a key.';
+      errEl.style.display = 'block';
+      return;
+    }
+
+    try {
+      // /admin/health always answers 200 when the key is valid, even if the
+      // gateway is degraded, so a non-2xx here really does mean the key failed.
+      var res = await fetch('/admin/health', {
+        headers: { 'Authorization': 'Bearer ' + key }
+      });
+      if (!res.ok) {
+        var data = await res.json().catch(function() { return {}; });
+        errEl.textContent = (data.error && data.error.message) || 'Invalid key.';
+        errEl.style.display = 'block';
+        return;
+      }
+      var health = await res.json();
+      localStorage.setItem('gw-admin-key', key);
+      if (health.scopes) {
+        localStorage.setItem('gw-scopes', JSON.stringify(health.scopes));
+      }
+      window.location.href = '/dashboard/overview';
+    } catch (err) {
+      errEl.textContent = 'Cannot reach gateway. Is it running?';
+      errEl.style.display = 'block';
+    }
+  });
+});

--- a/web/static/pages/playground.js
+++ b/web/static/pages/playground.js
@@ -1,5 +1,10 @@
 'use strict';
 
+registerActions({
+  'toggle-system-prompt': toggleSystemPrompt,
+  'send-message': sendMessage
+});
+
 function toggleSystemPrompt() {
   var textarea = document.getElementById('pg-system');
   var btn = document.getElementById('pg-system-toggle');

--- a/web/templates/layout.html
+++ b/web/templates/layout.html
@@ -43,9 +43,9 @@
         <a href="https://discord.gg/yCAeYvJeDV" target="_blank" rel="noopener" class="header-help-link" title="Discord">
           <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028c.462-.63.874-1.295 1.226-1.994a.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z"/></svg>
         </a>
-        <button id="theme-toggle" class="btn btn-secondary" onclick="toggleDarkMode()" style="width:36px;height:36px;padding:0;font-size:16px;">&#x263E;</button>
+        <button id="theme-toggle" class="btn btn-secondary" data-action="toggle-theme" style="width:36px;height:36px;padding:0;font-size:16px;">&#x263E;</button>
         <span id="scope-badge" class="badge" style="display:none;"></span>
-        <button id="logout-btn" class="btn btn-sm" style="display:none;" onclick="logout()">Logout</button>
+        <button id="logout-btn" class="btn btn-sm" style="display:none;" data-action="logout">Logout</button>
       </div>
     </header>
     <div class="content">

--- a/web/templates/login.html
+++ b/web/templates/login.html
@@ -89,45 +89,6 @@
       </div>
     </div>
   </div>
-  <script>
-    document.getElementById('login-form').addEventListener('submit', async function(e) {
-      e.preventDefault();
-      var key = document.getElementById('login-key').value.trim();
-      var errEl = document.getElementById('login-error');
-      errEl.style.display = 'none';
-
-      if (!key) {
-        errEl.textContent = 'Please enter a key.';
-        errEl.style.display = 'block';
-        return;
-      }
-
-      try {
-        var res = await fetch('/admin/health', {
-          headers: { 'Authorization': 'Bearer ' + key }
-        });
-        if (!res.ok) {
-          var data = await res.json().catch(function() { return {}; });
-          errEl.textContent = (data.error && data.error.message) || 'Invalid key.';
-          errEl.style.display = 'block';
-          return;
-        }
-        var health = await res.json();
-        localStorage.setItem('gw-admin-key', key);
-        if (health.scopes) {
-          localStorage.setItem('gw-scopes', JSON.stringify(health.scopes));
-        }
-        window.location.href = '/dashboard/overview';
-      } catch (err) {
-        errEl.textContent = 'Cannot reach gateway. Is it running?';
-        errEl.style.display = 'block';
-      }
-    });
-
-    // If already authenticated, redirect.
-    if (localStorage.getItem('gw-admin-key')) {
-      window.location.href = '/dashboard/overview';
-    }
-  </script>
+  <script src="/dashboard/static/pages/login.js"></script>
 </body>
 </html>

--- a/web/templates/pages/analytics.html
+++ b/web/templates/pages/analytics.html
@@ -1,9 +1,9 @@
 {{define "content"}}
 <div class="tabs" id="range-tabs">
-  <button class="tab active" onclick="setRange(this, 1)">1h</button>
-  <button class="tab" onclick="setRange(this, 6)">6h</button>
-  <button class="tab" onclick="setRange(this, 24)">24h</button>
-  <button class="tab" onclick="setRange(this, 168)">7d</button>
+  <button class="tab active" data-action="set-range" data-hours="1">1h</button>
+  <button class="tab" data-action="set-range" data-hours="6">6h</button>
+  <button class="tab" data-action="set-range" data-hours="24">24h</button>
+  <button class="tab" data-action="set-range" data-hours="168">7d</button>
 </div>
 
 <div class="stat-grid" style="grid-template-columns: repeat(3, 1fr);">

--- a/web/templates/pages/config.html
+++ b/web/templates/pages/config.html
@@ -1,7 +1,7 @@
 {{define "content"}}
 <div class="tabs">
-  <button class="tab active" id="tab-current" onclick="switchTab('current')">Current</button>
-  <button class="tab" id="tab-history" onclick="switchTab('history')">History</button>
+  <button class="tab active" id="tab-current" data-action="switch-tab" data-tab="current">Current</button>
+  <button class="tab" id="tab-history" data-action="switch-tab" data-tab="history">History</button>
 </div>
 
 <div id="panel-current">
@@ -9,14 +9,14 @@
     <div class="card-title" style="display:flex;align-items:center;justify-content:space-between;">
       <span>Current Config</span>
       <div style="display:flex;gap:8px;" id="config-actions">
-        <button class="btn btn-secondary" id="btn-edit" data-scope="admin" onclick="startEdit()">Edit</button>
+        <button class="btn btn-secondary" id="btn-edit" data-scope="admin" data-action="start-edit">Edit</button>
       </div>
     </div>
     <pre class="code-block" id="config-display"></pre>
     <textarea class="playground-textarea" id="config-editor" style="display:none;font-family:var(--font-mono);font-size:13px;min-height:400px;" spellcheck="false"></textarea>
     <div style="display:none;gap:8px;margin-top:12px;" id="edit-actions">
-      <button class="btn btn-primary" data-scope="admin" onclick="saveConfig()">Save</button>
-      <button class="btn btn-ghost" onclick="cancelEdit()">Cancel</button>
+      <button class="btn btn-primary" data-scope="admin" data-action="save-config">Save</button>
+      <button class="btn btn-ghost" data-action="cancel-edit">Cancel</button>
     </div>
   </div>
 </div>

--- a/web/templates/pages/keys.html
+++ b/web/templates/pages/keys.html
@@ -2,7 +2,7 @@
 <div id="keys-root">
   <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:20px;">
     <p id="keys-summary" style="color:var(--text-muted);font-size:14px;margin:0;">Loading...</p>
-    <button class="btn btn-primary" data-scope="admin" onclick="showCreateKeyModal()">Create Key</button>
+    <button class="btn btn-primary" data-scope="admin" data-action="show-create-key">Create Key</button>
   </div>
 
   <div class="card" style="padding:0;overflow:hidden;">
@@ -26,8 +26,8 @@
 </div>
 
 <!-- Create Key Modal -->
-<div id="create-key-modal" class="modal-overlay" style="display:none;" onclick="handleOverlayClick(event,'create-key-modal')">
-  <div class="modal" onclick="event.stopPropagation()">
+<div id="create-key-modal" class="modal-overlay" style="display:none;" data-action="close-modal" data-modal="create-key-modal">
+  <div class="modal" data-action="modal-body">
     <div class="modal-title">Create API Key</div>
     <div class="form-group">
       <label class="form-label" for="key-name-input">Name</label>
@@ -56,15 +56,15 @@
       </select>
     </div>
     <div class="modal-actions">
-      <button class="btn btn-secondary" onclick="closeModal('create-key-modal')">Cancel</button>
-      <button class="btn btn-primary" data-scope="admin" onclick="submitCreateKey()">Create</button>
+      <button class="btn btn-secondary" data-action="close-modal" data-modal="create-key-modal">Cancel</button>
+      <button class="btn btn-primary" data-scope="admin" data-action="submit-create-key">Create</button>
     </div>
   </div>
 </div>
 
 <!-- Key Created Modal -->
-<div id="key-created-modal" class="modal-overlay" style="display:none;" onclick="handleOverlayClick(event,'key-created-modal')">
-  <div class="modal" onclick="event.stopPropagation()">
+<div id="key-created-modal" class="modal-overlay" style="display:none;" data-action="close-modal" data-modal="key-created-modal">
+  <div class="modal" data-action="modal-body">
     <div class="modal-title">Key Created</div>
     <p style="font-size:13px;color:var(--text-muted);margin-bottom:12px;">
       Copy your key now — it will not be shown again.
@@ -72,14 +72,14 @@
     <div class="form-group">
       <div style="display:flex;align-items:center;gap:8px;">
         <code id="created-key-display" class="mono" style="flex:1;padding:10px 12px;background:var(--bg-secondary);border:1px solid var(--border);border-radius:6px;font-size:13px;word-break:break-all;"></code>
-        <button class="btn btn-secondary" onclick="copyCreatedKey()" style="white-space:nowrap;">Copy</button>
+        <button class="btn btn-secondary" data-action="copy-created-key" style="white-space:nowrap;">Copy</button>
       </div>
     </div>
     <div style="padding:10px 12px;background:color-mix(in srgb,var(--warning) 10%,transparent);border:1px solid color-mix(in srgb,var(--warning) 30%,transparent);border-radius:6px;font-size:13px;color:var(--text-primary);margin-bottom:16px;">
       Store this key securely. Once you close this dialog, the key cannot be recovered.
     </div>
     <div class="modal-actions">
-      <button class="btn btn-primary" onclick="closeModal('key-created-modal')">Done</button>
+      <button class="btn btn-primary" data-action="close-modal" data-modal="key-created-modal">Done</button>
     </div>
   </div>
 </div>

--- a/web/templates/pages/playground.html
+++ b/web/templates/pages/playground.html
@@ -26,7 +26,7 @@
       <div class="form-group">
         <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:4px;">
           <label class="form-label" for="pg-system" style="margin-bottom:0;">System Prompt</label>
-          <button id="pg-system-toggle" class="btn btn-ghost" style="padding:2px 8px;font-size:12px;" onclick="toggleSystemPrompt()">Show</button>
+          <button id="pg-system-toggle" class="btn btn-ghost" style="padding:2px 8px;font-size:12px;" data-action="toggle-system-prompt">Show</button>
         </div>
         <textarea id="pg-system" class="playground-textarea" placeholder="Optional system instructions..." style="display:none;min-height:80px;"></textarea>
       </div>
@@ -39,7 +39,7 @@
         <div class="form-group" style="margin-bottom:12px;">
           <textarea id="pg-user" class="playground-textarea" placeholder="Enter your message..." autofocus style="min-height:140px;"></textarea>
         </div>
-        <button id="pg-send" class="btn btn-primary" onclick="sendMessage()">Send</button>
+        <button id="pg-send" class="btn btn-primary" data-action="send-message">Send</button>
       </div>
 
       <div id="pg-response-card" class="card" style="display:none;margin-bottom:0;">


### PR DESCRIPTION
## Summary

Third phase of the post-audit hardening line, following v1.1.18 (#331) and v1.1.19 (#332). No public config key or Go signature is removed or renamed. Four behavior changes are visible to operators and are called out under **Behavior changes** below.

- **Long-lived streams are no longer truncated.** `http.Server`'s 120s `WriteTimeout` applies to the whole response, so a pass-through proxy or legacy `/v1/completions` stream was cut mid-flight once it outlived it. A new `internal/streamio` package applies a short deadline around each individual write and clears it afterwards, mirroring the pattern `internal/sse` already used. `internal/sse` now shares that helper instead of carrying its own copy.

- **A stalled upstream can no longer pin a connection.** Clearing the per-write deadline also clears `WriteTimeout` for the connection, which removes the only bound that existed on the gap *between* writes. Both streaming paths now cancel the upstream request context after 5 minutes with no completed read, so a trickling or half-stalled provider releases its goroutine and connection. `101 Switching Protocols` responses are exempt: the reverse proxy hands that body to the upgrade path as an `io.ReadWriteCloser`, and a tunnelled connection (e.g. `/v1/realtime`) is legitimately idle.

- **A single misconfigured provider no longer prevents startup.** The generic provider-registration loop warns and skips a provider whose factory fails, matching the existing Bedrock branch. `os.Exit(1)` is reserved for whole-gateway-fatal errors: invalid config, store initialization, plugin loading. Because `/health` counts only *registered* providers and therefore stays healthy, each skip increments a new `gateway_provider_init_failures_total{provider}` counter — alert on any non-zero value.

- **Bounded Prometheus `model` label.** A request naming a model no provider can route reached `gateway_requests_total{status="error"}` with the client-supplied string verbatim, minting a new time series and a permanent entry in the metric-handle cache. This needed no plugin and no authentication. Unknown model names are now bucketed as `unknown` at every call site that can observe a raw client model — the two rejected paths and the two error paths. The guard reads the existing O(1) exact-match routing index rather than rebuilding the model list per request.

- **Content-Security-Policy and Permissions-Policy.** The admin token lives in `localStorage`, so the policy sets `script-src 'self'`. That required making the dashboard CSP-clean first: `login.html`'s inline `<script>` moved to `web/static/pages/login.js`, and the 22 inline `on*=` handlers across five templates became `data-action` attributes dispatched by a delegated listener in `dashboard.js`. Nearest-ancestor resolution reproduces the modal-overlay semantics, so `handleOverlayClick` and its `stopPropagation` guards are gone. `style-src` retains `'unsafe-inline'` for the remaining `style="…"` attributes and allows the CDN serving the font stylesheet. `web.TestTemplatesCarryNoInlineScript` fails the build if an inline handler is reintroduced.

- **Panic recovery moved outermost and shaped consistently.** `chimw.Recoverer` sat below the tracing and logging middleware, so a panic in either escaped it. `middleware.RecoverJSON` now sits at the outside of the chain, returns the gateway's JSON error envelope, logs a stack trace and the request's trace ID, and re-panics `http.ErrAbortHandler` so the reverse proxy can still drop a connection. It does **not** write the envelope once the response has been committed — appending an error object to a stream the client is already reading would corrupt it. The commit-tracking `ResponseWriter` implements `Unwrap`, so `http.NewResponseController` still reaches the real writer's `Flush`, `Hijack` and `SetWriteDeadline`; router-level tests cover a protocol upgrade and an incremental stream and both fail if that chain breaks.

See `CHANGELOG.md` for the user-facing entry.

## Behavior changes

| Change | Impact |
|---|---|
| `/health` returns `503` when the gateway has no registered providers | Load-balancer and Kubernetes probes will now mark such a pod unready. This is the intent; the JSON body shape is unchanged. |
| `/admin/health` continues to return `200` while degraded | Deliberate. It is bearer-authenticated and never a probe target, and three clients read any non-2xx from it as an auth failure or an outage: the dashboard login probe, the dashboard providers page, and `ferrogw admin health`. State is reported in the body. |
| A recovered panic now returns a JSON error envelope | Previously an empty `500` body. Only applies when nothing has been written yet. |
| A provider whose factory fails is skipped rather than fatal | The gateway starts and serves its remaining providers. Watch `gateway_provider_init_failures_total`. |

`ferrogw status` and `ferrogw doctor` now decode a `503` from `/health` and report the gateway as degraded rather than unreachable — previously they printed a connection error against exactly the gateway they exist to diagnose.

## Test plan

- [x] `make fmt lint test` (includes `-race`) — green, `golangci-lint run ./...` reports 0 issues
- [x] `make build` — green
- [x] `go test -tags=integration -race ./test/integration/...` — green
- [x] Every fix reproduced RED before being fixed, and each guard re-verified by removing it:
  - Removing the metric guard makes the unroutable-model tests fail with a raw label series
  - Removing the proxy's idle-timeout wiring makes `TestProxyHandler_StalledUpstreamIsCutByIdleTimeout` hang to its timeout
  - Removing the `101` exemption makes `TestProxyHandler_SwitchingProtocolsUpgradeStillWorks` return `502`
  - Removing `Unwrap` from the commit-tracking writer `502`s the upgrade test and hangs the incremental-stream test
  - Reintroducing an inline handler fails `TestTemplatesCarryNoInlineScript`
- [x] New coverage: `internal/streamio` (write deadlines, idle reader, `ResponseWriter` wrapper), proxy stalled-upstream and upgrade tests, router-level panic/upgrade/streaming tests, CSP header and template-guard tests, health-status table tests for `healthy`/`degraded`/`no_providers`, bootstrap skip-and-count test, `AdminClient.GetHealth` 503-tolerance tests, metric-label tests on both the rejected and error paths
- [x] Dashboard verified in a browser under the enforced policy: login page renders and submits, no CSP violations in the console, create-key modal opens and closes with the correct overlay semantics, theme toggle, config tabs and analytics range buttons all functional
- [x] Degraded gateway verified end to end: `/health` → `503`, `/admin/health` → `200 no_providers`, `ferrogw status`/`doctor` → `[!] no_providers`, dashboard Providers page renders "No providers configured."


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added standalone dashboard login page and delegated dashboard UI actions via `data-action`.
  * Improved streaming robustness with shared idle/read and per-write deadline handling.
* **Bug Fixes**
  * `/health` now returns 503 for degraded/no-provider states while preserving JSON body; `/admin/health` stays 200 with status in-body.
  * Provider startup now skips broken providers with init-failure metrics.
  * Metrics now bucket unrecognized/empty model names under a bounded `unknown` label.
* **Security**
  * Added Content-Security-Policy and Permissions-Policy headers; tightened dashboard to avoid inline script execution.
* **Chores**
  * Pinned Go toolchain to 1.25.12.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->