### PR TITLE
feat(providers): add Eden AI as an OpenAI-compatible provider

### DIFF
--- a/providers/edenai/edenai.go
+++ b/providers/edenai/edenai.go
@@ -1,0 +1,117 @@
+// Package edenai provides a client for the Eden AI API.
+//
+// Eden AI (https://www.edenai.co) is an EU-hosted, OpenAI-compatible gateway
+// that exposes 100+ models from many providers through a single endpoint and
+// API key. Models use the "provider/model" naming scheme (e.g.
+// "anthropic/claude-sonnet-4-5"); the full id is forwarded upstream unchanged.
+package edenai
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	discov "github.com/ferro-labs/ai-gateway/internal/discovery"
+	providerhttp "github.com/ferro-labs/ai-gateway/internal/httpclient"
+	"github.com/ferro-labs/ai-gateway/providers/core"
+	"github.com/ferro-labs/ai-gateway/providers/internal/openaicompat"
+)
+
+const (
+	// Name is the canonical identifier for the Eden AI provider.
+	// Re-exported as providers.NameEdenAI in providers/names.go.
+	Name           = "edenai"
+	defaultBaseURL = "https://api.edenai.run/v3"
+)
+
+// Provider implements the core.Provider interface for Eden AI.
+type Provider struct {
+	name       string
+	apiKey     string
+	baseURL    string
+	httpClient *http.Client
+}
+
+// Compile-time interface assertions.
+var (
+	_ core.Provider          = (*Provider)(nil)
+	_ core.StreamProvider    = (*Provider)(nil)
+	_ core.DiscoveryProvider = (*Provider)(nil)
+	_ core.ProxiableProvider = (*Provider)(nil)
+)
+
+// New creates a new Eden AI provider.
+func New(apiKey, baseURL string) (*Provider, error) {
+	baseURL = strings.TrimSpace(baseURL)
+	if baseURL == "" {
+		baseURL = defaultBaseURL
+	} else if err := core.ValidateBaseURL(Name, baseURL); err != nil {
+		return nil, err
+	}
+	baseURL = strings.TrimRight(baseURL, "/")
+	return &Provider{
+		name:       Name,
+		apiKey:     apiKey,
+		baseURL:    baseURL,
+		httpClient: providerhttp.ForProvider(Name),
+	}, nil
+}
+
+// Name implements core.Provider.
+func (p *Provider) Name() string { return p.name }
+
+// BaseURL implements core.ProxiableProvider.
+func (p *Provider) BaseURL() string { return p.baseURL }
+
+// AuthHeaders implements core.ProxiableProvider.
+func (p *Provider) AuthHeaders() map[string]string {
+	return map[string]string{"Authorization": "Bearer " + p.apiKey}
+}
+
+// SupportedModels returns a static list of representative Eden AI models.
+// Eden AI serves 100+ models; the live list is available via DiscoverModels.
+func (p *Provider) SupportedModels() []string {
+	return []string{
+		"anthropic/claude-sonnet-4-5",
+		"anthropic/claude-haiku-4-5",
+		"openai/gpt-5.1",
+		"mistral/codestral-latest",
+		"deepseek/deepseek-v4-pro",
+		"xai/grok-4",
+	}
+}
+
+// SupportsModel returns true for any model name.
+func (p *Provider) SupportsModel(_ string) bool { return true }
+
+// Models returns structured model metadata.
+func (p *Provider) Models() []core.ModelInfo {
+	return core.ModelsFromList(p.name, p.SupportedModels())
+}
+
+// DiscoverModels fetches the live model list from the Eden AI /models endpoint.
+func (p *Provider) DiscoverModels(ctx context.Context) ([]core.ModelInfo, error) {
+	return discov.DiscoverOpenAICompatibleModels(ctx, p.httpClient, p.baseURL+"/models", p.apiKey, p.name)
+}
+
+// Complete sends a chat completion request to Eden AI.
+func (p *Provider) Complete(ctx context.Context, req core.Request) (*core.Response, error) {
+	return openaicompat.PostChat(ctx, openaicompat.ChatParams{
+		HTTPClient: p.httpClient,
+		URL:        p.baseURL + "/chat/completions",
+		Provider:   p.name,
+		Label:      "edenai",
+		Headers:    map[string]string{"Authorization": "Bearer " + p.apiKey, "Content-Type": "application/json"},
+	}, req)
+}
+
+// CompleteStream sends a streaming chat completion request to Eden AI.
+func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan core.StreamChunk, error) {
+	return openaicompat.PostStream(ctx, openaicompat.ChatParams{
+		HTTPClient: p.httpClient,
+		URL:        p.baseURL + "/chat/completions",
+		Provider:   p.name,
+		Label:      "edenai",
+		Headers:    map[string]string{"Authorization": "Bearer " + p.apiKey, "Content-Type": "application/json"},
+	}, req)
+}

--- a/providers/edenai/edenai_test.go
+++ b/providers/edenai/edenai_test.go
@@ -1,0 +1,68 @@
+package edenai
+
+import (
+	"testing"
+
+	"github.com/ferro-labs/ai-gateway/providers/core"
+)
+
+func TestNewEdenAI(t *testing.T) {
+	p, err := New("test-key", "")
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+	if p.Name() != "edenai" {
+		t.Errorf("Name() = %q, want edenai", p.Name())
+	}
+	if p.BaseURL() != defaultBaseURL {
+		t.Errorf("BaseURL() = %q, want %q", p.BaseURL(), defaultBaseURL)
+	}
+}
+
+func TestEdenAIProvider_SupportedModels(t *testing.T) {
+	p, _ := New("test-key", "")
+	models := p.SupportedModels()
+	if len(models) == 0 {
+		t.Fatal("SupportedModels() returned empty")
+	}
+	found := false
+	for _, m := range models {
+		if m == "anthropic/claude-sonnet-4-5" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("anthropic/claude-sonnet-4-5 not found")
+	}
+}
+
+func TestEdenAIProvider_SupportsModel(t *testing.T) {
+	p, _ := New("test-key", "")
+	if !p.SupportsModel("anthropic/claude-sonnet-4-5") {
+		t.Error("expected anthropic/claude-sonnet-4-5 to be supported")
+	}
+	if !p.SupportsModel("custom/model") {
+		t.Error("passthrough: expected all models to return true")
+	}
+}
+
+func TestEdenAIProvider_Models(t *testing.T) {
+	p, _ := New("test-key", "")
+	for _, m := range p.Models() {
+		if m.OwnedBy != "edenai" {
+			t.Errorf("ModelInfo.OwnedBy = %q, want edenai", m.OwnedBy)
+		}
+	}
+}
+
+func TestEdenAIProvider_AuthHeaders(t *testing.T) {
+	p, _ := New("test-key", "")
+	if got := p.AuthHeaders()["Authorization"]; got != "Bearer test-key" {
+		t.Errorf("Authorization = %q, want Bearer test-key", got)
+	}
+}
+
+func TestEdenAIProvider_StreamInterface(_ *testing.T) {
+	p, _ := New("test-key", "")
+	var _ core.StreamProvider = p
+}

--- a/providers/names.go
+++ b/providers/names.go
@@ -12,6 +12,7 @@ import (
 	databrickspkg "github.com/ferro-labs/ai-gateway/providers/databricks"
 	deepinfrapkg "github.com/ferro-labs/ai-gateway/providers/deepinfra"
 	deepseekpkg "github.com/ferro-labs/ai-gateway/providers/deepseek"
+	edenaipkg "github.com/ferro-labs/ai-gateway/providers/edenai"
 	fireworkspkg "github.com/ferro-labs/ai-gateway/providers/fireworks"
 	geminipkg "github.com/ferro-labs/ai-gateway/providers/gemini"
 	groqpkg "github.com/ferro-labs/ai-gateway/providers/groq"
@@ -72,6 +73,9 @@ const (
 
 	// NameDeepSeek is the canonical name for the DeepSeek provider.
 	NameDeepSeek = deepseekpkg.Name
+
+	// NameEdenAI is the canonical name for the Eden AI provider.
+	NameEdenAI = edenaipkg.Name
 
 	// NamePerplexity is the canonical name for the Perplexity provider.
 	NamePerplexity = perplexitypkg.Name
@@ -156,6 +160,7 @@ func AllProviderNames() []string {
 		NameDatabricks,
 		NameDeepInfra,
 		NameDeepSeek,
+		NameEdenAI,
 		NameFireworks,
 		NameGemini,
 		NameGroq,

--- a/providers/providers_list.go
+++ b/providers/providers_list.go
@@ -15,6 +15,7 @@ import (
 	databrickspkg "github.com/ferro-labs/ai-gateway/providers/databricks"
 	deepinfrapkg "github.com/ferro-labs/ai-gateway/providers/deepinfra"
 	deepseekpkg "github.com/ferro-labs/ai-gateway/providers/deepseek"
+	edenaipkg "github.com/ferro-labs/ai-gateway/providers/edenai"
 	fireworkspkg "github.com/ferro-labs/ai-gateway/providers/fireworks"
 	geminipkg "github.com/ferro-labs/ai-gateway/providers/gemini"
 	groqpkg "github.com/ferro-labs/ai-gateway/providers/groq"
@@ -138,6 +139,17 @@ var allProviders = []ProviderEntry{
 		},
 		Build: func(cfg ProviderConfig) (Provider, error) {
 			return cerebraspkg.New(cfg[CfgKeyAPIKey], cfg[CfgKeyBaseURL])
+		},
+	},
+	{
+		ID:           NameEdenAI,
+		Capabilities: []string{CapabilityChat, CapabilityStream, CapabilityDiscovery, CapabilityProxy},
+		EnvMappings: []EnvMapping{
+			{CfgKeyAPIKey, "EDENAI_API_KEY", true},
+			{CfgKeyBaseURL, "EDENAI_BASE_URL", false},
+		},
+		Build: func(cfg ProviderConfig) (Provider, error) {
+			return edenaipkg.New(cfg[CfgKeyAPIKey], cfg[CfgKeyBaseURL])
 		},
 	},
 	{

--- a/providers/stability_test.go
+++ b/providers/stability_test.go
@@ -15,6 +15,7 @@ import (
 	databrickspkg "github.com/ferro-labs/ai-gateway/providers/databricks"
 	deepinfrapkg "github.com/ferro-labs/ai-gateway/providers/deepinfra"
 	deepseekpkg "github.com/ferro-labs/ai-gateway/providers/deepseek"
+	edenaipkg "github.com/ferro-labs/ai-gateway/providers/edenai"
 	fireworkspkg "github.com/ferro-labs/ai-gateway/providers/fireworks"
 	geminipkg "github.com/ferro-labs/ai-gateway/providers/gemini"
 	groqpkg "github.com/ferro-labs/ai-gateway/providers/groq"
@@ -176,6 +177,17 @@ func providerNameStabilityCoreCases() []providerNameStabilityCase {
 				p, err := deepseekpkg.New(testAPIKey, "")
 				if err != nil {
 					t.Fatalf("NewDeepSeek: %v", err)
+				}
+				return p
+			},
+		},
+		{
+			wantName: NameEdenAI,
+			build: func(t *testing.T) Provider {
+				t.Helper()
+				p, err := edenaipkg.New(testAPIKey, "")
+				if err != nil {
+					t.Fatalf("NewEdenAI: %v", err)
 				}
 				return p
 			},


### PR DESCRIPTION
## Description

Adds **Eden AI** (https://www.edenai.co) as a first-class OpenAI-compatible provider. Eden AI is an EU-hosted gateway that exposes 100+ models from many providers (OpenAI, Anthropic, Google, Mistral, DeepSeek, …) through a single endpoint and API key. Models use the `provider/model` naming scheme; the full id is forwarded upstream unchanged.

Follows the existing provider pattern (mirrors `providers/cerebras`), reusing the shared `openaicompat` chat/stream helpers:

- `providers/edenai/edenai.go` — provider (`baseURL: https://api.edenai.run/v3`, Bearer auth, `DiscoverModels` via `/models`)
- `providers/names.go` — `NameEdenAI` + added to `AllProviderNames()`
- `providers/providers_list.go` — registry entry (caps chat/stream/discovery/proxy, env `EDENAI_API_KEY` / `EDENAI_BASE_URL`)
- `providers/edenai/edenai_test.go` — unit tests
- `providers/stability_test.go` — stability case

## Testing

- `go build ./...`, `go vet`, `gofmt` clean.
- `go test ./providers/...` all pass, including the registry completeness / name-stability guards and the new `edenai` unit tests.
- Verified live against the Eden AI API (`/v3/chat/completions` → 200).
- API key via `EDENAI_API_KEY` only; never hardcoded.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Eden AI as a supported provider.
  * Supports chat completions, streaming responses, model discovery, and configurable API endpoints.
  * Added Eden AI configuration through `EDENAI_API_KEY` and optional `EDENAI_BASE_URL`.
  * Added representative supported model listings and provider validation.

* **Tests**
  * Added coverage for provider setup, authentication, model support, streaming compatibility, and provider registration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->