### PR TITLE
v1.3.0 — MCP stdio transport, subprocess supervision, and MCP correctness fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to Ferro Labs AI Gateway are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.0] — 2026-07-20
+
+MCP servers can now be launched as local subprocesses, so any `npx`, `uvx`, or binary MCP server can be used without standing up an HTTP endpoint for it. Alongside the new transport, two long-standing defects in the existing MCP path are fixed — both of which affected the gateway whether or not you used MCP deliberately.
+
+Thanks to [@gr3enarr0w](https://github.com/gr3enarr0w) for contributing the stdio transport (#121).
+
+### Added
+
+- **MCP stdio transport.** An `mcp_servers` entry may now set `command` (with optional `args`) instead of `url`, and the gateway launches that process and speaks MCP over its stdin/stdout for the gateway's lifetime. Exactly one of `url` or `command` must be set; both or neither is a config error naming the server. The existing Streamable HTTP transport is unchanged, and the two are interchangeable everywhere tools are consumed (#121).
+- **Subprocess environment isolation.** An MCP subprocess does **not** inherit the gateway's environment. It receives `PATH`, `HOME`, `LANG`, and `TMPDIR` when set, plus exactly the keys under that server's `env` — so `OPENAI_API_KEY`, `MASTER_KEY`, and every other gateway credential are unreachable from an MCP server. A server needing anything else, such as `HTTPS_PROXY`, `NODE_PATH`, or `SSL_CERT_FILE`, must have it listed explicitly.
+- **`${VAR}` references in a stdio server's `env`.** Resolved when the MCP client is constructed, the same treatment `headers` already received, so the config keeps the reference and never stores the secret. Since the gateway environment is not inherited, this is the only channel by which a credential reaches an MCP subprocess. `GET /admin/config` redacts `env` alongside `headers`.
+- **Subprocess diagnostics.** A stdio server's `stderr` is drained into the gateway log at debug level, one record per line. A server that dies on a missing API key or a permission error now says so in the log instead of surfacing as an opaque timeout.
+
+### Fixed
+
+- **A misconfigured MCP server no longer disables streaming.** The agentic-loop redirect keyed off whether any MCP server was *registered*, which is true before the handshake runs and stays true after one fails. A single unreachable endpoint or typo'd command therefore turned every `stream: true` request on the gateway into one buffered chunk — for every caller, including those making no use of MCP — with no error and no way to notice beyond the missing token-by-token delivery. Activation now keys off tools actually discovered, matching the non-streaming path.
+- **Caller-supplied tool calls are no longer intercepted.** With MCP active, every tool call in a model response was executed as if the gateway owned it. A client that sent its own `tools` array — the ordinary OpenAI function-calling pattern, where the client executes the call and posts the result back — had its call swallowed and answered with a fabricated *"tool not found in any registered MCP server"*, never receiving `finish_reason: "tool_calls"`. Tool calls the gateway does not own are now passed through untouched, so enabling MCP no longer breaks existing client-side tool integrations.
+- **A single model response can no longer trigger unbounded tool execution.** `max_call_depth` bounded how many turns the agentic loop ran but nothing bounded the calls within one turn, so a response carrying thousands of `tool_calls` produced that many executions and conversation messages, re-sent to the provider on every subsequent turn. Tool calls are capped per turn.
+- **Stdio servers launched via `npx` no longer leak processes.** `npx` and `uvx` exec the real server as a separate process, and terminating the launcher does not terminate what it started, so every gateway shutdown and config reload left a live server behind holding its pipes. Subprocesses are now started in their own process group and the group is swept after the polite shutdown sequence completes. On Windows the previous single-process teardown is retained.
+- **A stdio server writing heavily to `stderr` no longer wedges.** Its output went to a pipe nobody read, so once the operating system's pipe buffer filled, the server blocked mid-write and stopped answering requests entirely while still appearing to be running.
+
+### Changed
+
+- **MCP tools are advertised only when the request carries no tools of its own.** Previously every MCP tool definition was injected into every chat completion, alongside whatever the caller sent. That let the model answer with one MCP call and one caller call in the same turn — which neither side can complete: the gateway has no implementation for the caller's tool, and the caller never declared the MCP one. Requests that send their own `tools` array now pass through untouched, streaming included, and are unaffected by MCP entirely. Requests that send none behave exactly as before.
+- **`mcp_servers[].env` documentation corrected.** The published field documentation described `env` as merged with the gateway's environment. It is not, and was not: the values listed are combined with a minimal base only. The godoc, README, and example config now describe the actual behavior.
+- **Environment-reference documentation corrected across the config surface.** Several field docs and example comments described `$VAR` as a usable reference and attributed substitution to `LoadConfig`. Only the braced `${VAR}` form is a reference, a bare `$` is literal data, an undefined variable is an error, and resolution happens when the component is constructed — never at config load, which is what keeps secrets out of the config-history store. The behavior is unchanged since v1.2.0; only the documentation was wrong.
+
 ## [1.2.0] — 2026-07-14
 
 The capability release. The gateway now has a single, declarative record of what each provider can actually express, and enforces it — so a parameter a provider cannot honor is no longer silently dropped on the wire. Alongside it: per-request deadlines, per-target concurrency limits, split liveness/readiness probes, and a cross-provider conformance suite.
@@ -286,7 +313,7 @@ Enterprise-endpoint & Cohere fidelity release. The third provider-readiness reme
 
 ## [1.1.11] — 2026-07-03
 
-Native tier-1 provider fidelity release. Aligns the OpenAI, Anthropic, Google Gemini, and AWS Bedrock providers on request/response correctness: forwards multimodal image content and sampling parameters that the streaming paths previously dropped, surfaces token usage the Bedrock and Gemini streaming paths discarded, refreshes stale model catalogs, and consolidates the duplicated Anthropic Messages decoding shared by the native Anthropic and Anthropic-on-Bedrock paths. No breaking API changes relative to v1.1.10. Closes [#265](https://github.com/ferro-labs/ai-gateway/issues/265); advances [#264](https://github.com/ferro-labs/ai-gateway/issues/264) and [#286](https://github.com/ferro-labs/ai-gateway/issues/286).
+Native tier-1 provider fidelity release. <!-- drift-ok: release name, not a provider count --> Aligns the OpenAI, Anthropic, Google Gemini, and AWS Bedrock providers on request/response correctness: forwards multimodal image content and sampling parameters that the streaming paths previously dropped, surfaces token usage the Bedrock and Gemini streaming paths discarded, refreshes stale model catalogs, and consolidates the duplicated Anthropic Messages decoding shared by the native Anthropic and Anthropic-on-Bedrock paths. No breaking API changes relative to v1.1.10. Closes [#265](https://github.com/ferro-labs/ai-gateway/issues/265); advances [#264](https://github.com/ferro-labs/ai-gateway/issues/264) and [#286](https://github.com/ferro-labs/ai-gateway/issues/286).
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -383,11 +383,15 @@ mcp_servers:
   - name: brave-search
     command: npx
     args: ["-y", "@modelcontextprotocol/server-brave-search"]
+    # The subprocess does NOT inherit the gateway's environment: it gets
+    # PATH/HOME/LANG/TMPDIR plus exactly the keys below. This keeps gateway
+    # credentials out of MCP servers, so anything the server needs — including
+    # HTTPS_PROXY, NODE_PATH or SSL_CERT_FILE — must be listed here.
     env:
       BRAVE_API_KEY: ${BRAVE_API_KEY}
 ```
 
-`${VAR}` references in MCP headers, plugin config, and observability exporter config are substituted **when that component is constructed**, not when the config file is read. The config itself keeps the `${VAR}` reference for its whole life, so a secret is never written to the config-history store, never returned by `GET /admin/config`, and never restored into the database on a rollback — while the plugin, exporter, or MCP client still receives the real value.
+`${VAR}` references in MCP headers, MCP stdio `env`, plugin config, and observability exporter config are substituted **when that component is constructed**, not when the config file is read. The config itself keeps the `${VAR}` reference for its whole life, so a secret is never written to the config-history store, never returned by `GET /admin/config`, and never restored into the database on a rollback — while the plugin, exporter, or MCP client still receives the real value.
 
 Because substitution happens at construction rather than at file load, a `${VAR}` pushed through the admin/GitOps config API is resolved exactly the same way.
 

--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ Full methodology, raw results, and flamegraph analysis:
 ### 🤖 MCP (Model Context Protocol)
 
 - Agentic tool-call loop — the gateway drives `tool_calls` automatically
-- Streamable HTTP transport (MCP 2025-11-25 spec)
+- **Streamable HTTP transport** (MCP 2025-11-25 spec) and **stdio transport** (subprocess)
 - Tool filtering with `allowed_tools` and bounded `max_call_depth`
 - Multiple MCP servers with cross-server tool deduplication
 
@@ -369,7 +369,7 @@ plugins:
       backend: sqlite
       dsn: ferrogw-requests.db
 
-# MCP tool servers (optional)
+# MCP tool servers — HTTP transport
 mcp_servers:
   - name: my-tools
     url: https://mcp.example.com/mcp
@@ -378,6 +378,13 @@ mcp_servers:
     allowed_tools: [search, get_weather]
     max_call_depth: 5
     timeout_seconds: 30
+
+  # stdio transport — gateway spawns the subprocess
+  - name: brave-search
+    command: npx
+    args: ["-y", "@modelcontextprotocol/server-brave-search"]
+    env:
+      BRAVE_API_KEY: ${BRAVE_API_KEY}
 ```
 
 `${VAR}` references in MCP headers, plugin config, and observability exporter config are substituted **when that component is constructed**, not when the config file is read. The config itself keeps the `${VAR}` reference for its whole life, so a secret is never written to the config-history store, never returned by `GET /admin/config`, and never restored into the database on a rollback — while the plugin, exporter, or MCP client still receives the real value.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -103,9 +103,14 @@ Builds on the v1.1.4 forwarding fix to make per-provider parameter support **exp
 
 ## v1.3.0 — MCP stdio Transport
 
-Status: Planning (target 2026-07-17). Tracking issue: [#121](https://github.com/ferro-labs/ai-gateway/issues/121).
+Status: Release candidate — dated 2026-07-20, awaiting tag. Tracking issue: [#121](https://github.com/ferro-labs/ai-gateway/issues/121).
 
-- **stdio transport** for the Model Context Protocol so the gateway can speak MCP over stdio alongside the existing transport, enabling local / embedded MCP clients.
+### What ships
+
+- **stdio transport** for the Model Context Protocol: an `mcp_servers` entry may set `command` instead of `url`, and the gateway launches and supervises that process for its lifetime. Any `npx`, `uvx`, or binary MCP server works without a separate HTTP endpoint. Contributed by [@gr3enarr0w](https://github.com/gr3enarr0w).
+- **Subprocess environment isolation** — MCP servers do not inherit the gateway environment, so gateway credentials are unreachable from them. `${VAR}` in a server's `env` is resolved at client construction and redacted from `GET /admin/config`.
+- **Process-group teardown and stderr capture** — `npx`-style servers no longer leak their real worker on shutdown or reload, and a server's diagnostics reach the log instead of a pipe nobody reads.
+- **Two fixes to the existing MCP path**: a misconfigured server no longer collapses streaming gateway-wide, and caller-supplied tool calls are no longer intercepted by the agentic loop. Both affected operators regardless of whether they used stdio.
 
 ## v1.4.0 — Embeddable Gateway
 

--- a/config.example.json
+++ b/config.example.json
@@ -218,6 +218,20 @@
         "web_read"
       ],
       "timeout_seconds": 20
+    },
+    {
+      "name": "brave-search",
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-brave-search"],
+      "env": { "BRAVE_API_KEY": "${BRAVE_API_KEY}" },
+      "max_call_depth": 3
+    },
+    {
+      "name": "sqlite-db",
+      "command": "/path/to/venv/bin/python",
+      "args": ["-m", "mcp_server_sqlite", "--db-path", "/var/data/app.db"],
+      "allowed_tools": ["query", "list_tables"],
+      "max_call_depth": 5
     }
   ],
   "observability": {

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -201,8 +201,13 @@ plugins:
 # MCP (Model Context Protocol) agentic tool servers.
 # When configured, the gateway injects these tools into every chat completion
 # request and runs an agentic loop when the LLM returns tool_calls.
-# Requires MCP 2025-11-25 Streamable HTTP servers.
+#
+# Two transports are supported:
+#   • Streamable HTTP (MCP 2025-11-25) — set url; command must be omitted.
+#   • stdio                            — set command; url must be omitted.
 mcp_servers:
+  # ── HTTP transport examples ──────────────────────────────────────────────────
+
   # Local filesystem tool server (no auth required).
   - name: filesystem
     url: "http://localhost:3001/mcp"
@@ -228,6 +233,33 @@ mcp_servers:
       - web_search
       - web_read
     timeout_seconds: 20
+
+  # ── stdio transport examples ─────────────────────────────────────────────────
+  # The gateway launches the subprocess and communicates via stdin/stdout.
+  # The process runs for the lifetime of the gateway.
+
+  # npx-based MCP server (no pre-installation required).
+  - name: brave-search
+    command: npx
+    args:
+      - -y
+      - "@modelcontextprotocol/server-brave-search"
+    env:
+      BRAVE_API_KEY: "${BRAVE_API_KEY}"
+    max_call_depth: 3
+
+  # Python-based MCP server installed in a virtualenv.
+  - name: sqlite-db
+    command: /path/to/venv/bin/python
+    args:
+      - -m
+      - mcp_server_sqlite
+      - --db-path
+      - /var/data/app.db
+    allowed_tools:
+      - query
+      - list_tables
+    max_call_depth: 5
 
 # Compatibility controls how the gateway treats OpenAI request parameters that a
 # routed provider cannot express (see GET /v1/capabilities for the matrix).

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -125,7 +125,8 @@ aliases:
   code: deepseek-coder
 
 # Optional plugins
-# Plugin config string values loaded via LoadConfig support $VAR / ${VAR} interpolation.
+# Plugin config string values support ${VAR} references — only the braced form;
+# a bare $ is literal data. Resolved when the plugin is constructed, not at load.
 plugins:
   - name: word-filter
     type: guardrail
@@ -218,7 +219,9 @@ mcp_servers:
   - name: database
     url: "https://mcp-db.internal/mcp"
     headers:
-      # Values loaded via LoadConfig support $VAR / ${VAR} interpolation.
+      # ${VAR} is resolved when the MCP client is constructed, so the config
+      # keeps the reference and never stores the secret. Only the braced form is
+      # a reference; a bare $ is literal data, and an undefined variable errors.
       Authorization: "Bearer ${MCP_DB_TOKEN}"
     allowed_tools:
       - query_readonly
@@ -237,6 +240,13 @@ mcp_servers:
   # ── stdio transport examples ─────────────────────────────────────────────────
   # The gateway launches the subprocess and communicates via stdin/stdout.
   # The process runs for the lifetime of the gateway.
+  #
+  # The subprocess does NOT inherit the gateway's environment. It receives
+  # PATH, HOME, LANG and TMPDIR (when set) plus exactly the keys under `env`,
+  # so gateway credentials such as OPENAI_API_KEY and MASTER_KEY can never
+  # reach an MCP server. Anything else the server needs — HTTPS_PROXY,
+  # NODE_PATH, SSL_CERT_FILE, or SYSTEMROOT/APPDATA on Windows — must be
+  # listed explicitly.
 
   # npx-based MCP server (no pre-installation required).
   - name: brave-search
@@ -245,6 +255,9 @@ mcp_servers:
       - -y
       - "@modelcontextprotocol/server-brave-search"
     env:
+      # Resolved when the MCP client is constructed; the config keeps the
+      # reference. This is the only channel for a credential, since the
+      # gateway environment is not inherited.
       BRAVE_API_KEY: "${BRAVE_API_KEY}"
     max_call_depth: 3
 
@@ -284,11 +297,12 @@ observability:
     privacy_level: metadata  # none | metadata | full
     shutdown_grace: 10s      # per OTel shutdown stage; total can take up to 2x this value
     # headers:                       # OTLP export headers (e.g. vendor API keys)
-    #   dd-api-key: "${DATADOG_API_KEY}"   # values support ${ENV} interpolation
+    #   dd-api-key: "${DATADOG_API_KEY}"   # values support ${ENV_VAR} references
 
   # exporters lists plugin observability exporters that receive
   # gateway.request.completed / gateway.request.failed events.
-  # Config string values loaded via LoadConfig support $VAR / ${VAR} interpolation.
+  # Config string values support ${VAR} references — only the braced form;
+  # resolved when the exporter is constructed, not at config load.
   # Each entry names a factory registered via observability.RegisterExporter
   # in a plugin's init().  Unrecognised names emit a warning and are skipped
   # (non-fatal).  No built-in exporters ship with this repo — they are

--- a/config.go
+++ b/config.go
@@ -134,9 +134,13 @@ type ExporterConfig struct {
 	// Enabled gates the exporter. Set to false to temporarily disable
 	// without removing the config block.
 	Enabled bool `json:"enabled" yaml:"enabled"`
-	// Config is the exporter-specific configuration map. When loaded via
-	// LoadConfig, string values may reference environment variables using $VAR
-	// or ${VAR}; resolved values are passed to Exporter.Init at gateway startup.
+	// Config is the exporter-specific configuration map. String values may
+	// reference environment variables using ${VAR} — only the braced form is a
+	// reference, a bare $ is literal data, and an undefined variable is an
+	// error. References are resolved when the exporter is constructed, not when
+	// the config is loaded, so the Config never carries a materialised secret
+	// into the config-history store or GET /admin/config. Resolved values are
+	// passed to Exporter.Init at gateway startup.
 	Config map[string]any `json:"config,omitempty" yaml:"config,omitempty"`
 }
 
@@ -318,8 +322,11 @@ type CircuitBreakerConfig struct {
 	Timeout string `json:"timeout" yaml:"timeout"`
 }
 
-// PluginConfig holds plugin configuration. When loaded via LoadConfig, string
-// values in Config may reference environment variables using $VAR or ${VAR}.
+// PluginConfig holds plugin configuration. String values in Config may
+// reference environment variables using ${VAR} — only the braced form is a
+// reference, a bare $ is literal data, and an undefined variable is an error.
+// References are resolved when the plugin is constructed, not when the config
+// is loaded, so a secret never reaches the config-history store.
 type PluginConfig struct {
 	Name    string         `json:"name" yaml:"name"`
 	Type    string         `json:"type" yaml:"type"`

--- a/config_load.go
+++ b/config_load.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/ferro-labs/ai-gateway/internal/tracingpolicy"
+	pubmcp "github.com/ferro-labs/ai-gateway/mcp"
 	"github.com/ferro-labs/ai-gateway/providers/core"
 	"gopkg.in/yaml.v3"
 )
@@ -170,6 +171,28 @@ func ValidateConfig(cfg Config) error {
 		}
 	}
 
+	if err := validateMCPServers(cfg.MCPServers); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// validateMCPServers checks each server's transport selection: exactly one of
+// URL (Streamable HTTP) or Command (stdio) must be set. Leaving both empty fails
+// later during async initialization with a confusing error; leaving both set
+// silently prefers stdio and drops Headers, which is surprising.
+func validateMCPServers(servers []pubmcp.ServerConfig) error {
+	for _, mcpCfg := range servers {
+		hasURL := mcpCfg.URL != ""
+		hasCommand := mcpCfg.Command != ""
+		switch {
+		case hasURL && hasCommand:
+			return fmt.Errorf("mcp server %q: url and command are mutually exclusive; set exactly one to select transport", mcpCfg.Name)
+		case !hasURL && !hasCommand:
+			return fmt.Errorf("mcp server %q: either url (Streamable HTTP) or command (stdio) is required", mcpCfg.Name)
+		}
+	}
 	return nil
 }
 

--- a/config_load.go
+++ b/config_load.go
@@ -183,7 +183,19 @@ func ValidateConfig(cfg Config) error {
 // later during async initialization with a confusing error; leaving both set
 // silently prefers stdio and drops Headers, which is surprising.
 func validateMCPServers(servers []pubmcp.ServerConfig) error {
-	for _, mcpCfg := range servers {
+	seen := make(map[string]struct{}, len(servers))
+	for i, mcpCfg := range servers {
+		// Name is the registry key. An empty one produces a server nothing can
+		// refer to in logs or metrics; a duplicate silently replaces the earlier
+		// server, taking its tool mappings with it.
+		if strings.TrimSpace(mcpCfg.Name) == "" {
+			return fmt.Errorf("mcp server at index %d: name is required", i)
+		}
+		if _, dup := seen[mcpCfg.Name]; dup {
+			return fmt.Errorf("mcp server %q: duplicate name; each server needs a unique name", mcpCfg.Name)
+		}
+		seen[mcpCfg.Name] = struct{}{}
+
 		hasURL := mcpCfg.URL != ""
 		hasCommand := mcpCfg.Command != ""
 		switch {

--- a/config_load_test.go
+++ b/config_load_test.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	pubmcp "github.com/ferro-labs/ai-gateway/mcp"
 )
 
 func TestLoadConfig_Valid(t *testing.T) {
@@ -663,4 +665,43 @@ func writeTempFile(t *testing.T, name, content string) string {
 		t.Fatalf("writing temp file: %v", err)
 	}
 	return path
+}
+
+func TestValidateConfig_MCPServerTransportSelection(t *testing.T) {
+	base := Config{
+		Strategy: StrategyConfig{Mode: ModeSingle},
+		Targets:  []Target{{VirtualKey: "key1"}},
+	}
+
+	t.Run("url only is valid", func(t *testing.T) {
+		cfg := base
+		cfg.MCPServers = []pubmcp.ServerConfig{{Name: "http-server", URL: "https://mcp.example.com/mcp"}}
+		if err := ValidateConfig(cfg); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("command only is valid", func(t *testing.T) {
+		cfg := base
+		cfg.MCPServers = []pubmcp.ServerConfig{{Name: "stdio-server", Command: "npx", Args: []string{"some-mcp-server"}}}
+		if err := ValidateConfig(cfg); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("both url and command is invalid", func(t *testing.T) {
+		cfg := base
+		cfg.MCPServers = []pubmcp.ServerConfig{{Name: "ambiguous", URL: "https://mcp.example.com/mcp", Command: "npx"}}
+		if err := ValidateConfig(cfg); err == nil {
+			t.Error("expected error when both url and command are set, got nil")
+		}
+	})
+
+	t.Run("neither url nor command is invalid", func(t *testing.T) {
+		cfg := base
+		cfg.MCPServers = []pubmcp.ServerConfig{{Name: "empty"}}
+		if err := ValidateConfig(cfg); err == nil {
+			t.Error("expected error when neither url nor command is set, got nil")
+		}
+	})
 }

--- a/config_load_test.go
+++ b/config_load_test.go
@@ -705,3 +705,52 @@ func TestValidateConfig_MCPServerTransportSelection(t *testing.T) {
 		}
 	})
 }
+
+func TestValidateMCPServers_NameRequiredAndUnique(t *testing.T) {
+	base := Config{
+		Strategy: StrategyConfig{Mode: ModeSingle},
+		Targets:  []Target{{VirtualKey: "openai"}},
+	}
+
+	t.Run("empty name is rejected", func(t *testing.T) {
+		cfg := base
+		cfg.MCPServers = []pubmcp.ServerConfig{{URL: "https://mcp.example.com/mcp"}}
+		if err := ValidateConfig(cfg); err == nil {
+			t.Error("expected an error for an unnamed mcp server, got nil")
+		}
+	})
+
+	t.Run("whitespace-only name is rejected", func(t *testing.T) {
+		cfg := base
+		cfg.MCPServers = []pubmcp.ServerConfig{{Name: "   ", URL: "https://mcp.example.com/mcp"}}
+		if err := ValidateConfig(cfg); err == nil {
+			t.Error("expected an error for a whitespace-only mcp server name, got nil")
+		}
+	})
+
+	t.Run("duplicate names are rejected", func(t *testing.T) {
+		cfg := base
+		cfg.MCPServers = []pubmcp.ServerConfig{
+			{Name: "tools", URL: "https://a.example.com/mcp"},
+			{Name: "tools", URL: "https://b.example.com/mcp"},
+		}
+		err := ValidateConfig(cfg)
+		if err == nil {
+			t.Fatal("expected an error for duplicate mcp server names, got nil")
+		}
+		if !strings.Contains(err.Error(), "tools") {
+			t.Errorf("error %q should name the duplicated server", err)
+		}
+	})
+
+	t.Run("distinct names are accepted", func(t *testing.T) {
+		cfg := base
+		cfg.MCPServers = []pubmcp.ServerConfig{
+			{Name: "a", URL: "https://a.example.com/mcp"},
+			{Name: "b", Command: "npx"},
+		}
+		if err := ValidateConfig(cfg); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+}

--- a/gateway.go
+++ b/gateway.go
@@ -502,6 +502,9 @@ func (g *Gateway) FindStreamingByModel(model string) (providers.StreamProvider, 
 // times out — Close must never block indefinitely (a panicking hook could
 // otherwise wedge shutdown).
 //
+// For stdio MCP servers this terminates their subprocesses; HTTP MCP servers
+// require no explicit teardown.
+//
 // Safe to call multiple times; subsequent calls are no-ops.
 func (g *Gateway) Close() error {
 	g.closeOnce.Do(func() {
@@ -524,5 +527,8 @@ func (g *Gateway) Close() error {
 		case <-time.After(5 * time.Second):
 		}
 	})
+	if g.mcpRegistry != nil {
+		_ = g.mcpRegistry.Close()
+	}
 	return nil
 }

--- a/gateway.go
+++ b/gateway.go
@@ -526,9 +526,9 @@ func (g *Gateway) Close() error {
 		case <-done:
 		case <-time.After(5 * time.Second):
 		}
+		if g.mcpRegistry != nil {
+			_ = g.mcpRegistry.Close()
+		}
 	})
-	if g.mcpRegistry != nil {
-		_ = g.mcpRegistry.Close()
-	}
 	return nil
 }

--- a/gateway.go
+++ b/gateway.go
@@ -12,6 +12,7 @@ package aigateway
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"maps"
@@ -34,18 +35,28 @@ import (
 
 // Gateway is the main entry point for routing LLM requests.
 type Gateway struct {
-	mu                 sync.RWMutex
-	config             Config
-	catalog            models.Catalog
-	providers          map[string]providers.Provider
-	providerNames      []string
-	strategy           strategies.Strategy
-	streamingContent   []streamingContentCondition
-	plugins            *plugin.Manager
-	requestLogWriter   requestlog.Writer
-	closeOnce          sync.Once
+	mu               sync.RWMutex
+	config           Config
+	catalog          models.Catalog
+	providers        map[string]providers.Provider
+	providerNames    []string
+	strategy         strategies.Strategy
+	streamingContent []streamingContentCondition
+	plugins          *plugin.Manager
+	requestLogWriter requestlog.Writer
+	closeOnce        sync.Once
+	// closed is set under mu by Close. ReloadConfig checks it because closeOnce
+	// has already fired by then: a reload landing after shutdown would build a
+	// fresh MCP registry, spawn its subprocesses, and leave nothing to ever
+	// close them.
+	closed             bool
 	hooks              *hookBus
 	catalogRefreshDone sync.WaitGroup
+	// pendingMCPCloses tracks registries retired by a config reload, whose
+	// teardown runs asynchronously. Close waits on it so a reload landing just
+	// before shutdown cannot leave a subprocess termination ladder running past
+	// process exit.
+	pendingMCPCloses sync.WaitGroup
 	// shutdownCtx is a lifecycle context, not a request context. Storing it on the
 	// struct is the intended idiom here: it is created once in New, parents the
 	// gateway's background workers (hook dispatch, catalog refresh, MCP init), and
@@ -312,6 +323,10 @@ func (g *Gateway) ReloadConfig(ctx context.Context, cfg Config) error {
 		}
 	}()
 	g.mu.Lock()
+	if g.closed {
+		g.mu.Unlock()
+		return errors.New("gateway is closed")
+	}
 	oldPlugins := g.plugins
 	g.config = cfg
 	g.streamingContent = streamingContent
@@ -423,6 +438,17 @@ func acquirePluginManager(plugins *plugin.Manager) func() {
 	return plugins.Acquire()
 }
 
+// acquireMCPRegistry pins a registry snapshot for the life of one request, so a
+// concurrent config reload retires the old registry only after this request has
+// finished with it. Without it, a reload terminates the stdio subprocess
+// underneath an in-flight tool call and the call fails with "transport closed".
+func acquireMCPRegistry(reg *mcp.Registry) func() {
+	if reg == nil {
+		return func() {}
+	}
+	return reg.Acquire()
+}
+
 // ── Registry-consolidation helpers ──────────────────────────────────────────
 // These methods make *Gateway satisfy providers.ProviderSource so that HTTP
 // handlers that previously held a *providers.Registry can accept the gateway
@@ -509,15 +535,40 @@ func (g *Gateway) FindStreamingByModel(model string) (providers.StreamProvider, 
 func (g *Gateway) Close() error {
 	g.closeOnce.Do(func() {
 		g.shutdownCancel()
+		// Snapshot and clear the MCP registry under the same lock that
+		// ReloadConfig writes it through. Reading g.mcpRegistry after unlocking
+		// raced with a concurrent reload, and the losing interleaving left a
+		// live registry unclosed — every subprocess leaked for the life of the
+		// process, since closeOnce can never fire again.
 		g.mu.Lock()
 		plugins := g.plugins
 		g.plugins = plugin.NewManager()
+		mcpRegistry := g.mcpRegistry
+		g.mcpRegistry = nil
+		g.mcpExecutor = nil
+		g.closed = true
 		g.mu.Unlock()
 		if err := closePluginManager(plugins); err != nil {
 			slog.Warn("plugin close failed during gateway shutdown", "error", err)
 		}
+		// Retire MCP *inside* the bounded drain, not ahead of it. With no active
+		// holders Close tears transports down inline, and one wedged stdio server
+		// can spend seconds in the graceful/SIGTERM/SIGKILL ladder — ahead of the
+		// budget that would consume the whole grace period before the timer even
+		// starts, and an orchestrator would SIGKILL mid-cleanup.
+		//
+		// The wait also covers registries retired by earlier reloads, whose
+		// teardown runs in its own goroutine. Without that a reload shortly
+		// before shutdown could leave a termination ladder running past process
+		// exit, orphaning exactly the subprocess the sweep exists to reap.
 		done := make(chan struct{})
 		go func() {
+			if mcpRegistry != nil {
+				if err := mcpRegistry.Close(); err != nil {
+					slog.Warn("mcp registry close failed during gateway shutdown", "error", err)
+				}
+			}
+			g.pendingMCPCloses.Wait()
 			g.hooks.wait()
 			g.catalogRefreshDone.Wait()
 			close(done)
@@ -525,9 +576,6 @@ func (g *Gateway) Close() error {
 		select {
 		case <-done:
 		case <-time.After(5 * time.Second):
-		}
-		if g.mcpRegistry != nil {
-			_ = g.mcpRegistry.Close()
 		}
 	})
 	return nil

--- a/gateway_mcp.go
+++ b/gateway_mcp.go
@@ -2,6 +2,7 @@ package aigateway
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"time"
 
@@ -60,15 +61,49 @@ const mcpInitTimeout = 60 * time.Second
 // It is safe to call from New (before the gateway is published, so no lock is
 // held) and from ReloadConfig (with g.mu held by the caller); the field writes
 // target the same gateway and, once published, are serialized by g.mu.
+// resolveMCPServerRefs returns a copy of cfg with its ${VAR} references
+// resolved, ready to hand to the transport.
+//
+// Resolution happens here rather than at config load so the Config keeps the
+// references: a bearer token or API key is never persisted to the config store
+// nor served by GET /admin/config. The returned copy owns fresh maps, so the
+// caller's Config is never mutated.
+//
+// Both Headers and Env are resolved. Env matters most: MCP subprocesses do not
+// inherit the gateway's environment (see internal/mcp.newStdioClient), which
+// makes this map the only route by which a credential can reach one.
+func resolveMCPServerRefs(cfg pubmcp.ServerConfig) (pubmcp.ServerConfig, error) {
+	headers, err := envref.StringMap(cfg.Headers)
+	if err != nil {
+		return pubmcp.ServerConfig{}, fmt.Errorf("headers: %w", err)
+	}
+	env, err := envref.StringMap(cfg.Env)
+	if err != nil {
+		return pubmcp.ServerConfig{}, fmt.Errorf("env: %w", err)
+	}
+	cfg.Headers = headers
+	cfg.Env = env
+	return cfg, nil
+}
+
 func (g *Gateway) wireMCPLocked(cfg Config, failLogMsg string) {
 	// The previous registry — and any live stdio subprocess clients it holds — is
-	// swapped out below. Close it, or a reload leaks an orphaned subprocess per
+	// swapped out below. Retire it, or a reload leaks an orphaned subprocess per
 	// stdio server: RegisterConfig only closes old clients when re-registering
-	// into the *same* Registry, and this rebuilds a fresh one. Closing runs in a
-	// goroutine because the caller holds g.mu and shutting a subprocess down can
-	// block. Nil on the construction path, where there is nothing to close.
+	// into the *same* Registry, and this rebuilds a fresh one.
+	//
+	// Registry.Close is refcounted, so requests already holding this snapshot
+	// keep their subprocesses until they finish; teardown happens once the last
+	// one releases. Still dispatched to a goroutine because the caller holds
+	// g.mu and an unheld registry closes inline, which can block on the
+	// transport's shutdown ladder. Nil on the construction path.
 	if old := g.mcpRegistry; old != nil {
+		// Tracked, not fire-and-forget: Gateway.Close waits on this group, so a
+		// reload immediately before shutdown cannot leave the termination ladder
+		// running past process exit.
+		g.pendingMCPCloses.Add(1)
 		go func() {
+			defer g.pendingMCPCloses.Done()
 			if err := old.Close(); err != nil {
 				slog.Error("mcp: failed to close previous registry after reload", "error", err)
 			}
@@ -85,10 +120,7 @@ func (g *Gateway) wireMCPLocked(cfg Config, failLogMsg string) {
 	reg := mcp.NewRegistry()
 	registered := make([]pubmcp.ServerConfig, 0, len(cfg.MCPServers))
 	for _, mcpCfg := range cfg.MCPServers {
-		// Resolve ${VAR} references into the MCP client's headers here, not in the
-		// Config: the Config keeps the references, so a bearer token is never
-		// persisted to the config store nor served by GET /admin/config.
-		headers, err := envref.StringMap(mcpCfg.Headers)
+		resolved, err := resolveMCPServerRefs(mcpCfg)
 		if err != nil {
 			// Skip only this server: an unrelated server's config must not be able to
 			// disable every other server, and the caller (ReloadConfig) must still get
@@ -96,9 +128,8 @@ func (g *Gateway) wireMCPLocked(cfg Config, failLogMsg string) {
 			slog.Error(failLogMsg, "server", mcpCfg.Name, "error", err)
 			continue
 		}
-		mcpCfg.Headers = headers
-		reg.RegisterConfig(mcpCfg)
-		registered = append(registered, mcpCfg)
+		reg.RegisterConfig(resolved)
+		registered = append(registered, resolved)
 	}
 
 	// Only servers that actually registered can contribute to the shared

--- a/gateway_mcp.go
+++ b/gateway_mcp.go
@@ -61,6 +61,20 @@ const mcpInitTimeout = 60 * time.Second
 // held) and from ReloadConfig (with g.mu held by the caller); the field writes
 // target the same gateway and, once published, are serialized by g.mu.
 func (g *Gateway) wireMCPLocked(cfg Config, failLogMsg string) {
+	// The previous registry — and any live stdio subprocess clients it holds — is
+	// swapped out below. Close it, or a reload leaks an orphaned subprocess per
+	// stdio server: RegisterConfig only closes old clients when re-registering
+	// into the *same* Registry, and this rebuilds a fresh one. Closing runs in a
+	// goroutine because the caller holds g.mu and shutting a subprocess down can
+	// block. Nil on the construction path, where there is nothing to close.
+	if old := g.mcpRegistry; old != nil {
+		go func() {
+			if err := old.Close(); err != nil {
+				slog.Error("mcp: failed to close previous registry after reload", "error", err)
+			}
+		}()
+	}
+
 	if len(cfg.MCPServers) == 0 {
 		g.mcpRegistry = nil
 		g.mcpExecutor = nil

--- a/gateway_mcp_caller_tools_test.go
+++ b/gateway_mcp_caller_tools_test.go
@@ -1,0 +1,325 @@
+package aigateway
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ferro-labs/ai-gateway/mcp"
+	"github.com/ferro-labs/ai-gateway/plugin"
+	providers "github.com/ferro-labs/ai-gateway/providers"
+)
+
+// callerTool is a tool the client declares and intends to execute itself.
+func callerTool() providers.Tool {
+	return providers.Tool{
+		Type: "function",
+		Function: providers.Function{
+			Name:        "client_side_lookup",
+			Description: "Executed by the caller, not the gateway.",
+		},
+	}
+}
+
+// The gateway must not advertise MCP tools on a request whose caller supplied
+// its own tools array.
+//
+// Injecting both manufactures a turn neither party can resolve: the gateway
+// cannot answer the caller's calls, and the caller cannot answer a tool it never
+// declared and has no implementation for. Before this guard the gateway
+// advertised mcp tools unconditionally, the model could call one alongside a
+// caller tool, and the executor's ownership gate then declined the whole turn —
+// returning a 200 carrying a tool_call_id the client could not act on, with no
+// error surfaced anywhere.
+func TestRoute_CallerSuppliedToolsSuppressMCPInjection(t *testing.T) {
+	mcpSrv := newMCPTestServer(t)
+	defer mcpSrv.Close()
+
+	var (
+		mu   sync.Mutex
+		seen []providers.Tool
+	)
+	mp := &mockProvider{
+		name:   "mock-tools",
+		models: []string{"gpt-4o"},
+		completeFn: func(_ context.Context, req providers.Request) (*providers.Response, error) {
+			mu.Lock()
+			seen = append([]providers.Tool{}, req.Tools...)
+			mu.Unlock()
+			return &providers.Response{
+				ID:    "r1",
+				Model: "gpt-4o",
+				Choices: []providers.Choice{{
+					Message:      providers.Message{Role: "assistant", Content: "done"},
+					FinishReason: "stop",
+				}},
+			}, nil
+		},
+	}
+
+	gw, err := newTestGateway(t, Config{
+		Strategy:   StrategyConfig{Mode: ModeSingle},
+		Targets:    []Target{{VirtualKey: "mock-tools"}},
+		MCPServers: []mcp.ServerConfig{{Name: "s1", URL: mcpSrv.URL, TimeoutSeconds: 5}},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	gw.RegisterProvider(mp)
+
+	select {
+	case <-gw.MCPInitDone():
+	case <-time.After(10 * time.Second):
+		t.Fatal("MCP init timeout")
+	}
+
+	if _, err := gw.Route(context.Background(), providers.Request{
+		Model:    "gpt-4o",
+		Tools:    []providers.Tool{callerTool()},
+		Messages: []providers.Message{{Role: "user", Content: "hi"}},
+	}); err != nil {
+		t.Fatalf("Route: %v", err)
+	}
+
+	mu.Lock()
+	got := seen
+	mu.Unlock()
+
+	if len(got) != 1 {
+		t.Fatalf("provider saw %d tools, want only the caller's 1: %+v", len(got), got)
+	}
+	if got[0].Function.Name != "client_side_lookup" {
+		t.Errorf("provider saw tool %q, want the caller's client_side_lookup", got[0].Function.Name)
+	}
+	for _, tool := range got {
+		if tool.Function.Name == "get_answer" {
+			t.Error("gateway injected an MCP tool alongside the caller's own tools; " +
+				"the model can then emit a turn neither party can resolve")
+		}
+	}
+}
+
+// With no caller tools, MCP still participates exactly as before.
+func TestRoute_NoCallerToolsStillInjectsMCP(t *testing.T) {
+	mcpSrv := newMCPTestServer(t)
+	defer mcpSrv.Close()
+
+	var (
+		mu   sync.Mutex
+		seen []providers.Tool
+	)
+	mp := &mockProvider{
+		name:   "mock-tools2",
+		models: []string{"gpt-4o"},
+		completeFn: func(_ context.Context, req providers.Request) (*providers.Response, error) {
+			mu.Lock()
+			seen = append([]providers.Tool{}, req.Tools...)
+			mu.Unlock()
+			return &providers.Response{
+				ID:    "r1",
+				Model: "gpt-4o",
+				Choices: []providers.Choice{{
+					Message:      providers.Message{Role: "assistant", Content: "done"},
+					FinishReason: "stop",
+				}},
+			}, nil
+		},
+	}
+
+	gw, err := newTestGateway(t, Config{
+		Strategy:   StrategyConfig{Mode: ModeSingle},
+		Targets:    []Target{{VirtualKey: "mock-tools2"}},
+		MCPServers: []mcp.ServerConfig{{Name: "s1", URL: mcpSrv.URL, TimeoutSeconds: 5}},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	gw.RegisterProvider(mp)
+
+	select {
+	case <-gw.MCPInitDone():
+	case <-time.After(10 * time.Second):
+		t.Fatal("MCP init timeout")
+	}
+
+	if _, err := gw.Route(context.Background(), providers.Request{
+		Model:    "gpt-4o",
+		Messages: []providers.Message{{Role: "user", Content: "hi"}},
+	}); err != nil {
+		t.Fatalf("Route: %v", err)
+	}
+
+	mu.Lock()
+	got := seen
+	mu.Unlock()
+
+	var found bool
+	for _, tool := range got {
+		if tool.Function.Name == "get_answer" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("MCP tool was not injected for a caller that supplied none: %+v", got)
+	}
+}
+
+// Suppressing injection must also restore streaming: MCP is not participating,
+// so there is nothing to buffer the stream for.
+func TestRouteStream_CallerSuppliedToolsKeepStreaming(t *testing.T) {
+	mcpSrv := newMCPTestServer(t)
+	defer mcpSrv.Close()
+
+	const wantChunks = 3
+	sp := &chunkStreamProvider{
+		mockProvider: mockProvider{name: "mock-stream-tools", models: []string{"gpt-4o"}},
+		chunks:       wantChunks,
+	}
+
+	gw, err := newTestGateway(t, Config{
+		Strategy:   StrategyConfig{Mode: ModeSingle},
+		Targets:    []Target{{VirtualKey: "mock-stream-tools"}},
+		MCPServers: []mcp.ServerConfig{{Name: "s1", URL: mcpSrv.URL, TimeoutSeconds: 5}},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	gw.RegisterProvider(sp)
+
+	select {
+	case <-gw.MCPInitDone():
+	case <-time.After(10 * time.Second):
+		t.Fatal("MCP init timeout")
+	}
+
+	ch, err := gw.RouteStream(context.Background(), providers.Request{
+		Model:    "gpt-4o",
+		Stream:   true,
+		Tools:    []providers.Tool{callerTool()},
+		Messages: []providers.Message{{Role: "user", Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("RouteStream: %v", err)
+	}
+
+	var got int
+	for chunk := range ch {
+		if chunk.Error != nil {
+			t.Fatalf("stream chunk error: %v", chunk.Error)
+		}
+		got++
+	}
+	if got != wantChunks {
+		t.Fatalf("got %d chunks, want %d — MCP collapsed the stream for a caller "+
+			"whose own tools mean MCP is not participating", got, wantChunks)
+	}
+}
+
+// A before_request plugin that adds tools must not retroactively disable MCP.
+//
+// RouteStream decides whether to divert a streaming request into the agentic
+// loop before plugins run; Route used to decide whether MCP participates after
+// they run. A transform plugin adding tools in between produced the worst of
+// both: the stream was already diverted and buffered, and then MCP was switched
+// off, so the caller lost streaming and got no agentic loop for it. Both
+// decisions now read the caller's original request.
+//
+// Chunk count cannot distinguish the two cases — an active MCP loop collapses
+// the stream legitimately — so the assertion is on whether MCP actually
+// participated, i.e. whether its tools reached the provider.
+func TestRouteStream_PluginAddedToolsDoNotDisableMCP(t *testing.T) {
+	mcpSrv := newMCPTestServer(t)
+	defer mcpSrv.Close()
+
+	var (
+		mu   sync.Mutex
+		seen []providers.Tool
+	)
+	mp := &mockProvider{
+		name:   "mock-plugin-tools",
+		models: []string{"gpt-4o"},
+		completeFn: func(_ context.Context, req providers.Request) (*providers.Response, error) {
+			mu.Lock()
+			seen = append([]providers.Tool{}, req.Tools...)
+			mu.Unlock()
+			return &providers.Response{
+				ID:    "r1",
+				Model: "gpt-4o",
+				Choices: []providers.Choice{{
+					Message:      providers.Message{Role: "assistant", Content: "done"},
+					FinishReason: "stop",
+				}},
+			}, nil
+		},
+	}
+
+	// The MCP server must actually be registered: without it g.mcpRegistry is
+	// nil, RouteStream's diversion gate can never fire, and the assertion below
+	// would hold whether or not the fix is present.
+	gw, err := newTestGateway(t, Config{
+		Strategy:   StrategyConfig{Mode: ModeSingle},
+		Targets:    []Target{{VirtualKey: "mock-plugin-tools"}},
+		MCPServers: []mcp.ServerConfig{{Name: "s1", URL: mcpSrv.URL, TimeoutSeconds: 5}},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	gw.RegisterProvider(mp)
+
+	select {
+	case <-gw.MCPInitDone():
+	case <-time.After(10 * time.Second):
+		t.Fatal("MCP init timeout")
+	}
+
+	// Adds a tool the caller never sent, mid-flight.
+	if err := gw.RegisterPlugin(plugin.StageBeforeRequest, &testPlugin{
+		name: "tool-adder",
+		typ:  plugin.TypeTransform,
+		execFn: func(_ context.Context, pctx *plugin.Context) error {
+			if pctx.Request != nil {
+				pctx.Request.Tools = append(pctx.Request.Tools, callerTool())
+			}
+			return nil
+		},
+	}); err != nil {
+		t.Fatalf("RegisterPlugin: %v", err)
+	}
+
+	ch, err := gw.RouteStream(context.Background(), providers.Request{
+		Model:    "gpt-4o",
+		Stream:   true,
+		Messages: []providers.Message{{Role: "user", Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("RouteStream: %v", err)
+	}
+	for chunk := range ch {
+		if chunk.Error != nil {
+			t.Fatalf("stream chunk error: %v", chunk.Error)
+		}
+	}
+
+	mu.Lock()
+	got := seen
+	mu.Unlock()
+
+	var sawMCPTool, sawPluginTool bool
+	for _, tool := range got {
+		switch tool.Function.Name {
+		case "get_answer":
+			sawMCPTool = true
+		case "client_side_lookup":
+			sawPluginTool = true
+		}
+	}
+	if !sawPluginTool {
+		t.Fatalf("the plugin's tool never reached the provider (%+v); the probe is broken, "+
+			"so the assertion below would pass vacuously", got)
+	}
+	if !sawMCPTool {
+		t.Errorf("MCP was disabled by a plugin-added tool after the stream had already been "+
+			"diverted — the caller lost streaming and got no agentic loop for it: %+v", got)
+	}
+}

--- a/gateway_mcp_env_test.go
+++ b/gateway_mcp_env_test.go
@@ -1,0 +1,70 @@
+package aigateway
+
+import (
+	"testing"
+
+	"github.com/ferro-labs/ai-gateway/mcp"
+)
+
+// B5: the gateway's environment is deliberately not inherited by MCP
+// subprocesses, so ServerConfig.Env is the only channel by which a credential
+// can reach one. Before this fix ${VAR} was resolved for Headers only, so a
+// subprocess received the literal reference and there was no working way to
+// pass a secret at all — which is what config.example.yaml's BRAVE_API_KEY
+// entry depended on.
+func TestResolveMCPServerRefs_ResolvesEnvAndHeaders(t *testing.T) {
+	t.Setenv("FERRO_TEST_MCP_SECRET", "s3cret-value")
+	t.Setenv("FERRO_TEST_MCP_TOKEN", "tok-123")
+
+	in := mcp.ServerConfig{
+		Name:    "srv",
+		Command: "true",
+		Env:     map[string]string{"API_KEY": "${FERRO_TEST_MCP_SECRET}"},
+		Headers: map[string]string{"Authorization": "Bearer ${FERRO_TEST_MCP_TOKEN}"},
+	}
+
+	got, err := resolveMCPServerRefs(in)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Env["API_KEY"] != "s3cret-value" {
+		t.Errorf("Env[API_KEY] = %q, want %q", got.Env["API_KEY"], "s3cret-value")
+	}
+	if got.Headers["Authorization"] != "Bearer tok-123" {
+		t.Errorf("Headers[Authorization] = %q, want %q", got.Headers["Authorization"], "Bearer tok-123")
+	}
+}
+
+// The caller's Config must keep the reference, never the resolved secret —
+// otherwise the secret reaches the config-history store and GET /admin/config.
+func TestResolveMCPServerRefs_DoesNotMutateInput(t *testing.T) {
+	t.Setenv("FERRO_TEST_MCP_SECRET", "s3cret-value")
+
+	env := map[string]string{"API_KEY": "${FERRO_TEST_MCP_SECRET}"}
+	in := mcp.ServerConfig{Name: "srv", Command: "true", Env: env}
+
+	if _, err := resolveMCPServerRefs(in); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if env["API_KEY"] != "${FERRO_TEST_MCP_SECRET}" {
+		t.Errorf("input Env was mutated to %q; the resolved secret must not leak back into Config", env["API_KEY"])
+	}
+}
+
+// An unresolvable reference in Env must fail the server the same way an
+// unresolvable header does, rather than silently starting a subprocess with a
+// broken credential.
+func TestResolveMCPServerRefs_UndefinedEnvVarIsAnError(t *testing.T) {
+	requireUnsetEnv(t, mcpUndefinedVar)
+
+	in := mcp.ServerConfig{
+		Name:    "srv",
+		Command: "true",
+		Env:     map[string]string{"API_KEY": "${" + mcpUndefinedVar + "}"},
+	}
+
+	if _, err := resolveMCPServerRefs(in); err == nil {
+		t.Fatal("expected an error for an undefined ${VAR} in Env, got nil")
+	}
+}

--- a/gateway_mcp_lifecycle_test.go
+++ b/gateway_mcp_lifecycle_test.go
@@ -1,0 +1,79 @@
+package aigateway
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ferro-labs/ai-gateway/mcp"
+)
+
+// R8: closeOnce has already fired by the time a late reload lands, so a registry
+// built after shutdown would spawn its subprocesses and leave nothing able to
+// close them — leaked for the life of the host process.
+func TestReloadConfigAfterCloseIsRejected(t *testing.T) {
+	gw, err := New(Config{
+		Strategy: StrategyConfig{Mode: ModeSingle},
+		Targets:  []Target{{VirtualKey: "openai"}},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	if err := gw.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	err = gw.ReloadConfig(context.Background(), Config{
+		Strategy: StrategyConfig{Mode: ModeSingle},
+		Targets:  []Target{{VirtualKey: "openai"}},
+		MCPServers: []mcp.ServerConfig{{
+			Name: "late", URL: "http://127.0.0.1:1/mcp",
+		}},
+	})
+	if err == nil {
+		t.Fatal("ReloadConfig after Close succeeded; it would spawn MCP subprocesses nothing can ever close")
+	}
+}
+
+// R5: ReloadConfig writes g.mcpRegistry under g.mu while Close used to read it
+// after unlocking. Race-detector reproducible, and the losing interleaving left
+// a live registry unclosed. Run this with -race.
+func TestCloseAndReloadConfigDoNotRace(t *testing.T) {
+	mcpSrv := newMCPTestServer(t)
+	defer mcpSrv.Close()
+
+	base := Config{
+		Strategy: StrategyConfig{Mode: ModeSingle},
+		Targets:  []Target{{VirtualKey: "openai"}},
+		MCPServers: []mcp.ServerConfig{{
+			Name: "s1", URL: mcpSrv.URL, TimeoutSeconds: 5,
+		}},
+	}
+
+	gw, err := New(base)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	select {
+	case <-gw.MCPInitDone():
+	case <-time.After(10 * time.Second):
+		t.Fatal("MCP init timeout")
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		// A late reload may legitimately be rejected once Close has won the
+		// race; both outcomes are correct, neither may race or leak.
+		_ = gw.ReloadConfig(context.Background(), base)
+	}()
+	go func() {
+		defer wg.Done()
+		_ = gw.Close()
+	}()
+	wg.Wait()
+}

--- a/gateway_mcp_stream_gate_test.go
+++ b/gateway_mcp_stream_gate_test.go
@@ -1,0 +1,98 @@
+package aigateway
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/ferro-labs/ai-gateway/mcp"
+	providers "github.com/ferro-labs/ai-gateway/providers"
+)
+
+// chunkStreamProvider emits several chunks so a test can tell real streaming
+// from the MCP redirect, which collapses the whole response into one chunk.
+type chunkStreamProvider struct {
+	mockProvider
+	chunks int
+}
+
+func (c *chunkStreamProvider) CompleteStream(ctx context.Context, _ providers.Request) (<-chan providers.StreamChunk, error) {
+	ch := make(chan providers.StreamChunk, c.chunks)
+	go func() {
+		defer close(ch)
+		for i := 0; i < c.chunks; i++ {
+			select {
+			case ch <- providers.StreamChunk{
+				ID:    "chunk",
+				Model: "gpt-4o",
+				Choices: []providers.StreamChoice{{
+					Delta: providers.MessageDelta{Content: "tok"},
+				}},
+			}:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+	return ch, nil
+}
+
+// A configured-but-unreachable MCP server must not disable streaming.
+//
+// Regression guard for B1: RouteStream gated on Registry.HasServers(), which is
+// true from the moment a server is *registered* — before, and regardless of,
+// the handshake. One typo'd command or a dead URL therefore turned every
+// stream:true request on the gateway into a fake single-chunk stream, forever,
+// for every caller — including callers who never used MCP.
+func TestGateway_RouteStream_BrokenMCPServerDoesNotDisableStreaming(t *testing.T) {
+	const wantChunks = 3
+
+	sp := &chunkStreamProvider{
+		mockProvider: mockProvider{name: "mock-stream", models: []string{"gpt-4o"}},
+		chunks:       wantChunks,
+	}
+
+	gw, err := newTestGateway(t, Config{
+		Strategy: StrategyConfig{Mode: ModeSingle},
+		Targets:  []Target{{VirtualKey: "mock-stream"}},
+		MCPServers: []mcp.ServerConfig{{
+			// Reserved discard port: registration succeeds, the handshake never does.
+			Name:           "dead-mcp",
+			URL:            "http://127.0.0.1:1/mcp",
+			TimeoutSeconds: 1,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	gw.RegisterProvider(sp)
+
+	// Let initialization run and fail before routing.
+	select {
+	case <-gw.MCPInitDone():
+	case <-time.After(10 * time.Second):
+		t.Fatal("MCP init timeout")
+	}
+
+	ch, err := gw.RouteStream(context.Background(), providers.Request{
+		Model:    "gpt-4o",
+		Stream:   true,
+		Messages: []providers.Message{{Role: "user", Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("RouteStream error: %v", err)
+	}
+
+	var got int
+	for chunk := range ch {
+		if chunk.Error != nil {
+			t.Fatalf("stream chunk error: %v", chunk.Error)
+		}
+		got++
+	}
+
+	if got != wantChunks {
+		t.Fatalf("got %d chunks, want %d — a dead MCP server collapsed the stream "+
+			"(got 1 chunk means RouteStream took the MCP redirect)", got, wantChunks)
+	}
+}

--- a/gateway_mcp_test.go
+++ b/gateway_mcp_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"slices"
 	"testing"
+	"time"
 
 	"github.com/ferro-labs/ai-gateway/mcp"
 	"github.com/ferro-labs/ai-gateway/providers/core"
@@ -139,6 +140,12 @@ func TestWireMCPLocked_MaxCallDepthIgnoresSkippedServers(t *testing.T) {
 	gw.shutdownCancel = cancel
 	t.Cleanup(cancel)
 
+	// The good server must actually serve tools: ShouldContinueLoop only arms
+	// for tool calls MCP owns, so a registry that discovered nothing can no
+	// longer stand in for a healthy one.
+	goodSrv := newMCPTestServer(t)
+	defer goodSrv.Close()
+
 	cfg := Config{
 		MCPServers: []mcp.ServerConfig{
 			{
@@ -151,7 +158,7 @@ func TestWireMCPLocked_MaxCallDepthIgnoresSkippedServers(t *testing.T) {
 			},
 			{
 				Name:         "good",
-				URL:          "http://127.0.0.1:1/mcp",
+				URL:          goodSrv.URL,
 				MaxCallDepth: 5,
 			},
 		},
@@ -163,9 +170,15 @@ func TestWireMCPLocked_MaxCallDepthIgnoresSkippedServers(t *testing.T) {
 		t.Fatal("mcpExecutor is nil, want an executor built from the well-formed server")
 	}
 
+	select {
+	case <-gw.MCPInitDone():
+	case <-time.After(10 * time.Second):
+		t.Fatal("MCP init timeout")
+	}
+
 	resp := &core.Response{
 		Choices: []core.Choice{
-			{Message: core.Message{ToolCalls: []core.ToolCall{{ID: "1", Function: core.FunctionCall{Name: "x"}}}}},
+			{Message: core.Message{ToolCalls: []core.ToolCall{{ID: "1", Function: core.FunctionCall{Name: "get_answer"}}}}},
 		},
 	}
 

--- a/gateway_route.go
+++ b/gateway_route.go
@@ -136,10 +136,12 @@ func (g *Gateway) Route(ctx context.Context, req providers.Request) (*providers.
 	obsEventsActive := g.obsEventsActive
 	mcpRegistrySnapshot := g.mcpRegistry
 	mcpExecutorSnapshot := g.mcpExecutor
+	releaseMCP := acquireMCPRegistry(mcpRegistrySnapshot)
 	plugins := g.plugins
 	releasePlugins := acquirePluginManager(plugins)
 	g.mu.RUnlock()
 	defer releasePlugins()
+	defer releaseMCP()
 
 	// Bound the whole non-streaming request — plugin stages, provider call, and
 	// every retry/fallback attempt — when a request timeout is configured. The
@@ -169,6 +171,15 @@ func (g *Gateway) Route(ctx context.Context, req providers.Request) (*providers.
 	// before any early plugin short-circuit, so hook/observability consumers
 	// always see the client's requested stream preference.
 	originalStream := req.Stream
+
+	// Whether the *caller* sent tools, captured before before_request plugins
+	// can mutate req.Tools. MCP participation is a statement about the caller's
+	// request, not about what a transform plugin later added — and RouteStream
+	// decides whether to divert using this same pre-plugin state. Reading the
+	// post-plugin slice instead let a plugin that adds tools flip MCP off after
+	// the stream had already been diverted, returning one buffered chunk to a
+	// caller who was entitled to a real stream.
+	callerSentTools := len(req.Tools) > 0
 
 	s, err := g.getStrategy()
 	if err != nil {
@@ -214,17 +225,23 @@ func (g *Gateway) Route(ctx context.Context, req providers.Request) (*providers.
 	if mcpRegistrySnapshot != nil {
 		mcpTools = mcpRegistrySnapshot.AllTools()
 	}
-	if len(mcpTools) > 0 {
-		// Build a set of tool names already present in the request so we do not
-		// inject duplicate definitions when the caller has pre-populated Tools.
-		existing := make(map[string]struct{}, len(req.Tools))
-		for _, t := range req.Tools {
-			existing[t.Function.Name] = struct{}{}
-		}
+
+	// MCP participates only when the caller supplied no tools of its own.
+	//
+	// Advertising both sets manufactures a turn neither party can resolve. The
+	// model may answer with one MCP call and one caller call; the gateway cannot
+	// execute the caller's (it has no implementation), and the caller cannot
+	// execute the MCP one (it never declared it and does not know the server
+	// exists). Answering only the gateway's half leaves an unmatched
+	// tool_call_id, which every OpenAI-compatible provider rejects — so the
+	// executor declines such turns outright (internal/mcp.Executor.ownsAll).
+	// Declining is the correct behaviour once the turn exists; not creating it
+	// is the correct fix. A caller that sent its own tools keeps the plain
+	// pass-through it asked for, streaming included.
+	mcpActive := len(mcpTools) > 0 && !callerSentTools
+
+	if mcpActive {
 		for _, t := range mcpTools {
-			if _, dup := existing[t.Name]; dup {
-				continue
-			}
 			req.Tools = append(req.Tools, core.Tool{
 				Type: "function",
 				Function: core.Function{
@@ -240,7 +257,7 @@ func (g *Gateway) Route(ctx context.Context, req providers.Request) (*providers.
 	// full response can be inspected for tool_calls. The client's original
 	// stream preference (captured above) is restored on the final response
 	// (Phase 1: always returns non-streaming for MCP requests).
-	if len(mcpTools) > 0 {
+	if mcpActive {
 		req.Stream = false
 	}
 
@@ -275,7 +292,7 @@ func (g *Gateway) Route(ctx context.Context, req providers.Request) (*providers.
 	// Agentic MCP tool-call loop. Runs only when MCP is active and the LLM
 	// returned tool_calls. Each iteration executes the tools and re-contacts
 	// the LLM until no more tool_calls are present or the depth limit is hit.
-	if mcpExecutorSnapshot != nil && len(mcpTools) > 0 {
+	if mcpExecutorSnapshot != nil && mcpActive {
 		var loopDuration time.Duration
 		var loopProvider string
 		resp, loopDuration, loopProvider, err = g.runMCPLoop(ctx, mcpExecutorSnapshot, s, &req, resp)

--- a/gateway_stream.go
+++ b/gateway_stream.go
@@ -81,11 +81,22 @@ func (g *Gateway) RouteStream(ctx context.Context, req providers.Request) (<-cha
 		req = g.resolveAlias(req)
 	})
 
-	// MCP redirect: when tool servers are registered, the agentic loop must
-	// run to completion before any response is sent. Route() handles this
+	// MCP redirect: when tool servers have advertised tools, the agentic loop
+	// must run to completion before any response is sent. Route() handles this
 	// entirely; we wrap its non-streaming result into a channel here.
-	hasMCP := mcpRegistrySnapshot != nil && mcpRegistrySnapshot.HasServers()
-	if hasMCP {
+	//
+	// Gate on discovered tools, not on registration. HasServers() is true from
+	// the moment a server is registered — before the handshake, and forever
+	// after one that failed — so gating on it let a single unreachable or
+	// typo'd MCP server silently collapse streaming into one buffered chunk for
+	// every caller on the gateway.
+	//
+	// The caller-tools condition mirrors Route's mcpActive: when the caller
+	// supplied its own tools MCP does not participate at all, so there is no
+	// agentic loop to buffer for and the stream must be left alone. Both paths
+	// must agree, or a request would be diverted here and then pass straight
+	// through Route as an ordinary non-streaming call.
+	if mcpRegistrySnapshot != nil && len(req.Tools) == 0 && len(mcpRegistrySnapshot.AllTools()) > 0 {
 		releasePluginManager()
 		// Do not force req.Stream = false here: let Route() capture the
 		// original stream flag via its own originalStream variable so that

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/aws/smithy-go v1.25.1
 	github.com/go-chi/chi/v5 v5.3.0
 	github.com/lib/pq v1.12.3
+	github.com/mark3labs/mcp-go v0.54.0
 	github.com/openai/openai-go v1.12.0
 	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/client_model v0.6.2
@@ -64,6 +65,7 @@ require (
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
+	github.com/google/jsonschema-go v0.4.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
@@ -89,8 +91,10 @@ require (
 	github.com/prometheus/common v0.66.1 // indirect
 	github.com/prometheus/procfs v0.16.1 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
+	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
 	github.com/shirou/gopsutil/v4 v4.26.3 // indirect
 	github.com/sirupsen/logrus v1.9.4 // indirect
+	github.com/spf13/cast v1.7.1 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
 	github.com/stretchr/testify v1.11.1 // indirect
 	github.com/testcontainers/testcontainers-go v0.42.0 // indirect
@@ -100,6 +104,7 @@ require (
 	github.com/tidwall/sjson v1.2.5 // indirect
 	github.com/tklauser/go-sysconf v0.3.16 // indirect
 	github.com/tklauser/numcpus v0.11.0 // indirect
+	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel/metric v1.44.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -65,6 +65,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
+github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
+github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/docker/go-connections v0.6.0 h1:LlMG9azAe1TqfR7sO+NJttz1gy6KO7VJBh+pMmjSD94=
 github.com/docker/go-connections v0.6.0/go.mod h1:AahvXYshr6JgfUJGdDCs2b5EZG/vmaMAntpSFH5BFKE=
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=
@@ -75,6 +77,8 @@ github.com/ebitengine/purego v0.10.0 h1:QIw4xfpWT6GWTzaW5XEKy3HXoqrJGx1ijYHzTF0/
 github.com/ebitengine/purego v0.10.0/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
+github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
+github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/go-chi/chi/v5 v5.3.0 h1:halUjDxhshgXHMrao5bB8eNBXo/rnzwr8m5m36glehM=
 github.com/go-chi/chi/v5 v5.3.0/go.mod h1:R+tYY2hNuVUUjxoPtqUdgBqevM9s9njzkTLutVsOCto=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
@@ -89,6 +93,8 @@ github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
+github.com/google/jsonschema-go v0.4.2 h1:tmrUohrwoLZZS/P3x7ex0WAVknEkBZM46iALbcqoRA8=
+github.com/google/jsonschema-go v0.4.2/go.mod h1:r5quNTdLOYEz95Ru18zA0ydNbBuYoo9tgaYcxEYhJVE=
 github.com/google/pprof v0.0.0-20250317173921-a4b03ec1a45e h1:ijClszYn+mADRFY17kjQEVQ1XRhq2/JR1M3sGqeJoxs=
 github.com/google/pprof v0.0.0-20250317173921-a4b03ec1a45e/go.mod h1:boTsfXsheKC2y+lKOCMpSfarhxDeIzfZG1jqGcPl3cA=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
@@ -121,6 +127,8 @@ github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
 github.com/magiconair/properties v1.8.10 h1:s31yESBquKXCV9a/ScB3ESkOjUYYv+X0rg8SYxI99mE=
 github.com/magiconair/properties v1.8.10/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=
+github.com/mark3labs/mcp-go v0.54.0 h1:PZhQvd+5xrT43cUoiaKn/hDcvLUhcLc1twSEKYPTcTA=
+github.com/mark3labs/mcp-go v0.54.0/go.mod h1:+8WclSK1ZUweCP3hvktSji8n8ABG/95QaEkeVE/Uwas=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mdelapenya/tlscert v0.2.0 h1:7H81W6Z/4weDvZBNOfQte5GpIMo0lGYEeWbkGp5LJHI=
@@ -170,10 +178,14 @@ github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qq
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 h1:KRzFb2m7YtdldCEkzs6KqmJw4nqEVZGK7IN2kJkjTuQ=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.2/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
 github.com/shirou/gopsutil/v4 v4.26.3 h1:2ESdQt90yU3oXF/CdOlRCJxrP+Am1aBYubTMTfxJ1qc=
 github.com/shirou/gopsutil/v4 v4.26.3/go.mod h1:LZ6ewCSkBqUpvSOf+LsTGnRinC6iaNUNMGBtDkJBaLQ=
 github.com/sirupsen/logrus v1.9.4 h1:TsZE7l11zFCLZnZ+teH4Umoq5BhEIfIzfRDZ1Uzql2w=
 github.com/sirupsen/logrus v1.9.4/go.mod h1:ftWc9WdOfJ0a92nsE2jF5u5ZwH8Bv2zdeOC42RjbV2g=
+github.com/spf13/cast v1.7.1 h1:cuNEagBQEHWN1FnbGEjCXL2szYEXqfJPbP2HNUaca9Y=
+github.com/spf13/cast v1.7.1/go.mod h1:ancEpBxwJDODSW/UG4rDrAqiKolqNNh2DX3mk86cAdo=
 github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
 github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=
 github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=
@@ -200,6 +212,8 @@ github.com/tklauser/go-sysconf v0.3.16 h1:frioLaCQSsF5Cy1jgRBrzr6t502KIIwQ0MArYI
 github.com/tklauser/go-sysconf v0.3.16/go.mod h1:/qNL9xxDhc7tx3HSRsLWNnuzbVfh3e7gh/BmM179nYI=
 github.com/tklauser/numcpus v0.11.0 h1:nSTwhKH5e1dMNsCdVBukSZrURJRoHbSEQjdEbY+9RXw=
 github.com/tklauser/numcpus v0.11.0/go.mod h1:z+LwcLq54uWZTX0u/bGobaV34u6V7KNlTZejzM6/3MQ=
+github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=
+github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=

--- a/internal/admin/config_scrub.go
+++ b/internal/admin/config_scrub.go
@@ -159,6 +159,7 @@ func scrubAnyMap(m map[string]any) map[string]any {
 // Fields scrubbed:
 //   - Observability.Tracing.Headers (map[string]string)
 //   - each MCPServers[i].Headers (map[string]string)
+//   - each MCPServers[i].Env (map[string]string)
 //   - each Observability.Exporters[i].Config (map[string]any)
 //   - each Plugins[i].Config (map[string]interface{})
 //
@@ -172,6 +173,10 @@ func scrubConfigSecrets(cfg aigateway.Config) aigateway.Config {
 		servers := make([]mcp.ServerConfig, len(cfg.MCPServers))
 		for i, server := range cfg.MCPServers {
 			server.Headers = scrubStringMap(server.Headers)
+			// Env carries stdio credentials. Since MCP subprocesses do not
+			// inherit the gateway environment, it is the only place an operator
+			// can put one, so it is at least as secret-bearing as Headers.
+			server.Env = scrubStringMap(server.Env)
 			servers[i] = server
 		}
 		cfg.MCPServers = servers

--- a/internal/admin/handlers_redaction_test.go
+++ b/internal/admin/handlers_redaction_test.go
@@ -28,6 +28,14 @@ func TestGetConfigRedactsSecrets(t *testing.T) {
 					"X-Env":         "${MCP_TOKEN}",
 				},
 			},
+			{
+				Name:    "stdio-tools",
+				Command: "some-mcp-server",
+				Env: map[string]string{
+					"API_KEY":  "literal-mcp-env-secret",
+					"REF_ONLY": "${MCP_ENV_TOKEN}",
+				},
+			},
 		},
 		Observability: aigateway.ObservabilityConfig{
 			Tracing: aigateway.TracingConfig{
@@ -105,6 +113,18 @@ func TestGetConfigRedactsSecrets(t *testing.T) {
 		t.Errorf("MCP X-Env header: got %q, want ${MCP_TOKEN}", got)
 	}
 
+	// Same for stdio Env: it is the only credential channel for a subprocess,
+	// so a literal there is as secret-bearing as an Authorization header.
+	if len(respCfg.MCPServers) < 2 {
+		t.Fatal("expected the stdio MCP server in response")
+	}
+	if got := respCfg.MCPServers[1].Env["API_KEY"]; got != "[REDACTED]" {
+		t.Errorf("MCP Env API_KEY: got %q, want [REDACTED]", got)
+	}
+	if got := respCfg.MCPServers[1].Env["REF_ONLY"]; got != "${MCP_ENV_TOKEN}" {
+		t.Errorf("MCP Env REF_ONLY: got %q, want ${MCP_ENV_TOKEN}", got)
+	}
+
 	// Exporter string config must be redacted.
 	if len(respCfg.Observability.Exporters) == 0 {
 		t.Fatal("expected exporters in response")
@@ -132,6 +152,9 @@ func TestGetConfigRedactsSecrets(t *testing.T) {
 	}
 	if got := liveCfg.MCPServers[0].Headers["Authorization"]; got != "literal-mcp-secret" {
 		t.Errorf("live config MCP Authorization mutated: got %q, want literal-mcp-secret", got)
+	}
+	if got := liveCfg.MCPServers[1].Env["API_KEY"]; got != "literal-mcp-env-secret" {
+		t.Errorf("live config MCP Env API_KEY mutated: got %q, want literal-mcp-env-secret", got)
 	}
 	if got := liveCfg.Observability.Exporters[0].Config["api_key"].(string); got != "literal-ls-key" {
 		t.Errorf("live config api_key mutated: got %q, want literal-ls-key", got)

--- a/internal/mcp/client.go
+++ b/internal/mcp/client.go
@@ -256,3 +256,8 @@ func (c *Client) setSessionID(sid string) {
 	c.sessionID = sid
 	c.sessionMu.Unlock()
 }
+
+// Close is a no-op for the HTTP transport: the underlying http.Client has no
+// persistent connection state that requires explicit cleanup.
+// It exists so that *Client satisfies the mcpClient interface.
+func (c *Client) Close() error { return nil }

--- a/internal/mcp/executor.go
+++ b/internal/mcp/executor.go
@@ -188,12 +188,17 @@ func (e *Executor) executeToolCall(ctx context.Context, tc core.ToolCall) core.M
 		),
 	)
 
+	// Guard against hung subprocesses (stdio) or slow servers (HTTP).
+	callTimeout := e.registry.timeoutForServer(serverName)
+	toolCtx, cancelCall := context.WithTimeout(toolCtx, callTimeout)
+
 	callStart := time.Now()
 	var result *ToolCallResult
 	var err error
 	rtrace.WithRegion(toolCtx, "mcp.call_tool", func() {
 		result, err = client.CallTool(toolCtx, toolName, args)
 	})
+	cancelCall()
 	elapsed := time.Since(callStart)
 	metricToolCallDuration.WithLabelValues(serverName, toolName).Observe(elapsed.Seconds())
 	latencyMs := int(elapsed.Milliseconds())

--- a/internal/mcp/executor.go
+++ b/internal/mcp/executor.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"context"
 	"encoding/json"
+	"log/slog"
 	rtrace "runtime/trace"
 	"time"
 
@@ -21,6 +22,13 @@ import (
 // MCP tool-call child spans. Matches the package import path so backends
 // can identify the source of these spans.
 const mcpTracerName = "github.com/ferro-labs/ai-gateway/internal/mcp"
+
+// maxToolCallsPerTurn bounds how many tool calls a single LLM response may
+// trigger. maxCallDepth limits how many *turns* the agentic loop runs, but
+// nothing limited the calls within one turn: a response carrying 20 000
+// tool_calls produced 20 000 executions and 20 001 conversation messages,
+// each re-sent to the provider on every subsequent turn.
+const maxToolCallsPerTurn = 64
 
 // mcpTracer returns the OpenTelemetry tracer for MCP-instrumentation
 // spans. When OTel is not configured by the gateway, the global
@@ -107,7 +115,11 @@ func (e *Executor) ShouldContinueLoop(resp *core.Response, depth int) bool {
 		return false
 	}
 	for _, ch := range resp.Choices {
-		if len(ch.Message.ToolCalls) > 0 {
+		// Only a fully MCP-owned turn arms the loop. A turn containing any
+		// caller-supplied call must reach the client with its finish_reason
+		// intact — the gateway cannot answer those, and answering only its own
+		// would leave unmatched tool_call_ids that the provider rejects.
+		if e.ownsAll(ch.Message.ToolCalls) {
 			return true
 		}
 	}
@@ -126,26 +138,66 @@ func (e *Executor) ResolvePendingToolCalls(ctx context.Context, resp *core.Respo
 	}
 
 	var extra []core.Message
+	budget := maxToolCallsPerTurn
 
 	for _, ch := range resp.Choices {
-		if len(ch.Message.ToolCalls) == 0 {
+		calls := ch.Message.ToolCalls
+		if len(calls) == 0 {
 			continue
 		}
 
-		// Preserve the full assistant message from the LLM (all fields, correct role).
+		// The gateway can only answer calls it owns, and a provider rejects an
+		// assistant turn whose tool_call_ids are not all answered. So a turn
+		// mixing MCP-owned and caller-supplied calls cannot be continued at all:
+		// executing half of it would turn a working request into a 400. Hand the
+		// whole turn back instead and let the client resolve it.
+		if !e.ownsAll(calls) {
+			continue
+		}
+
+		if budget <= 0 {
+			break
+		}
+		if len(calls) > budget {
+			// Report the number actually executed, not the per-turn constant:
+			// with several choices the remaining budget is what truncates, and
+			// logging the constant would misstate it.
+			slog.Warn("mcp: tool calls truncated for this turn",
+				"turn_limit", maxToolCallsPerTurn,
+				"executed", budget,
+				"requested", len(calls),
+			)
+			calls = calls[:budget]
+		}
+		budget -= len(calls)
+
+		// Preserve the assistant message (all fields, correct role) but carry
+		// exactly the calls answered below. Truncating the executions without
+		// truncating this list would leave unmatched tool_call_ids in the
+		// continuation, which the provider rejects outright.
 		assistantMsg := ch.Message
 		if assistantMsg.Role == "" {
 			assistantMsg.Role = core.RoleAssistant
 		}
+		assistantMsg.ToolCalls = calls
 		extra = append(extra, assistantMsg)
 
-		// Execute each tool call and collect its result message.
-		for _, tc := range ch.Message.ToolCalls {
+		for _, tc := range calls {
 			extra = append(extra, e.executeToolCall(ctx, tc))
 		}
 	}
 
 	return extra, nil
+}
+
+// ownsAll reports whether every call in the turn belongs to a ready MCP server.
+func (e *Executor) ownsAll(calls []core.ToolCall) bool {
+	for _, tc := range calls {
+		if !e.registry.Owns(tc.Function.Name) {
+			return false
+		}
+	}
+	return len(calls) > 0
 }
 
 // executeToolCall runs a single MCP tool call and returns the tool-role
@@ -187,10 +239,19 @@ func (e *Executor) executeToolCall(ctx context.Context, tc core.ToolCall) core.M
 			attribute.String(observability.AttrFerroMCPTool, toolName),
 		),
 	)
+	// Deferred, not called inline after the RPC: a panic in a transport unwinds
+	// past an inline End(), and the HTTP recover middleware keeps the process
+	// alive, so the span would be orphaned for good rather than dying with the
+	// process. Nothing below re-ends or reuses the span.
+	defer span.End()
 
 	// Guard against hung subprocesses (stdio) or slow servers (HTTP).
 	callTimeout := e.registry.timeoutForServer(serverName)
 	toolCtx, cancelCall := context.WithTimeout(toolCtx, callTimeout)
+	// Same reasoning as the span: an inline cancel is skipped on panic, stranding
+	// the timer until the timeout elapses. toolCtx is unused after the RPC, so
+	// holding it to function end costs nothing.
+	defer cancelCall()
 
 	callStart := time.Now()
 	var result *ToolCallResult
@@ -198,7 +259,6 @@ func (e *Executor) executeToolCall(ctx context.Context, tc core.ToolCall) core.M
 	rtrace.WithRegion(toolCtx, "mcp.call_tool", func() {
 		result, err = client.CallTool(toolCtx, toolName, args)
 	})
-	cancelCall()
 	elapsed := time.Since(callStart)
 	metricToolCallDuration.WithLabelValues(serverName, toolName).Observe(elapsed.Seconds())
 	latencyMs := int(elapsed.Milliseconds())
@@ -209,7 +269,6 @@ func (e *Executor) executeToolCall(ctx context.Context, tc core.ToolCall) core.M
 		// Relies on the non-blocking AuditFn contract: the per-call goroutine returns promptly.
 		e.callAuditFn(ctx, serverName, toolName, "error", latencyMs, err.Error())
 		gwotel.RecordSpanError(span, err)
-		span.End()
 		errPayload, _ := json.Marshal(map[string]string{"error": err.Error()})
 		return core.Message{
 			Role:       core.RoleTool,
@@ -222,7 +281,6 @@ func (e *Executor) executeToolCall(ctx context.Context, tc core.ToolCall) core.M
 	// Relies on the non-blocking AuditFn contract: the per-call goroutine returns promptly.
 	e.callAuditFn(ctx, serverName, toolName, "ok", latencyMs, "")
 	span.SetStatus(codes.Ok, "")
-	span.End()
 
 	// Convert MCP content blocks to a plain string for the LLM.
 	content, err := contentBlocksToString(result.Content)

--- a/internal/mcp/executor_test.go
+++ b/internal/mcp/executor_test.go
@@ -95,7 +95,10 @@ func TestShouldContinueLoopNoToolCalls(t *testing.T) {
 }
 
 func TestShouldContinueLoopWithToolCalls(t *testing.T) {
-	exec := NewExecutor(NewRegistry(), 5, nil)
+	// The loop arms only for tool calls MCP actually owns. Previously an empty
+	// registry armed it for any tool name, which is what let the executor
+	// hijack caller-supplied tool calls.
+	exec := NewExecutor(readyRegistry(t, []Tool{{Name: "do_thing"}}), 5, nil)
 	resp := &core.Response{
 		Choices: []core.Choice{{
 			Message: core.Message{
@@ -105,7 +108,7 @@ func TestShouldContinueLoopWithToolCalls(t *testing.T) {
 		}},
 	}
 	if !exec.ShouldContinueLoop(resp, 0) {
-		t.Error("expected true when tool calls present and depth < max")
+		t.Error("expected true when an MCP-owned tool call is present and depth < max")
 	}
 }
 
@@ -161,7 +164,11 @@ func TestResolvePendingToolCallsFoundTool(t *testing.T) {
 	}
 }
 
-func TestResolvePendingToolCallsUnknownTool(t *testing.T) {
+func TestResolvePendingToolCallsUnownedToolPassesThrough(t *testing.T) {
+	// A tool no MCP server owns belongs to the caller. The executor must not
+	// answer it — it previously fabricated
+	// {"error":"tool X not found in any registered MCP server"}, which swallowed
+	// the client's own function calls and hid finish_reason: tool_calls.
 	exec := NewExecutor(NewRegistry(), 5, nil) // empty registry
 
 	resp := &core.Response{
@@ -180,19 +187,8 @@ func TestResolvePendingToolCallsUnknownTool(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(msgs) != 2 {
-		t.Fatalf("expected 2 messages (assistant + error tool result), got %d", len(msgs))
-	}
-	// Tool result should embed an error JSON
-	if msgs[1].Role != core.RoleTool {
-		t.Errorf("expected role tool, got %q", msgs[1].Role)
-	}
-	var payload map[string]string
-	if err := json.Unmarshal([]byte(msgs[1].Content), &payload); err != nil {
-		t.Fatalf("tool result content is not valid JSON: %v — content: %q", err, msgs[1].Content)
-	}
-	if payload["error"] == "" {
-		t.Error("expected error field in tool result content")
+	if len(msgs) != 0 {
+		t.Fatalf("expected 0 messages for an unowned tool call (caller executes it), got %d: %+v", len(msgs), msgs)
 	}
 }
 

--- a/internal/mcp/lifecycle_test.go
+++ b/internal/mcp/lifecycle_test.go
@@ -1,0 +1,190 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// slowClient records when it was closed and can stall to model a wedged stdio
+// subprocess working through the transport's graceful/SIGTERM/SIGKILL ladder.
+type slowClient struct {
+	closeDelay time.Duration
+	closed     atomic.Bool
+}
+
+func (s *slowClient) Initialize(context.Context) (*ServerInfo, error) { return &ServerInfo{}, nil }
+func (s *slowClient) ListTools(context.Context) ([]Tool, error)       { return nil, nil }
+func (s *slowClient) CallTool(context.Context, string, json.RawMessage) (*ToolCallResult, error) {
+	return &ToolCallResult{}, nil
+}
+func (s *slowClient) Close() error {
+	time.Sleep(s.closeDelay)
+	s.closed.Store(true)
+	return nil
+}
+
+// registryWith installs pre-built clients without going through RegisterConfig,
+// which would spawn real transports.
+func registryWith(clients map[string]mcpClient) *Registry {
+	r := NewRegistry()
+	for name, c := range clients {
+		r.serverIndex[name] = len(r.regOrder)
+		r.regOrder = append(r.regOrder, name)
+		r.servers[name] = &serverEntry{config: ServerConfig{Name: name}, client: c, ready: true}
+	}
+	return r
+}
+
+// P2-2: each stdio Close can spend seconds in the transport's shutdown ladder.
+// Closing serially multiplies that by the number of servers, and Gateway.Close
+// already has only a 5s budget — several wedged servers blow past an
+// orchestrator's grace period, which SIGKILLs the pod and re-orphans every
+// subprocess the group sweep exists to reap.
+func TestRegistryCloseIsConcurrent(t *testing.T) {
+	const (
+		servers = 6
+		delay   = 200 * time.Millisecond
+	)
+
+	clients := make(map[string]mcpClient, servers)
+	all := make([]*slowClient, 0, servers)
+	for i := range servers {
+		c := &slowClient{closeDelay: delay}
+		all = append(all, c)
+		clients[string(rune('a'+i))] = c
+	}
+	reg := registryWith(clients)
+
+	start := time.Now()
+	if err := reg.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	elapsed := time.Since(start)
+
+	// Serial would be servers*delay (1.2s). Allow generous slack for CI.
+	if elapsed >= servers*delay {
+		t.Errorf("Close took %v for %d servers at %v each — clients are being closed serially",
+			elapsed, servers, delay)
+	}
+	for i, c := range all {
+		if !c.closed.Load() {
+			t.Errorf("client %d was not closed", i)
+		}
+	}
+}
+
+// P1-2: Route snapshots the registry at request entry and uses it after
+// releasing the gateway lock. A config reload that closes the old registry
+// immediately terminates the stdio subprocess underneath an in-flight tool call,
+// which then fails with "transport closed". Retirement must wait for holders.
+func TestRegistryCloseWaitsForInFlightHolders(t *testing.T) {
+	c := &slowClient{}
+	reg := registryWith(map[string]mcpClient{"s1": c})
+
+	release := reg.Acquire()
+
+	if err := reg.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	// The holder is still in-flight, so the subprocess must still be alive.
+	time.Sleep(50 * time.Millisecond)
+	if c.closed.Load() {
+		t.Fatal("registry closed its clients while a request still held a snapshot: " +
+			"an in-flight tool call would see its subprocess terminated")
+	}
+
+	release()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if c.closed.Load() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatal("registry never closed its clients after the last holder released")
+}
+
+// Acquire after Close must not resurrect a retiring registry, and its release
+// must not double-close.
+func TestRegistryAcquireAfterCloseIsInert(t *testing.T) {
+	c := &slowClient{}
+	reg := registryWith(map[string]mcpClient{"s1": c})
+
+	if err := reg.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if !c.closed.Load() {
+		t.Fatal("expected an unheld registry to close immediately")
+	}
+
+	release := reg.Acquire()
+	release()
+	release() // idempotent
+}
+
+// Close detaches each entry's client so a second teardown cannot re-close the
+// same transport. An initialisation already in flight holds no reference of its
+// own, so re-reading entry.client across its unlocked handshake nil-dereferenced
+// and crashed the process. Reproduced under parallel package load.
+func TestRegistryCloseDuringInitializeDoesNotPanic(t *testing.T) {
+	for range 20 {
+		srv := newMockServer(t, []Tool{{Name: "t1"}})
+
+		reg := NewRegistry()
+		reg.RegisterConfig(ServerConfig{Name: "s1", URL: srv.URL, TimeoutSeconds: 5})
+
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			reg.InitializeAll(context.Background(), func(string, error) {})
+		}()
+		go func() {
+			defer wg.Done()
+			_ = reg.Close()
+		}()
+		wg.Wait()
+		srv.Close()
+	}
+}
+
+// Concurrent Acquire/release against Close must not deadlock or double-close.
+func TestRegistryLifecycleUnderConcurrency(t *testing.T) {
+	c := &slowClient{}
+	reg := registryWith(map[string]mcpClient{"s1": c})
+
+	var wg sync.WaitGroup
+	for range 32 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			release := reg.Acquire()
+			time.Sleep(time.Millisecond)
+			release()
+		}()
+	}
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		time.Sleep(5 * time.Millisecond)
+		_ = reg.Close()
+	}()
+
+	wg.Wait()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if c.closed.Load() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatal("registry never closed after all holders released")
+}

--- a/internal/mcp/ownership_test.go
+++ b/internal/mcp/ownership_test.go
@@ -1,0 +1,209 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/ferro-labs/ai-gateway/providers/core"
+)
+
+// A caller that supplies its own tools array (the ordinary OpenAI
+// function-calling pattern) intends to execute those calls itself. The MCP
+// executor must leave them alone: swallowing them and answering with a
+// fabricated "not found" breaks every client-side integration the moment one
+// MCP server is enabled.
+
+func readyRegistry(t *testing.T, tools []Tool) *Registry {
+	t.Helper()
+	srv := newMockServer(t, tools)
+	t.Cleanup(srv.Close)
+
+	reg := NewRegistry()
+	reg.RegisterConfig(ServerConfig{Name: "s1", URL: srv.URL, TimeoutSeconds: 5})
+	reg.InitializeAll(context.Background(), func(name string, err error) {
+		t.Fatalf("init %s: %v", name, err)
+	})
+	return reg
+}
+
+func toolCallResponse(names ...string) *core.Response {
+	// IDs must be unique: the protocol-completeness check pairs each
+	// tool_call_id with exactly one tool result.
+	calls := make([]core.ToolCall, 0, len(names))
+	for i, n := range names {
+		calls = append(calls, core.ToolCall{
+			ID:       fmt.Sprintf("call-%d-%s", i, n),
+			Type:     "function",
+			Function: core.FunctionCall{Name: n, Arguments: "{}"},
+		})
+	}
+	return &core.Response{Choices: []core.Choice{{Message: core.Message{
+		Role:      core.RoleAssistant,
+		ToolCalls: calls,
+	}}}}
+}
+
+func TestRegistryOwns(t *testing.T) {
+	reg := readyRegistry(t, []Tool{{Name: "mcp_tool"}})
+
+	if !reg.Owns("mcp_tool") {
+		t.Error("Owns(mcp_tool) = false, want true for a ready indexed tool")
+	}
+	if reg.Owns("caller_tool") {
+		t.Error("Owns(caller_tool) = true, want false for an unknown tool")
+	}
+}
+
+func TestExecutorSkipsCallerOwnedToolCalls(t *testing.T) {
+	reg := readyRegistry(t, []Tool{{Name: "mcp_tool"}})
+	exec := NewExecutor(reg, 5, nil)
+
+	resp := toolCallResponse("caller_tool")
+	extra, err := exec.ResolvePendingToolCalls(context.Background(), resp)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(extra) != 0 {
+		t.Fatalf("expected no messages for a caller-owned tool call, got %d: %+v", len(extra), extra)
+	}
+}
+
+// assertProtocolComplete checks the invariant every OpenAI-compatible provider
+// enforces: an assistant message carrying tool_calls must be followed by exactly
+// one tool message per tool_call_id. A continuation that violates this is
+// rejected outright, so a partially-answered turn is not a degraded result — it
+// is a failed request.
+func assertProtocolComplete(t *testing.T, msgs []core.Message) {
+	t.Helper()
+	answered := make(map[string]int)
+	for _, m := range msgs {
+		if m.Role == core.RoleTool {
+			answered[m.ToolCallID]++
+		}
+	}
+	for _, m := range msgs {
+		if m.Role != core.RoleAssistant {
+			continue
+		}
+		for _, tc := range m.ToolCalls {
+			switch answered[tc.ID] {
+			case 1:
+				delete(answered, tc.ID)
+			case 0:
+				t.Errorf("tool_call %q has no tool result: the provider will reject this continuation", tc.ID)
+			default:
+				t.Errorf("tool_call %q answered %d times", tc.ID, answered[tc.ID])
+			}
+		}
+	}
+	for id := range answered {
+		t.Errorf("tool result for %q has no matching tool_call in any assistant message", id)
+	}
+}
+
+// A turn mixing MCP-owned and caller-owned calls cannot be satisfied by the
+// gateway: it can answer only its own, and an assistant message with an
+// unanswered tool_call_id is rejected by the provider. Executing the owned half
+// and leaving the caller's unanswered turns a working request into a 400, so the
+// whole turn is handed back to the client untouched.
+func TestExecutorSkipsMixedOwnershipTurn(t *testing.T) {
+	reg := readyRegistry(t, []Tool{{Name: "mcp_tool"}})
+	exec := NewExecutor(reg, 5, nil)
+
+	resp := toolCallResponse("mcp_tool", "caller_tool")
+	extra, err := exec.ResolvePendingToolCalls(context.Background(), resp)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(extra) != 0 {
+		t.Fatalf("expected a mixed-ownership turn to contribute no messages, got %d: %+v", len(extra), extra)
+	}
+	assertProtocolComplete(t, extra)
+}
+
+// The fully-owned case still runs, and must be protocol-complete.
+func TestExecutorResolvesFullyOwnedTurn(t *testing.T) {
+	reg := readyRegistry(t, []Tool{{Name: "mcp_tool"}, {Name: "mcp_other"}})
+	exec := NewExecutor(reg, 5, nil)
+
+	extra, err := exec.ResolvePendingToolCalls(context.Background(), toolCallResponse("mcp_tool", "mcp_other"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var toolMsgs int
+	for _, m := range extra {
+		if m.Role == core.RoleTool {
+			toolMsgs++
+		}
+	}
+	if toolMsgs != 2 {
+		t.Fatalf("expected 2 tool results for 2 owned calls, got %d", toolMsgs)
+	}
+	assertProtocolComplete(t, extra)
+
+	// No fabricated MCP errors on a healthy path.
+	for _, m := range extra {
+		if m.Role != core.RoleTool {
+			continue
+		}
+		var payload map[string]string
+		if json.Unmarshal([]byte(m.Content), &payload) == nil {
+			if payload["error"] != "" {
+				t.Errorf("unexpected error result for an owned call: %s", m.Content)
+			}
+		}
+	}
+}
+
+func TestShouldContinueLoopIgnoresUnownedCalls(t *testing.T) {
+	reg := readyRegistry(t, []Tool{{Name: "mcp_tool"}})
+	exec := NewExecutor(reg, 5, nil)
+
+	if exec.ShouldContinueLoop(toolCallResponse("caller_tool"), 0) {
+		t.Error("loop armed for a caller-owned tool call; the client must receive finish_reason tool_calls")
+	}
+	if !exec.ShouldContinueLoop(toolCallResponse("mcp_tool"), 0) {
+		t.Error("loop not armed for an MCP-owned tool call")
+	}
+	// Mixed ownership cannot be continued: the gateway can answer only its own
+	// calls, and a partially-answered assistant turn is rejected by the provider.
+	if exec.ShouldContinueLoop(toolCallResponse("caller_tool", "mcp_tool"), 0) {
+		t.Error("loop armed for a mixed-ownership turn, which the gateway cannot satisfy")
+	}
+}
+
+// R2: a response carrying an absurd number of tool calls must not translate
+// into an unbounded number of executions and conversation messages.
+func TestResolvePendingToolCallsIsBoundedPerTurn(t *testing.T) {
+	reg := readyRegistry(t, []Tool{{Name: "mcp_tool"}})
+	exec := NewExecutor(reg, 1, nil)
+
+	names := make([]string, 0, maxToolCallsPerTurn+50)
+	for i := 0; i < maxToolCallsPerTurn+50; i++ {
+		names = append(names, "mcp_tool")
+	}
+
+	extra, err := exec.ResolvePendingToolCalls(context.Background(), toolCallResponse(names...))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var toolMsgs int
+	for _, m := range extra {
+		if m.Role == core.RoleTool {
+			toolMsgs++
+		}
+	}
+	if toolMsgs > maxToolCallsPerTurn {
+		t.Errorf("executed %d tool calls in one turn, want at most %d", toolMsgs, maxToolCallsPerTurn)
+	}
+
+	// Truncating the executions is not enough: the assistant message must be
+	// truncated with them, or the continuation carries tool_call_ids nothing
+	// answers and the provider rejects the whole request.
+	assertProtocolComplete(t, extra)
+}

--- a/internal/mcp/proc_other.go
+++ b/internal/mcp/proc_other.go
@@ -1,0 +1,16 @@
+//go:build !unix
+
+package mcp
+
+import "os/exec"
+
+// Windows process-tree teardown needs a Job Object (CREATE_NEW_PROCESS_GROUP
+// plus AssignProcessToJobObject), which is a materially different mechanism from
+// a POSIX process group. Until an MCP-on-Windows user asks for it, the shipped
+// behaviour is the single-process teardown the transport already performs: an
+// npx-style server may outlive Close here.
+func configureProcGroup(*exec.Cmd) {}
+
+// sweepProcessGroup is a no-op on platforms without POSIX process groups.
+// The argument would be a group id captured at spawn; there is no group here.
+func sweepProcessGroup(int) error { return nil }

--- a/internal/mcp/proc_unix.go
+++ b/internal/mcp/proc_unix.go
@@ -1,0 +1,49 @@
+//go:build unix
+
+package mcp
+
+import (
+	"fmt"
+	"os/exec"
+	"syscall"
+)
+
+// configureProcGroup puts the child in its own process group so the whole tree
+// can be signalled at teardown.
+//
+// MCP servers are commonly launched via npx or uvx, which exec the real server
+// as a separate process. os.Process.Kill signals "only the Process itself, not
+// any other processes it may have started", so without a group the real server
+// survives teardown holding the old pipes open, and they accumulate across every
+// close and config reload.
+//
+// Setpgid makes the child the leader of a new group whose pgid equals its pid,
+// which is why the pid captured at spawn is a valid group id later.
+func configureProcGroup(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+}
+
+// sweepProcessGroup force-kills every process remaining in the group led by
+// pgid. Best-effort: an already-empty group is not a failure worth surfacing.
+//
+// pgid must be captured at spawn, not looked up at teardown. By the time this
+// runs the transport has called cmd.Wait and reaped the leader, so Getpgid on
+// that pid fails with ESRCH and the surviving descendants would never be
+// signalled — which is precisely the bug this exists to fix.
+//
+// The pgid <= 1 guard is load-bearing, not padding. kill(-0, …) signals the
+// *caller's* process group, so falling through on a zero value would make the
+// gateway SIGKILL itself and every sibling in its group; -1 broadcasts to every
+// process the user may signal.
+func sweepProcessGroup(pgid int) error {
+	if pgid <= 1 {
+		return fmt.Errorf("mcp: refusing to signal process group %d", pgid)
+	}
+	if err := syscall.Kill(-pgid, syscall.SIGKILL); err != nil {
+		if err == syscall.ESRCH {
+			return nil // no survivors; the polite ladder was sufficient
+		}
+		return err
+	}
+	return nil
+}

--- a/internal/mcp/proc_unix_test.go
+++ b/internal/mcp/proc_unix_test.go
@@ -1,0 +1,216 @@
+//go:build unix
+
+package mcp
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// waitFor polls until cond holds or the deadline expires.
+func waitFor(t *testing.T, d time.Duration, cond func() bool) bool {
+	t.Helper()
+	deadline := time.Now().Add(d)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return true
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return cond()
+}
+
+// B3: the transport creates a stderr pipe and never reads it. Once the OS pipe
+// buffer fills (64 KiB on Linux) the child blocks in write(2) and stops
+// answering JSON-RPC entirely — a live process with a silent stdout and no
+// recovery path. The drain is required for correctness, not just diagnostics.
+func TestStdioClient_StderrIsDrained_NoDeadlock(t *testing.T) {
+	dir := t.TempDir()
+	marker := filepath.Join(dir, "finished")
+
+	// Write ~150 KiB to stderr — comfortably past the pipe buffer — then record
+	// that we got past it and idle so the process stays alive for Close().
+	script := `i=0
+while [ $i -lt 3000 ]; do
+  echo "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" >&2
+  i=$((i+1))
+done
+echo done > "` + marker + `"
+exec cat`
+
+	c := newStdioClient("stderr-flood", "sh", []string{"-c", script}, nil)
+	t.Cleanup(func() { _ = c.Close() })
+
+	if _, isErr := c.(*errClient); isErr {
+		t.Fatal("failed to spawn test subprocess")
+	}
+
+	if !waitFor(t, 15*time.Second, func() bool {
+		_, err := os.Stat(marker)
+		return err == nil
+	}) {
+		t.Fatal("child never finished writing to stderr: the pipe filled and it is " +
+			"blocked in write(2) — stderr is not being drained")
+	}
+}
+
+// A single stderr line longer than the scanner's 64 KiB token limit stops Scan
+// with ErrTooLong. Returning at that point would re-create the very deadlock the
+// drain exists to prevent, so the drain must keep the pipe moving.
+func TestStdioClient_StderrOverlongLineDoesNotDeadlock(t *testing.T) {
+	dir := t.TempDir()
+	marker := filepath.Join(dir, "finished")
+
+	// One 200 KiB line with no newline, then a normal burst, then the marker.
+	//
+	// Generated with head+tr, not awk: building the string by concatenation in
+	// awk is O(n^2) over 204800 iterations, which is tolerable under gawk and
+	// pathological under mawk — it blew a 20s deadline on CI while finishing in
+	// 1.5s locally.
+	script := `head -c 204800 /dev/zero | tr '\0' 'a' >&2
+i=0
+while [ $i -lt 2000 ]; do
+  echo "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" >&2
+  i=$((i+1))
+done
+echo done > "` + marker + `"
+exec cat`
+
+	c := newStdioClient("stderr-overlong", "sh", []string{"-c", script}, nil)
+	t.Cleanup(func() { _ = c.Close() })
+
+	if _, isErr := c.(*errClient); isErr {
+		t.Fatal("failed to spawn test subprocess")
+	}
+
+	if !waitFor(t, 20*time.Second, func() bool {
+		_, err := os.Stat(marker)
+		return err == nil
+	}) {
+		t.Fatal("child blocked after an over-long stderr line: the drain stopped " +
+			"reading on ErrTooLong instead of discarding the remainder")
+	}
+}
+
+// B4: npx and uvx exec the real MCP server as a separate process. os.Process.Kill
+// signals "only the Process itself, not any other processes it may have started",
+// so without a process group the real server survives every close and reload with
+// the old pipes still open.
+func TestStdioClient_CloseKillsGrandchild(t *testing.T) {
+	dir := t.TempDir()
+	pidFile := filepath.Join(dir, "grandchild.pid")
+
+	// Stand in for `npx`: fork the real work into a separate process, record its
+	// pid, and keep the leader alive so it is the one Close() signals.
+	script := `sleep 300 &
+echo $! > "` + pidFile + `"
+exec cat`
+
+	c := newStdioClient("grandchild-owner", "sh", []string{"-c", script}, nil)
+	if _, isErr := c.(*errClient); isErr {
+		t.Fatal("failed to spawn test subprocess")
+	}
+
+	if !waitFor(t, 10*time.Second, func() bool {
+		b, err := os.ReadFile(pidFile) //nolint:gosec // test-owned path under t.TempDir()
+		return err == nil && len(strings.TrimSpace(string(b))) > 0
+	}) {
+		t.Fatal("grandchild pid file never appeared")
+	}
+
+	raw, err := os.ReadFile(pidFile) //nolint:gosec // test-owned path under t.TempDir()
+	if err != nil {
+		t.Fatalf("read pid file: %v", err)
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(raw)))
+	if err != nil {
+		t.Fatalf("parse grandchild pid %q: %v", raw, err)
+	}
+
+	// Sanity: it is alive before we close.
+	if err := syscall.Kill(pid, 0); err != nil {
+		t.Fatalf("grandchild %d not alive before Close: %v", pid, err)
+	}
+
+	if err := c.Close(); err != nil {
+		t.Logf("Close returned %v (tolerated: the leader is not an MCP server)", err)
+	}
+
+	alive := func() bool { return syscall.Kill(pid, 0) == nil }
+	if !waitFor(t, 10*time.Second, func() bool { return !alive() }) {
+		_ = syscall.Kill(pid, syscall.SIGKILL) // do not leak the process out of the test
+		t.Fatalf("grandchild %d survived Close(): the process group was not swept, "+
+			"so an npx-style server outlives every close and reload", pid)
+	}
+}
+
+// The guard exists because kill(-0, …) signals the caller's own process group:
+// a failed Getpgid that fell through to that would make the gateway SIGKILL
+// itself and every sibling in its group.
+func TestSweepProcessGroup_RejectsUnownedPid(t *testing.T) {
+	// A pid that cannot be ours. Getpgid must fail, and the sweep must report
+	// that rather than broadcasting a signal.
+	if err := sweepProcessGroup(-1); err == nil {
+		t.Error("sweepProcessGroup(-1) = nil, want an error rather than a group-wide signal")
+	}
+}
+
+// The subprocess must never inherit the gateway environment, and the failure
+// mode is silent: os/exec treats a nil Cmd.Env as "inherit everything", so an
+// empty base env plus no overrides would hand an MCP server every gateway
+// credential rather than none.
+func TestStdioClient_EmptyEnvDoesNotInheritGatewayEnvironment(t *testing.T) {
+	// Strip every key the minimal base would otherwise pick up, so env ends up
+	// empty — the exact condition that produced a nil slice.
+	for _, k := range []string{"PATH", "HOME", "LANG", "TMPDIR"} {
+		t.Setenv(k, "")
+	}
+	t.Setenv("FERRO_TEST_LEAKED_SECRET", "must-not-reach-subprocess")
+
+	dir := t.TempDir()
+	out := filepath.Join(dir, "env.txt")
+
+	// envOverrides MUST stay nil here: a single override makes the slice
+	// non-empty, which is exactly what stops it being nil, and the precondition
+	// for the bug is that the base env AND the overrides are both empty.
+	//
+	// The shell expands the variable itself — no external binary — so an empty
+	// PATH cannot make the probe silently no-op. An earlier version used bare
+	// `env`, which PATH could not resolve; the redirect created the file anyway
+	// and the assertion then passed against empty content, vacuously green
+	// against the very bug it exists to catch. The "leaked=[" marker is the
+	// anti-vacuous guard: it is present only if printf actually ran.
+	c := newStdioClient("env-isolation", "/bin/sh",
+		[]string{"-c", `printf 'leaked=[%s]\n' "$FERRO_TEST_LEAKED_SECRET" > ` + out + `; exec cat`},
+		nil)
+	t.Cleanup(func() { _ = c.Close() })
+
+	if _, isErr := c.(*errClient); isErr {
+		t.Fatal("failed to spawn test subprocess")
+	}
+
+	if !waitFor(t, 10*time.Second, func() bool {
+		b, err := os.ReadFile(out) //nolint:gosec // test-owned path under t.TempDir()
+		return err == nil && strings.Contains(string(b), "leaked=[")
+	}) {
+		t.Fatal("subprocess never reported its environment")
+	}
+
+	got, err := os.ReadFile(out) //nolint:gosec // test-owned path under t.TempDir()
+	if err != nil {
+		t.Fatalf("read env dump: %v", err)
+	}
+	dump := strings.TrimSpace(string(got))
+
+	if !strings.Contains(dump, "leaked=[") {
+		t.Fatalf("probe did not run (%q); the isolation assertion below would pass vacuously", dump)
+	}
+	if dump != "leaked=[]" {
+		t.Errorf("subprocess inherited the gateway environment; isolation is inverted: %q", dump)
+	}
+}

--- a/internal/mcp/registry.go
+++ b/internal/mcp/registry.go
@@ -316,3 +316,15 @@ func (r *Registry) serverNameForTool(toolName string) string {
 	defer r.mu.RUnlock()
 	return r.toolMap[toolName]
 }
+
+// timeoutForServer returns the configured per-call timeout for the named server.
+// Falls back to 30 s when the server is not found or TimeoutSeconds is unset.
+func (r *Registry) timeoutForServer(name string) time.Duration {
+	r.mu.RLock()
+	entry, ok := r.servers[name]
+	r.mu.RUnlock()
+	if ok && entry.config.TimeoutSeconds > 0 {
+		return time.Duration(entry.config.TimeoutSeconds) * time.Second
+	}
+	return 30 * time.Second
+}

--- a/internal/mcp/registry.go
+++ b/internal/mcp/registry.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"runtime/trace"
 	"sync"
@@ -25,7 +26,7 @@ type Registry struct {
 // serverEntry holds the live state for one registered MCP server.
 type serverEntry struct {
 	config       ServerConfig
-	client       *Client
+	client       mcpClient
 	tools        []Tool
 	ready        bool  // true once Initialize + ListTools have succeeded
 	initializing bool  // true while initServer goroutine is running for this entry
@@ -41,21 +42,29 @@ func NewRegistry() *Registry {
 	}
 }
 
-// RegisterConfig stores an MCP server configuration and creates its client
-// without making any network calls. Call InitializeAll in a background
+// RegisterConfig stores an MCP server configuration and creates its transport
+// client without performing any I/O. Call InitializeAll in a background
 // goroutine after gateway.New() returns so the first LLM request is never
 // blocked by MCP cold-start latency.
 //
-// Re-registering a server with the same Name preserves its original
-// registration order (and therefore its tool-conflict priority). Stale
-// tool→server mappings owned by the old entry are removed immediately so
-// FindToolServer never routes to stale state.
+// Transport selection: when cfg.Command is non-empty a stdio client is created
+// (the subprocess is started immediately); otherwise an HTTP client is created.
+//
+// Re-registering a server with the same Name closes the old client, preserves
+// the original registration order (and therefore its tool-conflict priority),
+// and removes stale tool→server mappings so FindToolServer never routes to
+// stale state.
 func (r *Registry) RegisterConfig(cfg ServerConfig) {
-	timeout := time.Duration(cfg.TimeoutSeconds) * time.Second
-	if timeout <= 0 {
-		timeout = 30 * time.Second
+	var client mcpClient
+	if cfg.Command != "" {
+		client = newStdioClient(cfg.Command, cfg.Args, cfg.Env)
+	} else {
+		timeout := time.Duration(cfg.TimeoutSeconds) * time.Second
+		if timeout <= 0 {
+			timeout = 30 * time.Second
+		}
+		client = NewClient(cfg.URL, cfg.Headers, timeout)
 	}
-	client := NewClient(cfg.URL, cfg.Headers, timeout)
 
 	r.mu.Lock()
 	if old, ok := r.servers[cfg.Name]; ok {
@@ -64,6 +73,10 @@ func (r *Registry) RegisterConfig(cfg ServerConfig) {
 			if r.toolMap[t.Name] == cfg.Name {
 				delete(r.toolMap, t.Name)
 			}
+		}
+		// Close the old client (no-op for HTTP; terminates subprocess for stdio).
+		if old.client != nil {
+			_ = old.client.Close()
 		}
 		// Registration order and serverIndex are preserved on re-registration.
 	} else {
@@ -207,9 +220,9 @@ func (r *Registry) initServer(ctx context.Context, name string) error {
 	return nil
 }
 
-// FindToolServer returns the Client responsible for the named tool.
+// FindToolServer returns the transport client responsible for the named tool.
 // Returns (nil, false) when no ready server exposes the tool.
-func (r *Registry) FindToolServer(toolName string) (*Client, bool) {
+func (r *Registry) FindToolServer(toolName string) (mcpClient, bool) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
@@ -222,6 +235,28 @@ func (r *Registry) FindToolServer(toolName string) (*Client, bool) {
 		return nil, false
 	}
 	return entry.client, true
+}
+
+// Close shuts down all registered MCP server clients. For stdio servers this
+// terminates the subprocess; for HTTP servers it is a no-op. Errors from
+// individual clients are joined and returned together.
+func (r *Registry) Close() error {
+	r.mu.Lock()
+	clients := make([]mcpClient, 0, len(r.servers))
+	for _, entry := range r.servers {
+		if entry.client != nil {
+			clients = append(clients, entry.client)
+		}
+	}
+	r.mu.Unlock()
+
+	var errs []error
+	for _, c := range clients {
+		if err := c.Close(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
 }
 
 // AllTools returns the combined list of tools from all ready servers.

--- a/internal/mcp/registry.go
+++ b/internal/mcp/registry.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"runtime/trace"
 	"sync"
 	"time"
@@ -21,6 +22,16 @@ type Registry struct {
 	toolMap     map[string]string       // tool name => server name (O(1) lookup)
 	regOrder    []string                // server names in registration order
 	serverIndex map[string]int          // server name => position in regOrder
+
+	// Retirement lifecycle. A request snapshots the registry at entry and uses
+	// it after releasing the gateway lock, so a config reload that closed the
+	// old registry immediately would terminate a stdio subprocess underneath an
+	// in-flight tool call. Holders are counted, and teardown waits for the last
+	// one. Mirrors the plugin.Manager lifecycle.
+	lifecycleMu sync.Mutex
+	lifecycle   *sync.Cond
+	active      int
+	closed      bool
 }
 
 // serverEntry holds the live state for one registered MCP server.
@@ -57,7 +68,7 @@ func NewRegistry() *Registry {
 func (r *Registry) RegisterConfig(cfg ServerConfig) {
 	var client mcpClient
 	if cfg.Command != "" {
-		client = newStdioClient(cfg.Command, cfg.Args, cfg.Env)
+		client = newStdioClient(cfg.Name, cfg.Command, cfg.Args, cfg.Env)
 	} else {
 		timeout := time.Duration(cfg.TimeoutSeconds) * time.Second
 		if timeout <= 0 {
@@ -75,8 +86,13 @@ func (r *Registry) RegisterConfig(cfg ServerConfig) {
 			}
 		}
 		// Close the old client (no-op for HTTP; terminates subprocess for stdio).
+		// A failure here means a subprocess may have survived re-registration,
+		// which is the leak this call exists to prevent — never silent.
 		if old.client != nil {
-			_ = old.client.Close()
+			if err := old.client.Close(); err != nil {
+				slog.Warn("mcp: failed to close replaced server client",
+					"server", cfg.Name, "error", err)
+			}
 		}
 		// Registration order and serverIndex are preserved on re-registration.
 	} else {
@@ -131,6 +147,12 @@ func (r *Registry) InitializeAll(ctx context.Context, logErr func(name string, e
 		wg.Add(1)
 		go func(n string) {
 			defer wg.Done()
+			// Hold the registry for the handshake. Without it Close can retire the
+			// registry mid-initialisation and return while transports are still
+			// being spoken to, and the entry could be published ready after
+			// closeClients had already detached its client.
+			release := r.Acquire()
+			defer release()
 			if err := r.initServer(ctx, n); err != nil && logErr != nil {
 				logErr(n, err)
 			}
@@ -142,16 +164,31 @@ func (r *Registry) InitializeAll(ctx context.Context, logErr func(name string, e
 // initServer performs the Initialize + ListTools handshake for a single server
 // and indexes its tools. It applies the AllowedTools filter if configured.
 func (r *Registry) initServer(ctx context.Context, name string) error {
+	// Capture the client under the lock and use that copy for the whole
+	// handshake. A concurrent Close detaches entry.client, so re-reading the
+	// field across the unlocked I/O below would nil-deref mid-initialisation.
 	r.mu.RLock()
 	entry, ok := r.servers[name]
+	var client mcpClient
+	if ok {
+		client = entry.client
+	}
 	r.mu.RUnlock()
 	if !ok {
 		return fmt.Errorf("mcp: server %q not registered", name)
 	}
+	if client == nil {
+		// The registry was closed while this initialisation was queued. Stop
+		// rather than resurrecting a retired server.
+		r.mu.Lock()
+		entry.initializing = false
+		r.mu.Unlock()
+		return fmt.Errorf("mcp: server %q closed before initialization", name)
+	}
 
 	var err error
 	trace.WithRegion(ctx, "mcp.init_server.initialize", func() {
-		_, err = entry.client.Initialize(ctx)
+		_, err = client.Initialize(ctx)
 	})
 	if err != nil {
 		r.mu.Lock()
@@ -163,7 +200,7 @@ func (r *Registry) initServer(ctx context.Context, name string) error {
 
 	var tools []Tool
 	trace.WithRegion(ctx, "mcp.init_server.list_tools", func() {
-		tools, err = entry.client.ListTools(ctx)
+		tools, err = client.ListTools(ctx)
 	})
 	if err != nil {
 		r.mu.Lock()
@@ -237,25 +274,127 @@ func (r *Registry) FindToolServer(toolName string) (mcpClient, bool) {
 	return entry.client, true
 }
 
+// Owns reports whether a ready server exposes the named tool.
+//
+// This is the ownership boundary between MCP tools and tools the caller
+// supplied in their own request. A caller posting an OpenAI-style tools array
+// intends to execute those calls itself and post the results back, so the
+// agentic loop must neither execute them nor answer them — it must let the
+// tool_calls response reach the client untouched.
+func (r *Registry) Owns(toolName string) bool {
+	_, ok := r.FindToolServer(toolName)
+	return ok
+}
+
+// Acquire marks the registry as in use by one in-flight request and returns a
+// release function. Close defers the actual teardown until every holder has
+// released, so a config reload cannot terminate a stdio subprocess out from
+// under a tool call that is still running.
+//
+// The returned function is idempotent. Acquiring an already-closed registry
+// returns a no-op release rather than resurrecting it.
+func (r *Registry) Acquire() func() {
+	r.lifecycleMu.Lock()
+	r.ensureLifecycleLocked()
+	if r.closed {
+		r.lifecycleMu.Unlock()
+		return func() {}
+	}
+	r.active++
+	r.lifecycleMu.Unlock()
+
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			r.lifecycleMu.Lock()
+			r.active--
+			if r.active == 0 {
+				r.lifecycle.Broadcast()
+			}
+			r.lifecycleMu.Unlock()
+		})
+	}
+}
+
+// ensureLifecycleLocked lazily builds the condition variable so a Registry
+// created by NewRegistry or as a zero value both work. Caller holds lifecycleMu.
+func (r *Registry) ensureLifecycleLocked() {
+	if r.lifecycle == nil {
+		r.lifecycle = sync.NewCond(&r.lifecycleMu)
+	}
+}
+
+// closeWhenDrained blocks until the last holder releases, then tears down.
+func (r *Registry) closeWhenDrained() {
+	r.lifecycleMu.Lock()
+	r.ensureLifecycleLocked()
+	for r.active > 0 {
+		r.lifecycle.Wait()
+	}
+	r.lifecycleMu.Unlock()
+
+	if err := r.closeClients(); err != nil {
+		slog.Error("mcp: failed to close retired registry", "error", err)
+	}
+}
+
 // Close shuts down all registered MCP server clients. For stdio servers this
 // terminates the subprocess; for HTTP servers it is a no-op. Errors from
 // individual clients are joined and returned together.
+// Close is idempotent. When requests still hold the registry it returns
+// immediately and teardown completes in the background once they release.
 func (r *Registry) Close() error {
+	r.lifecycleMu.Lock()
+	r.ensureLifecycleLocked()
+	if r.closed {
+		r.lifecycleMu.Unlock()
+		return nil
+	}
+	r.closed = true
+	if r.active > 0 {
+		r.lifecycleMu.Unlock()
+		go r.closeWhenDrained()
+		return nil
+	}
+	r.lifecycleMu.Unlock()
+
+	return r.closeClients()
+}
+
+// closeClients tears down every transport concurrently.
+//
+// Serial teardown does not fit the shutdown budget: one wedged stdio server can
+// spend seconds in the transport's graceful/SIGTERM/SIGKILL ladder, and
+// Gateway.Close allows only 5s in total. Several of them serially would blow an
+// orchestrator's grace period, which then SIGKILLs the process and re-orphans
+// the very subprocesses the process-group sweep exists to reap.
+func (r *Registry) closeClients() error {
 	r.mu.Lock()
 	clients := make([]mcpClient, 0, len(r.servers))
 	for _, entry := range r.servers {
 		if entry.client != nil {
 			clients = append(clients, entry.client)
+			// Detach so a second call cannot close the same transport again.
+			// Close is guarded by the closed flag, but this function is reachable
+			// from both Close and closeWhenDrained; leaving the references in
+			// place made double-close depend on that guard alone.
+			entry.client = nil
 		}
+		entry.ready = false
 	}
 	r.mu.Unlock()
 
-	var errs []error
-	for _, c := range clients {
-		if err := c.Close(); err != nil {
-			errs = append(errs, err)
-		}
+	errs := make([]error, len(clients))
+	var wg sync.WaitGroup
+	for i, c := range clients {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			errs[i] = c.Close()
+		}()
 	}
+	wg.Wait()
+
 	return errors.Join(errs...)
 }
 

--- a/internal/mcp/registry_test.go
+++ b/internal/mcp/registry_test.go
@@ -31,6 +31,14 @@ func newMockServer(t *testing.T, tools []Tool) *httptest.Server {
 				JSONRPC: "2.0", ID: req.ID,
 				Result: mustMarshal(map[string]any{"tools": tools}),
 			})
+		case mcpMethodToolsCall:
+			_ = json.NewEncoder(w).Encode(JSONRPCResponse{
+				JSONRPC: "2.0", ID: req.ID,
+				Result: mustMarshal(map[string]any{
+					"content": []map[string]any{{"type": "text", "text": "ok"}},
+					"isError": false,
+				}),
+			})
 		default:
 			w.WriteHeader(http.StatusNotFound)
 		}

--- a/internal/mcp/stdio.go
+++ b/internal/mcp/stdio.go
@@ -48,8 +48,8 @@ func newStdioClient(command string, args []string, envOverrides map[string]strin
 	// os.Environ(). The library passes c.env to cmdFunc, but we ignore that
 	// parameter and use our already-built slice to keep the logic self-contained.
 	isolatedEnv := env
-	cmdFunc := transport.CommandFunc(func(_ context.Context, command string, _ []string, args []string) (*exec.Cmd, error) {
-		cmd := exec.Command(command, args...) //nolint:gosec // command comes from gateway config, not user input
+	cmdFunc := transport.CommandFunc(func(ctx context.Context, command string, _ []string, args []string) (*exec.Cmd, error) {
+		cmd := exec.CommandContext(ctx, command, args...) //nolint:gosec // command comes from gateway config, not user input
 		cmd.Env = isolatedEnv
 		return cmd, nil
 	})

--- a/internal/mcp/stdio.go
+++ b/internal/mcp/stdio.go
@@ -5,8 +5,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"os/exec"
 
 	mcpclient "github.com/mark3labs/mcp-go/client"
+	"github.com/mark3labs/mcp-go/client/transport"
 	mcpgo "github.com/mark3labs/mcp-go/mcp"
 
 	"github.com/ferro-labs/ai-gateway/internal/version"
@@ -21,24 +23,38 @@ type stdioClient struct {
 
 // newStdioClient creates a stdio MCP client by launching command with args.
 // The subprocess receives a minimal base environment (PATH, HOME, LANG, TMPDIR)
-// plus any KEY=VALUE pairs from envOverrides, so that gateway credentials
-// (OPENAI_API_KEY, MASTER_KEY, etc.) are never inherited by child processes.
+// plus any KEY=VALUE pairs from envOverrides. We use a custom CommandFunc so
+// that gateway credentials (OPENAI_API_KEY, MASTER_KEY, etc.) are never
+// inherited: the default mark3labs transport unconditionally prepends
+// os.Environ() to whatever env slice is passed, so the only way to fully
+// replace the environment is to supply a CommandFunc that sets cmd.Env
+// directly without calling os.Environ().
 // Returns an errClient instead of an error so that the Registry API (which has
 // no error return) can defer the failure to InitializeAll, where it will be
 // logged by the normal error path.
 func newStdioClient(command string, args []string, envOverrides map[string]string) mcpClient {
 	// Build a minimal base env — safe inherited variables only.
-	var merged []string
+	var env []string
 	for _, key := range []string{"PATH", "HOME", "LANG", "TMPDIR"} {
 		if val := os.Getenv(key); val != "" {
-			merged = append(merged, key+"="+val)
+			env = append(env, key+"="+val)
 		}
 	}
 	for k, v := range envOverrides {
-		merged = append(merged, k+"="+v)
+		env = append(env, k+"="+v)
 	}
 
-	c, err := mcpclient.NewStdioMCPClient(command, merged, args...)
+	// Capture env for the closure so the CommandFunc does not need to call
+	// os.Environ(). The library passes c.env to cmdFunc, but we ignore that
+	// parameter and use our already-built slice to keep the logic self-contained.
+	isolatedEnv := env
+	cmdFunc := transport.CommandFunc(func(_ context.Context, command string, _ []string, args []string) (*exec.Cmd, error) {
+		cmd := exec.Command(command, args...) //nolint:gosec // command comes from gateway config, not user input
+		cmd.Env = isolatedEnv
+		return cmd, nil
+	})
+
+	c, err := mcpclient.NewStdioMCPClientWithOptions(command, nil, args, transport.WithCommandFunc(cmdFunc))
 	if err != nil {
 		return &errClient{err: fmt.Errorf("mcp stdio: start %q: %w", command, err)}
 	}

--- a/internal/mcp/stdio.go
+++ b/internal/mcp/stdio.go
@@ -20,12 +20,20 @@ type stdioClient struct {
 }
 
 // newStdioClient creates a stdio MCP client by launching command with args.
-// Additional env pairs from envOverrides (KEY → VALUE) are merged on top of the
-// current process environment. Returns an errClient instead of an error so that
-// the Registry API (which has no error return) can defer the failure to
-// InitializeAll, where it will be logged by the normal error path.
+// The subprocess receives a minimal base environment (PATH, HOME, LANG, TMPDIR)
+// plus any KEY=VALUE pairs from envOverrides, so that gateway credentials
+// (OPENAI_API_KEY, MASTER_KEY, etc.) are never inherited by child processes.
+// Returns an errClient instead of an error so that the Registry API (which has
+// no error return) can defer the failure to InitializeAll, where it will be
+// logged by the normal error path.
 func newStdioClient(command string, args []string, envOverrides map[string]string) mcpClient {
-	merged := os.Environ()
+	// Build a minimal base env — safe inherited variables only.
+	var merged []string
+	for _, key := range []string{"PATH", "HOME", "LANG", "TMPDIR"} {
+		if val := os.Getenv(key); val != "" {
+			merged = append(merged, key+"="+val)
+		}
+	}
 	for k, v := range envOverrides {
 		merged = append(merged, k+"="+v)
 	}

--- a/internal/mcp/stdio.go
+++ b/internal/mcp/stdio.go
@@ -1,0 +1,138 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	mcpclient "github.com/mark3labs/mcp-go/client"
+	mcpgo "github.com/mark3labs/mcp-go/mcp"
+
+	"github.com/ferro-labs/ai-gateway/internal/version"
+)
+
+// stdioClient wraps a mark3labs MCP client for the stdio transport.
+// It launches a subprocess and communicates via stdin/stdout pipes,
+// converting between mark3labs protocol types and ferro-labs internal types.
+type stdioClient struct {
+	inner mcpclient.MCPClient
+}
+
+// newStdioClient creates a stdio MCP client by launching command with args.
+// Additional env pairs from envOverrides (KEY → VALUE) are merged on top of the
+// current process environment. Returns an errClient instead of an error so that
+// the Registry API (which has no error return) can defer the failure to
+// InitializeAll, where it will be logged by the normal error path.
+func newStdioClient(command string, args []string, envOverrides map[string]string) mcpClient {
+	merged := os.Environ()
+	for k, v := range envOverrides {
+		merged = append(merged, k+"="+v)
+	}
+
+	c, err := mcpclient.NewStdioMCPClient(command, merged, args...)
+	if err != nil {
+		return &errClient{err: fmt.Errorf("mcp stdio: start %q: %w", command, err)}
+	}
+	return &stdioClient{inner: c}
+}
+
+// Initialize performs the MCP initialization handshake over stdio.
+// mark3labs automatically sends the notifications/initialized notification.
+func (c *stdioClient) Initialize(ctx context.Context) (*ServerInfo, error) {
+	req := mcpgo.InitializeRequest{}
+	req.Params.ProtocolVersion = mcpgo.LATEST_PROTOCOL_VERSION
+	req.Params.ClientInfo = mcpgo.Implementation{
+		Name:    "ferro-ai-gateway",
+		Version: version.Short(),
+	}
+
+	result, err := c.inner.Initialize(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("mcp stdio initialize: %w", err)
+	}
+
+	return &ServerInfo{
+		Name:    result.ServerInfo.Name,
+		Version: result.ServerInfo.Version,
+	}, nil
+}
+
+// ListTools fetches the tool list over stdio and converts it to ferro-labs types
+// via a JSON round-trip. The mark3labs Tool type marshals to the same JSON
+// structure as the ferro-labs Tool type (name, description, inputSchema).
+func (c *stdioClient) ListTools(ctx context.Context) ([]Tool, error) {
+	result, err := c.inner.ListTools(ctx, mcpgo.ListToolsRequest{})
+	if err != nil {
+		return nil, fmt.Errorf("mcp stdio tools/list: %w", err)
+	}
+
+	toolsJSON, err := json.Marshal(result.Tools)
+	if err != nil {
+		return nil, fmt.Errorf("mcp stdio tools/list marshal: %w", err)
+	}
+	var tools []Tool
+	if err := json.Unmarshal(toolsJSON, &tools); err != nil {
+		return nil, fmt.Errorf("mcp stdio tools/list unmarshal: %w", err)
+	}
+	return tools, nil
+}
+
+// CallTool invokes a named tool over stdio. Arguments are unmarshaled from
+// RawMessage into any for mark3labs, and the result is converted back to
+// ferro-labs types via a JSON round-trip.
+func (c *stdioClient) CallTool(ctx context.Context, name string, arguments json.RawMessage) (*ToolCallResult, error) {
+	req := mcpgo.CallToolRequest{}
+	req.Params.Name = name
+
+	if len(arguments) > 0 {
+		var args any
+		if err := json.Unmarshal(arguments, &args); err != nil {
+			return nil, fmt.Errorf("mcp stdio tools/call %s: unmarshal args: %w", name, err)
+		}
+		req.Params.Arguments = args
+	}
+
+	result, err := c.inner.CallTool(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("mcp stdio tools/call %s: %w", name, err)
+	}
+
+	// Convert via JSON: mark3labs content blocks share the same JSON structure
+	// as ferro-labs ContentBlock (type, text, data, mimeType, resource fields).
+	resultJSON, err := json.Marshal(result)
+	if err != nil {
+		return nil, fmt.Errorf("mcp stdio tools/call %s: marshal result: %w", name, err)
+	}
+	var toolResult ToolCallResult
+	if err := json.Unmarshal(resultJSON, &toolResult); err != nil {
+		return nil, fmt.Errorf("mcp stdio tools/call %s: unmarshal result: %w", name, err)
+	}
+	return &toolResult, nil
+}
+
+// Close terminates the stdio subprocess.
+func (c *stdioClient) Close() error { return c.inner.Close() }
+
+// ─── errClient ───────────────────────────────────────────────────────────────
+
+// errClient is returned by newStdioClient when the subprocess cannot be started.
+// Every method returns the construction-time error so that it surfaces in the
+// normal InitializeAll error log rather than being silently swallowed.
+type errClient struct {
+	err error
+}
+
+func (e *errClient) Initialize(_ context.Context) (*ServerInfo, error) {
+	return nil, e.err
+}
+
+func (e *errClient) ListTools(_ context.Context) ([]Tool, error) {
+	return nil, e.err
+}
+
+func (e *errClient) CallTool(_ context.Context, _ string, _ json.RawMessage) (*ToolCallResult, error) {
+	return nil, e.err
+}
+
+func (e *errClient) Close() error { return nil }

--- a/internal/mcp/stdio.go
+++ b/internal/mcp/stdio.go
@@ -1,11 +1,15 @@
 package mcp
 
 import (
+	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"log/slog"
 	"os"
 	"os/exec"
+	"time"
 
 	mcpclient "github.com/mark3labs/mcp-go/client"
 	"github.com/mark3labs/mcp-go/client/transport"
@@ -18,10 +22,16 @@ import (
 // It launches a subprocess and communicates via stdin/stdout pipes,
 // converting between mark3labs protocol types and ferro-labs internal types.
 type stdioClient struct {
-	inner mcpclient.MCPClient
+	inner *mcpclient.Client
+	// pgid of the child's process group, captured at spawn — the transport reaps
+	// the leader before Close returns, so it cannot be looked up afterwards.
+	// Zero when the process never started or the platform has no process groups.
+	pgid int
 }
 
 // newStdioClient creates a stdio MCP client by launching command with args.
+// name identifies the server in log records.
+//
 // The subprocess receives a minimal base environment (PATH, HOME, LANG, TMPDIR)
 // plus any KEY=VALUE pairs from envOverrides. We use a custom CommandFunc so
 // that gateway credentials (OPENAI_API_KEY, MASTER_KEY, etc.) are never
@@ -32,9 +42,16 @@ type stdioClient struct {
 // Returns an errClient instead of an error so that the Registry API (which has
 // no error return) can defer the failure to InitializeAll, where it will be
 // logged by the normal error path.
-func newStdioClient(command string, args []string, envOverrides map[string]string) mcpClient {
+func newStdioClient(name, command string, args []string, envOverrides map[string]string) mcpClient {
 	// Build a minimal base env — safe inherited variables only.
-	var env []string
+	//
+	// Non-nil even when empty, and that is the whole isolation guarantee: os/exec
+	// documents "If Env is nil, the new process uses the current process's
+	// environment", so a nil slice here would silently hand the subprocess every
+	// gateway credential. Reachable whenever PATH, HOME, LANG and TMPDIR are all
+	// unset and the server declares no env of its own — an ordinary stripped
+	// container (env -i, distroless).
+	env := make([]string, 0, 4+len(envOverrides))
 	for _, key := range []string{"PATH", "HOME", "LANG", "TMPDIR"} {
 		if val := os.Getenv(key); val != "" {
 			env = append(env, key+"="+val)
@@ -48,9 +65,22 @@ func newStdioClient(command string, args []string, envOverrides map[string]strin
 	// os.Environ(). The library passes c.env to cmdFunc, but we ignore that
 	// parameter and use our already-built slice to keep the logic self-contained.
 	isolatedEnv := env
+	// The transport calls cmdFunc before cmd.Start, so the pid is not readable
+	// here; keep the *exec.Cmd and read it once the constructor has returned.
+	var spawned *exec.Cmd
 	cmdFunc := transport.CommandFunc(func(ctx context.Context, command string, _ []string, args []string) (*exec.Cmd, error) {
+		// INVARIANT: ctx here is context.Background() — mark3labs starts the
+		// transport with it (client/stdio.go:40), so the child correctly
+		// outlives individual requests and cmd.Cancel never fires. Do not
+		// "fix" this to a request context: that would SIGKILL the MCP server
+		// mid-flight whenever one request is cancelled.
 		cmd := exec.CommandContext(ctx, command, args...) //nolint:gosec // command comes from gateway config, not user input
 		cmd.Env = isolatedEnv
+		configureProcGroup(cmd)
+		// Bounds a child that ignores cancellation, and one that exits leaving
+		// its pipes held open by an orphaned grandchild.
+		cmd.WaitDelay = 10 * time.Second
+		spawned = cmd
 		return cmd, nil
 	})
 
@@ -58,7 +88,37 @@ func newStdioClient(command string, args []string, envOverrides map[string]strin
 	if err != nil {
 		return &errClient{err: fmt.Errorf("mcp stdio: start %q: %w", command, err)}
 	}
-	return &stdioClient{inner: c}
+
+	// Draining stderr is required for correctness, not just diagnostics: the
+	// transport creates the pipe but never reads it, so once the OS pipe buffer
+	// fills the child blocks in write(2) and stops answering JSON-RPC entirely.
+	if r, ok := mcpclient.GetStderr(c); ok {
+		go drainStderr(r, name)
+	}
+
+	sc := &stdioClient{inner: c}
+	if spawned != nil && spawned.Process != nil {
+		// Setpgid made the child its own group leader, so pid == pgid.
+		sc.pgid = spawned.Process.Pid
+	}
+	return sc
+}
+
+// drainStderr copies a child's stderr into the gateway log, one record per line.
+//
+// Debug level, never warn: the spec says a server MAY write anything to stderr,
+// and that a client SHOULD NOT assume stderr output indicates an error.
+func drainStderr(r io.Reader, server string) {
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		slog.Debug("mcp server stderr", "server", server, "line", scanner.Text())
+	}
+	// A single line past the scanner's 64 KiB token limit stops Scan with
+	// ErrTooLong. Returning here would re-create the very deadlock this function
+	// exists to prevent, so keep the pipe moving.
+	if scanner.Err() != nil {
+		_, _ = io.Copy(io.Discard, r)
+	}
 }
 
 // Initialize performs the MCP initialization handshake over stdio.
@@ -135,8 +195,25 @@ func (c *stdioClient) CallTool(ctx context.Context, name string, arguments json.
 	return &toolResult, nil
 }
 
-// Close terminates the stdio subprocess.
-func (c *stdioClient) Close() error { return c.inner.Close() }
+// Close terminates the stdio subprocess and any descendant it left behind.
+//
+// The transport's own ladder (close stdin, 2s grace, SIGTERM, 3s, SIGKILL, then
+// cmd.Wait) is already the shape the spec prescribes, so it runs first and
+// unchanged. The sweep afterwards only reaches survivors — typically the real
+// server that an npx or uvx leader exec'd into a separate process, which the
+// ladder never signalled because it targets the leader pid alone.
+func (c *stdioClient) Close() error {
+	err := c.inner.Close()
+	if c.pgid > 0 {
+		// Best-effort: an already-empty group reports no error. Debug, not Warn —
+		// the only reachable failure is a rare EPERM, which is not actionable and
+		// must not page anyone.
+		if sweepErr := sweepProcessGroup(c.pgid); sweepErr != nil {
+			slog.Debug("mcp: process group sweep failed", "pgid", c.pgid, "error", sweepErr)
+		}
+	}
+	return err
+}
 
 // ─── errClient ───────────────────────────────────────────────────────────────
 

--- a/internal/mcp/stdio_integration_test.go
+++ b/internal/mcp/stdio_integration_test.go
@@ -1,4 +1,5 @@
 //go:build integration
+// +build integration
 
 package mcp
 

--- a/internal/mcp/stdio_integration_test.go
+++ b/internal/mcp/stdio_integration_test.go
@@ -1,0 +1,65 @@
+//go:build integration
+
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+// TestStdioIntegration_FilesystemServer runs an end-to-end test against the
+// @modelcontextprotocol/server-filesystem package via npx.
+// Requires npx to be on PATH and network access to the npm registry.
+// Run with: go test -tags integration ./internal/mcp/... -run TestStdioIntegration
+func TestStdioIntegration_FilesystemServer(t *testing.T) {
+	reg := NewRegistry()
+	reg.RegisterConfig(ServerConfig{
+		Name:    "filesystem",
+		Command: "npx",
+		Args:    []string{"-y", "@modelcontextprotocol/server-filesystem", t.TempDir()},
+	})
+	defer func() { _ = reg.Close() }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	reg.InitializeAll(ctx, func(name string, err error) {
+		t.Errorf("MCP init error for %s: %v", name, err)
+	})
+
+	if !reg.IsReady("filesystem") {
+		t.Fatal("filesystem server not ready after InitializeAll")
+	}
+
+	tools := reg.AllTools()
+	if len(tools) == 0 {
+		t.Fatal("expected at least one tool from filesystem server, got none")
+	}
+	t.Logf("discovered %d tools: %v", len(tools), toolNames(tools))
+
+	// Verify FindToolServer routes correctly.
+	client, ok := reg.FindToolServer(tools[0].Name)
+	if !ok || client == nil {
+		t.Fatalf("FindToolServer(%q) returned ok=%v", tools[0].Name, ok)
+	}
+
+	// Call read_file with an argument (file won't exist, but the tool call
+	// should round-trip without panicking; IsError=true is an acceptable result).
+	result, err := client.CallTool(ctx, tools[0].Name, json.RawMessage(`{"path":"/nonexistent"}`))
+	if err != nil {
+		// A protocol-level error (not a tool error) is unexpected.
+		t.Logf("CallTool returned err (acceptable if tool-level): %v", err)
+	} else {
+		t.Logf("CallTool result: isError=%v, content=%d blocks", result.IsError, len(result.Content))
+	}
+}
+
+func toolNames(tools []Tool) []string {
+	names := make([]string, len(tools))
+	for i, t := range tools {
+		names[i] = t.Name
+	}
+	return names
+}

--- a/internal/mcp/stdio_test.go
+++ b/internal/mcp/stdio_test.go
@@ -1,0 +1,79 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+)
+
+// TestNewStdioClientInvalidCommand verifies that starting a non-existent
+// executable returns an errClient whose Initialize method surfaces the error.
+func TestNewStdioClientInvalidCommand(t *testing.T) {
+	c := newStdioClient("/nonexistent/binary-that-does-not-exist", nil, nil)
+	if c == nil {
+		t.Fatal("expected non-nil client")
+	}
+
+	_, err := c.Initialize(context.Background())
+	if err == nil {
+		t.Fatal("expected error from Initialize on bad command, got nil")
+	}
+
+	_, err = c.ListTools(context.Background())
+	if err == nil {
+		t.Fatal("expected error from ListTools on bad command, got nil")
+	}
+
+	_, err = c.CallTool(context.Background(), "any", json.RawMessage("{}"))
+	if err == nil {
+		t.Fatal("expected error from CallTool on bad command, got nil")
+	}
+
+	if err := c.Close(); err != nil {
+		t.Fatalf("errClient.Close() unexpected error: %v", err)
+	}
+}
+
+// TestRegistryStdioConfigDispatch verifies that a ServerConfig with a Command
+// field creates a stdio client (not an HTTP client) in the registry.
+// It uses an invalid command so no subprocess actually starts.
+func TestRegistryStdioConfigDispatch(t *testing.T) {
+	reg := NewRegistry()
+	reg.RegisterConfig(ServerConfig{
+		Name:    "stdio-srv",
+		Command: "/nonexistent/mcp-server",
+		Args:    []string{"--stdio"},
+	})
+
+	if !reg.HasServers() {
+		t.Fatal("expected HasServers true")
+	}
+
+	var initErr error
+	reg.InitializeAll(context.Background(), func(_ string, err error) {
+		initErr = err
+	})
+
+	// The server should fail to initialize (bad command), not panic.
+	if initErr == nil {
+		t.Fatal("expected initialization error for non-existent command")
+	}
+	if reg.IsReady("stdio-srv") {
+		t.Fatal("expected server not ready after failed init")
+	}
+}
+
+// TestRegistryStdioClose verifies that Registry.Close() does not panic when
+// stdio clients are registered (even if they failed to start).
+func TestRegistryStdioClose(t *testing.T) {
+	reg := NewRegistry()
+	reg.RegisterConfig(ServerConfig{
+		Name:    "stdio-close",
+		Command: "/nonexistent/mcp-server",
+	})
+	// Close must not panic regardless of client state.
+	if err := reg.Close(); err != nil {
+		// errClient.Close() returns nil, so this is unexpected.
+		t.Fatalf("Registry.Close() unexpected error: %v", err)
+	}
+}

--- a/internal/mcp/stdio_test.go
+++ b/internal/mcp/stdio_test.go
@@ -11,7 +11,7 @@ import (
 // TestNewStdioClientInvalidCommand verifies that starting a non-existent
 // executable returns an errClient whose Initialize method surfaces the error.
 func TestNewStdioClientInvalidCommand(t *testing.T) {
-	c := newStdioClient("/nonexistent/binary-that-does-not-exist", nil, nil)
+	c := newStdioClient("test", "/nonexistent/binary-that-does-not-exist", nil, nil)
 	if c == nil {
 		t.Fatal("expected non-nil client")
 	}
@@ -83,7 +83,7 @@ func realCmd(t *testing.T) string {
 // *stdioClient (not an errClient) when the command exists on disk.
 func TestStdioClientHappyPathCreation(t *testing.T) {
 	cmd := realCmd(t)
-	c := newStdioClient(cmd, nil, nil)
+	c := newStdioClient("test", cmd, nil, nil)
 	if c == nil {
 		t.Fatal("expected non-nil client")
 	}
@@ -96,7 +96,7 @@ func TestStdioClientHappyPathCreation(t *testing.T) {
 // TestStdioClientEnvOverrides verifies that env overrides are merged without
 // panic. Uses an invalid command so no subprocess is actually started.
 func TestStdioClientEnvOverrides(t *testing.T) {
-	c := newStdioClient("/nonexistent/mcp-srv", nil, map[string]string{
+	c := newStdioClient("test", "/nonexistent/mcp-srv", nil, map[string]string{
 		"CUSTOM_KEY": "custom_val",
 		"OTHER_KEY":  "other_val",
 	})
@@ -113,7 +113,7 @@ func TestStdioClientEnvOverrides(t *testing.T) {
 // a non-nil error when the subprocess exits without sending an MCP response.
 func TestStdioClientInitializeError(t *testing.T) {
 	cmd := realCmd(t)
-	c := newStdioClient(cmd, nil, nil)
+	c := newStdioClient("test", cmd, nil, nil)
 	if _, isErr := c.(*errClient); isErr {
 		t.Skip("command failed to start — skipping stdioClient path")
 	}
@@ -132,7 +132,7 @@ func TestStdioClientInitializeError(t *testing.T) {
 // non-nil error when the subprocess has not completed MCP initialization.
 func TestStdioClientListToolsError(t *testing.T) {
 	cmd := realCmd(t)
-	c := newStdioClient(cmd, nil, nil)
+	c := newStdioClient("test", cmd, nil, nil)
 	if _, isErr := c.(*errClient); isErr {
 		t.Skip("command failed to start — skipping stdioClient path")
 	}
@@ -151,7 +151,7 @@ func TestStdioClientListToolsError(t *testing.T) {
 // non-nil error when the subprocess has not completed MCP initialization.
 func TestStdioClientCallToolError(t *testing.T) {
 	cmd := realCmd(t)
-	c := newStdioClient(cmd, nil, nil)
+	c := newStdioClient("test", cmd, nil, nil)
 	if _, isErr := c.(*errClient); isErr {
 		t.Skip("command failed to start — skipping stdioClient path")
 	}
@@ -170,7 +170,7 @@ func TestStdioClientCallToolError(t *testing.T) {
 // stdioClient whose subprocess exited before any MCP handshake.
 func TestStdioClientCloseAfterError(t *testing.T) {
 	cmd := realCmd(t)
-	c := newStdioClient(cmd, nil, nil)
+	c := newStdioClient("test", cmd, nil, nil)
 	if _, isErr := c.(*errClient); isErr {
 		t.Skip("command failed to start — skipping stdioClient path")
 	}

--- a/internal/mcp/stdio_test.go
+++ b/internal/mcp/stdio_test.go
@@ -3,7 +3,9 @@ package mcp
 import (
 	"context"
 	"encoding/json"
+	"os"
 	"testing"
+	"time"
 )
 
 // TestNewStdioClientInvalidCommand verifies that starting a non-existent
@@ -60,6 +62,142 @@ func TestRegistryStdioConfigDispatch(t *testing.T) {
 	}
 	if reg.IsReady("stdio-srv") {
 		t.Fatal("expected server not ready after failed init")
+	}
+}
+
+// realCmd returns a command guaranteed to exist on the current platform, or
+// skips the test if none is found. The command exits immediately without
+// speaking the MCP protocol, so all stdioClient methods must return errors.
+func realCmd(t *testing.T) string {
+	t.Helper()
+	for _, p := range []string{"/usr/bin/true", "/bin/true"} {
+		if _, err := os.Stat(p); err == nil {
+			return p
+		}
+	}
+	t.Skip("no suitable real command found for stdio tests on this platform")
+	return ""
+}
+
+// TestStdioClientHappyPathCreation verifies that newStdioClient returns a
+// *stdioClient (not an errClient) when the command exists on disk.
+func TestStdioClientHappyPathCreation(t *testing.T) {
+	cmd := realCmd(t)
+	c := newStdioClient(cmd, nil, nil)
+	if c == nil {
+		t.Fatal("expected non-nil client")
+	}
+	if _, isErr := c.(*errClient); isErr {
+		t.Fatal("expected stdioClient, got errClient for valid command")
+	}
+	_ = c.Close()
+}
+
+// TestStdioClientEnvOverrides verifies that env overrides are merged without
+// panic. Uses an invalid command so no subprocess is actually started.
+func TestStdioClientEnvOverrides(t *testing.T) {
+	c := newStdioClient("/nonexistent/mcp-srv", nil, map[string]string{
+		"CUSTOM_KEY": "custom_val",
+		"OTHER_KEY":  "other_val",
+	})
+	if c == nil {
+		t.Fatal("expected non-nil client")
+	}
+	_, err := c.Initialize(context.Background())
+	if err == nil {
+		t.Fatal("expected error from errClient Initialize")
+	}
+}
+
+// TestStdioClientInitializeError verifies that stdioClient.Initialize returns
+// a non-nil error when the subprocess exits without sending an MCP response.
+func TestStdioClientInitializeError(t *testing.T) {
+	cmd := realCmd(t)
+	c := newStdioClient(cmd, nil, nil)
+	if _, isErr := c.(*errClient); isErr {
+		t.Skip("command failed to start — skipping stdioClient path")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, err := c.Initialize(ctx)
+	if err == nil {
+		t.Fatal("expected error initializing with non-MCP subprocess")
+	}
+	_ = c.Close()
+}
+
+// TestStdioClientListToolsError verifies that stdioClient.ListTools returns a
+// non-nil error when the subprocess has not completed MCP initialization.
+func TestStdioClientListToolsError(t *testing.T) {
+	cmd := realCmd(t)
+	c := newStdioClient(cmd, nil, nil)
+	if _, isErr := c.(*errClient); isErr {
+		t.Skip("command failed to start — skipping stdioClient path")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, err := c.ListTools(ctx)
+	if err == nil {
+		t.Fatal("expected error calling ListTools on non-MCP subprocess")
+	}
+	_ = c.Close()
+}
+
+// TestStdioClientCallToolError verifies that stdioClient.CallTool returns a
+// non-nil error when the subprocess has not completed MCP initialization.
+func TestStdioClientCallToolError(t *testing.T) {
+	cmd := realCmd(t)
+	c := newStdioClient(cmd, nil, nil)
+	if _, isErr := c.(*errClient); isErr {
+		t.Skip("command failed to start — skipping stdioClient path")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, err := c.CallTool(ctx, "test-tool", json.RawMessage(`{"key":"val"}`))
+	if err == nil {
+		t.Fatal("expected error calling CallTool on non-MCP subprocess")
+	}
+	_ = c.Close()
+}
+
+// TestStdioClientCloseAfterError verifies that Close does not panic on a
+// stdioClient whose subprocess exited before any MCP handshake.
+func TestStdioClientCloseAfterError(t *testing.T) {
+	cmd := realCmd(t)
+	c := newStdioClient(cmd, nil, nil)
+	if _, isErr := c.(*errClient); isErr {
+		t.Skip("command failed to start — skipping stdioClient path")
+	}
+	if err := c.Close(); err != nil {
+		// Some transports return an error on close after subprocess exit; that
+		// is acceptable as long as Close does not panic.
+		t.Logf("Close returned (acceptable) error: %v", err)
+	}
+}
+
+// TestRegistryReregistration verifies that re-registering a server with the
+// same name preserves registration order and does not duplicate entries.
+func TestRegistryReregistration(t *testing.T) {
+	reg := NewRegistry()
+	cfg := ServerConfig{
+		Name:    "reregister-srv",
+		Command: "/nonexistent/mcp-server",
+	}
+	reg.RegisterConfig(cfg)
+	reg.RegisterConfig(cfg) // second registration of the same name
+
+	names := reg.ServerNames()
+	if len(names) != 1 {
+		t.Fatalf("expected 1 server after re-registration, got %d", len(names))
+	}
+	if names[0] != "reregister-srv" {
+		t.Fatalf("unexpected server name: %s", names[0])
 	}
 }
 

--- a/internal/mcp/transport.go
+++ b/internal/mcp/transport.go
@@ -1,0 +1,20 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+)
+
+// mcpClient is the internal interface all MCP transport adapters must satisfy.
+// Both the hand-rolled HTTP client (*Client) and the stdio adapter (*stdioClient)
+// implement this interface so the Registry is transport-agnostic.
+type mcpClient interface {
+	// Initialize performs the MCP initialization handshake with the server.
+	Initialize(ctx context.Context) (*ServerInfo, error)
+	// ListTools retrieves the full list of tools advertised by the server.
+	ListTools(ctx context.Context) ([]Tool, error)
+	// CallTool invokes a named tool with JSON-encoded arguments.
+	CallTool(ctx context.Context, name string, arguments json.RawMessage) (*ToolCallResult, error)
+	// Close releases any resources held by the transport (e.g. subprocess, connection).
+	Close() error
+}

--- a/mcp/config.go
+++ b/mcp/config.go
@@ -11,15 +11,35 @@ import "context"
 
 // ServerConfig defines how the gateway connects to one external MCP server.
 // It lives in gateway.Config.MCPServers and is consumed by the internal Registry.
+//
+// Transport selection: when Command is non-empty the gateway uses stdio transport
+// (the server is launched as a subprocess). Otherwise Streamable HTTP transport
+// is used and URL must be provided.
 type ServerConfig struct {
 	// Name is a unique human-readable identifier for this MCP server.
 	Name string `json:"name" yaml:"name"`
+
+	// ── HTTP transport (URL must be set when Command is empty) ───────────────
 	// URL is the Streamable HTTP endpoint (e.g. "https://mcp.example.com/mcp").
-	URL string `json:"url" yaml:"url"`
+	URL string `json:"url,omitempty" yaml:"url,omitempty"`
 	// Headers are additional HTTP headers sent with every MCP request
 	// (e.g. authorization tokens). When loaded via aigateway.LoadConfig,
 	// values may reference environment variables using $VAR or ${VAR}.
 	Headers map[string]string `json:"headers,omitempty" yaml:"headers,omitempty"`
+
+	// ── Stdio transport (Command must be set; URL/Headers are ignored) ───────
+	// Command is the executable to launch as an MCP stdio server.
+	// The process is started at gateway-init time and kept alive for the
+	// lifetime of the gateway.
+	Command string `json:"command,omitempty" yaml:"command,omitempty"`
+	// Args are the command-line arguments passed to Command.
+	Args []string `json:"args,omitempty" yaml:"args,omitempty"`
+	// Env are additional environment variables injected into the subprocess.
+	// They are merged with the current process environment; keys listed here
+	// take precedence over any identically-named inherited variables.
+	Env map[string]string `json:"env,omitempty" yaml:"env,omitempty"`
+
+	// ── Common options ────────────────────────────────────────────────────────
 	// AllowedTools restricts which tools from this server are exposed to the LLM.
 	// An empty slice means all discovered tools are allowed.
 	AllowedTools []string `json:"allowed_tools,omitempty" yaml:"allowed_tools,omitempty"`
@@ -29,7 +49,7 @@ type ServerConfig struct {
 	// Defaults to 5 when all servers leave MaxCallDepth unset or zero.
 	MaxCallDepth int `json:"max_call_depth,omitempty" yaml:"max_call_depth,omitempty"`
 	// TimeoutSeconds is the per-request timeout for calls to this server.
-	// Defaults to 30 when unset or zero.
+	// Applies to HTTP transport only. Defaults to 30 when unset or zero.
 	TimeoutSeconds int `json:"timeout_seconds,omitempty" yaml:"timeout_seconds,omitempty"`
 }
 

--- a/mcp/config.go
+++ b/mcp/config.go
@@ -48,8 +48,9 @@ type ServerConfig struct {
 	// servers with MaxCallDepth ≤ 0 are excluded from the minimum.
 	// Defaults to 5 when all servers leave MaxCallDepth unset or zero.
 	MaxCallDepth int `json:"max_call_depth,omitempty" yaml:"max_call_depth,omitempty"`
-	// TimeoutSeconds is the per-request timeout for calls to this server.
-	// Applies to HTTP transport only. Defaults to 30 when unset or zero.
+	// TimeoutSeconds is the per-request timeout for individual tool calls to
+	// this server. Applies to both HTTP and stdio transports. Defaults to 30
+	// when unset or zero.
 	TimeoutSeconds int `json:"timeout_seconds,omitempty" yaml:"timeout_seconds,omitempty"`
 }
 

--- a/mcp/config.go
+++ b/mcp/config.go
@@ -23,8 +23,14 @@ type ServerConfig struct {
 	// URL is the Streamable HTTP endpoint (e.g. "https://mcp.example.com/mcp").
 	URL string `json:"url,omitempty" yaml:"url,omitempty"`
 	// Headers are additional HTTP headers sent with every MCP request
-	// (e.g. authorization tokens). When loaded via aigateway.LoadConfig,
-	// values may reference environment variables using $VAR or ${VAR}.
+	// (e.g. authorization tokens). Values may reference environment variables
+	// using ${VAR} — only the braced form is a reference, a bare $ is literal
+	// data, and an undefined variable is an error rather than a blank secret.
+	// References are resolved when the MCP client is constructed, not when the
+	// config is loaded, so the Config itself never carries a materialised secret
+	// into the config-history store or GET /admin/config.
+	//
+	// Ignored for stdio servers (those setting Command).
 	Headers map[string]string `json:"headers,omitempty" yaml:"headers,omitempty"`
 
 	// ── Stdio transport (Command must be set; URL/Headers are ignored) ───────
@@ -34,9 +40,21 @@ type ServerConfig struct {
 	Command string `json:"command,omitempty" yaml:"command,omitempty"`
 	// Args are the command-line arguments passed to Command.
 	Args []string `json:"args,omitempty" yaml:"args,omitempty"`
-	// Env are additional environment variables injected into the subprocess.
-	// They are merged with the current process environment; keys listed here
-	// take precedence over any identically-named inherited variables.
+	// Env are the environment variables injected into the subprocess.
+	//
+	// The subprocess does NOT inherit the gateway's environment. It receives a
+	// minimal base — PATH, HOME, LANG and TMPDIR, when set — plus exactly the
+	// keys listed here, which override the base. This keeps gateway credentials
+	// such as OPENAI_API_KEY and MASTER_KEY out of MCP server processes.
+	//
+	// A consequence worth knowing: servers that need other inherited variables
+	// (HTTPS_PROXY, NODE_PATH, SSL_CERT_FILE, or SYSTEMROOT and APPDATA on
+	// Windows) must have them listed here explicitly.
+	//
+	// Values may reference environment variables using ${VAR} — only the braced
+	// form, same rules as Headers — resolved when the MCP client is constructed.
+	// Since the gateway's own environment is not inherited, this is the only
+	// channel by which a credential can reach an MCP subprocess.
 	Env map[string]string `json:"env,omitempty" yaml:"env,omitempty"`
 
 	// ── Common options ────────────────────────────────────────────────────────


### PR DESCRIPTION
Adds MCP stdio transport, so any `npx`, `uvx`, or binary MCP server can be used without standing up an HTTP endpoint for it — plus the supervision, isolation, and correctness work needed to make it safe to run.

Closes #121. The stdio transport was contributed by @gr3enarr0w (Clark Everson); those seven commits are preserved here with original authorship.

## What ships

**stdio transport** — an `mcp_servers` entry may set `command` (with `args`) instead of `url`. Exactly one of the two must be set; both or neither is a config error naming the server. The existing Streamable HTTP transport is unchanged and the two are interchangeable everywhere tools are consumed.

**Subprocess isolation** — MCP servers do not inherit the gateway's environment. They get `PATH`, `HOME`, `LANG`, `TMPDIR` when set, plus exactly the keys under that server's `env`, so `OPENAI_API_KEY`, `MASTER_KEY`, and every other gateway credential are unreachable from an MCP server. Servers needing anything else (`HTTPS_PROXY`, `NODE_PATH`, `SSL_CERT_FILE`) must list it explicitly.

**Process-group teardown** — `npx` and `uvx` exec the real server as a separate process, and killing the launcher does not kill what it started. Subprocesses now start in their own process group and the group is swept after the transport's polite shutdown ladder, so a close or reload no longer leaves a live server holding its pipes.

**stderr capture** — a stdio server's `stderr` is drained into the gateway log at debug level. This is required for correctness, not just diagnostics: the pipe was never read, so once the OS buffer filled the child blocked mid-write and stopped answering requests entirely while still appearing to run.

## Fixes to the already-shipped MCP path

Four of these affect operators who never configured a stdio server, and two affect operators who never used MCP at all.

- **A misconfigured MCP server no longer disables streaming.** Activation keyed off whether a server was *registered*, which is true before the handshake and stays true after one fails. A single unreachable endpoint or typo'd command turned every `stream: true` request on the gateway into one buffered chunk — for every caller — with no error. Activation now keys off tools actually discovered.
- **Caller-supplied tool calls are no longer intercepted.** MCP tools were injected into every request alongside whatever the caller sent, so the model could answer with one MCP call and one caller call in the same turn. Neither party can complete that turn, and answering half of it leaves an unmatched `tool_call_id` that providers reject outright. MCP now participates only when the request carries no tools of its own; such requests pass through untouched, streaming included.
- **Bounded tool execution per turn.** `max_call_depth` limited turns but nothing limited calls within one, so a response carrying thousands of `tool_calls` produced that many executions and messages, re-sent on every subsequent turn.
- **`${VAR}` is resolved in `mcp_servers[].env`.** Since the gateway environment is not inherited, `env` is the only channel by which a credential can reach a subprocess — and the shipped `BRAVE_API_KEY` example could not work without this. Ships with the paired admin fix: `GET /admin/config` now redacts `env` alongside `headers`.

## Lifecycle and shutdown

- **Registry retirement is refcounted.** `Route` snapshots the registry at entry and uses it after releasing the gateway lock; a reload used to close that registry immediately, terminating a stdio subprocess under an in-flight tool call. Retirement now waits for in-flight holders, mirroring the existing `plugin.Manager` lifecycle.
- **`Close` no longer races `ReloadConfig`.** The registry was read after the lock was released. Beyond the race, the losing interleaving observed `nil` and skipped closing a live registry, leaking every subprocess for the life of the process since `closeOnce` cannot fire twice. It is now snapshotted and cleared under the same lock, and `ReloadConfig` after `Close` is rejected.
- **Transports close concurrently.** One wedged server can spend seconds in the graceful/SIGTERM/SIGKILL ladder; serial teardown multiplied that by server count against a 5s budget, overrunning orchestrator grace periods — which SIGKILLs the process and re-orphans the subprocesses the group sweep exists to reap.

## Documentation corrections

The public `mcp_servers[].env` godoc promised a merge with the process environment that the code does not perform. Separately, several field docs and example comments described `$VAR` as a usable reference and attributed substitution to `LoadConfig`; only `${VAR}` is a reference, a bare `$` is literal data, an undefined variable is an error, and resolution happens at component construction — which is what keeps secrets out of the config-history store. Behavior unchanged since v1.2.0; the docs were wrong.

## Test plan

- [x] `go test ./...` — green, three consecutive clean runs
- [x] `go test -race ./internal/mcp/... ./internal/admin/... .` — green
- [x] `golangci-lint run ./...` — 0 issues
- [x] `GOOS=windows`, `GOOS=darwin`, `GOOS=freebsd` — build
- [x] Regression guards added for every fix above, including a real-subprocess test that a `sh`-launched grandchild dies on `Close`, a >64 KiB stderr flood that must not wedge, and a close-racing-initialization loop
- [ ] Manual smoke against a real `npx` MCP server before tagging

## Reviewer notes

Three behaviours are deliberate and worth a second opinion:

1. **A turn mixing MCP and caller tools is never executed.** With injection now conditional this should be unreachable, but the executor still declines it defensively rather than half-answering.
2. **`AllowedTools` is enforced transitively** — filtering happens before tool indexing, so a filtered tool is never owned and never callable. It is a real boundary, but an emergent one rather than an explicit check.
3. **Windows keeps single-process teardown.** Process trees there need a Job Object, a materially different mechanism; an `npx`-style server may outlive `Close` on Windows. Documented in `proc_other.go`.

Known and deliberately deferred: there is still no detection or restart of a crashed stdio subprocess. `mark3labs/mcp-go` calls `cmd.Wait()` internally and never surfaces process exit, so wait-driven supervision needs the SDK migration tracked separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added MCP stdio transport support via `command`/`args` with per-server `env`, alongside existing HTTP transport.
  * Updated example configs/templates with ready-to-run stdio server definitions.
* **Bug Fixes**
  * Hardened MCP streaming so misconfigured/unreachable servers no longer collapse streaming.
  * Refined MCP tool injection and agent behavior: caller-supplied tools are respected; MCP is gated on discovered tools; added per-turn tool-call limits.
  * Improved shutdown/reload safety and stdio subprocess handling (including stderr draining).
* **Documentation**
  * Clarified `${VAR}`-only interpolation and secret redaction for MCP env/header values.
* **Tests**
  * Expanded coverage for stdio lifecycle, env/header interpolation, tool ownership/injection, and reload/shutdown race scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->