### PR TITLE
refactor: testability hardening for CLI, authctx, and tracingpolicy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,6 @@ require (
 	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/client_model v0.6.2
 	github.com/spf13/cobra v1.10.2
-	github.com/spf13/pflag v1.0.9
 	github.com/testcontainers/testcontainers-go/modules/postgres v0.42.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.68.0
 	go.opentelemetry.io/otel v1.44.0
@@ -92,6 +91,7 @@ require (
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/shirou/gopsutil/v4 v4.26.3 // indirect
 	github.com/sirupsen/logrus v1.9.4 // indirect
+	github.com/spf13/pflag v1.0.9 // indirect
 	github.com/stretchr/testify v1.11.1 // indirect
 	github.com/testcontainers/testcontainers-go v0.42.0 // indirect
 	github.com/tidwall/gjson v1.14.4 // indirect

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/client_model v0.6.2
 	github.com/spf13/cobra v1.10.2
+	github.com/spf13/pflag v1.0.9
 	github.com/testcontainers/testcontainers-go/modules/postgres v0.42.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.68.0
 	go.opentelemetry.io/otel v1.44.0
@@ -91,7 +92,6 @@ require (
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/shirou/gopsutil/v4 v4.26.3 // indirect
 	github.com/sirupsen/logrus v1.9.4 // indirect
-	github.com/spf13/pflag v1.0.9 // indirect
 	github.com/stretchr/testify v1.11.1 // indirect
 	github.com/testcontainers/testcontainers-go v0.42.0 // indirect
 	github.com/tidwall/gjson v1.14.4 // indirect

--- a/internal/authctx/authctx_test.go
+++ b/internal/authctx/authctx_test.go
@@ -1,0 +1,64 @@
+package authctx
+
+import (
+	"context"
+	"testing"
+)
+
+func TestKeyID(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		ctx    func() context.Context
+		wantID string
+		wantOK bool
+	}{
+		{
+			name:   "absent id reports not-ok",
+			ctx:    context.Background,
+			wantID: "",
+			wantOK: false,
+		},
+		{
+			name:   "stored id round-trips",
+			ctx:    func() context.Context { return WithKeyID(context.Background(), "key-123") },
+			wantID: "key-123",
+			wantOK: true,
+		},
+		{
+			// Security boundary: an empty id must read as absent so per-key
+			// limits never collapse empty-keyed callers into a shared bucket.
+			name:   "empty id is treated as absent",
+			ctx:    func() context.Context { return WithKeyID(context.Background(), "") },
+			wantID: "",
+			wantOK: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			gotID, gotOK := KeyID(tt.ctx())
+			if gotID != tt.wantID || gotOK != tt.wantOK {
+				t.Errorf("KeyID() = (%q, %v), want (%q, %v)", gotID, gotOK, tt.wantID, tt.wantOK)
+			}
+		})
+	}
+}
+
+func TestWithKeyID_OverwritesPreviousValue(t *testing.T) {
+	t.Parallel()
+	ctx := WithKeyID(WithKeyID(context.Background(), "first"), "second")
+	if id, ok := KeyID(ctx); !ok || id != "second" {
+		t.Errorf("KeyID() = (%q, %v), want (second, true)", id, ok)
+	}
+}
+
+func TestWithKeyID_DoesNotMutateParent(t *testing.T) {
+	t.Parallel()
+	parent := context.Background()
+	_ = WithKeyID(parent, "child")
+	if id, ok := KeyID(parent); ok || id != "" {
+		t.Errorf("parent context was mutated: KeyID() = (%q, %v), want empty", id, ok)
+	}
+}

--- a/internal/cli/admin.go
+++ b/internal/cli/admin.go
@@ -30,94 +30,104 @@ var keysCmd = &cobra.Command{
 var keysListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List all API keys",
-	RunE: func(cmd *cobra.Command, _ []string) error {
-		c := adminClientFromCmd(cmd)
-		var result any
-		if err := c.Get(cmd.Context(), "/admin/keys", &result); err != nil {
-			return err
-		}
-		return printResult(cmd, &jsonSlice{
-			headers: []string{"ID", "NAME", "SCOPE", "EXPIRES", "REVOKED"},
-			data:    toSlice(result),
-			rowFn: func(m map[string]any) []string {
-				return []string{
-					str(m, "id"), str(m, "name"), str(m, "scope"),
-					fmtTime(m, "expires_at"), strBool(m, "revoked"),
-				}
-			},
-		})
-	},
+	RunE:  runKeysList,
+}
+
+func runKeysList(cmd *cobra.Command, _ []string) error {
+	c := adminClientFromCmd(cmd)
+	var result any
+	if err := c.Get(cmd.Context(), "/admin/keys", &result); err != nil {
+		return err
+	}
+	return printResult(cmd, &jsonSlice{
+		headers: []string{"ID", "NAME", "SCOPE", "EXPIRES", "REVOKED"},
+		data:    toSlice(result),
+		rowFn: func(m map[string]any) []string {
+			return []string{
+				str(m, "id"), str(m, "name"), str(m, "scope"),
+				fmtTime(m, "expires_at"), strBool(m, "revoked"),
+			}
+		},
+	})
 }
 
 var keysGetCmd = &cobra.Command{
 	Use:   "get <id>",
 	Short: "Get details of an API key",
 	Args:  cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		c := adminClientFromCmd(cmd)
-		var result any
-		if err := c.Get(cmd.Context(), "/admin/keys/"+args[0], &result); err != nil {
-			return err
-		}
-		return printResult(cmd, result)
-	},
+	RunE:  runKeysGet,
+}
+
+func runKeysGet(cmd *cobra.Command, args []string) error {
+	c := adminClientFromCmd(cmd)
+	var result any
+	if err := c.Get(cmd.Context(), "/admin/keys/"+args[0], &result); err != nil {
+		return err
+	}
+	return printResult(cmd, result)
 }
 
 var keysCreateCmd = &cobra.Command{
 	Use:   "create",
 	Short: "Create a new API key",
-	RunE: func(cmd *cobra.Command, _ []string) error {
-		name, _ := cmd.Flags().GetString("name")
-		scope, _ := cmd.Flags().GetString("scope")
-		expiresIn, _ := cmd.Flags().GetString("expires-in")
+	RunE:  runKeysCreate,
+}
 
-		body := map[string]any{
-			"name":  name,
-			"scope": scope,
-		}
-		if expiresIn != "" {
-			d, err := time.ParseDuration(expiresIn)
-			if err != nil {
-				return fmt.Errorf("invalid --expires-in duration: %w", err)
-			}
-			body["expires_at"] = time.Now().UTC().Add(d).Format(time.RFC3339)
-		}
+func runKeysCreate(cmd *cobra.Command, _ []string) error {
+	name, _ := cmd.Flags().GetString("name")
+	scope, _ := cmd.Flags().GetString("scope")
+	expiresIn, _ := cmd.Flags().GetString("expires-in")
 
-		c := adminClientFromCmd(cmd)
-		var result any
-		if err := c.Post(cmd.Context(), "/admin/keys", body, &result); err != nil {
-			return err
+	body := map[string]any{
+		"name":  name,
+		"scope": scope,
+	}
+	if expiresIn != "" {
+		d, err := time.ParseDuration(expiresIn)
+		if err != nil {
+			return fmt.Errorf("invalid --expires-in duration: %w", err)
 		}
-		return printResult(cmd, result)
-	},
+		body["expires_at"] = time.Now().UTC().Add(d).Format(time.RFC3339)
+	}
+
+	c := adminClientFromCmd(cmd)
+	var result any
+	if err := c.Post(cmd.Context(), "/admin/keys", body, &result); err != nil {
+		return err
+	}
+	return printResult(cmd, result)
 }
 
 var keysRevokeCmd = &cobra.Command{
 	Use:   "revoke <id>",
 	Short: "Revoke an API key",
 	Args:  cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		c := adminClientFromCmd(cmd)
-		if err := c.Post(cmd.Context(), "/admin/keys/"+args[0]+"/revoke", nil, nil); err != nil {
-			return err
-		}
-		PrintSuccess(cmd.OutOrStdout(), "Key revoked.")
-		return nil
-	},
+	RunE:  runKeysRevoke,
+}
+
+func runKeysRevoke(cmd *cobra.Command, args []string) error {
+	c := adminClientFromCmd(cmd)
+	if err := c.Post(cmd.Context(), "/admin/keys/"+args[0]+"/revoke", nil, nil); err != nil {
+		return err
+	}
+	PrintSuccess(cmd.OutOrStdout(), "Key revoked.")
+	return nil
 }
 
 var keysRotateCmd = &cobra.Command{
 	Use:   "rotate <id>",
 	Short: "Rotate an API key (generates a new key value)",
 	Args:  cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		c := adminClientFromCmd(cmd)
-		var result any
-		if err := c.Post(cmd.Context(), "/admin/keys/"+args[0]+"/rotate", nil, &result); err != nil {
-			return err
-		}
-		return printResult(cmd, result)
-	},
+	RunE:  runKeysRotate,
+}
+
+func runKeysRotate(cmd *cobra.Command, args []string) error {
+	c := adminClientFromCmd(cmd)
+	var result any
+	if err := c.Post(cmd.Context(), "/admin/keys/"+args[0]+"/rotate", nil, &result); err != nil {
+		return err
+	}
+	return printResult(cmd, result)
 }
 
 // ── Config ───────────────────────────────────────────────────────────────────
@@ -130,79 +140,87 @@ var configCmd = &cobra.Command{
 var configGetCmd = &cobra.Command{
 	Use:   "get",
 	Short: "Print the current runtime configuration",
-	RunE: func(cmd *cobra.Command, _ []string) error {
-		c := adminClientFromCmd(cmd)
-		var result any
-		if err := c.Get(cmd.Context(), "/admin/config", &result); err != nil {
-			return err
-		}
-		return printResult(cmd, result)
-	},
+	RunE:  runConfigGet,
+}
+
+func runConfigGet(cmd *cobra.Command, _ []string) error {
+	c := adminClientFromCmd(cmd)
+	var result any
+	if err := c.Get(cmd.Context(), "/admin/config", &result); err != nil {
+		return err
+	}
+	return printResult(cmd, result)
 }
 
 var configHistoryCmd = &cobra.Command{
 	Use:   "history",
 	Short: "Show configuration change history",
-	RunE: func(cmd *cobra.Command, _ []string) error {
-		c := adminClientFromCmd(cmd)
-		var result any
-		if err := c.Get(cmd.Context(), "/admin/config/history", &result); err != nil {
-			return err
-		}
-		return printResult(cmd, &jsonSlice{
-			headers: []string{"VERSION", "UPDATED_AT", "ROLLED_BACK_FROM"},
-			data:    toSlice(result),
-			rowFn: func(m map[string]any) []string {
-				rolledBack := ""
-				if v, ok := m["rolled_back_from"]; ok && v != nil {
-					rolledBack = fmt.Sprintf("%v", v)
-				}
-				return []string{fmt.Sprintf("%.0f", numVal(m, "version")), fmtTime(m, "updated_at"), rolledBack}
-			},
-		})
-	},
+	RunE:  runConfigHistory,
+}
+
+func runConfigHistory(cmd *cobra.Command, _ []string) error {
+	c := adminClientFromCmd(cmd)
+	var result any
+	if err := c.Get(cmd.Context(), "/admin/config/history", &result); err != nil {
+		return err
+	}
+	return printResult(cmd, &jsonSlice{
+		headers: []string{"VERSION", "UPDATED_AT", "ROLLED_BACK_FROM"},
+		data:    toSlice(result),
+		rowFn: func(m map[string]any) []string {
+			rolledBack := ""
+			if v, ok := m["rolled_back_from"]; ok && v != nil {
+				rolledBack = fmt.Sprintf("%v", v)
+			}
+			return []string{fmt.Sprintf("%.0f", numVal(m, "version")), fmtTime(m, "updated_at"), rolledBack}
+		},
+	})
 }
 
 var configSetCmd = &cobra.Command{
 	Use:   "set",
 	Short: "Apply a new configuration (JSON file)",
-	RunE: func(cmd *cobra.Command, _ []string) error {
-		filePath, _ := cmd.Flags().GetString("file")
-		if filePath == "" {
-			return fmt.Errorf("--file is required")
-		}
-		raw, err := os.ReadFile(filePath) //nolint:gosec // G304: file path comes from the operator's --file CLI flag, not request input
-		if err != nil {
-			return fmt.Errorf("read file: %w", err)
-		}
-		// Decode locally so we send JSON regardless of input format.
-		var body any
-		if err := json.Unmarshal(raw, &body); err != nil {
-			return fmt.Errorf("parse config file: %w (only JSON is accepted by this command; convert YAML first)", err)
-		}
-		c := adminClientFromCmd(cmd)
-		var result any
-		if err := c.Put(cmd.Context(), "/admin/config", body, &result); err != nil {
-			return err
-		}
-		PrintSuccess(cmd.OutOrStdout(), "Configuration updated.")
-		return nil
-	},
+	RunE:  runConfigSet,
+}
+
+func runConfigSet(cmd *cobra.Command, _ []string) error {
+	filePath, _ := cmd.Flags().GetString("file")
+	if filePath == "" {
+		return fmt.Errorf("--file is required")
+	}
+	raw, err := os.ReadFile(filePath) //nolint:gosec // G304: file path comes from the operator's --file CLI flag, not request input
+	if err != nil {
+		return fmt.Errorf("read file: %w", err)
+	}
+	// Decode locally so we send JSON regardless of input format.
+	var body any
+	if err := json.Unmarshal(raw, &body); err != nil {
+		return fmt.Errorf("parse config file: %w (only JSON is accepted by this command; convert YAML first)", err)
+	}
+	c := adminClientFromCmd(cmd)
+	var result any
+	if err := c.Put(cmd.Context(), "/admin/config", body, &result); err != nil {
+		return err
+	}
+	PrintSuccess(cmd.OutOrStdout(), "Configuration updated.")
+	return nil
 }
 
 var configRollbackCmd = &cobra.Command{
 	Use:   "rollback <version>",
 	Short: "Roll back to a previous configuration version",
 	Args:  cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		c := adminClientFromCmd(cmd)
-		var result any
-		if err := c.Post(cmd.Context(), "/admin/config/rollback/"+args[0], nil, &result); err != nil {
-			return err
-		}
-		PrintSuccess(cmd.OutOrStdout(), "Rolled back to version "+args[0]+".")
-		return nil
-	},
+	RunE:  runConfigRollback,
+}
+
+func runConfigRollback(cmd *cobra.Command, args []string) error {
+	c := adminClientFromCmd(cmd)
+	var result any
+	if err := c.Post(cmd.Context(), "/admin/config/rollback/"+args[0], nil, &result); err != nil {
+		return err
+	}
+	PrintSuccess(cmd.OutOrStdout(), "Rolled back to version "+args[0]+".")
+	return nil
 }
 
 // ── Logs ─────────────────────────────────────────────────────────────────────
@@ -215,40 +233,44 @@ var logsCmd = &cobra.Command{
 var logsListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List persisted request logs",
-	RunE: func(cmd *cobra.Command, _ []string) error {
-		c := adminClientFromCmd(cmd)
-		limit, _ := cmd.Flags().GetInt("limit")
-		path := fmt.Sprintf("/admin/logs?limit=%d", limit)
-		var result any
-		if err := c.Get(cmd.Context(), path, &result); err != nil {
-			return err
-		}
-		return printResult(cmd, &jsonSlice{
-			headers: []string{"TRACE_ID", "PROVIDER", "MODEL", "STATUS", "LATENCY_MS", "TIMESTAMP"},
-			data:    toSlice(result),
-			rowFn: func(m map[string]any) []string {
-				return []string{
-					str(m, "trace_id"), str(m, "provider"), str(m, "model"),
-					fmt.Sprintf("%.0f", numVal(m, "status")),
-					fmt.Sprintf("%.0f", numVal(m, "latency_ms")),
-					str(m, "timestamp"),
-				}
-			},
-		})
-	},
+	RunE:  runLogsList,
+}
+
+func runLogsList(cmd *cobra.Command, _ []string) error {
+	c := adminClientFromCmd(cmd)
+	limit, _ := cmd.Flags().GetInt("limit")
+	path := fmt.Sprintf("/admin/logs?limit=%d", limit)
+	var result any
+	if err := c.Get(cmd.Context(), path, &result); err != nil {
+		return err
+	}
+	return printResult(cmd, &jsonSlice{
+		headers: []string{"TRACE_ID", "PROVIDER", "MODEL", "STATUS", "LATENCY_MS", "TIMESTAMP"},
+		data:    toSlice(result),
+		rowFn: func(m map[string]any) []string {
+			return []string{
+				str(m, "trace_id"), str(m, "provider"), str(m, "model"),
+				fmt.Sprintf("%.0f", numVal(m, "status")),
+				fmt.Sprintf("%.0f", numVal(m, "latency_ms")),
+				str(m, "timestamp"),
+			}
+		},
+	})
 }
 
 var logsStatsCmd = &cobra.Command{
 	Use:   "stats",
 	Short: "Show aggregated log statistics",
-	RunE: func(cmd *cobra.Command, _ []string) error {
-		c := adminClientFromCmd(cmd)
-		var result any
-		if err := c.Get(cmd.Context(), "/admin/logs/stats", &result); err != nil {
-			return err
-		}
-		return printResult(cmd, result)
-	},
+	RunE:  runLogsStats,
+}
+
+func runLogsStats(cmd *cobra.Command, _ []string) error {
+	c := adminClientFromCmd(cmd)
+	var result any
+	if err := c.Get(cmd.Context(), "/admin/logs/stats", &result); err != nil {
+		return err
+	}
+	return printResult(cmd, result)
 }
 
 // ── Providers ────────────────────────────────────────────────────────────────
@@ -261,33 +283,37 @@ var providersCmd = &cobra.Command{
 var providersListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List all registered providers and their model counts",
-	RunE: func(cmd *cobra.Command, _ []string) error {
-		c := adminClientFromCmd(cmd)
-		var result any
-		if err := c.Get(cmd.Context(), "/admin/providers", &result); err != nil {
-			return err
-		}
-		return printResult(cmd, &jsonSlice{
-			headers: []string{"PROVIDER", "MODELS"},
-			data:    toSlice(result),
-			rowFn: func(m map[string]any) []string {
-				return []string{str(m, "name"), fmt.Sprintf("%.0f", numVal(m, "model_count"))}
-			},
-		})
-	},
+	RunE:  runProvidersList,
+}
+
+func runProvidersList(cmd *cobra.Command, _ []string) error {
+	c := adminClientFromCmd(cmd)
+	var result any
+	if err := c.Get(cmd.Context(), "/admin/providers", &result); err != nil {
+		return err
+	}
+	return printResult(cmd, &jsonSlice{
+		headers: []string{"PROVIDER", "MODELS"},
+		data:    toSlice(result),
+		rowFn: func(m map[string]any) []string {
+			return []string{str(m, "name"), fmt.Sprintf("%.0f", numVal(m, "model_count"))}
+		},
+	})
 }
 
 var providersHealthCmd = &cobra.Command{
 	Use:   "health",
 	Short: "Show per-provider health status",
-	RunE: func(cmd *cobra.Command, _ []string) error {
-		c := adminClientFromCmd(cmd)
-		var result any
-		if err := c.Get(cmd.Context(), "/admin/health", &result); err != nil {
-			return err
-		}
-		return printResult(cmd, result)
-	},
+	RunE:  runProvidersHealth,
+}
+
+func runProvidersHealth(cmd *cobra.Command, _ []string) error {
+	c := adminClientFromCmd(cmd)
+	var result any
+	if err := c.Get(cmd.Context(), "/admin/health", &result); err != nil {
+		return err
+	}
+	return printResult(cmd, result)
 }
 
 // ── Wire-up ───────────────────────────────────────────────────────────────────

--- a/internal/cli/admin.go
+++ b/internal/cli/admin.go
@@ -101,7 +101,7 @@ var keysRevokeCmd = &cobra.Command{
 		if err := c.Post(cmd.Context(), "/admin/keys/"+args[0]+"/revoke", nil, nil); err != nil {
 			return err
 		}
-		PrintSuccess("Key revoked.")
+		PrintSuccess(cmd.OutOrStdout(), "Key revoked.")
 		return nil
 	},
 }
@@ -185,7 +185,7 @@ var configSetCmd = &cobra.Command{
 		if err := c.Put(cmd.Context(), "/admin/config", body, &result); err != nil {
 			return err
 		}
-		PrintSuccess("Configuration updated.")
+		PrintSuccess(cmd.OutOrStdout(), "Configuration updated.")
 		return nil
 	},
 }
@@ -200,7 +200,7 @@ var configRollbackCmd = &cobra.Command{
 		if err := c.Post(cmd.Context(), "/admin/config/rollback/"+args[0], nil, &result); err != nil {
 			return err
 		}
-		PrintSuccess("Rolled back to version " + args[0] + ".")
+		PrintSuccess(cmd.OutOrStdout(), "Rolled back to version "+args[0]+".")
 		return nil
 	},
 }
@@ -370,10 +370,10 @@ func str(m map[string]any, key string) string {
 func strBool(m map[string]any, key string) string {
 	if v, ok := m[key]; ok {
 		if b, ok := v.(bool); ok && b {
-			return "yes"
+			return boolYes
 		}
 	}
-	return "no"
+	return boolNo
 }
 
 // numVal extracts a float64 from JSON number fields.

--- a/internal/cli/admin_test.go
+++ b/internal/cli/admin_test.go
@@ -114,96 +114,122 @@ func TestJSONSlice_Rendering(t *testing.T) {
 	}
 }
 
-// ── Admin sub-command handlers (through cobra Execute) ──────────────────────────
+// ── Admin sub-command handlers (called directly on a fresh command) ─────────────
 
-func TestAdminKeysList(t *testing.T) {
+func TestRunKeysList(t *testing.T) {
 	srv := stubGateway(t, map[string]http.HandlerFunc{
 		"/admin/keys": jsonHandler(http.StatusOK, `[{"id":"k1","name":"prod","scope":"admin","revoked":false}]`),
 	})
+	cmd, out := newHandlerCmd(t, srv.URL, "table")
 
-	out, err := execAdmin(t, srv.URL, "admin", "keys", "list")
-	if err != nil {
-		t.Fatalf("execute: %v", err)
+	if err := runKeysList(cmd, nil); err != nil {
+		t.Fatalf("runKeysList: %v", err)
 	}
 	for _, want := range []string{"ID", "k1", "prod", "admin"} {
-		if !strings.Contains(out, want) {
-			t.Errorf("output missing %q:\n%s", want, out)
+		if !strings.Contains(out.String(), want) {
+			t.Errorf("output missing %q:\n%s", want, out.String())
 		}
 	}
 }
 
-func TestAdminKeysGet(t *testing.T) {
+func TestRunKeysGet(t *testing.T) {
 	srv := stubGateway(t, map[string]http.HandlerFunc{
 		"/admin/keys/k1": jsonHandler(http.StatusOK, `{"id":"k1","name":"prod"}`),
 	})
+	cmd, out := newHandlerCmd(t, srv.URL, "table")
 
-	out, err := execAdmin(t, srv.URL, "admin", "keys", "get", "k1")
-	if err != nil {
-		t.Fatalf("execute: %v", err)
+	if err := runKeysGet(cmd, []string{"k1"}); err != nil {
+		t.Fatalf("runKeysGet: %v", err)
 	}
-	if !strings.Contains(out, "k1") {
-		t.Errorf("want key detail, got:\n%s", out)
+	if !strings.Contains(out.String(), "k1") {
+		t.Errorf("want key detail, got:\n%s", out.String())
 	}
 }
 
-func TestAdminKeysCreate(t *testing.T) {
+func TestRunKeysCreate(t *testing.T) {
 	srv := stubGateway(t, map[string]http.HandlerFunc{
 		"/admin/keys": jsonHandler(http.StatusOK, `{"id":"new","key":"fgw_secret"}`),
 	})
 
 	t.Run("with a valid expiry", func(t *testing.T) {
-		out, err := execAdmin(t, srv.URL, "admin", "keys", "create", "--name", "ci", "--expires-in", "1h")
-		if err != nil {
-			t.Fatalf("execute: %v", err)
+		cmd, out := newHandlerCmd(t, srv.URL, "table")
+		cmd.Flags().String("name", "ci", "")
+		cmd.Flags().String("scope", "read_only", "")
+		cmd.Flags().String("expires-in", "1h", "")
+
+		if err := runKeysCreate(cmd, nil); err != nil {
+			t.Fatalf("runKeysCreate: %v", err)
 		}
-		if !strings.Contains(out, "new") {
-			t.Errorf("want created key in output, got:\n%s", out)
+		if !strings.Contains(out.String(), "new") {
+			t.Errorf("want created key in output, got:\n%s", out.String())
 		}
 	})
 
 	t.Run("rejects an invalid expiry duration", func(t *testing.T) {
-		_, err := execAdmin(t, srv.URL, "admin", "keys", "create", "--expires-in", "bogus")
+		cmd, _ := newHandlerCmd(t, srv.URL, "table")
+		cmd.Flags().String("name", "", "")
+		cmd.Flags().String("scope", "read_only", "")
+		cmd.Flags().String("expires-in", "bogus", "")
+
+		err := runKeysCreate(cmd, nil)
 		if err == nil || !strings.Contains(err.Error(), "invalid --expires-in") {
 			t.Fatalf("want expiry parse error, got %v", err)
 		}
 	})
 }
 
-func TestAdminKeysRevoke(t *testing.T) {
+func TestRunKeysRevoke(t *testing.T) {
 	srv := stubGateway(t, map[string]http.HandlerFunc{
 		"/admin/keys/k1/revoke": jsonHandler(http.StatusOK, `{}`),
 	})
+	cmd, out := newHandlerCmd(t, srv.URL, "table")
 
-	out, err := execAdmin(t, srv.URL, "admin", "keys", "revoke", "k1")
-	if err != nil {
-		t.Fatalf("execute: %v", err)
+	if err := runKeysRevoke(cmd, []string{"k1"}); err != nil {
+		t.Fatalf("runKeysRevoke: %v", err)
 	}
-	if !strings.Contains(out, "Key revoked.") {
-		t.Errorf("want success message, got:\n%s", out)
+	if !strings.Contains(out.String(), "Key revoked.") {
+		t.Errorf("want success message, got:\n%s", out.String())
 	}
 }
 
-func TestAdminLogsList(t *testing.T) {
+func TestRunConfigHistory(t *testing.T) {
 	srv := stubGateway(t, map[string]http.HandlerFunc{
-		"/admin/logs": jsonHandler(http.StatusOK, `[{"trace_id":"t1","provider":"openai","model":"gpt-4","status":200,"latency_ms":42}]`),
+		"/admin/config/history": jsonHandler(http.StatusOK, `[{"version":3,"updated_at":"2026-07-15T09:30:00Z","rolled_back_from":1}]`),
 	})
+	cmd, out := newHandlerCmd(t, srv.URL, "table")
 
-	out, err := execAdmin(t, srv.URL, "admin", "logs", "list")
-	if err != nil {
-		t.Fatalf("execute: %v", err)
+	if err := runConfigHistory(cmd, nil); err != nil {
+		t.Fatalf("runConfigHistory: %v", err)
 	}
-	for _, want := range []string{"TRACE_ID", "t1", "openai", "gpt-4"} {
-		if !strings.Contains(out, want) {
-			t.Errorf("output missing %q:\n%s", want, out)
+	for _, want := range []string{"VERSION", "3", "1"} {
+		if !strings.Contains(out.String(), want) {
+			t.Errorf("output missing %q:\n%s", want, out.String())
 		}
 	}
 }
 
-func TestAdminConfigSet(t *testing.T) {
-	// execAdmin resets the command flags before each run, so these subtests are
-	// independent of ordering.
+func TestRunConfigRollback(t *testing.T) {
+	srv := stubGateway(t, map[string]http.HandlerFunc{
+		"/admin/config/rollback/2": jsonHandler(http.StatusOK, `{}`),
+	})
+	cmd, out := newHandlerCmd(t, srv.URL, "table")
+
+	if err := runConfigRollback(cmd, []string{"2"}); err != nil {
+		t.Fatalf("runConfigRollback: %v", err)
+	}
+	if !strings.Contains(out.String(), "Rolled back to version 2.") {
+		t.Errorf("want rollback message, got:\n%s", out.String())
+	}
+}
+
+func TestRunConfigSet(t *testing.T) {
+	// Each subtest builds its own command, so there is no shared flag state and
+	// no dependence on execution order.
 	t.Run("requires the file flag", func(t *testing.T) {
-		_, err := execAdmin(t, "http://127.0.0.1:1", "admin", "config", "set")
+		cmd, _ := newHandlerCmd(t, "http://127.0.0.1:1", "table")
+		cmd.Flags().String("file", "", "")
+
+		err := runConfigSet(cmd, nil)
 		if err == nil || !strings.Contains(err.Error(), "--file is required") {
 			t.Fatalf("want --file required error, got %v", err)
 		}
@@ -217,13 +243,47 @@ func TestAdminConfigSet(t *testing.T) {
 		if err := os.WriteFile(path, []byte(`{"strategy":{"mode":"fallback"},"targets":[{"virtual_key":"openai"}]}`), 0600); err != nil {
 			t.Fatalf("write config: %v", err)
 		}
+		cmd, out := newHandlerCmd(t, srv.URL, "table")
+		cmd.Flags().String("file", path, "")
 
-		out, err := execAdmin(t, srv.URL, "admin", "config", "set", "--file", path)
-		if err != nil {
-			t.Fatalf("execute: %v", err)
+		if err := runConfigSet(cmd, nil); err != nil {
+			t.Fatalf("runConfigSet: %v", err)
 		}
-		if !strings.Contains(out, "Configuration updated.") {
-			t.Errorf("want success message, got:\n%s", out)
+		if !strings.Contains(out.String(), "Configuration updated.") {
+			t.Errorf("want success message, got:\n%s", out.String())
 		}
 	})
+}
+
+func TestRunLogsList(t *testing.T) {
+	srv := stubGateway(t, map[string]http.HandlerFunc{
+		"/admin/logs": jsonHandler(http.StatusOK, `[{"trace_id":"t1","provider":"openai","model":"gpt-4","status":200,"latency_ms":42}]`),
+	})
+	cmd, out := newHandlerCmd(t, srv.URL, "table")
+	cmd.Flags().Int("limit", 50, "")
+
+	if err := runLogsList(cmd, nil); err != nil {
+		t.Fatalf("runLogsList: %v", err)
+	}
+	for _, want := range []string{"TRACE_ID", "t1", "openai", "gpt-4"} {
+		if !strings.Contains(out.String(), want) {
+			t.Errorf("output missing %q:\n%s", want, out.String())
+		}
+	}
+}
+
+func TestRunProvidersList(t *testing.T) {
+	srv := stubGateway(t, map[string]http.HandlerFunc{
+		"/admin/providers": jsonHandler(http.StatusOK, `[{"name":"openai","model_count":12}]`),
+	})
+	cmd, out := newHandlerCmd(t, srv.URL, "table")
+
+	if err := runProvidersList(cmd, nil); err != nil {
+		t.Fatalf("runProvidersList: %v", err)
+	}
+	for _, want := range []string{"PROVIDER", "openai", "12"} {
+		if !strings.Contains(out.String(), want) {
+			t.Errorf("output missing %q:\n%s", want, out.String())
+		}
+	}
 }

--- a/internal/cli/admin_test.go
+++ b/internal/cli/admin_test.go
@@ -1,0 +1,229 @@
+package cli
+
+import (
+	"encoding/json"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestToSlice(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		in   any
+		want int
+	}{
+		{name: "json array of objects", in: []any{map[string]any{"a": 1}, map[string]any{"b": 2}}, want: 2},
+		{name: "single object is wrapped", in: map[string]any{"a": 1}, want: 1},
+		{name: "array with non-object entries skips them", in: []any{map[string]any{"a": 1}, "nope"}, want: 1},
+		{name: "unsupported type yields nil", in: 42, want: 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := len(toSlice(tt.in)); got != tt.want {
+				t.Errorf("toSlice length = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMapHelpers(t *testing.T) {
+	t.Parallel()
+	m := map[string]any{
+		"name":    "openai",
+		"revoked": true,
+		"count":   float64(7),
+		"nilval":  nil,
+	}
+
+	if got := str(m, "name"); got != "openai" {
+		t.Errorf("str = %q, want openai", got)
+	}
+	if got := str(m, "missing"); got != "" {
+		t.Errorf("str(missing) = %q, want empty", got)
+	}
+	if got := str(m, "nilval"); got != "" {
+		t.Errorf("str(nil) = %q, want empty", got)
+	}
+	if got := strBool(m, "revoked"); got != "yes" {
+		t.Errorf("strBool(true) = %q, want yes", got)
+	}
+	if got := strBool(m, "missing"); got != "no" {
+		t.Errorf("strBool(missing) = %q, want no", got)
+	}
+	if got := numVal(m, "count"); got != 7 {
+		t.Errorf("numVal = %v, want 7", got)
+	}
+	if got := numVal(m, "missing"); got != 0 {
+		t.Errorf("numVal(missing) = %v, want 0", got)
+	}
+}
+
+func TestFmtTime(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "rfc3339 renders short UTC", in: "2026-07-15T09:30:00Z", want: "2026-07-15 09:30 UTC"},
+		{name: "empty renders dash", in: "", want: "-"},
+		{name: "unparseable returns the raw value", in: "not-a-time", want: "not-a-time"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			m := map[string]any{"ts": tt.in}
+			if got := fmtTime(m, "ts"); got != tt.want {
+				t.Errorf("fmtTime = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestJSONSlice_Rendering(t *testing.T) {
+	t.Parallel()
+	js := &jsonSlice{
+		headers: []string{"NAME"},
+		data:    []map[string]any{{"name": "openai"}},
+		rowFn:   func(m map[string]any) []string { return []string{str(m, "name")} },
+	}
+
+	if got := js.Headers(); len(got) != 1 || got[0] != "NAME" {
+		t.Errorf("Headers = %v, want [NAME]", got)
+	}
+	rows := js.Rows()
+	if len(rows) != 1 || rows[0][0] != "openai" {
+		t.Errorf("Rows = %v, want [[openai]]", rows)
+	}
+
+	b, err := json.Marshal(js)
+	if err != nil || !strings.Contains(string(b), "openai") {
+		t.Errorf("MarshalJSON = %s, err = %v", b, err)
+	}
+	y, err := js.MarshalYAML()
+	if err != nil {
+		t.Errorf("MarshalYAML err = %v", err)
+	}
+	if _, ok := y.([]map[string]any); !ok {
+		t.Errorf("MarshalYAML = %T, want []map[string]any", y)
+	}
+}
+
+// ── Admin sub-command handlers (through cobra Execute) ──────────────────────────
+
+func TestAdminKeysList(t *testing.T) {
+	srv := stubGateway(t, map[string]http.HandlerFunc{
+		"/admin/keys": jsonHandler(http.StatusOK, `[{"id":"k1","name":"prod","scope":"admin","revoked":false}]`),
+	})
+
+	out, err := execAdmin(t, srv.URL, "admin", "keys", "list")
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	for _, want := range []string{"ID", "k1", "prod", "admin"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestAdminKeysGet(t *testing.T) {
+	srv := stubGateway(t, map[string]http.HandlerFunc{
+		"/admin/keys/k1": jsonHandler(http.StatusOK, `{"id":"k1","name":"prod"}`),
+	})
+
+	out, err := execAdmin(t, srv.URL, "admin", "keys", "get", "k1")
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if !strings.Contains(out, "k1") {
+		t.Errorf("want key detail, got:\n%s", out)
+	}
+}
+
+func TestAdminKeysCreate(t *testing.T) {
+	srv := stubGateway(t, map[string]http.HandlerFunc{
+		"/admin/keys": jsonHandler(http.StatusOK, `{"id":"new","key":"fgw_secret"}`),
+	})
+
+	t.Run("with a valid expiry", func(t *testing.T) {
+		out, err := execAdmin(t, srv.URL, "admin", "keys", "create", "--name", "ci", "--expires-in", "1h")
+		if err != nil {
+			t.Fatalf("execute: %v", err)
+		}
+		if !strings.Contains(out, "new") {
+			t.Errorf("want created key in output, got:\n%s", out)
+		}
+	})
+
+	t.Run("rejects an invalid expiry duration", func(t *testing.T) {
+		_, err := execAdmin(t, srv.URL, "admin", "keys", "create", "--expires-in", "bogus")
+		if err == nil || !strings.Contains(err.Error(), "invalid --expires-in") {
+			t.Fatalf("want expiry parse error, got %v", err)
+		}
+	})
+}
+
+func TestAdminKeysRevoke(t *testing.T) {
+	srv := stubGateway(t, map[string]http.HandlerFunc{
+		"/admin/keys/k1/revoke": jsonHandler(http.StatusOK, `{}`),
+	})
+
+	out, err := execAdmin(t, srv.URL, "admin", "keys", "revoke", "k1")
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if !strings.Contains(out, "Key revoked.") {
+		t.Errorf("want success message, got:\n%s", out)
+	}
+}
+
+func TestAdminLogsList(t *testing.T) {
+	srv := stubGateway(t, map[string]http.HandlerFunc{
+		"/admin/logs": jsonHandler(http.StatusOK, `[{"trace_id":"t1","provider":"openai","model":"gpt-4","status":200,"latency_ms":42}]`),
+	})
+
+	out, err := execAdmin(t, srv.URL, "admin", "logs", "list")
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	for _, want := range []string{"TRACE_ID", "t1", "openai", "gpt-4"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestAdminConfigSet(t *testing.T) {
+	// Ordered subtests: the missing-flag case must run before any case that
+	// sets --file, because the flag lives on the package-global command.
+	t.Run("requires the file flag", func(t *testing.T) {
+		_, err := execAdmin(t, "http://127.0.0.1:1", "admin", "config", "set")
+		if err == nil || !strings.Contains(err.Error(), "--file is required") {
+			t.Fatalf("want --file required error, got %v", err)
+		}
+	})
+
+	t.Run("applies a JSON config file", func(t *testing.T) {
+		srv := stubGateway(t, map[string]http.HandlerFunc{
+			"/admin/config": jsonHandler(http.StatusOK, `{}`),
+		})
+		path := filepath.Join(t.TempDir(), "config.json")
+		if err := os.WriteFile(path, []byte(`{"strategy":{"mode":"fallback"},"targets":[{"virtual_key":"openai"}]}`), 0600); err != nil {
+			t.Fatalf("write config: %v", err)
+		}
+
+		out, err := execAdmin(t, srv.URL, "admin", "config", "set", "--file", path)
+		if err != nil {
+			t.Fatalf("execute: %v", err)
+		}
+		if !strings.Contains(out, "Configuration updated.") {
+			t.Errorf("want success message, got:\n%s", out)
+		}
+	})
+}

--- a/internal/cli/admin_test.go
+++ b/internal/cli/admin_test.go
@@ -200,8 +200,8 @@ func TestAdminLogsList(t *testing.T) {
 }
 
 func TestAdminConfigSet(t *testing.T) {
-	// Ordered subtests: the missing-flag case must run before any case that
-	// sets --file, because the flag lives on the package-global command.
+	// execAdmin resets the command flags before each run, so these subtests are
+	// independent of ordering.
 	t.Run("requires the file flag", func(t *testing.T) {
 		_, err := execAdmin(t, "http://127.0.0.1:1", "admin", "config", "set")
 		if err == nil || !strings.Contains(err.Error(), "--file is required") {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1,0 +1,89 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// newHandlerCmd builds a child command mounted under a root carrying the
+// gateway-url/api-key/format persistent flags (as cmd/ferrogw/main.go wires
+// them), with the child's output and error writers pointed at a buffer so a
+// handler called directly (e.g. runStatus(child, nil)) can be asserted against
+// its output. NO_COLOR is forced so assertions ignore ANSI codes, and the
+// FERROGW_*/MASTER_KEY env vars are cleared so only the flags under test drive
+// client construction. Callers are therefore serial (t.Setenv).
+func newHandlerCmd(t *testing.T, gatewayURL, format string) (*cobra.Command, *bytes.Buffer) {
+	t.Helper()
+	t.Setenv("NO_COLOR", "1")
+	t.Setenv("FERROGW_URL", "")
+	t.Setenv("FERROGW_API_KEY", "")
+	t.Setenv("MASTER_KEY", "")
+
+	root := &cobra.Command{Use: "ferrogw"}
+	root.PersistentFlags().String("gateway-url", gatewayURL, "")
+	root.PersistentFlags().String("api-key", "", "")
+	root.PersistentFlags().String("format", format, "")
+
+	child := &cobra.Command{Use: "child"}
+	root.AddCommand(child)
+	// Handlers are called directly here (not via Execute), so cmd.Context()
+	// would otherwise be nil; set it so request building has a context.
+	child.SetContext(context.Background())
+
+	buf := &bytes.Buffer{}
+	child.SetOut(buf)
+	child.SetErr(buf)
+	return child, buf
+}
+
+// execAdmin runs the real AdminCmd tree through cobra's Execute with output
+// captured to a buffer, so the admin sub-command RunE closures are exercised
+// end to end. AdminCmd is a package global, so these tests must stay serial.
+func execAdmin(t *testing.T, gatewayURL string, args ...string) (string, error) {
+	t.Helper()
+	t.Setenv("NO_COLOR", "1")
+	t.Setenv("FERROGW_URL", "")
+	t.Setenv("FERROGW_API_KEY", "")
+	t.Setenv("MASTER_KEY", "")
+
+	root := &cobra.Command{Use: "ferrogw", SilenceUsage: true, SilenceErrors: true}
+	root.PersistentFlags().String("gateway-url", gatewayURL, "")
+	root.PersistentFlags().String("api-key", "", "")
+	root.PersistentFlags().String("format", "table", "")
+	root.AddCommand(AdminCmd)
+
+	buf := &bytes.Buffer{}
+	root.SetOut(buf)
+	root.SetErr(buf)
+	root.SetArgs(args)
+	err := root.Execute()
+	return buf.String(), err
+}
+
+// stubGateway starts an httptest server routing the given path patterns and
+// tears it down via t.Cleanup so it is closed even when the test fails.
+func stubGateway(t *testing.T, routes map[string]http.HandlerFunc) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	for pattern, h := range routes {
+		mux.HandleFunc(pattern, h)
+	}
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// jsonHandler responds with a fixed status and JSON body.
+func jsonHandler(status int, body string) http.HandlerFunc {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		_, _ = io.WriteString(w, body)
+	}
+}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 // newHandlerCmd builds a child command mounted under a root carrying the
@@ -44,13 +45,17 @@ func newHandlerCmd(t *testing.T, gatewayURL, format string) (*cobra.Command, *by
 
 // execAdmin runs the real AdminCmd tree through cobra's Execute with output
 // captured to a buffer, so the admin sub-command RunE closures are exercised
-// end to end. AdminCmd is a package global, so these tests must stay serial.
+// end to end. AdminCmd is a package global whose flag values would otherwise
+// persist between runs; its flags are reset first so tests do not depend on
+// ordering. The tests stay serial because the global tree is re-parented here.
 func execAdmin(t *testing.T, gatewayURL string, args ...string) (string, error) {
 	t.Helper()
 	t.Setenv("NO_COLOR", "1")
 	t.Setenv("FERROGW_URL", "")
 	t.Setenv("FERROGW_API_KEY", "")
 	t.Setenv("MASTER_KEY", "")
+
+	resetCommandFlags(AdminCmd)
 
 	root := &cobra.Command{Use: "ferrogw", SilenceUsage: true, SilenceErrors: true}
 	root.PersistentFlags().String("gateway-url", gatewayURL, "")
@@ -77,6 +82,20 @@ func stubGateway(t *testing.T, routes map[string]http.HandlerFunc) *httptest.Ser
 	srv := httptest.NewServer(mux)
 	t.Cleanup(srv.Close)
 	return srv
+}
+
+// resetCommandFlags restores every flag in a command tree to its default value
+// and clears its "changed" state, so a flag set by one execution does not leak
+// into the next. Needed because the admin commands are package globals reused
+// across execAdmin calls.
+func resetCommandFlags(cmd *cobra.Command) {
+	cmd.Flags().VisitAll(func(f *pflag.Flag) {
+		_ = f.Value.Set(f.DefValue)
+		f.Changed = false
+	})
+	for _, sub := range cmd.Commands() {
+		resetCommandFlags(sub)
+	}
 }
 
 // jsonHandler responds with a fixed status and JSON body.

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 )
 
 // newHandlerCmd builds a child command mounted under a root carrying the
@@ -43,34 +42,6 @@ func newHandlerCmd(t *testing.T, gatewayURL, format string) (*cobra.Command, *by
 	return child, buf
 }
 
-// execAdmin runs the real AdminCmd tree through cobra's Execute with output
-// captured to a buffer, so the admin sub-command RunE closures are exercised
-// end to end. AdminCmd is a package global whose flag values would otherwise
-// persist between runs; its flags are reset first so tests do not depend on
-// ordering. The tests stay serial because the global tree is re-parented here.
-func execAdmin(t *testing.T, gatewayURL string, args ...string) (string, error) {
-	t.Helper()
-	t.Setenv("NO_COLOR", "1")
-	t.Setenv("FERROGW_URL", "")
-	t.Setenv("FERROGW_API_KEY", "")
-	t.Setenv("MASTER_KEY", "")
-
-	resetCommandFlags(AdminCmd)
-
-	root := &cobra.Command{Use: "ferrogw", SilenceUsage: true, SilenceErrors: true}
-	root.PersistentFlags().String("gateway-url", gatewayURL, "")
-	root.PersistentFlags().String("api-key", "", "")
-	root.PersistentFlags().String("format", "table", "")
-	root.AddCommand(AdminCmd)
-
-	buf := &bytes.Buffer{}
-	root.SetOut(buf)
-	root.SetErr(buf)
-	root.SetArgs(args)
-	err := root.Execute()
-	return buf.String(), err
-}
-
 // stubGateway starts an httptest server routing the given path patterns and
 // tears it down via t.Cleanup so it is closed even when the test fails.
 func stubGateway(t *testing.T, routes map[string]http.HandlerFunc) *httptest.Server {
@@ -82,20 +53,6 @@ func stubGateway(t *testing.T, routes map[string]http.HandlerFunc) *httptest.Ser
 	srv := httptest.NewServer(mux)
 	t.Cleanup(srv.Close)
 	return srv
-}
-
-// resetCommandFlags restores every flag in a command tree to its default value
-// and clears its "changed" state, so a flag set by one execution does not leak
-// into the next. Needed because the admin commands are package globals reused
-// across execAdmin calls.
-func resetCommandFlags(cmd *cobra.Command) {
-	cmd.Flags().VisitAll(func(f *pflag.Flag) {
-		_ = f.Value.Set(f.DefValue)
-		f.Changed = false
-	})
-	for _, sub := range cmd.Commands() {
-		resetCommandFlags(sub)
-	}
 }
 
 // jsonHandler responds with a fixed status and JSON body.

--- a/internal/cli/colors_test.go
+++ b/internal/cli/colors_test.go
@@ -1,0 +1,30 @@
+package cli
+
+import (
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestClr(t *testing.T) {
+	t.Run("passes text through when NO_COLOR is set", func(t *testing.T) {
+		t.Setenv("NO_COLOR", "1")
+		if got := Clr(ColorGreen, "hi"); got != "hi" {
+			t.Errorf("Clr = %q, want unwrapped %q", got, "hi")
+		}
+	})
+
+	t.Run("wraps text in ANSI codes when color is enabled", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("color is disabled on bare Windows terminals")
+		}
+		t.Setenv("NO_COLOR", "")
+		got := Clr(ColorGreen, "hi")
+		if !strings.Contains(got, "hi") || got == "hi" {
+			t.Errorf("Clr = %q, want ANSI-wrapped %q", got, "hi")
+		}
+		if !strings.HasSuffix(got, ColorReset) {
+			t.Errorf("Clr = %q, want trailing reset code", got)
+		}
+	})
+}

--- a/internal/cli/command.go
+++ b/internal/cli/command.go
@@ -10,8 +10,17 @@ func adminClientFromCmd(cmd *cobra.Command) *AdminClient {
 	return NewAdminClient(flagURL, flagKey)
 }
 
+// printerFromCmd builds a Printer using the format persistent flag on the
+// command's root and bound to the command's output writer, so command output
+// is redirectable (via cmd.SetOut) and therefore testable.
+func printerFromCmd(cmd *cobra.Command) *Printer {
+	format, _ := cmd.Root().PersistentFlags().GetString("format")
+	pr := NewPrinter(format)
+	pr.Out = cmd.OutOrStdout()
+	return pr
+}
+
 // printResult renders v using the format persistent flag on the command's root.
 func printResult(cmd *cobra.Command, v any) error {
-	format, _ := cmd.Root().PersistentFlags().GetString("format")
-	return NewPrinter(format).Print(v)
+	return printerFromCmd(cmd).Print(v)
 }

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -17,7 +17,8 @@ var DoctorCmd = &cobra.Command{
 }
 
 func runDoctor(cmd *cobra.Command, _ []string) error {
-	fmt.Println("  Provider API Keys")
+	out := cmd.OutOrStdout()
+	_, _ = fmt.Fprintln(out, "  Provider API Keys")
 
 	topProviders := []struct {
 		name   string
@@ -33,49 +34,49 @@ func runDoctor(cmd *cobra.Command, _ []string) error {
 	found := 0
 	for _, p := range topProviders {
 		if os.Getenv(p.envKey) != "" {
-			fmt.Printf("    %s %s\n", Clr(ColorGreen, SymOK), p.name)
+			_, _ = fmt.Fprintf(out, "    %s %s\n", Clr(ColorGreen, SymOK), p.name)
 			found++
 		} else {
-			fmt.Printf("    %s %s\n", Clr(ColorDim, SymDASH), p.name)
+			_, _ = fmt.Fprintf(out, "    %s %s\n", Clr(ColorDim, SymDASH), p.name)
 		}
 	}
 
 	if found == 0 {
-		fmt.Printf("\n    %s no provider API keys detected\n", Clr(ColorYellow, SymWARN))
+		_, _ = fmt.Fprintf(out, "\n    %s no provider API keys detected\n", Clr(ColorYellow, SymWARN))
 	} else {
-		fmt.Printf("\n    %d found\n", found)
+		_, _ = fmt.Fprintf(out, "\n    %d found\n", found)
 	}
 
 	// Configuration check.
-	fmt.Println()
-	fmt.Println("  Configuration")
+	_, _ = fmt.Fprintln(out)
+	_, _ = fmt.Fprintln(out, "  Configuration")
 	cfgPath := os.Getenv("GATEWAY_CONFIG")
 	if cfgPath == "" {
-		fmt.Printf("    %s GATEWAY_CONFIG not set (using defaults)\n", Clr(ColorDim, SymDASH))
+		_, _ = fmt.Fprintf(out, "    %s GATEWAY_CONFIG not set (using defaults)\n", Clr(ColorDim, SymDASH))
 	} else {
 		cfg, err := aigateway.LoadConfig(cfgPath)
 		if err != nil {
-			fmt.Printf("    %s %s: %v\n", Clr(ColorRed, SymFAIL), cfgPath, err)
+			_, _ = fmt.Fprintf(out, "    %s %s: %v\n", Clr(ColorRed, SymFAIL), cfgPath, err)
 		} else if err := aigateway.ValidateConfig(*cfg); err != nil {
-			fmt.Printf("    %s %s: %v\n", Clr(ColorRed, SymFAIL), cfgPath, err)
+			_, _ = fmt.Fprintf(out, "    %s %s: %v\n", Clr(ColorRed, SymFAIL), cfgPath, err)
 		} else {
-			fmt.Printf("    %s %s (strategy=%s, targets=%d)\n",
+			_, _ = fmt.Fprintf(out, "    %s %s (strategy=%s, targets=%d)\n",
 				Clr(ColorGreen, SymOK), cfgPath, cfg.Strategy.Mode, len(cfg.Targets))
 		}
 	}
 
 	// Master key check.
-	fmt.Println()
-	fmt.Println("  Auth")
+	_, _ = fmt.Fprintln(out)
+	_, _ = fmt.Fprintln(out, "  Auth")
 	if os.Getenv("MASTER_KEY") != "" {
-		fmt.Printf("    %s MASTER_KEY is set\n", Clr(ColorGreen, SymOK))
+		_, _ = fmt.Fprintf(out, "    %s MASTER_KEY is set\n", Clr(ColorGreen, SymOK))
 	} else {
-		fmt.Printf("    %s MASTER_KEY not set -- run 'ferrogw init' to generate one\n", Clr(ColorYellow, SymWARN))
+		_, _ = fmt.Fprintf(out, "    %s MASTER_KEY not set -- run 'ferrogw init' to generate one\n", Clr(ColorYellow, SymWARN))
 	}
 
 	// Connectivity check.
-	fmt.Println()
-	fmt.Println("  Gateway Connectivity")
+	_, _ = fmt.Fprintln(out)
+	_, _ = fmt.Fprintln(out, "  Gateway Connectivity")
 
 	c := adminClientFromCmd(cmd)
 	var h struct {
@@ -88,13 +89,13 @@ func runDoctor(cmd *cobra.Command, _ []string) error {
 	latency := time.Since(start)
 	switch {
 	case err != nil:
-		fmt.Printf("    %s %s: %v\n", Clr(ColorRed, SymFAIL), c.BaseURL, err)
+		_, _ = fmt.Fprintf(out, "    %s %s: %v\n", Clr(ColorRed, SymFAIL), c.BaseURL, err)
 	case h.Status != "ok":
-		fmt.Printf("    %s %s -- %s (%dms)\n", Clr(ColorYellow, SymWARN), c.BaseURL, h.Status, latency.Milliseconds())
+		_, _ = fmt.Fprintf(out, "    %s %s -- %s (%dms)\n", Clr(ColorYellow, SymWARN), c.BaseURL, h.Status, latency.Milliseconds())
 	default:
-		fmt.Printf("    %s %s -- healthy (%dms)\n", Clr(ColorGreen, SymOK), c.BaseURL, latency.Milliseconds())
+		_, _ = fmt.Fprintf(out, "    %s %s -- healthy (%dms)\n", Clr(ColorGreen, SymOK), c.BaseURL, latency.Milliseconds())
 	}
 
-	fmt.Println()
+	_, _ = fmt.Fprintln(out)
 	return nil
 }

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -1,0 +1,75 @@
+package cli
+
+import (
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRunDoctor(t *testing.T) {
+	// clearProviderKeys blanks every provider env var doctor probes so host
+	// environment leakage does not skew the "N found" count.
+	clearProviderKeys := func(t *testing.T) {
+		for _, k := range []string{
+			"OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GEMINI_API_KEY",
+			"GROQ_API_KEY", "MISTRAL_API_KEY",
+		} {
+			t.Setenv(k, "")
+		}
+	}
+
+	t.Run("reports keys, config, auth and healthy connectivity", func(t *testing.T) {
+		srv := stubGateway(t, map[string]http.HandlerFunc{
+			"/health": jsonHandler(http.StatusOK, `{"status":"ok"}`),
+		})
+		cmd, out := newHandlerCmd(t, srv.URL, "table")
+		clearProviderKeys(t)
+		t.Setenv("OPENAI_API_KEY", "sk-test")
+		t.Setenv("GATEWAY_CONFIG", "")
+		t.Setenv("MASTER_KEY", "master-test")
+
+		if err := runDoctor(cmd, nil); err != nil {
+			t.Fatalf("runDoctor: %v", err)
+		}
+
+		got := out.String()
+		for _, want := range []string{
+			"Provider API Keys", "openai", "1 found",
+			"MASTER_KEY is set", "healthy",
+		} {
+			if !strings.Contains(got, want) {
+				t.Errorf("output missing %q:\n%s", want, got)
+			}
+		}
+	})
+
+	t.Run("flags no keys and an invalid config file", func(t *testing.T) {
+		cfgPath := filepath.Join(t.TempDir(), "bad.yaml")
+		// Valid YAML, invalid config: an unknown strategy mode fails validation.
+		if err := os.WriteFile(cfgPath, []byte("strategy:\n  mode: bogus\ntargets:\n  - virtual_key: openai\n"), 0600); err != nil {
+			t.Fatalf("write config: %v", err)
+		}
+
+		cmd, out := newHandlerCmd(t, "http://127.0.0.1:1", "table")
+		clearProviderKeys(t)
+		t.Setenv("GATEWAY_CONFIG", cfgPath)
+		t.Setenv("MASTER_KEY", "")
+
+		if err := runDoctor(cmd, nil); err != nil {
+			t.Fatalf("runDoctor: %v", err)
+		}
+
+		got := out.String()
+		for _, want := range []string{
+			"no provider API keys detected",
+			cfgPath,
+			"MASTER_KEY not set",
+		} {
+			if !strings.Contains(got, want) {
+				t.Errorf("output missing %q:\n%s", want, got)
+			}
+		}
+	})
+}

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -95,7 +95,7 @@ func runInit(cmd *cobra.Command, _ []string) error {
 	output, _ := cmd.Flags().GetString("output")
 	nonInteractive, _ := cmd.Flags().GetBool("non-interactive")
 
-	out := os.Stderr
+	out := cmd.ErrOrStderr()
 	eprintf := func(format string, a ...any) { _, _ = fmt.Fprintf(out, format, a...) }
 
 	if !nonInteractive {

--- a/internal/cli/init_run_test.go
+++ b/internal/cli/init_run_test.go
@@ -1,0 +1,81 @@
+package cli
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// newInitCmd builds a command carrying init's own flags, with stderr captured.
+func newInitCmd(t *testing.T) (*cobra.Command, *bytes.Buffer) {
+	t.Helper()
+	t.Setenv("NO_COLOR", "1")
+	cmd := &cobra.Command{Use: "init"}
+	cmd.Flags().String("config-format", "yaml", "")
+	cmd.Flags().StringP("output", "o", "", "")
+	cmd.Flags().Bool("non-interactive", false, "")
+	buf := &bytes.Buffer{}
+	cmd.SetErr(buf)
+	return cmd, buf
+}
+
+func TestRunInit(t *testing.T) {
+	t.Run("creates the config and prints a master key", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "config.yaml")
+		cmd, errOut := newInitCmd(t)
+		if err := cmd.Flags().Set("output", path); err != nil {
+			t.Fatalf("set output: %v", err)
+		}
+		if err := cmd.Flags().Set("non-interactive", "true"); err != nil {
+			t.Fatalf("set non-interactive: %v", err)
+		}
+
+		if err := runInit(cmd, nil); err != nil {
+			t.Fatalf("runInit: %v", err)
+		}
+
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("config file not written: %v", err)
+		}
+		got := errOut.String()
+		for _, want := range []string{"Created", "Master key:", "fgw_"} {
+			if !strings.Contains(got, want) {
+				t.Errorf("stderr missing %q:\n%s", want, got)
+			}
+		}
+	})
+
+	t.Run("does not overwrite an existing config", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "config.yaml")
+		if err := os.WriteFile(path, []byte("existing: true\n"), 0600); err != nil {
+			t.Fatalf("seed config: %v", err)
+		}
+		cmd, errOut := newInitCmd(t)
+		if err := cmd.Flags().Set("output", path); err != nil {
+			t.Fatalf("set output: %v", err)
+		}
+		if err := cmd.Flags().Set("non-interactive", "true"); err != nil {
+			t.Fatalf("set non-interactive: %v", err)
+		}
+
+		if err := runInit(cmd, nil); err != nil {
+			t.Fatalf("runInit: %v", err)
+		}
+
+		if !strings.Contains(errOut.String(), "skipped") {
+			t.Errorf("want skip notice, got:\n%s", errOut.String())
+		}
+		// The pre-existing content must survive.
+		data, err := os.ReadFile(path) //nolint:gosec // G304: path is a test-local temp file
+		if err != nil {
+			t.Fatalf("read config: %v", err)
+		}
+		if !strings.Contains(string(data), "existing: true") {
+			t.Errorf("existing config was overwritten: %s", data)
+		}
+	})
+}

--- a/internal/cli/output.go
+++ b/internal/cli/output.go
@@ -18,6 +18,12 @@ const (
 	FormatYAML  = "yaml"
 )
 
+// Boolean cell labels for table output.
+const (
+	boolYes = "yes"
+	boolNo  = "no"
+)
+
 // TableData is implemented by types that can render as an ASCII table.
 type TableData interface {
 	Headers() []string
@@ -76,7 +82,7 @@ func (p *Printer) PrintTable(td TableData) error {
 	return w.Flush()
 }
 
-// PrintSuccess prints a success indicator with a message.
-func PrintSuccess(msg string) {
-	fmt.Println(Clr(ColorGreen, "  "+SymOK+" ") + msg)
+// PrintSuccess writes a success indicator with a message to w.
+func PrintSuccess(w io.Writer, msg string) {
+	_, _ = fmt.Fprintln(w, Clr(ColorGreen, "  "+SymOK+" ")+msg)
 }

--- a/internal/cli/plugins.go
+++ b/internal/cli/plugins.go
@@ -25,25 +25,25 @@ func runPlugins(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	format, _ := cmd.Root().PersistentFlags().GetString("format")
-	pr := NewPrinter(format)
+	pr := printerFromCmd(cmd)
 	if pr.Format != FormatTable {
 		return pr.Print(plugins)
 	}
 
+	out := cmd.OutOrStdout()
 	if len(plugins) == 0 {
-		fmt.Println("No plugins registered.")
+		_, _ = fmt.Fprintln(out, "No plugins registered.")
 		return nil
 	}
 
-	fmt.Printf("%-24s %-16s %s\n", "NAME", "TYPE", "ENABLED")
-	fmt.Printf("%-24s %-16s %s\n", "----", "----", "-------")
+	_, _ = fmt.Fprintf(out, "%-24s %-16s %s\n", "NAME", "TYPE", "ENABLED")
+	_, _ = fmt.Fprintf(out, "%-24s %-16s %s\n", "----", "----", "-------")
 	for _, p := range plugins {
-		enabled := "no"
+		enabled := boolNo
 		if p.Enabled {
-			enabled = "yes"
+			enabled = boolYes
 		}
-		fmt.Printf("%-24s %-16s %s\n", p.Name, p.Type, enabled)
+		_, _ = fmt.Fprintf(out, "%-24s %-16s %s\n", p.Name, p.Type, enabled)
 	}
 	return nil
 }

--- a/internal/cli/plugins_test.go
+++ b/internal/cli/plugins_test.go
@@ -1,0 +1,69 @@
+package cli
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestRunPlugins(t *testing.T) {
+	const listBody = `[{"name":"word-filter","type":"guardrail","enabled":true}]`
+
+	t.Run("table renders registered plugins", func(t *testing.T) {
+		srv := stubGateway(t, map[string]http.HandlerFunc{
+			"/admin/plugins": jsonHandler(http.StatusOK, listBody),
+		})
+		cmd, out := newHandlerCmd(t, srv.URL, "table")
+
+		if err := runPlugins(cmd, nil); err != nil {
+			t.Fatalf("runPlugins: %v", err)
+		}
+		got := out.String()
+		for _, want := range []string{"NAME", "ENABLED", "word-filter", "guardrail"} {
+			if !strings.Contains(got, want) {
+				t.Errorf("output missing %q:\n%s", want, got)
+			}
+		}
+	})
+
+	t.Run("json format bypasses the table", func(t *testing.T) {
+		srv := stubGateway(t, map[string]http.HandlerFunc{
+			"/admin/plugins": jsonHandler(http.StatusOK, listBody),
+		})
+		cmd, out := newHandlerCmd(t, srv.URL, "json")
+
+		if err := runPlugins(cmd, nil); err != nil {
+			t.Fatalf("runPlugins: %v", err)
+		}
+		got := out.String()
+		if !strings.Contains(got, `"name"`) || !strings.Contains(got, "word-filter") {
+			t.Errorf("want JSON payload, got:\n%s", got)
+		}
+	})
+
+	t.Run("empty list prints a friendly message", func(t *testing.T) {
+		srv := stubGateway(t, map[string]http.HandlerFunc{
+			"/admin/plugins": jsonHandler(http.StatusOK, `[]`),
+		})
+		cmd, out := newHandlerCmd(t, srv.URL, "table")
+
+		if err := runPlugins(cmd, nil); err != nil {
+			t.Fatalf("runPlugins: %v", err)
+		}
+		if !strings.Contains(out.String(), "No plugins registered.") {
+			t.Errorf("want empty-state message, got:\n%s", out.String())
+		}
+	})
+
+	t.Run("propagates an admin API error", func(t *testing.T) {
+		srv := stubGateway(t, map[string]http.HandlerFunc{
+			"/admin/plugins": jsonHandler(http.StatusInternalServerError, `{"error":{"message":"boom"}}`),
+		})
+		cmd, _ := newHandlerCmd(t, srv.URL, "table")
+
+		err := runPlugins(cmd, nil)
+		if err == nil || !strings.Contains(err.Error(), "boom") {
+			t.Fatalf("want error carrying 'boom', got %v", err)
+		}
+	})
+}

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -15,12 +15,13 @@ var StatusCmd = &cobra.Command{
 }
 
 func runStatus(cmd *cobra.Command, _ []string) error {
+	out := cmd.OutOrStdout()
 	c := adminClientFromCmd(cmd)
 
 	start := time.Now()
 	var health map[string]any
 	if err := c.GetHealth(cmd.Context(), "/health", &health); err != nil {
-		fmt.Printf("  %s Gateway unreachable: %v\n", Clr(ColorRed, SymFAIL), err)
+		_, _ = fmt.Fprintf(out, "  %s Gateway unreachable: %v\n", Clr(ColorRed, SymFAIL), err)
 		return nil
 	}
 	latency := time.Since(start)
@@ -36,7 +37,7 @@ func runStatus(cmd *cobra.Command, _ []string) error {
 			status = s
 		}
 	}
-	fmt.Printf("  %s %s -- %s (%s)\n",
+	_, _ = fmt.Fprintf(out, "  %s %s -- %s (%s)\n",
 		Clr(color, symbol),
 		c.BaseURL,
 		Clr(ColorBold+color, status),
@@ -44,7 +45,7 @@ func runStatus(cmd *cobra.Command, _ []string) error {
 	)
 
 	if v, ok := health["version"]; ok {
-		fmt.Printf("  Version: %s\n", Clr(ColorYellow, fmt.Sprint(v)))
+		_, _ = fmt.Fprintf(out, "  Version: %s\n", Clr(ColorYellow, fmt.Sprint(v)))
 	}
 
 	// Try to get provider count.
@@ -56,7 +57,7 @@ func runStatus(cmd *cobra.Command, _ []string) error {
 				models += len(m)
 			}
 		}
-		fmt.Printf("  Providers: %s (%d models)\n",
+		_, _ = fmt.Fprintf(out, "  Providers: %s (%d models)\n",
 			Clr(ColorCyan, fmt.Sprintf("%d", len(provResp))), models)
 	}
 

--- a/internal/cli/status_test.go
+++ b/internal/cli/status_test.go
@@ -1,0 +1,59 @@
+package cli
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestRunStatus(t *testing.T) {
+	t.Run("healthy gateway reports version and providers", func(t *testing.T) {
+		srv := stubGateway(t, map[string]http.HandlerFunc{
+			"/health":          jsonHandler(http.StatusOK, `{"status":"ok","version":"1.2.0"}`),
+			"/admin/providers": jsonHandler(http.StatusOK, `[{"name":"openai","models":["gpt-4","gpt-4o"]}]`),
+		})
+		cmd, out := newHandlerCmd(t, srv.URL, "table")
+
+		if err := runStatus(cmd, nil); err != nil {
+			t.Fatalf("runStatus: %v", err)
+		}
+
+		got := out.String()
+		for _, want := range []string{"healthy", "1.2.0", "Providers", "2 models"} {
+			if !strings.Contains(got, want) {
+				t.Errorf("output missing %q:\n%s", want, got)
+			}
+		}
+	})
+
+	t.Run("degraded gateway shows status rather than unreachable", func(t *testing.T) {
+		srv := stubGateway(t, map[string]http.HandlerFunc{
+			"/health": jsonHandler(http.StatusServiceUnavailable, `{"status":"no_providers"}`),
+		})
+		cmd, out := newHandlerCmd(t, srv.URL, "table")
+
+		if err := runStatus(cmd, nil); err != nil {
+			t.Fatalf("runStatus: %v", err)
+		}
+
+		got := out.String()
+		if !strings.Contains(got, "no_providers") {
+			t.Errorf("want degraded status in output, got:\n%s", got)
+		}
+		if strings.Contains(got, "unreachable") {
+			t.Errorf("a degraded gateway must not be reported unreachable:\n%s", got)
+		}
+	})
+
+	t.Run("unreachable gateway is reported without an error", func(t *testing.T) {
+		// Port 1 refuses connections immediately.
+		cmd, out := newHandlerCmd(t, "http://127.0.0.1:1", "table")
+
+		if err := runStatus(cmd, nil); err != nil {
+			t.Fatalf("runStatus should not error for an unreachable gateway: %v", err)
+		}
+		if !strings.Contains(out.String(), "unreachable") {
+			t.Errorf("want 'unreachable', got:\n%s", out.String())
+		}
+	})
+}

--- a/internal/cli/validate.go
+++ b/internal/cli/validate.go
@@ -27,23 +27,22 @@ func runValidate(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("validation failed: %w", err)
 	}
 
-	format, _ := cmd.Root().PersistentFlags().GetString("format")
-	pr := NewPrinter(format)
-
+	pr := printerFromCmd(cmd)
 	if pr.Format != FormatTable {
 		return pr.Print(cfg)
 	}
 
-	fmt.Printf("%s Config is valid\n", SymOK)
-	fmt.Printf("  Strategy:  %s\n", cfg.Strategy.Mode)
-	fmt.Printf("  Targets:   %d\n", len(cfg.Targets))
+	out := cmd.OutOrStdout()
+	_, _ = fmt.Fprintf(out, "%s Config is valid\n", SymOK)
+	_, _ = fmt.Fprintf(out, "  Strategy:  %s\n", cfg.Strategy.Mode)
+	_, _ = fmt.Fprintf(out, "  Targets:   %d\n", len(cfg.Targets))
 
 	var targetNames []string
 	for _, t := range cfg.Targets {
 		targetNames = append(targetNames, t.VirtualKey)
 	}
 	if len(targetNames) > 0 {
-		fmt.Printf("  Providers: %s\n", strings.Join(targetNames, ", "))
+		_, _ = fmt.Fprintf(out, "  Providers: %s\n", strings.Join(targetNames, ", "))
 	}
 
 	if len(cfg.Plugins) > 0 {
@@ -55,11 +54,11 @@ func runValidate(cmd *cobra.Command, args []string) error {
 			}
 			pluginNames = append(pluginNames, fmt.Sprintf("%s (%s)", p.Name, status))
 		}
-		fmt.Printf("  Plugins:   %s\n", strings.Join(pluginNames, ", "))
+		_, _ = fmt.Fprintf(out, "  Plugins:   %s\n", strings.Join(pluginNames, ", "))
 	}
 
 	if len(cfg.Aliases) > 0 {
-		fmt.Printf("  Aliases:   %d\n", len(cfg.Aliases))
+		_, _ = fmt.Fprintf(out, "  Aliases:   %d\n", len(cfg.Aliases))
 	}
 	return nil
 }

--- a/internal/cli/validate_test.go
+++ b/internal/cli/validate_test.go
@@ -1,0 +1,67 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeConfig(t *testing.T, name, content string) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), name)
+	if err := os.WriteFile(p, []byte(content), 0600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	return p
+}
+
+func TestRunValidate(t *testing.T) {
+	const validYAML = "strategy:\n  mode: fallback\ntargets:\n  - virtual_key: openai\n"
+
+	t.Run("valid config renders a summary", func(t *testing.T) {
+		path := writeConfig(t, "config.yaml", validYAML)
+		cmd, out := newHandlerCmd(t, "", "table")
+
+		if err := runValidate(cmd, []string{path}); err != nil {
+			t.Fatalf("runValidate: %v", err)
+		}
+		got := out.String()
+		for _, want := range []string{"Config is valid", "fallback", "openai"} {
+			if !strings.Contains(got, want) {
+				t.Errorf("output missing %q:\n%s", want, got)
+			}
+		}
+	})
+
+	t.Run("json format prints the parsed config", func(t *testing.T) {
+		path := writeConfig(t, "config.yaml", validYAML)
+		cmd, out := newHandlerCmd(t, "", "json")
+
+		if err := runValidate(cmd, []string{path}); err != nil {
+			t.Fatalf("runValidate: %v", err)
+		}
+		if !strings.Contains(out.String(), "fallback") {
+			t.Errorf("want JSON config, got:\n%s", out.String())
+		}
+	})
+
+	t.Run("invalid config returns a validation error", func(t *testing.T) {
+		path := writeConfig(t, "config.yaml", "strategy:\n  mode: bogus\ntargets:\n  - virtual_key: openai\n")
+		cmd, _ := newHandlerCmd(t, "", "table")
+
+		err := runValidate(cmd, []string{path})
+		if err == nil || !strings.Contains(err.Error(), "validation failed") {
+			t.Fatalf("want validation error, got %v", err)
+		}
+	})
+
+	t.Run("missing file returns a load error", func(t *testing.T) {
+		cmd, _ := newHandlerCmd(t, "", "table")
+
+		err := runValidate(cmd, []string{filepath.Join(t.TempDir(), "nope.yaml")})
+		if err == nil || !strings.Contains(err.Error(), "load config") {
+			t.Fatalf("want load error, got %v", err)
+		}
+	})
+}

--- a/internal/cli/version.go
+++ b/internal/cli/version.go
@@ -24,16 +24,16 @@ func runVersion(cmd *cobra.Command, _ []string) error {
 		"os_arch": runtime.GOOS + "/" + runtime.GOARCH,
 	}
 
-	format, _ := cmd.Root().PersistentFlags().GetString("format")
-	pr := NewPrinter(format)
+	pr := printerFromCmd(cmd)
 	if pr.Format != FormatTable {
 		return pr.Print(info)
 	}
 
-	fmt.Printf("  %-12s %s\n", Clr(ColorBold, "Version"), Clr(ColorYellow, version.Version))
-	fmt.Printf("  %-12s %s\n", Clr(ColorBold, "Commit"), version.Commit)
-	fmt.Printf("  %-12s %s\n", Clr(ColorBold, "Built"), version.Date)
-	fmt.Printf("  %-12s %s\n", Clr(ColorBold, "Go"), runtime.Version())
-	fmt.Printf("  %-12s %s\n", Clr(ColorBold, "OS/Arch"), runtime.GOOS+"/"+runtime.GOARCH)
+	out := cmd.OutOrStdout()
+	_, _ = fmt.Fprintf(out, "  %-12s %s\n", Clr(ColorBold, "Version"), Clr(ColorYellow, version.Version))
+	_, _ = fmt.Fprintf(out, "  %-12s %s\n", Clr(ColorBold, "Commit"), version.Commit)
+	_, _ = fmt.Fprintf(out, "  %-12s %s\n", Clr(ColorBold, "Built"), version.Date)
+	_, _ = fmt.Fprintf(out, "  %-12s %s\n", Clr(ColorBold, "Go"), runtime.Version())
+	_, _ = fmt.Fprintf(out, "  %-12s %s\n", Clr(ColorBold, "OS/Arch"), runtime.GOOS+"/"+runtime.GOARCH)
 	return nil
 }

--- a/internal/cli/version_test.go
+++ b/internal/cli/version_test.go
@@ -1,0 +1,33 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRunVersion(t *testing.T) {
+	t.Run("table format lists build fields", func(t *testing.T) {
+		cmd, out := newHandlerCmd(t, "", "table")
+
+		if err := runVersion(cmd, nil); err != nil {
+			t.Fatalf("runVersion: %v", err)
+		}
+		got := out.String()
+		for _, want := range []string{"Version", "Commit", "Go"} {
+			if !strings.Contains(got, want) {
+				t.Errorf("output missing %q:\n%s", want, got)
+			}
+		}
+	})
+
+	t.Run("json format emits a machine-readable object", func(t *testing.T) {
+		cmd, out := newHandlerCmd(t, "", "json")
+
+		if err := runVersion(cmd, nil); err != nil {
+			t.Fatalf("runVersion: %v", err)
+		}
+		if !strings.Contains(out.String(), `"version"`) {
+			t.Errorf("want json version key, got:\n%s", out.String())
+		}
+	})
+}

--- a/internal/tracingpolicy/privacy_test.go
+++ b/internal/tracingpolicy/privacy_test.go
@@ -1,0 +1,35 @@
+package tracingpolicy
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidatePrivacyLevel(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		level   string
+		wantErr bool
+	}{
+		{name: "empty is accepted as the default", level: "", wantErr: false},
+		{name: "none is valid", level: PrivacyLevelNone, wantErr: false},
+		{name: "metadata is valid", level: PrivacyLevelMetadata, wantErr: false},
+		{name: "full is valid", level: PrivacyLevelFull, wantErr: false},
+		{name: "unknown level is rejected", level: "verbose", wantErr: true},
+		{name: "validation is case-sensitive", level: "Full", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := ValidatePrivacyLevel(tt.level)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ValidatePrivacyLevel(%q) error = %v, wantErr %v", tt.level, err, tt.wantErr)
+			}
+			if tt.wantErr && !strings.Contains(err.Error(), tt.level) {
+				t.Errorf("error %q should name the offending level %q", err, tt.level)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Two behavior-preserving changes that make internal packages testable and lock in existing behavior with regression tests.

- **CLI output injection.** `ferrogw` command handlers wrote directly to `os.Stdout`/`os.Stderr`, so their output could not be captured in tests. Output now flows through `cmd.OutOrStdout()` / `cmd.ErrOrStderr()`, and `PrintSuccess` takes an `io.Writer`. The defaults are unchanged — both resolve to the process streams — so runtime behavior is identical. This unlocks table-driven tests for the `status`, `doctor`, `plugins`, `validate`, `version`, `init`, and `admin` sub-commands. Package coverage rises from ~24% to ~82%.
- **authctx / tracingpolicy tests.** Added regression tests for two small, security-relevant helpers that previously had none, with no production change:
  - `authctx.WithKeyID` / `KeyID` — the per-key rate-limit/budget scoping seam, including the boundary where an empty id must read as absent.
  - `tracingpolicy.ValidatePrivacyLevel` — the shared `privacy_level` gate used by both the gateway config validator and the tracing config validator.
  - Both reach full statement coverage.

## Public API

- `internal/cli`: `PrintSuccess(msg string)` → `PrintSuccess(w io.Writer, msg string)`. Internal package; the only caller lives within it. No other exported surface changes.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` — full unit suite green
- [x] `go test -race ./internal/cli/... ./internal/authctx/... ./internal/tracingpolicy/... ./cmd/ferrogw/...`
- [x] Pre-push `-race` suite green across all packages
- [x] `gofmt -l` clean, `go vet ./...` clean
- [x] `golangci-lint run` — 0 issues on changed packages


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved CLI output routing so messages consistently respect Cobra’s configured stdout/stderr streams across diagnostics, status, version, validation, doctor, and initialization flows.
  * Standardized success and boolean labels, and updated admin/plugin outputs for consistent formatting.
  * Added clearer messaging when no plugins are registered.
  * Enhanced output rendering behavior for table vs JSON formats.

* **Tests**
  * Expanded CLI test coverage for admin, doctor, init, plugins, status, validate, version, and formatting helpers.
  * Added unit tests for key-ID context semantics and privacy-level validation.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->