### PR TITLE
fix: routing, lifecycle, and request-handling defects (v1.3.1)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -231,6 +231,7 @@ observability:
 | `GATEWAY_ENV` | Set to `production` to enable production-mode safety guards (e.g. refuses to start if `ALLOW_UNAUTHENTICATED_PROXY=true`); unset or any other value is non-production mode |
 | `PORT` | Server port (default: 8080) |
 | `FERRO_MODEL_CATALOG_URL` | Override the model catalog source URL (used by `/v1/models` and model routing) |
+| `FERRO_MODEL_CATALOG_TIMEOUT` | Go duration bounding the catalog fetch (default 10s). The fetch runs during startup, before the listener binds, so a blocked-egress deployment waits this long before falling back to the embedded catalog. Set `0` to skip the remote fetch entirely |
 | `FERRO_MODEL_DISCOVERY_INTERVAL` | Opt-in interval (Go duration, e.g. 6h) to live-refresh model lists from provider /models endpoints; unset disables |
 | `ALLOW_UNAUTHENTICATED_PROXY` | Set to `true` to disable proxy-route auth (dev/local only; blocked when `GATEWAY_ENV=production`) |
 | `OPENAI_API_KEY` | OpenAI API key |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,11 +72,22 @@ disabled its target until restart.
 - **A misconfigured provider base URL was returned to the caller.** It can carry
   a credential in its query string; it is now logged server-side only.
 
+- **The model catalog was never actually downloaded.** The fetch was bounded at
+  one second, which is below the real cost of retrieving a multi-megabyte asset
+  through a redirecting CDN, so the gateway fell back to the snapshot embedded
+  at build time on essentially every start — silently, and with pricing that
+  goes stale between releases. The budget is now ten seconds.
+
 ### Added
 
 - **Request metrics, cost, tracing spans and lifecycle events for
   `/v1/embeddings` and `/v1/images/generations`.** These surfaces previously
   reported nothing, so they showed no traffic and no cost regardless of spend.
+- **`FERRO_MODEL_CATALOG_TIMEOUT`** bounds the catalog fetch (default `10s`).
+  The fetch runs during startup, before the listener binds, so a deployment with
+  blocked or filtered egress would otherwise wait the full budget on every start
+  before falling back. Set it to `0` to skip the remote fetch entirely and use
+  the embedded catalog immediately.
 
 ### Changed
 
@@ -102,6 +113,14 @@ upgrading.
   providers now include embedding and image requests for the first time, which
   can look like a step change at the upgrade with no change in actual usage.
   Volume- and cost-based alert thresholds are worth reviewing.
+- **Reported costs may change**, because the gateway now reaches the current
+  catalog instead of the one embedded at build time. Prices are more accurate;
+  models added since the embedded snapshot stop being costed at zero.
+- **Startup can take up to ten seconds longer where egress to the catalog host
+  is blocked or slow**, since the fetch precedes the listener binding. If
+  readiness probes are tight, either widen them or set
+  `FERRO_MODEL_CATALOG_TIMEOUT` to a shorter value — or to `0` on air-gapped
+  deployments, which skips the fetch entirely.
 
 ## [1.3.0] — 2026-07-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.3.1] — 2026-07-21
 
-Seven defects reported against `v1.3.0`. Every one is reachable from ordinary
-YAML or JSON configuration, and none of them changes the `/v1` API: same request
-shapes, same response shapes, same status codes, same authentication.
+Seven defects reported against `v1.3.0`, spanning request handling, routing, and
+runtime reliability. Every one is reachable from ordinary YAML or JSON
+configuration. Nothing that worked before stops working: no request the gateway
+accepted is now refused, no response shape changes, and authentication is
+untouched. Requests that were wrongly refused now succeed.
 
-The theme is configuration that was quietly not applied. A `retry` block worked
-on chat and was ignored on streaming. A `strategy.mode` of `fallback` fell back
-on `/v1/chat/completions` and did not on `/v1/embeddings`. If you have been
-running with settings that looked correct, some of them are now actually in
-effect — see **Upgrade notes**.
+Much of this is configuration that was quietly not applied. A `retry` block
+worked on chat and was ignored on streaming. A `strategy.mode` of `fallback`
+fell back on `/v1/chat/completions` and did not on `/v1/embeddings`. If you have
+been running with settings that looked correct, some of them are now actually in
+effect — see **Upgrade notes**. The rest are plain defects: a request format the
+endpoint documented but rejected, a discarded `stream_options` value, an API-key
+update applied after it had been refused, and a panicking provider call that
+disabled its target until restart.
 
 ### Fixed
 
@@ -81,8 +86,10 @@ effect — see **Upgrade notes**.
 
 ### Upgrade notes
 
-Nothing to do — but three things will look different, all of them the result of
-configuration now being applied where it previously was not.
+No migration runs and no configuration change is required. Three things will
+look different, though, all of them the result of configuration now being
+applied where it previously was not — each is worth an operational review before
+upgrading.
 
 - **Which provider serves a request may change.** If `strategy.mode` is anything
   other than `single` and more than one target can serve a model, embeddings and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to Ferro Labs AI Gateway are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] — 1.3.1
+## [1.3.1] — 2026-07-21
 
 Seven defects reported against `v1.3.0`. Every one is reachable from ordinary
 YAML or JSON configuration, and none of them changes the `/v1` API: same request

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,97 @@ All notable changes to Ferro Labs AI Gateway are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] — 1.3.1
+
+Seven defects reported against `v1.3.0`. Every one is reachable from ordinary
+YAML or JSON configuration, and none of them changes the `/v1` API: same request
+shapes, same response shapes, same status codes, same authentication.
+
+The theme is configuration that was quietly not applied. A `retry` block worked
+on chat and was ignored on streaming. A `strategy.mode` of `fallback` fell back
+on `/v1/chat/completions` and did not on `/v1/embeddings`. If you have been
+running with settings that looked correct, some of them are now actually in
+effect — see **Upgrade notes**.
+
+### Fixed
+
+- **`/v1/completions` rejected documented request shapes.** A `prompt` sent as
+  an array — the batch and token-id forms — and a `stop` sent as a bare string
+  both failed to decode, returning `400`. They failed before the handler chose
+  between pass-through and the chat shim, so they were refused even when the
+  request was being forwarded verbatim to an upstream that accepts them.
+  `gpt-3.5-turbo-instruct` is exactly where batch prompts are used.
+- **Streaming ignored its retry and fallback configuration.** `RouteStream`
+  resolved one provider, called it once, and gave up, so a target returning
+  `503` failed the request outright while the same configuration retried and
+  fell back for non-streaming. Only the start of a stream is retried, and only
+  before any data reaches the caller, so a stream that has begun is never
+  replayed. The start phase is bounded by the configured request timeout; a
+  stream that starts successfully is not.
+- **Retry backoff was zero on non-chat surfaces.** Chat applied a default delay
+  between attempts where streaming, embeddings and image generation fell through
+  to no delay at all, turning three configured attempts into three immediate
+  retries against a provider that had just asked for a pause. Backoff now comes
+  from one place for every surface.
+- **Embeddings and image generation ignored the configured strategy.** Both
+  resolved to the first capable provider, with no fallback, no retry and no
+  request timeout. They now follow the configured target order with the same
+  behaviour as chat. A model served by a registered provider that is not listed
+  under `targets` remains reachable, as before.
+- **A content rule matched every promptless request.** With
+  `strategy.mode: content-based`, a `prompt_not_contains` rule treated the
+  absence of messages as a match, so one such rule captured every embedding and
+  image request regardless of its configured value.
+- **Provider lookup was not stable between calls.** Registration order was not
+  retained, so which provider served a model available from several, the default
+  target order, and the order of `GET /v1/models` could all differ from one
+  request to the next within a single process.
+- **A panicking provider call disabled its target permanently.** Circuit-breaker
+  bookkeeping was not panic-safe: the half-open probe was left held, nothing
+  releases it, and the breaker then rejected every later request for that target
+  until the process restarted.
+- **`stream_options.include_usage` was ignored.** The caller's value was
+  discarded and a usage chunk always requested. A caller asking not to receive
+  one now does not receive one. Usage is still requested upstream and still
+  recorded, so cost accounting, metrics and spend limits are unaffected by what
+  the caller asks for.
+- **Updating an API key applied changes it had rejected.** The new name and
+  scopes were written before the expiration timestamp was validated, leaving the
+  key modified by a request that returned `400`.
+- **Errors raised while starting a stream were not redacted** before reaching
+  observability exporters and event hooks, unlike every other error path.
+- **A misconfigured provider base URL was returned to the caller.** It can carry
+  a credential in its query string; it is now logged server-side only.
+
+### Added
+
+- **Request metrics, cost, tracing spans and lifecycle events for
+  `/v1/embeddings` and `/v1/images/generations`.** These surfaces previously
+  reported nothing, so they showed no traffic and no cost regardless of spend.
+
+### Changed
+
+- **Target ranking no longer holds the gateway lock.** Latency and cost lookups,
+  and the random draw used for weighted load balancing, previously blocked every
+  other request for their duration.
+
+### Upgrade notes
+
+Nothing to do — but three things will look different, all of them the result of
+configuration now being applied where it previously was not.
+
+- **Which provider serves a request may change.** If `strategy.mode` is anything
+  other than `single` and more than one target can serve a model, embeddings and
+  image generation now follow that strategy instead of always using the first
+  capable provider. This has cost, latency and data-residency implications worth
+  checking before upgrading.
+- **Requests that used to fail may now succeed**, on streaming and on the
+  non-chat surfaces, because retry and fallback now apply there.
+- **Dashboards will show new traffic and cost.** Metrics that aggregate across
+  providers now include embedding and image requests for the first time, which
+  can look like a step change at the upgrade with no change in actual usage.
+  Volume- and cost-based alert thresholds are worth reviewing.
+
 ## [1.3.0] — 2026-07-20
 
 MCP servers can now be launched as local subprocesses, so any `npx`, `uvx`, or binary MCP server can be used without standing up an HTTP endpoint for it. Alongside the new transport, two long-standing defects in the existing MCP path are fixed — both of which affected the gateway whether or not you used MCP deliberately.

--- a/config.go
+++ b/config.go
@@ -49,13 +49,13 @@ type Config struct {
 	// MCPServers configures external MCP tool servers for agentic tool calling.
 	// When set, the gateway injects discovered tools into every chat completion
 	// request and executes an agentic loop when the LLM returns tool_calls.
-	// FerroCloud populates this field from the tenant's mcp_servers table at
-	// gateway.New() time — no separate MCPRegistry() public method is exposed.
+	// It is read once at New() time, so a caller embedding the gateway can
+	// populate it from its own source instead of a config file.
 	MCPServers []mcp.ServerConfig `json:"mcp_servers,omitempty" yaml:"mcp_servers,omitempty"`
-	// MCPToolCallAuditFn, if non-nil, is called after every MCP tool invocation.
-	// This field cannot be set via JSON or YAML — set it programmatically before
-	// calling New. FerroCloud uses it to write async audit entries to the
-	// mcp_tool_call_logs table.
+	// MCPToolCallAuditFn, if non-nil, is called after every MCP tool invocation,
+	// giving an embedding caller a hook to record tool use. It cannot be set via
+	// JSON or YAML — set it programmatically before calling New. It runs off the
+	// request path, so it must not block.
 	MCPToolCallAuditFn mcp.ToolCallAuditFn `json:"-" yaml:"-"`
 	// Observability configures OpenTelemetry tracing. When omitted the
 	// gateway runs with a NoOp provider (zero allocations on the hot

--- a/gateway.go
+++ b/gateway.go
@@ -108,8 +108,11 @@ func New(cfg Config) (*Gateway, error) {
 	}
 
 	// No lifecycle context exists yet at this point in construction (shutdownCtx
-	// is created below); this is a one-time startup fetch bounded by fetchRemote's
-	// own 1s client timeout, so context.Background() is the correct choice here.
+	// is created below), so context.Background() is the only choice available
+	// here. The fetch is bounded by fetchRemote's own client timeout, which an
+	// operator can shorten or disable entirely via FERRO_MODEL_CATALOG_TIMEOUT.
+	// That matters because this runs before the listener binds: until it
+	// returns, the process answers no readiness probe.
 	catalogResult, err := models.LoadWithInfoContext(context.Background())
 	recordCatalogLoad(catalogResult.Source, err)
 	catalog := catalogResult.Catalog
@@ -229,7 +232,7 @@ func (g *Gateway) startCatalogRefresh() {
 
 // refreshCatalog fetches the latest model catalog. ctx is g.shutdownCtx, so a
 // fetch already in flight when the gateway shuts down is canceled immediately
-// instead of running to fetchRemote's own 1s timeout.
+// instead of running to fetchRemote's own client timeout.
 func (g *Gateway) refreshCatalog(ctx context.Context) {
 	result, err := models.LoadWithInfoContext(ctx)
 	recordCatalogLoad(result.Source, err)

--- a/gateway_circuitbreaker.go
+++ b/gateway_circuitbreaker.go
@@ -39,17 +39,7 @@ func (p *cbProvider) Complete(ctx context.Context, req providers.Request) (resp 
 			metrics.CircuitBreakerState.WithLabelValues(p.name).Set(float64(p.cb.State()))
 			panic(r)
 		}
-		if err != nil {
-			if shouldRecordCircuitBreakerFailure(ctx, err) {
-				p.cb.RecordFailure()
-				metrics.CircuitBreakerState.WithLabelValues(p.name).Set(float64(p.cb.State()))
-			} else {
-				p.cb.ReleaseProbe()
-			}
-			return
-		}
-		p.cb.RecordSuccess()
-		metrics.CircuitBreakerState.WithLabelValues(p.name).Set(float64(p.cb.State()))
+		recordCircuitBreakerOutcome(ctx, p.cb, p.name, err)
 	}()
 	resp, err = p.Provider.Complete(ctx, req)
 	return resp, err

--- a/gateway_circuitbreaker.go
+++ b/gateway_circuitbreaker.go
@@ -21,24 +21,38 @@ type cbProvider struct {
 	name string
 }
 
-func (p *cbProvider) Complete(ctx context.Context, req providers.Request) (*providers.Response, error) {
+func (p *cbProvider) Complete(ctx context.Context, req providers.Request) (resp *providers.Response, err error) {
 	if !p.cb.Allow() {
 		metrics.CircuitBreakerState.WithLabelValues(p.name).Set(1) // open
 		return nil, circuitbreaker.ErrCircuitOpen
 	}
-	resp, err := p.Provider.Complete(ctx, req)
-	if err != nil {
-		if shouldRecordCircuitBreakerFailure(ctx, err) {
+	// Deferred so a panic from p.Provider.Complete still releases the
+	// half-open probe Allow() just admitted. Without this, a panicking probe
+	// leaks halfOpenProbes forever: resolveState() only turns Open into
+	// HalfOpen on a timeout, it never repairs a HalfOpen circuit stuck at its
+	// probe cap, so Allow() would reject every request for this provider
+	// until the process restarts. A panic is treated as a failure, then
+	// re-raised so it still propagates to the caller.
+	defer func() {
+		if r := recover(); r != nil {
 			p.cb.RecordFailure()
 			metrics.CircuitBreakerState.WithLabelValues(p.name).Set(float64(p.cb.State()))
-		} else {
-			p.cb.ReleaseProbe()
+			panic(r)
 		}
-		return nil, err
-	}
-	p.cb.RecordSuccess()
-	metrics.CircuitBreakerState.WithLabelValues(p.name).Set(float64(p.cb.State()))
-	return resp, nil
+		if err != nil {
+			if shouldRecordCircuitBreakerFailure(ctx, err) {
+				p.cb.RecordFailure()
+				metrics.CircuitBreakerState.WithLabelValues(p.name).Set(float64(p.cb.State()))
+			} else {
+				p.cb.ReleaseProbe()
+			}
+			return
+		}
+		p.cb.RecordSuccess()
+		metrics.CircuitBreakerState.WithLabelValues(p.name).Set(float64(p.cb.State()))
+	}()
+	resp, err = p.Provider.Complete(ctx, req)
+	return resp, err
 }
 
 func (p *cbProvider) CompleteStream(ctx context.Context, req providers.Request) (<-chan providers.StreamChunk, error) {
@@ -46,6 +60,19 @@ func (p *cbProvider) CompleteStream(ctx context.Context, req providers.Request) 
 		metrics.CircuitBreakerState.WithLabelValues(p.name).Set(1) // open
 		return nil, circuitbreaker.ErrCircuitOpen
 	}
+	// Deferred for the same reason as Complete: a panic out of CompleteStream
+	// would otherwise strand the half-open probe Allow() just admitted and
+	// reject every later request for this provider until restart. Only the
+	// panic path is handled here — a stream that starts is not yet a success,
+	// so the probe stays held and the outcome is reported at stream completion
+	// via MeterMeta.CircuitBreakerOutcome.
+	defer func() {
+		if r := recover(); r != nil {
+			p.cb.RecordFailure()
+			metrics.CircuitBreakerState.WithLabelValues(p.name).Set(float64(p.cb.State()))
+			panic(r)
+		}
+	}()
 	sp, ok := p.Provider.(providers.StreamProvider)
 	if !ok {
 		p.cb.ReleaseProbe()
@@ -148,6 +175,17 @@ func (g *Gateway) withTargetBreaker(ctx context.Context, target string, fn func(
 		metrics.CircuitBreakerState.WithLabelValues(target).Set(1) // open
 		return circuitbreaker.ErrCircuitOpen
 	}
+	// Deferred for the same reason as cbProvider.Complete: fn panicking must
+	// still resolve the half-open probe Allow() admitted, or the breaker gets
+	// stuck rejecting this target forever with no self-healing. A panic
+	// counts as a failure and is re-raised afterward, never swallowed.
+	defer func() {
+		if r := recover(); r != nil {
+			cb.RecordFailure()
+			metrics.CircuitBreakerState.WithLabelValues(target).Set(float64(cb.State()))
+			panic(r)
+		}
+	}()
 	err := fn(ctx)
 	recordCircuitBreakerOutcome(ctx, cb, target, err)
 	return err

--- a/gateway_circuitbreaker_test.go
+++ b/gateway_circuitbreaker_test.go
@@ -540,12 +540,16 @@ func TestGateway_RouteStream_FallbackSkipsOpenCircuitBreakerTarget(t *testing.T)
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
+	var flakyCalls atomic.Int32
 	gw.RegisterProvider(&mockStreamProvider{
 		mockProvider: mockProvider{
 			name:   "flaky-stream",
 			models: []string{"gpt-4o"},
 		},
-		streamErr: errors.New("stream startup failed"),
+		streamFn: func(_ context.Context, _ providers.Request) (<-chan providers.StreamChunk, error) {
+			flakyCalls.Add(1)
+			return nil, errors.New("stream startup failed")
+		},
 	})
 	gw.RegisterProvider(&mockStreamProvider{
 		mockProvider: mockProvider{
@@ -568,11 +572,19 @@ func TestGateway_RouteStream_FallbackSkipsOpenCircuitBreakerTarget(t *testing.T)
 
 	req := streamTestRequest()
 	for i := 0; i < 2; i++ {
-		_, err := gw.RouteStream(context.Background(), req)
-		if err == nil {
-			t.Fatalf("attempt %d: expected startup error to trip breaker", i+1)
+		ch, err := gw.RouteStream(context.Background(), req)
+		if err != nil {
+			t.Fatalf("attempt %d: RouteStream should fall back after synchronous startup failure: %v", i+1, err)
 		}
+		drainMeteredStream(t, ch)
 	}
+
+	// Snapshot before the final attempt. Now that a synchronous start failure
+	// falls back, reaching healthy-stream no longer proves the breaker did
+	// anything — an untripped flaky-stream would also fail and fall back to it.
+	// The open breaker must skip flaky-stream outright, so its call count has
+	// to stay frozen across the third attempt.
+	callsBeforeOpen := flakyCalls.Load()
 
 	ch, err := gw.RouteStream(context.Background(), req)
 	if err != nil {
@@ -581,6 +593,9 @@ func TestGateway_RouteStream_FallbackSkipsOpenCircuitBreakerTarget(t *testing.T)
 	drainMeteredStream(t, ch)
 	if got := selected.Load(); got != "healthy-stream" {
 		t.Fatalf("selected provider = %v, want healthy-stream", got)
+	}
+	if got := flakyCalls.Load(); got != callsBeforeOpen {
+		t.Fatalf("flaky-stream called %d more time(s) after its breaker opened; the open circuit must skip it, not retry it", got-callsBeforeOpen)
 	}
 }
 

--- a/gateway_circuitbreaker_test.go
+++ b/gateway_circuitbreaker_test.go
@@ -597,3 +597,76 @@ func TestShouldRecordCircuitBreakerFailure_ClientErrorNeverBlamesProvider(t *tes
 		t.Error("a reject-mode unsupported-parameter error is a client error; it must not trip the provider circuit")
 	}
 }
+
+// TestGateway_WithTargetBreaker_PanicDoesNotStrandHalfOpenProbe pins the panic
+// safety of the real withTargetBreaker. Allow() admits one half-open probe; if
+// a panic escapes before the outcome is recorded, that permit is never returned
+// and resolveState never repairs it — Allow() then rejects this target for the
+// life of the process. The bug is invisible on the happy path, so it needs a
+// test that panics through the production helper rather than a copy of it.
+func TestGateway_WithTargetBreaker_PanicDoesNotStrandHalfOpenProbe(t *testing.T) {
+	gw, err := newTestGateway(t, Config{
+		Strategy: StrategyConfig{Mode: ModeSingle},
+		Targets: []Target{{
+			VirtualKey: "panicky",
+			CircuitBreaker: &CircuitBreakerConfig{
+				FailureThreshold: 1,
+				SuccessThreshold: 1,
+				MaxHalfThreshold: 1,
+				Timeout:          "1ms",
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	gw.mu.RLock()
+	cb := gw.circuitBreakers["panicky"]
+	gw.mu.RUnlock()
+	if cb == nil {
+		t.Fatal("expected circuit breaker for panicky")
+	}
+	fakeNow := time.Unix(0, 0)
+	cb.SetNowForTest(func() time.Time { return fakeNow })
+
+	ctx := context.Background()
+	failing := func(context.Context) error { return errors.New("provider down") }
+
+	// Trip the breaker open (FailureThreshold=1).
+	if err := gw.withTargetBreaker(ctx, "panicky", failing); err == nil {
+		t.Fatal("expected the failing call to surface its error")
+	}
+	if cb.State() != circuitbreaker.StateOpen {
+		t.Fatalf("breaker state = %v, want open", cb.State())
+	}
+
+	// Advance past the timeout so the next call consumes the half-open probe,
+	// then panic inside it.
+	fakeNow = fakeNow.Add(5 * time.Millisecond)
+	func() {
+		defer func() {
+			if r := recover(); r == nil {
+				t.Error("panic was swallowed; it must still propagate to the caller")
+			}
+		}()
+		_ = gw.withTargetBreaker(ctx, "panicky", func(context.Context) error {
+			panic("provider blew up mid-probe")
+		})
+	}()
+
+	// The panicking probe must have been resolved as a failure, leaving the
+	// breaker open rather than stuck half-open at its probe cap. After another
+	// timeout a fresh probe must reach fn.
+	fakeNow = fakeNow.Add(5 * time.Millisecond)
+	reached := false
+	if err := gw.withTargetBreaker(ctx, "panicky", func(context.Context) error {
+		reached = true
+		return nil
+	}); err != nil {
+		t.Fatalf("post-panic probe: err = %v, want the call to be admitted", err)
+	}
+	if !reached {
+		t.Fatal("post-panic probe never reached fn: the half-open permit leaked")
+	}
+}

--- a/gateway_discovery.go
+++ b/gateway_discovery.go
@@ -229,7 +229,12 @@ func (g *Gateway) GenerateImage(ctx context.Context, req providers.ImageRequest)
 // span attribute; in this routing layer a target's virtual_key and its
 // provider's registered Name() are the same string (see RegisterProvider).
 func (g *Gateway) recordSurfaceSuccess(ctx context.Context, span observability.Span, obs observability.Provider, providerName, model string, usage models.Usage, latency time.Duration, hooksEnabled, obsEventsActive bool) {
-	requestMetrics := metrics.ForRequest(providerName, model)
+	// Bound the metric label but keep the raw model for the cost lookup below.
+	// Providers that accept any model ID (openrouter, ollama, azure_openai, …)
+	// echo the caller's string back on success, so an unbounded label here would
+	// let a client mint a new time series per request. The streaming path bounds
+	// its label the same way.
+	requestMetrics := metrics.ForRequest(providerName, g.metricModel(model))
 	requestMetrics.Duration.Observe(latency.Seconds())
 	requestMetrics.Success.Inc()
 	requestMetrics.TokensIn.Add(float64(usage.PromptTokens))

--- a/gateway_discovery.go
+++ b/gateway_discovery.go
@@ -20,6 +20,14 @@ import (
 	"github.com/ferro-labs/ai-gateway/providers/core"
 )
 
+// The non-chat surfaces this file routes. The name reaches operators as the
+// span's operation and as a metrics label, so it is fixed here rather than
+// spelled out at each of its call sites.
+const (
+	surfaceEmbeddings = "embeddings"
+	surfaceImages     = "images"
+)
+
 // Gateway model alias resolution, the multi-modal (embedding / image) routing
 // endpoints, and background model auto-discovery.
 
@@ -120,7 +128,7 @@ func (g *Gateway) Embed(ctx context.Context, req providers.EmbeddingRequest) (*p
 	defer cancelDeadline()
 
 	ctx, span := obs.StartRequestSpan(ctx, observability.RequestAttrs{
-		Operation:       "embeddings",
+		Operation:       surfaceEmbeddings,
 		RequestModel:    req.Model,
 		TraceID:         logging.TraceIDFromContext(ctx),
 		RoutingStrategy: strategyMode,
@@ -132,7 +140,7 @@ func (g *Gateway) Embed(ctx context.Context, req providers.EmbeddingRequest) (*p
 
 	var resp *providers.EmbeddingResponse
 	var providerName string
-	err := g.runSurfaceGovernance(ctx, "embeddings", span, func(ctx context.Context) (*providers.Usage, error) {
+	err := g.runSurfaceGovernance(ctx, surfaceEmbeddings, span, func(ctx context.Context) (*providers.Usage, error) {
 		var routeErr error
 		resp, providerName, routeErr = g.routeEmbedding(ctx, req)
 		if routeErr != nil {
@@ -187,7 +195,7 @@ func (g *Gateway) GenerateImage(ctx context.Context, req providers.ImageRequest)
 
 	var resp *providers.ImageResponse
 	var providerName string
-	err := g.runSurfaceGovernance(ctx, "images", span, func(ctx context.Context) (*providers.Usage, error) {
+	err := g.runSurfaceGovernance(ctx, surfaceImages, span, func(ctx context.Context) (*providers.Usage, error) {
 		var routeErr error
 		resp, providerName, routeErr = g.routeImage(ctx, req)
 		if routeErr != nil {
@@ -502,9 +510,9 @@ func surfaceHasPrice(catalog models.Catalog, modelKey, surface string) bool {
 		return false
 	}
 	switch surface {
-	case "embeddings":
+	case surfaceEmbeddings:
 		return model.Mode == models.ModeEmbedding && model.Pricing.EmbeddingPerMTokens != nil
-	case "images":
+	case surfaceImages:
 		return model.Mode == models.ModeImage && model.Pricing.ImagePerTile != nil
 	default:
 		return false
@@ -513,10 +521,10 @@ func surfaceHasPrice(catalog models.Catalog, modelKey, surface string) bool {
 
 func providerSupportsSurface(p providers.Provider, surface string) bool {
 	switch surface {
-	case "embeddings":
+	case surfaceEmbeddings:
 		_, ok := p.(providers.EmbeddingProvider)
 		return ok
-	case "images":
+	case surfaceImages:
 		_, ok := p.(providers.ImageProvider)
 		return ok
 	default:
@@ -534,7 +542,7 @@ func providerSupportsSurface(p providers.Provider, surface string) bool {
 // models it serves — mirroring startStreamWithStrategy's use of
 // resolveFallbackStreamProviderLocked for the streaming surface.
 func (g *Gateway) routeEmbedding(ctx context.Context, req providers.EmbeddingRequest) (*providers.EmbeddingResponse, string, error) {
-	keys, mode, err := g.surfaceTargetOrder(req.Model, "embeddings", models.Usage{PromptTokens: 1})
+	keys, mode, err := g.surfaceTargetOrder(req.Model, surfaceEmbeddings, models.Usage{PromptTokens: 1})
 	if err != nil {
 		return nil, "", err
 	}
@@ -591,7 +599,7 @@ func (g *Gateway) routeImage(ctx context.Context, req providers.ImageRequest) (*
 	if req.N != nil && *req.N > 0 {
 		imageCount = *req.N
 	}
-	keys, mode, err := g.surfaceTargetOrder(req.Model, "images", models.Usage{ImageCount: imageCount})
+	keys, mode, err := g.surfaceTargetOrder(req.Model, surfaceImages, models.Usage{ImageCount: imageCount})
 	if err != nil {
 		return nil, "", err
 	}

--- a/gateway_discovery.go
+++ b/gateway_discovery.go
@@ -2,12 +2,19 @@ package aigateway
 
 import (
 	"context"
+	cryptorand "crypto/rand"
+	"encoding/binary"
 	"fmt"
 	"log/slog"
+	"maps"
+	"sort"
 	"time"
 
 	"github.com/ferro-labs/ai-gateway/internal/authctx"
 	"github.com/ferro-labs/ai-gateway/internal/logging"
+	"github.com/ferro-labs/ai-gateway/internal/metrics"
+	"github.com/ferro-labs/ai-gateway/models"
+	"github.com/ferro-labs/ai-gateway/observability"
 	"github.com/ferro-labs/ai-gateway/plugin"
 	"github.com/ferro-labs/ai-gateway/providers"
 	"github.com/ferro-labs/ai-gateway/providers/core"
@@ -43,8 +50,10 @@ func (g *Gateway) resolveAlias(req providers.Request) providers.Request {
 // and, on success, normalized token usage flow through Metadata — the sanctioned
 // additive channel (plugins architecture D8). call performs the provider request
 // and returns the token usage to account for, or nil when the surface reports
-// none (e.g. image generation).
-func (g *Gateway) runSurfaceGovernance(ctx context.Context, surface string, call func(context.Context) (*providers.Usage, error)) error {
+// none (e.g. image generation). span, when non-nil, is the surface's request
+// root span; plugin invocations open per-plugin child spans through it, same
+// as chat's runBeforePlugins.
+func (g *Gateway) runSurfaceGovernance(ctx context.Context, surface string, span observability.Span, call func(context.Context) (*providers.Usage, error)) error {
 	g.mu.RLock()
 	plugins := g.plugins
 	release := acquirePluginManager(plugins)
@@ -57,6 +66,7 @@ func (g *Gateway) runSurfaceGovernance(ctx context.Context, surface string, call
 	}
 
 	pctx := plugin.NewContext(nil)
+	pctx.Span = span
 	defer plugin.PutContext(pctx)
 	pctx.Metadata["surface"] = surface
 	if keyID, ok := authctx.KeyID(ctx); ok {
@@ -66,6 +76,14 @@ func (g *Gateway) runSurfaceGovernance(ctx context.Context, surface string, call
 	if err := plugins.RunBefore(ctx, pctx); err != nil {
 		return err
 	}
+	// A before-plugin can still set pctx.Reject (honoured above via the
+	// RunBefore error) or pctx.Skip (stops the remaining before-stage
+	// plugins). What it CANNOT do here is substitute a cached response the
+	// way response-cache does for chat: pctx.Response is providers.Response,
+	// the chat-shaped envelope, with no field able to hold an
+	// EmbeddingResponse or ImageResponse. So the provider call below always
+	// still runs after a before-stage Skip on this surface — Reject is the
+	// supported way to stop a request here, not Skip.
 
 	usage, err := call(ctx)
 	if err != nil {
@@ -82,89 +100,568 @@ func (g *Gateway) runSurfaceGovernance(ctx context.Context, surface string, call
 	return plugins.RunAfter(ctx, pctx)
 }
 
-// Embed routes an embedding request to the first registered EmbeddingProvider
-// that supports the requested model, under the shared governance pipeline.
+// Embed routes an embedding request across configured, capable targets using
+// the gateway strategy (honouring strategy.mode, retry, and fallback — see
+// surfaceTargetOrder), under the shared governance pipeline. It emits the same
+// class of observability signal as chat's Route: a request span, Prometheus
+// request metrics, cost accounting, and a completed/failed lifecycle event.
 func (g *Gateway) Embed(ctx context.Context, req providers.EmbeddingRequest) (*providers.EmbeddingResponse, error) {
 	log := logging.FromContext(ctx)
+	start := time.Now()
+	hooksEnabled := g.hasHooks()
+
+	g.mu.RLock()
+	requestTimeout := g.config.RequestTimeout
+	strategyMode := string(g.config.Strategy.Mode)
+	obs := g.obs
+	obsEventsActive := g.obsEventsActive
+	g.mu.RUnlock()
+	ctx, cancelDeadline := withRequestDeadline(ctx, requestTimeout)
+	defer cancelDeadline()
+
+	ctx, span := obs.StartRequestSpan(ctx, observability.RequestAttrs{
+		Operation:       "embeddings",
+		RequestModel:    req.Model,
+		TraceID:         logging.TraceIDFromContext(ctx),
+		RoutingStrategy: strategyMode,
+	})
+	defer span.End()
 
 	// Resolve model alias so embedding endpoints honour the same aliases as chat.
 	req.Model = g.resolveModelAlias(req.Model)
 
-	g.mu.RLock()
-	name, ep, ok := g.findEmbeddingProviderByModelLocked(req.Model)
-	g.mu.RUnlock()
-
-	if !ok {
-		return nil, fmt.Errorf("%w: no embedding provider for %q", core.ErrNoCapableProvider, req.Model)
-	}
-
 	var resp *providers.EmbeddingResponse
-	err := g.runSurfaceGovernance(ctx, "embeddings", func(ctx context.Context) (*providers.Usage, error) {
-		var r *providers.EmbeddingResponse
-		callErr := g.withTargetBreaker(ctx, name, func(ctx context.Context) error {
-			return g.withTargetSlot(ctx, name, func(ctx context.Context) error {
-				var err error
-				r, err = ep.Embed(ctx, req)
-				return err
-			})
-		})
-		if callErr != nil {
-			return nil, callErr
+	var providerName string
+	err := g.runSurfaceGovernance(ctx, "embeddings", span, func(ctx context.Context) (*providers.Usage, error) {
+		var routeErr error
+		resp, providerName, routeErr = g.routeEmbedding(ctx, req)
+		if routeErr != nil {
+			return nil, routeErr
 		}
-		resp = r
-		return &providers.Usage{PromptTokens: r.Usage.PromptTokens, TotalTokens: r.Usage.TotalTokens}, nil
+		return &providers.Usage{PromptTokens: resp.Usage.PromptTokens, TotalTokens: resp.Usage.TotalTokens}, nil
 	})
+	latency := time.Since(start)
 	if err != nil {
-		log.Error("embedding request failed", "model", req.Model, "error", err.Error())
+		safeErr := g.recordSurfaceError(ctx, span, obs, providerName, req.Model, err, latency, hooksEnabled, obsEventsActive)
+		log.Error("embedding request failed", "model", req.Model, "error", safeErr)
 		return nil, err
 	}
+
+	g.recordSurfaceSuccess(ctx, span, obs, providerName, resp.Model,
+		models.Usage{PromptTokens: resp.Usage.PromptTokens}, latency, hooksEnabled, obsEventsActive)
 
 	log.Info("embedding request completed", "model", resp.Model, "tokens", resp.Usage.TotalTokens)
 	return resp, nil
 }
 
-// GenerateImage routes an image generation request to the first registered
-// ImageProvider that supports the requested model, under the shared governance
-// pipeline. Image responses carry no token usage, so budget gates but does not
-// cost these requests.
+// GenerateImage routes an image request across configured, capable targets
+// using the gateway strategy (see surfaceTargetOrder), under the shared
+// governance pipeline. Image responses carry no token usage, so the budget
+// plugin gates but does not cost them via the Metadata["usage"] channel — cost
+// accounting here instead comes from models.Calculate against the returned
+// image count, the same way chat's cost accounting works from token counts.
 func (g *Gateway) GenerateImage(ctx context.Context, req providers.ImageRequest) (*providers.ImageResponse, error) {
 	log := logging.FromContext(ctx)
+	start := time.Now()
+	hooksEnabled := g.hasHooks()
+
+	g.mu.RLock()
+	requestTimeout := g.config.RequestTimeout
+	strategyMode := string(g.config.Strategy.Mode)
+	obs := g.obs
+	obsEventsActive := g.obsEventsActive
+	g.mu.RUnlock()
+	ctx, cancelDeadline := withRequestDeadline(ctx, requestTimeout)
+	defer cancelDeadline()
+
+	ctx, span := obs.StartRequestSpan(ctx, observability.RequestAttrs{
+		Operation:       "images.generate",
+		RequestModel:    req.Model,
+		TraceID:         logging.TraceIDFromContext(ctx),
+		RoutingStrategy: strategyMode,
+	})
+	defer span.End()
 
 	// Resolve model alias so image endpoints honour the same aliases as chat.
 	req.Model = g.resolveModelAlias(req.Model)
 
-	g.mu.RLock()
-	name, ip, ok := g.findImageProviderByModelLocked(req.Model)
-	g.mu.RUnlock()
-
-	if !ok {
-		return nil, fmt.Errorf("%w: no image generation provider for %q", core.ErrNoCapableProvider, req.Model)
-	}
-
 	var resp *providers.ImageResponse
-	err := g.runSurfaceGovernance(ctx, "images", func(ctx context.Context) (*providers.Usage, error) {
-		callErr := g.withTargetBreaker(ctx, name, func(ctx context.Context) error {
-			return g.withTargetSlot(ctx, name, func(ctx context.Context) error {
-				r, err := ip.GenerateImage(ctx, req)
-				if err != nil {
-					return err
-				}
-				resp = r
-				return nil
-			})
-		})
-		if callErr != nil {
-			return nil, callErr
+	var providerName string
+	err := g.runSurfaceGovernance(ctx, "images", span, func(ctx context.Context) (*providers.Usage, error) {
+		var routeErr error
+		resp, providerName, routeErr = g.routeImage(ctx, req)
+		if routeErr != nil {
+			return nil, routeErr
 		}
 		return nil, nil // image responses carry no token usage
 	})
+	latency := time.Since(start)
 	if err != nil {
-		log.Error("image generation request failed", "model", req.Model, "error", err.Error())
+		safeErr := g.recordSurfaceError(ctx, span, obs, providerName, req.Model, err, latency, hooksEnabled, obsEventsActive)
+		log.Error("image generation request failed", "model", req.Model, "error", safeErr)
 		return nil, err
 	}
 
+	g.recordSurfaceSuccess(ctx, span, obs, providerName, req.Model,
+		models.Usage{ImageCount: len(resp.Data)}, latency, hooksEnabled, obsEventsActive)
+
 	log.Info("image generation request completed", "model", req.Model, "images", len(resp.Data))
 	return resp, nil
+}
+
+// recordSurfaceSuccess finalizes a completed embeddings/images request: emits
+// Prometheus request metrics, computes cost via models.Calculate, stamps the
+// span, and dispatches the completed lifecycle event. It is the non-chat
+// counterpart of recordSuccess (gateway_route.go), reusing its lifecycle-event
+// plumbing (dispatchRequestEvent, completedEventData) rather than duplicating
+// it. It takes a models.Usage directly — rather than chat's providers.Usage —
+// because image cost depends on ImageCount, a field providers.Usage/Response
+// has no room for. providerName is the resolved provider's canonical Name(),
+// used for both the cost/catalog lookup key and the public routing-target-key
+// span attribute; in this routing layer a target's virtual_key and its
+// provider's registered Name() are the same string (see RegisterProvider).
+func (g *Gateway) recordSurfaceSuccess(ctx context.Context, span observability.Span, obs observability.Provider, providerName, model string, usage models.Usage, latency time.Duration, hooksEnabled, obsEventsActive bool) {
+	requestMetrics := metrics.ForRequest(providerName, model)
+	requestMetrics.Duration.Observe(latency.Seconds())
+	requestMetrics.Success.Inc()
+	requestMetrics.TokensIn.Add(float64(usage.PromptTokens))
+	requestMetrics.TokensOut.Add(float64(usage.CompletionTokens))
+
+	g.mu.RLock()
+	catalog := g.catalog
+	g.mu.RUnlock()
+	cost := models.Calculate(catalog, providerName+"/"+model, usage)
+	if cost.TotalUSD > 0 {
+		requestMetrics.CostUSD.Add(cost.TotalUSD)
+	}
+
+	span.SetAttribute(observability.AttrGenAISystem, providerName)
+	span.SetAttribute(observability.AttrGenAIResponseModel, model)
+	if providerName != "" {
+		span.SetAttribute(observability.AttrFerroRoutingTargetKey, providerName)
+	}
+	span.SetTokens(usage.PromptTokens, usage.CompletionTokens, usage.ReasoningTokens)
+	span.SetCost(observability.CostBreakdown{
+		TotalUSD:      cost.TotalUSD,
+		InputUSD:      cost.InputUSD,
+		OutputUSD:     cost.OutputUSD,
+		CacheReadUSD:  cost.CacheReadUSD,
+		CacheWriteUSD: cost.CacheWriteUSD,
+		ReasoningUSD:  cost.ReasoningUSD,
+		ModelFound:    cost.ModelFound,
+	})
+
+	if hooksEnabled || obsEventsActive {
+		he := completedEventData(
+			logging.TraceIDFromContext(ctx),
+			providerName,
+			model,
+			latency,
+			false,
+			usage.PromptTokens,
+			usage.CompletionTokens,
+			cost,
+		)
+		g.dispatchRequestEvent(ctx, obs, hooksEnabled, obsEventsActive, he)
+	}
+}
+
+// recordSurfaceError finalizes a failed embeddings/images request: increments
+// the Prometheus error counter, stamps the span with the error, and
+// dispatches the failed lifecycle event. It is the non-chat counterpart of
+// routeError (gateway_route.go), reusing its lifecycle-event plumbing
+// (dispatchRequestEvent, failedEventData) and gateway_stream.go's redaction
+// policy (streamStartErrRedactor) rather than duplicating them. providerName
+// is "" when routing never resolved any target, matching chat's
+// empty-provider error label (see Route's own routeError call on a strategy
+// Execute failure). It returns the redacted message so the caller's own log
+// line does not redact the same error twice.
+func (g *Gateway) recordSurfaceError(ctx context.Context, span observability.Span, obs observability.Provider, providerName, model string, err error, latency time.Duration, hooksEnabled, obsEventsActive bool) string {
+	metrics.ForRequest(providerName, g.metricModel(model)).Error.Inc()
+	span.SetError(err)
+	safeErr := streamStartErrRedactor.Redact(err.Error())
+
+	if hooksEnabled || obsEventsActive {
+		he := failedEventData(
+			logging.TraceIDFromContext(ctx),
+			providerName,
+			model,
+			safeErr,
+			latency,
+			false,
+		)
+		g.dispatchRequestEvent(ctx, obs, hooksEnabled, obsEventsActive, he)
+	}
+	return safeErr
+}
+
+// surfaceTargetOrder resolves the candidate target keys for one embeddings/
+// images request, honouring strategy.mode the same way chat's getStrategy
+// does. mode is returned so routeEmbedding/routeImage know whether to advance
+// to the next target on failure (ModeFallback) or stop at the first attempt.
+func (g *Gateway) surfaceTargetOrder(model, surface string, usage models.Usage) ([]string, StrategyMode, error) {
+	g.mu.Lock()
+	g.ensureCircuitBreakersLocked()
+	g.ensureProviderLimitersLocked()
+	mode := g.config.Strategy.Mode
+	targets := append([]Target(nil), g.config.Targets...)
+	if mode == ModeLatency || mode == ModeCostOptimized || mode == ModeLoadBalance {
+		// Snapshot everything ranking needs, then release g.mu before doing any
+		// of the actual work. rankConfiguredSurfaceTargets loops every target
+		// doing latency/catalog lookups and, for ModeLoadBalance, reads the
+		// system CSPRNG (secureRandomUnit) — none of that should run while
+		// every chat request, admin config read, and provider registration
+		// blocks on this single global write lock. Mirrors getStrategy's
+		// snapshot-then-release pattern (gateway_strategy.go): map values
+		// (Provider) are themselves immutable references, and g.catalog is
+		// replaced wholesale rather than mutated in place (see
+		// refreshCatalog), so a plain reference copy is safe without cloning.
+		providerSnap := maps.Clone(g.providers)
+		catalog := g.catalog
+		unpricedStrategy := g.config.Strategy.UnpricedStrategy
+		g.mu.Unlock()
+
+		keys, err := g.rankConfiguredSurfaceTargets(targets, providerSnap, catalog, unpricedStrategy, model, surface, usage, mode)
+		return keys, mode, err
+	}
+	g.mu.Unlock()
+
+	if mode == ModeContentBased {
+		// Content rules only look at req.Messages (prompt_contains /
+		// prompt_not_contains / prompt_regex), and this surface has none —
+		// Embed/GenerateImage requests carry no chat messages. prompt_contains
+		// and prompt_regex correctly find no match against zero messages, but
+		// strategies.ContentBased's prompt_not_contains rule is
+		// `!anyUserMessageContains(...)`, which is vacuously TRUE over an
+		// empty message set: it would match every embeddings/image request
+		// and win routing outright, regardless of what the rule actually
+		// says. No content rule can be meaningfully evaluated without a
+		// prompt, so route in configured target order instead — exactly what
+		// strategy.SelectTargets already falls back to when no rule matches.
+		keys := make([]string, len(targets))
+		for i, t := range targets {
+			keys[i] = t.VirtualKey
+		}
+		return keys, mode, nil
+	}
+
+	// Single, Fallback, Conditional, and ABTest key off req.Model (or nothing
+	// at all) — none of them need a prompt — so the shared strategy can
+	// resolve them exactly as it does for chat.
+	strategy, err := g.getStrategy()
+	if err != nil {
+		return nil, "", err
+	}
+	keys, err := strategy.SelectTargets(providers.Request{Model: model})
+	if err != nil {
+		return nil, "", err
+	}
+	return keys, mode, nil
+}
+
+type surfaceRankCandidate struct {
+	key        string
+	latency    time.Duration
+	hasLatency bool
+	cost       models.CostResult
+	priced     bool
+	weight     float64
+}
+
+// rankConfiguredSurfaceTargets orders configured targets for ModeLatency,
+// ModeCostOptimized, and ModeLoadBalance. It takes its inputs as arguments
+// instead of reading g.config/g.providers/g.catalog directly (g.latencyTracker
+// is the one exception — its own mutex makes it safe to read unlocked) so
+// surfaceTargetOrder can call it after releasing g.mu rather than holding the
+// gateway's single global write lock across ranking, latency/catalog lookups,
+// and a crypto/rand syscall.
+func (g *Gateway) rankConfiguredSurfaceTargets(targets []Target, providerSnap map[string]providers.Provider, catalog models.Catalog, unpricedStrategy, model, surface string, usage models.Usage, mode StrategyMode) ([]string, error) {
+	candidates := make([]surfaceRankCandidate, 0, len(targets))
+	for _, target := range targets {
+		p, ok := providerSnap[target.VirtualKey]
+		if !ok || !p.SupportsModel(model) || !providerSupportsSurface(p, surface) {
+			continue
+		}
+		candidate := surfaceRankCandidate{key: target.VirtualKey, weight: target.Weight}
+		if mode == ModeLatency {
+			candidate.latency, candidate.hasLatency = g.latencyTracker.Stats(target.VirtualKey)
+		} else {
+			modelKey := p.Name() + "/" + model
+			candidate.cost = models.Calculate(catalog, modelKey, usage)
+			candidate.priced = surfaceHasPrice(catalog, modelKey, surface)
+		}
+		candidates = append(candidates, candidate)
+	}
+	if len(candidates) == 0 {
+		return nil, nil
+	}
+
+	switch mode {
+	case ModeLoadBalance:
+		// Weight only providers that implement this surface. Running the generic
+		// load-balancer first would let a chat-only target distort which embedding
+		// or image provider is selected even though it can never serve the call.
+		totalWeight := 0.0
+		for _, candidate := range candidates {
+			totalWeight += surfaceWeight(candidate.weight)
+		}
+		randomUnit, err := secureRandomUnit()
+		if err != nil {
+			return nil, fmt.Errorf("select load-balanced surface target: %w", err)
+		}
+		pick := randomUnit * totalWeight
+		start := 0
+		for i, candidate := range candidates {
+			pick -= surfaceWeight(candidate.weight)
+			if pick < 0 {
+				start = i
+				break
+			}
+		}
+		rotated := make([]surfaceRankCandidate, 0, len(candidates))
+		rotated = append(rotated, candidates[start:]...)
+		rotated = append(rotated, candidates[:start]...)
+		candidates = rotated
+	case ModeLatency:
+		// Cold targets stay ahead of sampled ones so they receive a profiling
+		// request; within each group declared target order is the stable tie-break.
+		sort.SliceStable(candidates, func(i, j int) bool {
+			if candidates[i].hasLatency != candidates[j].hasLatency {
+				return !candidates[i].hasLatency
+			}
+			return candidates[i].latency < candidates[j].latency
+		})
+	default:
+		priced := make([]surfaceRankCandidate, 0, len(candidates))
+		unpriced := make([]surfaceRankCandidate, 0, len(candidates))
+		for _, candidate := range candidates {
+			if candidate.priced {
+				priced = append(priced, candidate)
+			} else {
+				unpriced = append(unpriced, candidate)
+			}
+		}
+		sort.SliceStable(priced, func(i, j int) bool { return priced[i].cost.TotalUSD < priced[j].cost.TotalUSD })
+		switch unpricedStrategy {
+		case unpricedStrategySkip:
+			if len(priced) == 0 {
+				return nil, fmt.Errorf("no priced provider supports model %s", model)
+			}
+			candidates = priced
+		case unpricedStrategyAllow:
+			// Match the chat cost strategy: unpriced candidates participate at
+			// estimated zero cost, while explicit zero prices remain priced.
+			ordered := make([]surfaceRankCandidate, 0, len(candidates))
+			ordered = append(ordered, unpriced...)
+			ordered = append(ordered, priced...)
+			candidates = ordered
+		default:
+			if len(priced) > 0 {
+				candidates = priced
+			} else {
+				candidates = unpriced
+			}
+		}
+	}
+
+	keys := make([]string, 0, len(candidates))
+	for _, candidate := range candidates {
+		keys = append(keys, candidate.key)
+	}
+	return keys, nil
+}
+
+// secureRandomUnit returns a uniformly distributed value in [0, 1). Routing
+// selection is externally observable, so use the system CSPRNG instead of a
+// predictable process-local pseudo-random stream. Entropy failure is surfaced
+// rather than silently biasing all traffic toward the first target.
+//
+// Only ever called from rankConfiguredSurfaceTargets, which surfaceTargetOrder
+// invokes AFTER releasing g.mu — so this syscall never runs while holding the
+// gateway's single global write lock.
+func secureRandomUnit() (float64, error) {
+	var randomBytes [8]byte
+	if _, err := cryptorand.Read(randomBytes[:]); err != nil {
+		return 0, err
+	}
+	const mantissaBits = 53
+	value := binary.LittleEndian.Uint64(randomBytes[:]) >> (64 - mantissaBits)
+	return float64(value) / float64(uint64(1)<<mantissaBits), nil
+}
+
+func surfaceWeight(weight float64) float64 {
+	if weight <= 0 {
+		return 1
+	}
+	return weight
+}
+
+func surfaceHasPrice(catalog models.Catalog, modelKey, surface string) bool {
+	model, ok := catalog.GetForPricing(modelKey)
+	if !ok {
+		return false
+	}
+	switch surface {
+	case "embeddings":
+		return model.Mode == models.ModeEmbedding && model.Pricing.EmbeddingPerMTokens != nil
+	case "images":
+		return model.Mode == models.ModeImage && model.Pricing.ImagePerTile != nil
+	default:
+		return false
+	}
+}
+
+func providerSupportsSurface(p providers.Provider, surface string) bool {
+	switch surface {
+	case "embeddings":
+		_, ok := p.(providers.EmbeddingProvider)
+		return ok
+	case "images":
+		_, ok := p.(providers.ImageProvider)
+		return ok
+	default:
+		return false
+	}
+}
+
+// routeEmbedding tries configured, model-compatible embedding targets in
+// strategy order, applying each target's retry policy and — in fallback mode —
+// advancing to the next target on failure (routeSurfaceTarget /
+// runTargetAttempts). If no configured target is even viable for the model
+// (wrong model, not an EmbeddingProvider, not registered) it falls back to any
+// registered embedding-capable provider for it, preserving v1.3.0's guarantee
+// that a provider registered outside the target list stays reachable for the
+// models it serves — mirroring startStreamWithStrategy's use of
+// resolveFallbackStreamProviderLocked for the streaming surface.
+func (g *Gateway) routeEmbedding(ctx context.Context, req providers.EmbeddingRequest) (*providers.EmbeddingResponse, string, error) {
+	keys, mode, err := g.surfaceTargetOrder(req.Model, "embeddings", models.Usage{PromptTokens: 1})
+	if err != nil {
+		return nil, "", err
+	}
+	var lastErr error
+	anyViable := false
+	for _, key := range keys {
+		g.mu.RLock()
+		p, ok := g.providers[key]
+		ep, capable := p.(providers.EmbeddingProvider)
+		g.mu.RUnlock()
+		if !ok || !capable || !p.SupportsModel(req.Model) {
+			continue
+		}
+		anyViable = true
+		providerName := p.Name()
+
+		resp, callErr := routeSurfaceTarget(ctx, g, key, func(callCtx context.Context) (*providers.EmbeddingResponse, error) {
+			return ep.Embed(callCtx, req)
+		})
+		if callErr == nil {
+			return resp, providerName, nil
+		}
+		lastErr = fmt.Errorf("embedding target %s: %w", key, callErr)
+		if mode != ModeFallback {
+			return nil, providerName, lastErr
+		}
+	}
+
+	if !anyViable {
+		g.mu.RLock()
+		name, ep, ok := g.findEmbeddingProviderByModelLocked(req.Model)
+		g.mu.RUnlock()
+		if ok {
+			resp, callErr := routeSurfaceTarget(ctx, g, name, func(callCtx context.Context) (*providers.EmbeddingResponse, error) {
+				return ep.Embed(callCtx, req)
+			})
+			if callErr == nil {
+				return resp, name, nil
+			}
+			return nil, name, fmt.Errorf("embedding target %s: %w", name, callErr)
+		}
+	}
+
+	if lastErr != nil {
+		return nil, "", lastErr
+	}
+	return nil, "", fmt.Errorf("%w: no embedding provider for %q", core.ErrNoCapableProvider, req.Model)
+}
+
+// routeImage is routeEmbedding's counterpart for image generation; see its
+// doc comment for the shared retry/fallback/registry-fallback shape.
+func (g *Gateway) routeImage(ctx context.Context, req providers.ImageRequest) (*providers.ImageResponse, string, error) {
+	imageCount := 1
+	if req.N != nil && *req.N > 0 {
+		imageCount = *req.N
+	}
+	keys, mode, err := g.surfaceTargetOrder(req.Model, "images", models.Usage{ImageCount: imageCount})
+	if err != nil {
+		return nil, "", err
+	}
+	var lastErr error
+	anyViable := false
+	for _, key := range keys {
+		g.mu.RLock()
+		p, ok := g.providers[key]
+		ip, capable := p.(providers.ImageProvider)
+		g.mu.RUnlock()
+		if !ok || !capable || !p.SupportsModel(req.Model) {
+			continue
+		}
+		anyViable = true
+		providerName := p.Name()
+
+		resp, callErr := routeSurfaceTarget(ctx, g, key, func(callCtx context.Context) (*providers.ImageResponse, error) {
+			return ip.GenerateImage(callCtx, req)
+		})
+		if callErr == nil {
+			return resp, providerName, nil
+		}
+		lastErr = fmt.Errorf("image target %s: %w", key, callErr)
+		if mode != ModeFallback {
+			return nil, providerName, lastErr
+		}
+	}
+
+	if !anyViable {
+		g.mu.RLock()
+		name, ip, ok := g.findImageProviderByModelLocked(req.Model)
+		g.mu.RUnlock()
+		if ok {
+			resp, callErr := routeSurfaceTarget(ctx, g, name, func(callCtx context.Context) (*providers.ImageResponse, error) {
+				return ip.GenerateImage(callCtx, req)
+			})
+			if callErr == nil {
+				return resp, name, nil
+			}
+			return nil, name, fmt.Errorf("image target %s: %w", name, callErr)
+		}
+	}
+
+	if lastErr != nil {
+		return nil, "", lastErr
+	}
+	return nil, "", fmt.Errorf("%w: no image generation provider for %q", core.ErrNoCapableProvider, req.Model)
+}
+
+// routeSurfaceTarget applies the shared retry, circuit-breaker, concurrency,
+// and latency-accounting lifecycle for a single non-chat target — the
+// embeddings/images counterpart of chat's decorateProvider + strategy.Execute
+// path, reusing the same runTargetAttempts (gateway_retry.go) so backoff stays
+// normalised in exactly one place.
+func routeSurfaceTarget[T any](ctx context.Context, g *Gateway, key string, call func(context.Context) (*T, error)) (*T, error) {
+	var response *T
+	started := time.Now()
+	err := g.runTargetAttempts(ctx, key, func(attemptCtx context.Context) error {
+		return g.withTargetBreaker(attemptCtx, key, func(breakerCtx context.Context) error {
+			return g.withTargetSlot(breakerCtx, key, func(slotCtx context.Context) error {
+				var callErr error
+				response, callErr = call(slotCtx)
+				return callErr
+			})
+		})
+	})
+	if err == nil {
+		g.latencyTracker.Record(key, time.Since(started))
+	}
+	return response, err
 }
 
 // StartDiscovery periodically refreshes model lists from providers that implement

--- a/gateway_multimodal_test.go
+++ b/gateway_multimodal_test.go
@@ -3,6 +3,7 @@ package aigateway
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -772,7 +773,9 @@ func TestGateway_GenerateImage_EmitsMetricsSpanAndEvent(t *testing.T) {
 func TestGateway_Embed_FailurePathEmitsMetricsAndErrorEvent(t *testing.T) {
 	ep := &mockEmbeddingProvider{
 		mockProvider: mockProvider{name: "embed-provider", models: []string{"text-embedding-3-small"}},
-		err:          errors.New("upstream exploded"),
+		// Carries a credential-shaped token so the assertions below prove the
+		// event text is redacted, not merely non-empty.
+		err: errors.New("upstream exploded: 401 invalid api key sk-abcdefghijklmnopqrstuvwxyz012345"),
 	}
 	gw, _ := newTestGateway(t, Config{
 		Strategy: StrategyConfig{Mode: ModeSingle},
@@ -813,5 +816,14 @@ func TestGateway_Embed_FailurePathEmitsMetricsAndErrorEvent(t *testing.T) {
 	}
 	if evts[0].Error == "" {
 		t.Error("event Error should be non-empty for a failed embedding request")
+	}
+	// Events reach observability exporters, which are third-party sinks. A
+	// provider that echoes the offending key in its error body must not carry
+	// it out of the process.
+	if strings.Contains(evts[0].Error, "sk-abcdefghijklmnopqrstuvwxyz012345") {
+		t.Errorf("event Error leaked the provider credential unredacted: %q", evts[0].Error)
+	}
+	if !strings.Contains(evts[0].Error, "upstream exploded") {
+		t.Errorf("event Error lost its diagnostic content to redaction: %q", evts[0].Error)
 	}
 }

--- a/gateway_multimodal_test.go
+++ b/gateway_multimodal_test.go
@@ -2,9 +2,13 @@ package aigateway
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
+	"github.com/ferro-labs/ai-gateway/internal/metrics"
+	"github.com/ferro-labs/ai-gateway/models"
+	"github.com/ferro-labs/ai-gateway/observability"
 	"github.com/ferro-labs/ai-gateway/plugin"
 	"github.com/ferro-labs/ai-gateway/providers"
 )
@@ -12,11 +16,29 @@ import (
 type mockEmbeddingProvider struct {
 	mockProvider
 	capturedModel string
+	calls         int
+	err           error
+	// promptTokens is echoed back as EmbeddingResponse.Usage.PromptTokens so
+	// tests can assert on the cost/metrics/span accounting Embed derives from it.
+	promptTokens int
+	// embedFn, when set, overrides the default success/err behavior — used by
+	// tests that need a call count to change behavior (e.g. fail-then-succeed).
+	embedFn func(context.Context, providers.EmbeddingRequest) (*providers.EmbeddingResponse, error)
 }
 
-func (m *mockEmbeddingProvider) Embed(_ context.Context, req providers.EmbeddingRequest) (*providers.EmbeddingResponse, error) {
+func (m *mockEmbeddingProvider) Embed(ctx context.Context, req providers.EmbeddingRequest) (*providers.EmbeddingResponse, error) {
+	m.calls++
 	m.capturedModel = req.Model
-	return &providers.EmbeddingResponse{Model: req.Model}, nil
+	if m.embedFn != nil {
+		return m.embedFn(ctx, req)
+	}
+	if m.err != nil {
+		return nil, m.err
+	}
+	return &providers.EmbeddingResponse{
+		Model: req.Model,
+		Usage: providers.EmbeddingUsage{PromptTokens: m.promptTokens, TotalTokens: m.promptTokens},
+	}, nil
 }
 
 // ── mockImageProvider ─────────────────────────────────────────────────────────
@@ -24,11 +46,30 @@ func (m *mockEmbeddingProvider) Embed(_ context.Context, req providers.Embedding
 type mockImageProvider struct {
 	mockProvider
 	capturedModel string
+	calls         int
+	err           error
+	// images is the number of entries GenerateImage puts in Data, so tests can
+	// assert on ImageCount-based cost accounting. 0 defaults to 1, matching the
+	// gateway's own req.N-unset fallback (see routeImage).
+	images int
+	// imageFn, when set, overrides the default success/err behavior.
+	imageFn func(context.Context, providers.ImageRequest) (*providers.ImageResponse, error)
 }
 
-func (m *mockImageProvider) GenerateImage(_ context.Context, req providers.ImageRequest) (*providers.ImageResponse, error) {
+func (m *mockImageProvider) GenerateImage(ctx context.Context, req providers.ImageRequest) (*providers.ImageResponse, error) {
+	m.calls++
 	m.capturedModel = req.Model
-	return &providers.ImageResponse{}, nil
+	if m.imageFn != nil {
+		return m.imageFn(ctx, req)
+	}
+	if m.err != nil {
+		return nil, m.err
+	}
+	n := m.images
+	if n == 0 {
+		n = 1
+	}
+	return &providers.ImageResponse{Data: make([]providers.GeneratedImage, n)}, nil
 }
 
 // ── alias resolution tests ────────────────────────────────────────────────────
@@ -186,6 +227,346 @@ func TestGateway_GenerateImage_ResolvesAlias(t *testing.T) {
 	}
 }
 
+// ── configured-target routing (A2 fix) ────────────────────────────────────────
+
+// TestGateway_Embed_UsesConfiguredTargetNotRegistrationOrder is the core A2
+// regression test: with two registered embedding providers, only the one
+// named in Targets may be called — registration order must not decide it.
+func TestGateway_Embed_UsesConfiguredTargetNotRegistrationOrder(t *testing.T) {
+	rogue := &mockEmbeddingProvider{mockProvider: mockProvider{name: "rogue", models: []string{"embed-model"}}}
+	selected := &mockEmbeddingProvider{mockProvider: mockProvider{name: "selected", models: []string{"embed-model"}}}
+	gw, _ := newTestGateway(t, Config{
+		Strategy: StrategyConfig{Mode: ModeSingle},
+		Targets:  []Target{{VirtualKey: "selected"}},
+	})
+	gw.RegisterProvider(rogue)
+	gw.RegisterProvider(selected)
+
+	if _, err := gw.Embed(context.Background(), providers.EmbeddingRequest{Model: "embed-model", Input: "hi"}); err != nil {
+		t.Fatalf("Embed: %v", err)
+	}
+	if rogue.calls != 0 || selected.calls != 1 {
+		t.Fatalf("calls rogue=%d selected=%d, want 0/1", rogue.calls, selected.calls)
+	}
+}
+
+// TestGateway_MultimodalFallbackAdvancesConfiguredTargets is the headline A2
+// regression: strategy.mode: fallback with two embedding/image-capable targets
+// must advance to the second target when the first fails — before the fix
+// these surfaces had no fallback at all.
+func TestGateway_MultimodalFallbackAdvancesConfiguredTargets(t *testing.T) {
+	t.Run("embeddings", func(t *testing.T) {
+		first := &mockEmbeddingProvider{mockProvider: mockProvider{name: "first", models: []string{"embed-model"}}, err: errors.New("down")}
+		second := &mockEmbeddingProvider{mockProvider: mockProvider{name: "second", models: []string{"embed-model"}}}
+		gw, _ := newTestGateway(t, Config{
+			Strategy: StrategyConfig{Mode: ModeFallback},
+			Targets:  []Target{{VirtualKey: "first"}, {VirtualKey: "second"}},
+		})
+		gw.RegisterProvider(first)
+		gw.RegisterProvider(second)
+		if _, err := gw.Embed(context.Background(), providers.EmbeddingRequest{Model: "embed-model", Input: "hi"}); err != nil {
+			t.Fatalf("Embed fallback: %v", err)
+		}
+		if first.calls != 1 || second.calls != 1 {
+			t.Fatalf("calls first=%d second=%d, want 1/1", first.calls, second.calls)
+		}
+	})
+
+	t.Run("images", func(t *testing.T) {
+		first := &mockImageProvider{mockProvider: mockProvider{name: "first", models: []string{"image-model"}}, err: errors.New("down")}
+		second := &mockImageProvider{mockProvider: mockProvider{name: "second", models: []string{"image-model"}}}
+		gw, _ := newTestGateway(t, Config{
+			Strategy: StrategyConfig{Mode: ModeFallback},
+			Targets:  []Target{{VirtualKey: "first"}, {VirtualKey: "second"}},
+		})
+		gw.RegisterProvider(first)
+		gw.RegisterProvider(second)
+		if _, err := gw.GenerateImage(context.Background(), providers.ImageRequest{Model: "image-model", Prompt: "cat"}); err != nil {
+			t.Fatalf("GenerateImage fallback: %v", err)
+		}
+		if first.calls != 1 || second.calls != 1 {
+			t.Fatalf("calls first=%d second=%d, want 1/1", first.calls, second.calls)
+		}
+	})
+}
+
+// TestGateway_MultimodalRetryHonoursConfiguredAttempts proves retries route
+// through the shared runTargetAttempts (gateway_retry.go) instead of a
+// one-shot call: with Retry.Attempts: 3 configured and an always-failing
+// target, the provider must be attempted exactly 3 times before giving up.
+func TestGateway_MultimodalRetryHonoursConfiguredAttempts(t *testing.T) {
+	t.Run("embeddings", func(t *testing.T) {
+		ep := &mockEmbeddingProvider{mockProvider: mockProvider{name: "flaky", models: []string{"embed-model"}}, err: errors.New("down")}
+		gw, _ := newTestGateway(t, Config{
+			Strategy: StrategyConfig{Mode: ModeFallback},
+			Targets:  []Target{{VirtualKey: "flaky", Retry: &RetryConfig{Attempts: 3, InitialBackoffMs: 1}}},
+		})
+		gw.RegisterProvider(ep)
+
+		if _, err := gw.Embed(context.Background(), providers.EmbeddingRequest{Model: "embed-model", Input: "hi"}); err == nil {
+			t.Fatal("expected Embed to fail after exhausting retries")
+		}
+		if ep.calls != 3 {
+			t.Fatalf("calls = %d, want 3 (the configured retry attempts)", ep.calls)
+		}
+	})
+
+	t.Run("images", func(t *testing.T) {
+		ip := &mockImageProvider{mockProvider: mockProvider{name: "flaky", models: []string{"image-model"}}, err: errors.New("down")}
+		gw, _ := newTestGateway(t, Config{
+			Strategy: StrategyConfig{Mode: ModeFallback},
+			Targets:  []Target{{VirtualKey: "flaky", Retry: &RetryConfig{Attempts: 3, InitialBackoffMs: 1}}},
+		})
+		gw.RegisterProvider(ip)
+
+		if _, err := gw.GenerateImage(context.Background(), providers.ImageRequest{Model: "image-model", Prompt: "cat"}); err == nil {
+			t.Fatal("expected GenerateImage to fail after exhausting retries")
+		}
+		if ip.calls != 3 {
+			t.Fatalf("calls = %d, want 3 (the configured retry attempts)", ip.calls)
+		}
+	})
+}
+
+// TestGateway_MultimodalRequestTimeoutBoundsTheRequest proves RequestTimeout
+// bounds Embed/GenerateImage the same way it bounds Route: a provider that
+// hangs past the configured timeout must be cut short, not run to completion.
+func TestGateway_MultimodalRequestTimeoutBoundsTheRequest(t *testing.T) {
+	const hang = 500 * time.Millisecond
+
+	t.Run("embeddings", func(t *testing.T) {
+		ep := &mockEmbeddingProvider{
+			mockProvider: mockProvider{name: "slow", models: []string{"embed-model"}},
+			embedFn: func(ctx context.Context, _ providers.EmbeddingRequest) (*providers.EmbeddingResponse, error) {
+				select {
+				case <-ctx.Done():
+					return nil, ctx.Err()
+				case <-time.After(hang):
+					return &providers.EmbeddingResponse{}, nil
+				}
+			},
+		}
+		gw, _ := newTestGateway(t, Config{
+			Strategy:       StrategyConfig{Mode: ModeSingle},
+			Targets:        []Target{{VirtualKey: "slow"}},
+			RequestTimeout: "50ms",
+		})
+		gw.RegisterProvider(ep)
+
+		start := time.Now()
+		_, err := gw.Embed(context.Background(), providers.EmbeddingRequest{Model: "embed-model", Input: "hi"})
+		elapsed := time.Since(start)
+
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("Embed error = %v, want context.DeadlineExceeded", err)
+		}
+		if elapsed >= hang {
+			t.Errorf("Embed took %v — the 50ms request_timeout did not bound it", elapsed)
+		}
+	})
+
+	t.Run("images", func(t *testing.T) {
+		ip := &mockImageProvider{
+			mockProvider: mockProvider{name: "slow", models: []string{"image-model"}},
+			imageFn: func(ctx context.Context, _ providers.ImageRequest) (*providers.ImageResponse, error) {
+				select {
+				case <-ctx.Done():
+					return nil, ctx.Err()
+				case <-time.After(hang):
+					return &providers.ImageResponse{}, nil
+				}
+			},
+		}
+		gw, _ := newTestGateway(t, Config{
+			Strategy:       StrategyConfig{Mode: ModeSingle},
+			Targets:        []Target{{VirtualKey: "slow"}},
+			RequestTimeout: "50ms",
+		})
+		gw.RegisterProvider(ip)
+
+		start := time.Now()
+		_, err := gw.GenerateImage(context.Background(), providers.ImageRequest{Model: "image-model", Prompt: "cat"})
+		elapsed := time.Since(start)
+
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("GenerateImage error = %v, want context.DeadlineExceeded", err)
+		}
+		if elapsed >= hang {
+			t.Errorf("GenerateImage took %v — the 50ms request_timeout did not bound it", elapsed)
+		}
+	})
+}
+
+// TestGateway_MultimodalRegistryFallbackReachableForUnlistedProvider is the B5
+// regression guard: a provider registered outside the target list must stay
+// reachable for the models it serves, matching v1.3.0 and mirroring
+// resolveFallbackStreamProviderLocked for streaming.
+func TestGateway_MultimodalRegistryFallbackReachableForUnlistedProvider(t *testing.T) {
+	t.Run("embeddings", func(t *testing.T) {
+		unlisted := &mockEmbeddingProvider{mockProvider: mockProvider{name: "unlisted", models: []string{"embed-model"}}}
+		gw, _ := newTestGateway(t, Config{
+			Strategy: StrategyConfig{Mode: ModeSingle},
+			// No target names "unlisted" and no target supports embed-model.
+			Targets: []Target{{VirtualKey: "chat-only"}},
+		})
+		gw.RegisterProvider(&mockProvider{name: "chat-only", models: []string{"embed-model"}})
+		gw.RegisterProvider(unlisted)
+
+		if _, err := gw.Embed(context.Background(), providers.EmbeddingRequest{Model: "embed-model", Input: "hi"}); err != nil {
+			t.Fatalf("Embed: %v", err)
+		}
+		if unlisted.calls != 1 {
+			t.Fatalf("unlisted provider calls = %d, want 1 (registry fallback)", unlisted.calls)
+		}
+	})
+
+	t.Run("images", func(t *testing.T) {
+		unlisted := &mockImageProvider{mockProvider: mockProvider{name: "unlisted", models: []string{"image-model"}}}
+		gw, _ := newTestGateway(t, Config{
+			Strategy: StrategyConfig{Mode: ModeSingle},
+			Targets:  []Target{{VirtualKey: "chat-only"}},
+		})
+		gw.RegisterProvider(&mockProvider{name: "chat-only", models: []string{"image-model"}})
+		gw.RegisterProvider(unlisted)
+
+		if _, err := gw.GenerateImage(context.Background(), providers.ImageRequest{Model: "image-model", Prompt: "cat"}); err != nil {
+			t.Fatalf("GenerateImage: %v", err)
+		}
+		if unlisted.calls != 1 {
+			t.Fatalf("unlisted provider calls = %d, want 1 (registry fallback)", unlisted.calls)
+		}
+	})
+}
+
+func TestGateway_MultimodalHonorsLatencyAndCostStrategies(t *testing.T) {
+	t.Run("image load balance weights only capable targets", func(t *testing.T) {
+		chatOnly := &mockProvider{name: "chat-only", models: []string{"image-model"}}
+		first := &mockImageProvider{mockProvider: mockProvider{name: "first", models: []string{"image-model"}}}
+		second := &mockImageProvider{mockProvider: mockProvider{name: "second", models: []string{"image-model"}}}
+		gw, _ := newTestGateway(t, Config{
+			Strategy: StrategyConfig{Mode: ModeLoadBalance},
+			Targets: []Target{
+				{VirtualKey: "chat-only", Weight: 1_000_000_000},
+				{VirtualKey: "first", Weight: 1},
+				{VirtualKey: "second", Weight: 1},
+			},
+		})
+		gw.RegisterProvider(chatOnly)
+		gw.RegisterProvider(first)
+		gw.RegisterProvider(second)
+
+		for range 64 {
+			if _, err := gw.GenerateImage(context.Background(), providers.ImageRequest{Model: "image-model", Prompt: "cat"}); err != nil {
+				t.Fatalf("GenerateImage: %v", err)
+			}
+		}
+		if first.calls == 0 || second.calls == 0 {
+			t.Fatalf("load balance calls first=%d second=%d; chat-only target distorted surface weights", first.calls, second.calls)
+		}
+	})
+
+	t.Run("embedding latency", func(t *testing.T) {
+		slow := &mockEmbeddingProvider{mockProvider: mockProvider{name: "slow", models: []string{"embed-model"}}}
+		fast := &mockEmbeddingProvider{mockProvider: mockProvider{name: "fast", models: []string{"embed-model"}}}
+		gw, _ := newTestGateway(t, Config{
+			Strategy: StrategyConfig{Mode: ModeLatency},
+			Targets:  []Target{{VirtualKey: "slow"}, {VirtualKey: "fast"}},
+		})
+		gw.RegisterProvider(slow)
+		gw.RegisterProvider(fast)
+		gw.latencyTracker.Record("slow", 100*time.Millisecond)
+		gw.latencyTracker.Record("fast", time.Millisecond)
+
+		if _, err := gw.Embed(context.Background(), providers.EmbeddingRequest{Model: "embed-model", Input: "hi"}); err != nil {
+			t.Fatalf("Embed: %v", err)
+		}
+		if slow.calls != 0 || fast.calls != 1 {
+			t.Fatalf("latency strategy calls slow=%d fast=%d, want 0/1", slow.calls, fast.calls)
+		}
+	})
+
+	t.Run("image cost", func(t *testing.T) {
+		expensive := &mockImageProvider{mockProvider: mockProvider{name: "expensive", models: []string{"image-model"}}}
+		cheap := &mockImageProvider{mockProvider: mockProvider{name: "cheap", models: []string{"image-model"}}}
+		gw, _ := newTestGateway(t, Config{
+			Strategy: StrategyConfig{Mode: ModeCostOptimized},
+			Targets:  []Target{{VirtualKey: "expensive"}, {VirtualKey: "cheap"}},
+		})
+		gw.RegisterProvider(expensive)
+		gw.RegisterProvider(cheap)
+		high, low := 0.10, 0.01
+		gw.mu.Lock()
+		gw.catalog = models.Catalog{
+			"expensive/image-model": {Provider: "expensive", ModelID: "image-model", Mode: models.ModeImage, Pricing: models.Pricing{ImagePerTile: &high}},
+			"cheap/image-model":     {Provider: "cheap", ModelID: "image-model", Mode: models.ModeImage, Pricing: models.Pricing{ImagePerTile: &low}},
+		}
+		gw.mu.Unlock()
+
+		if _, err := gw.GenerateImage(context.Background(), providers.ImageRequest{Model: "image-model", Prompt: "cat"}); err != nil {
+			t.Fatalf("GenerateImage: %v", err)
+		}
+		if expensive.calls != 0 || cheap.calls != 1 {
+			t.Fatalf("cost strategy calls expensive=%d cheap=%d, want 0/1", expensive.calls, cheap.calls)
+		}
+	})
+}
+
+// ── content-based routing on promptless surfaces ──────────────────────────────
+
+// TestGateway_Embed_ContentBasedPromptNotContains_DoesNotVacuouslyMatch is a
+// regression test: content-based routing rules key off req.Messages, which
+// embeddings/image requests never have. prompt_not_contains is
+// `!anyUserMessageContains(...)`, which is vacuously TRUE over zero messages —
+// before the fix this rule matched every embeddings request and always won
+// routing, regardless of the configured target order or what the rule said.
+func TestGateway_Embed_ContentBasedPromptNotContains_DoesNotVacuouslyMatch(t *testing.T) {
+	first := &mockEmbeddingProvider{mockProvider: mockProvider{name: "first", models: []string{"embed-model"}}}
+	special := &mockEmbeddingProvider{mockProvider: mockProvider{name: "special", models: []string{"embed-model"}}}
+	gw, _ := newTestGateway(t, Config{
+		Strategy: StrategyConfig{
+			Mode: ModeContentBased,
+			ContentConditions: []ContentCondition{
+				{Type: "prompt_not_contains", Value: "unrelated-topic", TargetKey: "special"},
+			},
+		},
+		Targets: []Target{{VirtualKey: "first"}, {VirtualKey: "special"}},
+	})
+	gw.RegisterProvider(first)
+	gw.RegisterProvider(special)
+
+	if _, err := gw.Embed(context.Background(), providers.EmbeddingRequest{Model: "embed-model", Input: "hi"}); err != nil {
+		t.Fatalf("Embed: %v", err)
+	}
+	if first.calls != 1 || special.calls != 0 {
+		t.Fatalf("calls first=%d special=%d, want 1/0 — prompt_not_contains vacuously matched a promptless request", first.calls, special.calls)
+	}
+}
+
+// TestGateway_GenerateImage_ContentBasedPromptNotContains_DoesNotVacuouslyMatch
+// is the image-surface counterpart of the embeddings regression above.
+func TestGateway_GenerateImage_ContentBasedPromptNotContains_DoesNotVacuouslyMatch(t *testing.T) {
+	first := &mockImageProvider{mockProvider: mockProvider{name: "first", models: []string{"image-model"}}}
+	special := &mockImageProvider{mockProvider: mockProvider{name: "special", models: []string{"image-model"}}}
+	gw, _ := newTestGateway(t, Config{
+		Strategy: StrategyConfig{
+			Mode: ModeContentBased,
+			ContentConditions: []ContentCondition{
+				{Type: "prompt_not_contains", Value: "unrelated-topic", TargetKey: "special"},
+			},
+		},
+		Targets: []Target{{VirtualKey: "first"}, {VirtualKey: "special"}},
+	})
+	gw.RegisterProvider(first)
+	gw.RegisterProvider(special)
+
+	if _, err := gw.GenerateImage(context.Background(), providers.ImageRequest{Model: "image-model", Prompt: "cat"}); err != nil {
+		t.Fatalf("GenerateImage: %v", err)
+	}
+	if first.calls != 1 || special.calls != 0 {
+		t.Fatalf("calls first=%d special=%d, want 1/0 — prompt_not_contains vacuously matched a promptless request", first.calls, special.calls)
+	}
+}
+
 // ── StartDiscovery interval validation tests ──────────────────────────────────
 
 func TestGateway_StartDiscovery_ZeroInterval(t *testing.T) {
@@ -227,4 +608,210 @@ func TestGateway_StartDiscovery_ValidInterval(t *testing.T) {
 	}
 	// Cancel immediately; just verifies no panic and clean return.
 	cancel()
+}
+
+// ── observability parity tests (metrics / span / cost / lifecycle events) ────
+
+// TestGateway_Embed_EmitsMetricsSpanAndEvent covers the embeddings observability
+// gap: before the fix, Embed never emitted Prometheus metrics, an OTel span, cost
+// accounting, or a lifecycle event. No plugins are registered on gw, which proves
+// cost/metrics/events are recorded unconditionally — not only when the budget
+// plugin happens to be installed (the pre-fix behavior).
+func TestGateway_Embed_EmitsMetricsSpanAndEvent(t *testing.T) {
+	ep := &mockEmbeddingProvider{
+		mockProvider: mockProvider{name: "embed-provider", models: []string{"text-embedding-3-small"}},
+		promptTokens: 100,
+	}
+	gw, _ := newTestGateway(t, Config{
+		Strategy: StrategyConfig{Mode: ModeSingle},
+		Targets:  []Target{{VirtualKey: "embed-provider"}},
+	})
+	gw.RegisterProvider(ep)
+
+	price := 0.02
+	gw.mu.Lock()
+	gw.catalog = models.Catalog{
+		"embed-provider/text-embedding-3-small": {
+			Provider: "embed-provider", ModelID: "text-embedding-3-small",
+			Mode: models.ModeEmbedding, Pricing: models.Pricing{EmbeddingPerMTokens: &price},
+		},
+	}
+	gw.mu.Unlock()
+
+	obs := &eventCapturingProvider{recordingActive: true}
+	gw.SetObservability(obs)
+	handles := metrics.ForRequest("embed-provider", "text-embedding-3-small")
+	successBefore := counterValue(t, handles.Success)
+	costBefore := counterValue(t, handles.CostUSD)
+
+	if _, err := gw.Embed(context.Background(), providers.EmbeddingRequest{
+		Model: "text-embedding-3-small",
+		Input: "hello world",
+	}); err != nil {
+		t.Fatalf("Embed: %v", err)
+	}
+
+	if got := counterValue(t, handles.Success); got != successBefore+1 {
+		t.Errorf("Success counter = %v, want %v", got, successBefore+1)
+	}
+	if got := counterValue(t, handles.CostUSD); got <= costBefore {
+		t.Errorf("CostUSD counter did not increase: got %v, before %v", got, costBefore)
+	}
+
+	if obs.attrs.Operation != "embeddings" {
+		t.Errorf("Operation = %q, want %q", obs.attrs.Operation, "embeddings")
+	}
+	sp := obs.rootSpan()
+	if sp == nil {
+		t.Fatal("expected a root span for Embed")
+	}
+	if !sp.ended {
+		t.Error("expected span.End() to be called")
+	}
+	if sp.tokensIn != 100 {
+		t.Errorf("span tokensIn = %d, want 100", sp.tokensIn)
+	}
+	if sp.cost.TotalUSD <= 0 {
+		t.Error("expected span cost to be recorded")
+	}
+	if got, ok := sp.attrs[observability.AttrFerroRoutingTargetKey]; !ok || got != "embed-provider" {
+		t.Errorf("routing target key attr = %v, want embed-provider", got)
+	}
+
+	evts := obs.capturedEvents()
+	if len(evts) != 1 {
+		t.Fatalf("expected 1 completed event, got %d", len(evts))
+	}
+	if evts[0].Subject != "gateway.request.completed" {
+		t.Errorf("event Subject = %q, want gateway.request.completed", evts[0].Subject)
+	}
+	if evts[0].Cost.TotalUSD <= 0 {
+		t.Error("expected event cost to be recorded")
+	}
+}
+
+// TestGateway_GenerateImage_EmitsMetricsSpanAndEvent covers the same
+// observability gap for the images surface. No plugins are registered on gw,
+// proving image cost/metrics/events do not depend on the budget plugin.
+func TestGateway_GenerateImage_EmitsMetricsSpanAndEvent(t *testing.T) {
+	ip := &mockImageProvider{
+		mockProvider: mockProvider{name: "image-provider", models: []string{"dall-e-3"}},
+		images:       2,
+	}
+	gw, _ := newTestGateway(t, Config{
+		Strategy: StrategyConfig{Mode: ModeSingle},
+		Targets:  []Target{{VirtualKey: "image-provider"}},
+	})
+	gw.RegisterProvider(ip)
+
+	price := 0.04
+	gw.mu.Lock()
+	gw.catalog = models.Catalog{
+		"image-provider/dall-e-3": {
+			Provider: "image-provider", ModelID: "dall-e-3",
+			Mode: models.ModeImage, Pricing: models.Pricing{ImagePerTile: &price},
+		},
+	}
+	gw.mu.Unlock()
+
+	obs := &eventCapturingProvider{recordingActive: true}
+	gw.SetObservability(obs)
+	handles := metrics.ForRequest("image-provider", "dall-e-3")
+	successBefore := counterValue(t, handles.Success)
+	costBefore := counterValue(t, handles.CostUSD)
+
+	if _, err := gw.GenerateImage(context.Background(), providers.ImageRequest{
+		Model:  "dall-e-3",
+		Prompt: "a cat",
+	}); err != nil {
+		t.Fatalf("GenerateImage: %v", err)
+	}
+
+	if got := counterValue(t, handles.Success); got != successBefore+1 {
+		t.Errorf("Success counter = %v, want %v", got, successBefore+1)
+	}
+	wantCost := costBefore + price*2 // 2 images at $0.04/tile
+	if got := counterValue(t, handles.CostUSD); got < wantCost {
+		t.Errorf("CostUSD counter = %v, want at least %v", got, wantCost)
+	}
+
+	if obs.attrs.Operation != "images.generate" {
+		t.Errorf("Operation = %q, want %q", obs.attrs.Operation, "images.generate")
+	}
+	sp := obs.rootSpan()
+	if sp == nil {
+		t.Fatal("expected a root span for GenerateImage")
+	}
+	if !sp.ended {
+		t.Error("expected span.End() to be called")
+	}
+	if sp.cost.TotalUSD <= 0 {
+		t.Error("expected span cost to be recorded")
+	}
+	if got, ok := sp.attrs[observability.AttrFerroRoutingTargetKey]; !ok || got != "image-provider" {
+		t.Errorf("routing target key attr = %v, want image-provider", got)
+	}
+
+	evts := obs.capturedEvents()
+	if len(evts) != 1 {
+		t.Fatalf("expected 1 completed event, got %d", len(evts))
+	}
+	if evts[0].Subject != "gateway.request.completed" {
+		t.Errorf("event Subject = %q, want gateway.request.completed", evts[0].Subject)
+	}
+	if evts[0].Cost.TotalUSD <= 0 {
+		t.Error("expected event cost to be recorded")
+	}
+}
+
+// TestGateway_Embed_FailurePathEmitsMetricsAndErrorEvent covers the
+// recordSurfaceError side: a routing failure must still increment the
+// Prometheus error counter, stamp the span with the error, and dispatch a
+// failed lifecycle event. The event's Error text must be redacted using the
+// same policy gateway_stream.go applies to synchronous stream-start failures.
+func TestGateway_Embed_FailurePathEmitsMetricsAndErrorEvent(t *testing.T) {
+	ep := &mockEmbeddingProvider{
+		mockProvider: mockProvider{name: "embed-provider", models: []string{"text-embedding-3-small"}},
+		err:          errors.New("upstream exploded"),
+	}
+	gw, _ := newTestGateway(t, Config{
+		Strategy: StrategyConfig{Mode: ModeSingle},
+		Targets:  []Target{{VirtualKey: "embed-provider"}},
+	})
+	gw.RegisterProvider(ep)
+
+	obs := &eventCapturingProvider{recordingActive: true}
+	gw.SetObservability(obs)
+	handles := metrics.ForRequest("embed-provider", "text-embedding-3-small")
+	errorsBefore := counterValue(t, handles.Error)
+
+	if _, err := gw.Embed(context.Background(), providers.EmbeddingRequest{
+		Model: "text-embedding-3-small",
+		Input: "hello",
+	}); err == nil {
+		t.Fatal("expected Embed to return an error")
+	}
+
+	if got := counterValue(t, handles.Error); got != errorsBefore+1 {
+		t.Errorf("Error counter = %v, want %v", got, errorsBefore+1)
+	}
+
+	sp := obs.rootSpan()
+	if sp == nil {
+		t.Fatal("expected a root span for Embed")
+	}
+	if sp.err == nil {
+		t.Error("expected span.SetError to be called")
+	}
+
+	evts := obs.capturedEvents()
+	if len(evts) != 1 {
+		t.Fatalf("expected 1 failed event, got %d", len(evts))
+	}
+	if evts[0].Subject != "gateway.request.failed" {
+		t.Errorf("event Subject = %q, want gateway.request.failed", evts[0].Subject)
+	}
+	if evts[0].Error == "" {
+		t.Error("event Error should be non-empty for a failed embedding request")
+	}
 }

--- a/gateway_retry.go
+++ b/gateway_retry.go
@@ -1,0 +1,63 @@
+package aigateway
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ferro-labs/ai-gateway/internal/strategies"
+)
+
+// runTargetAttempts applies the configured fallback retry policy to a generic
+// provider-start call. Other strategy modes perform exactly one attempt;
+// their retry fields have never been part of the documented contract — only
+// fallback's per-target retry block is. Backoff normalisation (an unset
+// InitialBackoffMs falling back to a sane default rather than 0) lives once
+// in strategies.WaitBeforeRetry, via strategies.NormalizeBackoffMs, so this
+// helper never re-derives that guard: an unset InitialBackoffMs gets the same
+// jittered-exponential wait here as it does for /v1/chat/completions instead
+// of hammering the provider with immediate retries.
+func (g *Gateway) runTargetAttempts(ctx context.Context, targetKey string, call func(context.Context) error) error {
+	g.mu.RLock()
+	mode := g.config.Strategy.Mode
+	var retry *RetryConfig
+	for i := range g.config.Targets {
+		if g.config.Targets[i].VirtualKey == targetKey {
+			retry = g.config.Targets[i].Retry
+			break
+		}
+	}
+	g.mu.RUnlock()
+
+	attempts := 1
+	if mode == ModeFallback && retry != nil && retry.Attempts > 0 {
+		attempts = retry.Attempts
+	}
+
+	var lastErr error
+	for attempt := 0; attempt < attempts; attempt++ {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if attempt > 0 {
+			proceed, err := strategies.WaitBeforeRetry(ctx, attempt, retry.InitialBackoffMs, lastErr)
+			if err != nil {
+				return err
+			}
+			if !proceed {
+				break
+			}
+		}
+		err := call(ctx)
+		if err == nil {
+			return nil
+		}
+		lastErr = err
+		if mode != ModeFallback || retry == nil || !strategies.ShouldRetry(err, retry.OnStatusCodes) {
+			break
+		}
+	}
+	if lastErr == nil {
+		return fmt.Errorf("provider %s was not attempted", targetKey)
+	}
+	return lastErr
+}

--- a/gateway_stream.go
+++ b/gateway_stream.go
@@ -14,21 +14,42 @@ import (
 	"github.com/ferro-labs/ai-gateway/internal/events"
 	"github.com/ferro-labs/ai-gateway/internal/logging"
 	"github.com/ferro-labs/ai-gateway/internal/metrics"
+	"github.com/ferro-labs/ai-gateway/internal/redact"
 	"github.com/ferro-labs/ai-gateway/internal/streamwrap"
 	"github.com/ferro-labs/ai-gateway/observability"
 	"github.com/ferro-labs/ai-gateway/plugin"
 	"github.com/ferro-labs/ai-gateway/providers"
+	"github.com/ferro-labs/ai-gateway/providers/core"
 )
 
 // Streaming request path (RouteStream) plus its streaming provider-resolution
 // and target-ordering helpers, the streaming latency/cost candidate types, and
 // the generic target-list helpers.
 
+// streamStartErrRedactor applies the default sensitive-data policies to a
+// synchronous stream-start failure before it reaches hooks and observability
+// exporters (events.HookEvent, not the span — span.SetError already redacts
+// per the configured privacy level). This is exactly the 401-with-key-fragment
+// path: an upstream error body can echo back part of the caller's own bearer
+// token. A single package-level instance avoids recompiling the redaction
+// regexes on every failed request, mirroring internal/redact's own
+// defaultRedactor.
+var streamStartErrRedactor = redact.DefaultRedactor()
+
 // RouteStream runs before-request plugins then returns a metered streaming
-// response channel. Provider resolution follows the configured strategy mode,
-// then falls back to any registered provider that supports the requested model
-// and streaming. Prometheus metrics and event hooks are emitted when the
-// returned channel drains (matching the behaviour of Route for non-streaming).
+// response channel. Provider resolution follows the configured strategy mode;
+// when no configured target matches the model it falls back to any registered
+// streaming-capable provider (matching Route's discovery-provider fallbacks).
+// Synchronous stream-start failures are retried and, in fallback mode,
+// advanced to the next target using the same per-target retry policy that
+// /v1/chat/completions honors — before any channel is exposed to the caller.
+// Once CompleteStream succeeds, nothing is retried or replayed. Target
+// selection, each CompleteStream call, and the retry/backoff waits between
+// them are bounded by Config.RequestTimeout, if configured; a stream that
+// does start is never bounded by it once its channel is visible below — see
+// startStreamWithStrategy and raceCompleteStream. Prometheus metrics and
+// event hooks are emitted when the returned channel drains (matching the
+// behaviour of Route for non-streaming).
 //
 // When MCP servers are configured the request is routed through Route instead
 // so that the full agentic tool-call loop can run. The final response is
@@ -50,6 +71,7 @@ func (g *Gateway) RouteStream(ctx context.Context, req providers.Request) (<-cha
 	g.mu.RLock()
 	strategyMode := string(g.config.Strategy.Mode)
 	compatMode := g.config.Compatibility.OnUnsupportedParam
+	requestTimeout := g.config.RequestTimeout
 	obs := g.obs
 	obsEventsActive := g.obsEventsActive
 	mcpRegistrySnapshot := g.mcpRegistry
@@ -118,26 +140,28 @@ func (g *Gateway) RouteStream(ctx context.Context, req providers.Request) (<-cha
 		return responseStream(early), nil
 	}
 
-	// Resolve provider according to strategy mode.
-	sp, err := g.resolveStreamOrError(ctx, span, plugins, pctx, releasePluginManager, req)
-	if err != nil {
-		return nil, err
-	}
-
-	providerName := sp.Name()
+	// Select and start the provider according to strategy mode. This is the
+	// only safe retry window: CompleteStream has not returned a channel yet,
+	// so no bytes can have reached the client. startCtx bounds that window
+	// (target selection, each CompleteStream call, and the retry/backoff waits
+	// between them) to RequestTimeout, so a hanging or endlessly-retrying
+	// provider can no longer hold this goroutine open indefinitely. startCtx is
+	// never the context CompleteStream actually runs on (see
+	// raceCompleteStream below), so a stream that starts successfully keeps
+	// running on the plain, undeadlined ctx and is not torn down once
+	// RequestTimeout elapses — cancelStart only ever releases startCtx's own
+	// timer, deferred here purely so a panic can't leak it.
+	startCtx, cancelStart := withRequestDeadline(ctx, requestTimeout)
+	defer cancelStart()
+	sp, providerName, rawCh, err := g.startStreamWithStrategy(startCtx, ctx, req)
 	span.SetAttribute(observability.AttrGenAISystem, providerName)
 	// Stamp the resolved target key (virtual key = provider name in this routing layer).
 	if providerName != "" {
 		span.SetAttribute(observability.AttrFerroRoutingTargetKey, providerName)
 	}
-	if logging.Enabled(ctx, slog.LevelDebug) {
+	if err == nil && logging.Enabled(ctx, slog.LevelDebug) {
 		logging.FromContext(ctx).Debug("stream request started", "model", req.Model, "provider", providerName)
 	}
-
-	var rawCh <-chan providers.StreamChunk
-	trace.WithRegion(ctx, "gateway.route_stream.provider.start", func() {
-		rawCh, err = sp.CompleteStream(ctx, req)
-	})
 	if err != nil {
 		errType := "provider_error"
 		if errors.Is(err, circuitbreaker.ErrCircuitOpen) {
@@ -159,7 +183,7 @@ func (g *Gateway) RouteStream(ctx context.Context, req providers.Request) (<-cha
 				logging.TraceIDFromContext(ctx),
 				providerName,
 				req.Model,
-				err.Error(),
+				streamStartErrRedactor.Redact(err.Error()),
 				time.Since(start),
 				true,
 			)
@@ -184,6 +208,10 @@ func (g *Gateway) RouteStream(ctx context.Context, req providers.Request) (<-cha
 		Catalog:         catalog,
 		TraceID:         logging.TraceIDFromContext(ctx),
 		LatencyRecorder: g.latencyTracker.Record,
+		// Usage is always requested upstream so metering, cost, and the budget
+		// plugin see real numbers; a caller that asked not to receive it just
+		// does not get the chunk forwarded.
+		SuppressUsageForClient: req.ClientStreamOptions != nil && !req.ClientStreamOptions.IncludeUsage,
 	}
 	if hooksEnabled {
 		meta.PublishFn = g.publishEvent
@@ -329,42 +357,145 @@ func (g *Gateway) runBeforePluginsStream(ctx context.Context, span observability
 	return pctx, nil, nil
 }
 
-// resolveStreamOrError resolves the streaming-capable provider for req under
-// the gateway lock. On failure (resolution error, or no streaming-capable
-// provider found) it finalizes bookkeeping (span error, plugin error hook if
-// pctx is live, plugin-context release, plugin-manager release) and returns
-// a non-nil error — the caller must return (nil, err) immediately, same as
-// every other terminal error path in RouteStream.
-func (g *Gateway) resolveStreamOrError(ctx context.Context, span observability.Span, plugins *plugin.Manager, pctx *plugin.Context, releasePluginManager func(), req providers.Request) (providers.StreamProvider, error) {
+// startStreamWithStrategy tries configured, model-compatible streaming
+// targets in strategy order. Fallback mode applies each target's retry policy
+// (runTargetAttempts) and advances to the next target on synchronous setup
+// failure; every other mode attempts only the first viable target, matching
+// the single-shot semantics Route's non-Fallback strategies already have. If
+// no configured target is even viable for the model (wrong model, not a
+// StreamProvider, not registered) it falls back to any registered
+// streaming-capable provider for the model — preserving v1.3.0's guarantee
+// that a provider registered outside the target list stays reachable for the
+// models it serves (see resolveFallbackStreamProviderLocked). A returned
+// channel is never replayed.
+//
+// startCtx bounds this whole selection/retry phase only — it is what
+// runTargetAttempts and strategies.WaitBeforeRetry check for expiry. streamCtx
+// is the context every CompleteStream call actually runs on and must stay
+// free of that deadline: a provider keeps reading its response body on
+// whatever context it was called with for as long as the returned channel is
+// alive, so a start-phase timeout attached to streamCtx would tear down an
+// already-successful stream the moment the clock ran out.
+func (g *Gateway) startStreamWithStrategy(startCtx, streamCtx context.Context, req providers.Request) (providers.StreamProvider, string, <-chan providers.StreamChunk, error) {
 	g.mu.Lock()
 	g.ensureCircuitBreakersLocked()
 	g.ensureProviderLimitersLocked()
 	g.mu.Unlock()
 
-	fail := func(err error) (providers.StreamProvider, error) {
-		span.SetError(err)
-		if pctx != nil {
-			pctx.Error = err
-			plugins.RunOnError(ctx, pctx)
-			plugin.PutContext(pctx)
-			releasePluginManager()
-		}
-		return nil, err
+	orderedKeys, err := g.streamingTargetOrder(req)
+	if err != nil {
+		return nil, "", nil, err
 	}
-
-	orderedKeys, orderErr := g.streamingTargetOrder(req)
-	if orderErr != nil {
-		return fail(orderErr)
-	}
-
 	g.mu.RLock()
-	sp := g.resolveStreamProviderFromKeysLocked(orderedKeys, req.Model)
+	mode := g.config.Strategy.Mode
 	g.mu.RUnlock()
 
-	if sp == nil {
-		return fail(fmt.Errorf("no streaming-capable provider found for model: %s", req.Model))
+	var (
+		lastErr      error
+		lastProvider string
+		anyViable    bool
+	)
+	for _, key := range orderedKeys {
+		g.mu.RLock()
+		sp, ok := g.streamingProviderForTargetLocked(key, req.Model)
+		g.mu.RUnlock()
+		if !ok {
+			continue
+		}
+		anyViable = true
+		providerName := sp.Name()
+
+		raw, attemptErr := g.attemptStreamStart(startCtx, streamCtx, key, sp, req)
+		if attemptErr == nil {
+			return sp, providerName, raw, nil
+		}
+		lastErr = fmt.Errorf("provider %s stream start: %w", key, attemptErr)
+		lastProvider = providerName
+		if mode != ModeFallback {
+			break
+		}
 	}
-	return sp, nil
+
+	// No configured target even matches this model/streaming capability — try
+	// any registered streaming-capable provider for it (v1.3.0 behaviour). This
+	// runs regardless of strategy mode, exactly like the resolution-only
+	// fallback it replaces: it is never reached when at least one configured
+	// target was viable, so it never overrides a real fallback-mode failure
+	// above with an unconfigured provider.
+	if !anyViable {
+		g.mu.RLock()
+		name, sp, ok := g.resolveFallbackStreamProviderLocked(req.Model)
+		g.mu.RUnlock()
+		if ok {
+			raw, attemptErr := g.attemptStreamStart(startCtx, streamCtx, name, sp, req)
+			if attemptErr == nil {
+				return sp, sp.Name(), raw, nil
+			}
+			lastErr = fmt.Errorf("provider %s stream start: %w", name, attemptErr)
+			lastProvider = sp.Name()
+		}
+	}
+
+	if lastErr != nil {
+		return nil, lastProvider, nil, lastErr
+	}
+	return nil, "", nil, fmt.Errorf("%w: no streaming provider for %q", core.ErrNoCapableProvider, req.Model)
+}
+
+// attemptStreamStart runs the configured retry policy for one resolved
+// candidate (g.runTargetAttempts), racing each try's CompleteStream call
+// against startCtx via raceCompleteStream. Shared by the configured-target
+// loop and the registry-fallback candidate in startStreamWithStrategy so both
+// attempt a candidate identically.
+func (g *Gateway) attemptStreamStart(startCtx, streamCtx context.Context, key string, sp providers.StreamProvider, req providers.Request) (<-chan providers.StreamChunk, error) {
+	var raw <-chan providers.StreamChunk
+	err := g.runTargetAttempts(startCtx, key, func(attemptCtx context.Context) error {
+		var startErr error
+		trace.WithRegion(attemptCtx, "gateway.route_stream.provider.start", func() {
+			raw, startErr = raceCompleteStream(attemptCtx, streamCtx, sp, req)
+		})
+		if startErr == nil && raw == nil {
+			return fmt.Errorf("provider %s returned a nil stream", key)
+		}
+		return startErr
+	})
+	return raw, err
+}
+
+// raceCompleteStream bounds only the wait for sp.CompleteStream to return. The
+// call itself always runs on streamCtx; waitCtx is consulted solely to decide
+// how long to keep waiting for a result. If waitCtx expires first, the attempt
+// is abandoned and reported as a failure so runTargetAttempts can retry or
+// fall back, while the abandoned call keeps running on streamCtx and resolves
+// independently — its result, and any circuit-breaker bookkeeping
+// CompleteStream performs, land whenever the provider actually answers.
+//
+// An abandoned attempt that later succeeds hands back a live channel no caller
+// will ever read. Its producer would then block forever on the first send,
+// holding the provider connection until streamCtx is cancelled, so the
+// abandoning path drains that channel to completion instead of dropping it.
+func raceCompleteStream(waitCtx, streamCtx context.Context, sp providers.StreamProvider, req providers.Request) (<-chan providers.StreamChunk, error) {
+	type startResult struct {
+		ch  <-chan providers.StreamChunk
+		err error
+	}
+	done := make(chan startResult, 1)
+	go func() {
+		ch, err := sp.CompleteStream(streamCtx, req)
+		done <- startResult{ch, err}
+	}()
+	select {
+	case r := <-done:
+		return r.ch, r.err
+	case <-waitCtx.Done():
+		go func() {
+			if r := <-done; r.ch != nil {
+				for range r.ch { //nolint:revive // drain so the provider's producer can finish
+				}
+			}
+		}()
+		return nil, context.Cause(waitCtx)
+	}
 }
 
 // streamingTargetOrder resolves the strategy — the same object Route executes —
@@ -405,47 +536,28 @@ func responseStream(resp *providers.Response) <-chan providers.StreamChunk {
 	return ch
 }
 
-// resolveStreamProviderFromKeysLocked walks orderedKeys and returns the first
-// streaming-capable, model-supporting provider whose circuit is not open. If
-// every ordered target has an open circuit it returns the last such target so
-// the caller still attempts it (and surfaces the open-circuit error). Failing
-// all ordered targets it falls back to any registered streaming-capable provider
-// for the model. Returns nil when nothing matches. Caller must hold g.mu.
-//
-// The breaker is probed with State() (non-consuming) rather than Allow() here:
-// the single Allow() inside cbProvider.CompleteStream is the one probe per
-// streaming request, matching the non-streaming path where cbProvider.Complete
-// performs the sole Allow(). Consuming a half-open permit at resolve time would
-// leave no permit for the actual stream, so a recovering provider could never be
-// probed by a streaming request.
-func (g *Gateway) resolveStreamProviderFromKeysLocked(orderedKeys []string, model string) providers.StreamProvider {
-	var openCircuitTarget providers.StreamProvider
-	for _, key := range orderedKeys {
-		sp, ok := g.streamingProviderForTargetLocked(key, model)
-		if !ok {
-			continue
-		}
-		if wrapped, isCB := sp.(*cbProvider); isCB && wrapped.cb.State() == circuitbreaker.StateOpen {
-			openCircuitTarget = sp
-			continue
-		}
-		return sp
-	}
-	if openCircuitTarget != nil {
-		return openCircuitTarget
-	}
-
-	// Fallback: any registered provider that supports this model and streaming.
+// resolveFallbackStreamProviderLocked returns any registered provider that
+// supports model via streaming, decorated with its own circuit breaker and
+// concurrency limiter, for use when no configured target matches. Preserving
+// this last-resort lookup is what keeps a model served by a
+// registered-but-unlisted provider streaming (v1.3.0 behaviour predating
+// per-target retry; see startStreamWithStrategy). Caller must hold g.mu (a
+// read lock is sufficient).
+func (g *Gateway) resolveFallbackStreamProviderLocked(model string) (string, providers.StreamProvider, bool) {
 	name, fallback, ok := g.findStreamingProviderMatchByModelLocked(model)
 	if !ok {
-		return nil
+		return "", nil, false
 	}
-	if decorated, ok := decorateProvider(name, g.providers[name], g.circuitBreakers[name], g.limiters[name]).(providers.StreamProvider); ok {
-		return decorated
+	if decorated, dok := decorateProvider(name, g.providers[name], g.circuitBreakers[name], g.limiters[name]).(providers.StreamProvider); dok {
+		return name, decorated, true
 	}
-	return fallback
+	return name, fallback, true
 }
 
+// streamingProviderForTargetLocked resolves the streaming-capable provider
+// for a single configured target key, applying its circuit breaker and
+// concurrency limiter decoration. Caller must hold g.mu (a read lock is
+// sufficient).
 func (g *Gateway) streamingProviderForTargetLocked(key, model string) (providers.StreamProvider, bool) {
 	p, ok := g.providers[key]
 	if !ok || !p.SupportsModel(model) {

--- a/gateway_stream_routing_test.go
+++ b/gateway_stream_routing_test.go
@@ -79,6 +79,176 @@ func TestGateway_RouteStream_ContentBasedPromptRegex(t *testing.T) {
 	}
 }
 
+func TestGateway_RouteStream_RetriesSynchronousStartBeforeFallback(t *testing.T) {
+	firstCalls := 0
+	secondCalls := 0
+	gw, err := newTestGateway(t, Config{
+		Strategy: StrategyConfig{Mode: ModeFallback},
+		Targets: []Target{
+			{VirtualKey: "first", Retry: &RetryConfig{Attempts: 2, InitialBackoffMs: 1}},
+			{VirtualKey: "second"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	gw.RegisterProvider(&mockStreamProvider{
+		mockProvider: mockProvider{name: "first", models: []string{"gpt-4o"}},
+		streamFn: func(context.Context, providers.Request) (<-chan providers.StreamChunk, error) {
+			firstCalls++
+			if firstCalls == 1 {
+				return nil, errors.New("transient start failure")
+			}
+			ch := make(chan providers.StreamChunk)
+			close(ch)
+			return ch, nil
+		},
+	})
+	gw.RegisterProvider(&mockStreamProvider{
+		mockProvider: mockProvider{name: "second", models: []string{"gpt-4o"}},
+		streamFn: func(context.Context, providers.Request) (<-chan providers.StreamChunk, error) {
+			secondCalls++
+			ch := make(chan providers.StreamChunk)
+			close(ch)
+			return ch, nil
+		},
+	})
+
+	ch, err := gw.RouteStream(context.Background(), streamTestRequest())
+	if err != nil {
+		t.Fatalf("RouteStream: %v", err)
+	}
+	drainMeteredStream(t, ch)
+	if firstCalls != 2 || secondCalls != 0 {
+		t.Fatalf("start calls first=%d second=%d, want 2/0", firstCalls, secondCalls)
+	}
+}
+
+func TestGateway_RouteStream_DoesNotReplayAfterChannelIsVisible(t *testing.T) {
+	secondCalls := 0
+	gw, err := newTestGateway(t, Config{
+		Strategy: StrategyConfig{Mode: ModeFallback},
+		Targets:  []Target{{VirtualKey: "first"}, {VirtualKey: "second"}},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	gw.RegisterProvider(&mockStreamProvider{
+		mockProvider: mockProvider{name: "first", models: []string{"gpt-4o"}},
+		streamFn: func(context.Context, providers.Request) (<-chan providers.StreamChunk, error) {
+			ch := make(chan providers.StreamChunk, 2)
+			ch <- providers.StreamChunk{Choices: []providers.StreamChoice{{Delta: providers.MessageDelta{Content: "visible"}}}}
+			ch <- providers.StreamChunk{Error: errors.New("midstream failure")}
+			close(ch)
+			return ch, nil
+		},
+	})
+	gw.RegisterProvider(&mockStreamProvider{
+		mockProvider: mockProvider{name: "second", models: []string{"gpt-4o"}},
+		streamFn: func(context.Context, providers.Request) (<-chan providers.StreamChunk, error) {
+			secondCalls++
+			ch := make(chan providers.StreamChunk)
+			close(ch)
+			return ch, nil
+		},
+	})
+
+	ch, err := gw.RouteStream(context.Background(), streamTestRequest())
+	if err != nil {
+		t.Fatalf("RouteStream: %v", err)
+	}
+	drainMeteredStream(t, ch)
+	if secondCalls != 0 {
+		t.Fatalf("fallback replayed after client-visible stream start: second calls=%d", secondCalls)
+	}
+}
+
+// TestGateway_RouteStream_HangingStartAbandonedAtRequestTimeout proves the
+// start/retry phase is bounded by Config.RequestTimeout: a target configured
+// with several retry attempts against a provider that never answers must not
+// hold RouteStream open for anywhere near the full retry/backoff window (it
+// would previously block until the caller's own context was cancelled).
+func TestGateway_RouteStream_HangingStartAbandonedAtRequestTimeout(t *testing.T) {
+	gw, err := newTestGateway(t, Config{
+		RequestTimeout: "50ms",
+		Strategy:       StrategyConfig{Mode: ModeFallback},
+		Targets: []Target{
+			{VirtualKey: "hangs", Retry: &RetryConfig{Attempts: 5, InitialBackoffMs: 1}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	gw.RegisterProvider(&mockStreamProvider{
+		mockProvider: mockProvider{name: "hangs", models: []string{"gpt-4o"}},
+		streamFn: func(ctx context.Context, _ providers.Request) (<-chan providers.StreamChunk, error) {
+			<-ctx.Done() // simulate a provider that never answers on its own
+			return nil, ctx.Err()
+		},
+	})
+
+	// A generous bound so the test itself terminates even if the fix regresses;
+	// the assertion below is what actually proves the abandonment is prompt.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	start := time.Now()
+	_, err = gw.RouteStream(ctx, streamTestRequest())
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected RouteStream to fail once the hanging start is abandoned")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("RouteStream error = %v, want a context-deadline error from the start-phase timeout", err)
+	}
+	if elapsed > 2*time.Second {
+		t.Fatalf("RouteStream took %s to abandon a hanging start with 5 configured retry attempts; want near the 50ms request timeout, not the full retry/backoff window", elapsed)
+	}
+}
+
+// TestGateway_RouteStream_LiveStreamNotKilledByStartPhaseDeadline is the
+// regression guard for the naive fix: RequestTimeout must bound only stream
+// START, never a stream already visible to the caller. A provider that
+// starts immediately but keeps sending well past RequestTimeout must drain
+// without error.
+func TestGateway_RouteStream_LiveStreamNotKilledByStartPhaseDeadline(t *testing.T) {
+	gw, err := newTestGateway(t, Config{
+		RequestTimeout: "20ms",
+		Strategy:       StrategyConfig{Mode: ModeSingle},
+		Targets:        []Target{{VirtualKey: "slow-body"}},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	gw.RegisterProvider(&mockStreamProvider{
+		mockProvider: mockProvider{name: "slow-body", models: []string{"gpt-4o"}},
+		streamFn: func(ctx context.Context, _ providers.Request) (<-chan providers.StreamChunk, error) {
+			ch := make(chan providers.StreamChunk, 1)
+			go func() {
+				defer close(ch)
+				// Outlives RequestTimeout before sending its only chunk. If the
+				// start-phase deadline leaked into this context instead of being
+				// released once the channel became visible, ctx would already be
+				// done by the time we get here.
+				time.Sleep(100 * time.Millisecond)
+				if ctx.Err() != nil {
+					ch <- providers.StreamChunk{Error: errors.New("stream context was cancelled by the start-phase deadline")}
+					return
+				}
+				ch <- providers.StreamChunk{Choices: []providers.StreamChoice{{Delta: providers.MessageDelta{Content: "still streaming"}}}}
+			}()
+			return ch, nil
+		},
+	})
+
+	ch, err := gw.RouteStream(context.Background(), streamTestRequest())
+	if err != nil {
+		t.Fatalf("RouteStream: %v", err)
+	}
+	drainStream(t, ch)
+}
+
 func TestGateway_NewRejectsInvalidStreamingPromptRegex(t *testing.T) {
 	_, err := newTestGateway(t, Config{
 		Strategy: StrategyConfig{

--- a/internal/admin/admin_keys_handlers.go
+++ b/internal/admin/admin_keys_handlers.go
@@ -217,6 +217,16 @@ func (h *Handlers) updateKey(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	var expiresAt *time.Time
+	if !body.ClearExpiration && body.ExpiresAt != "" {
+		parsed, parseErr := time.Parse(time.RFC3339, body.ExpiresAt)
+		if parseErr != nil {
+			writeError(w, http.StatusBadRequest, "invalid expires_at: must be RFC3339 format", "invalid_request_error", "invalid_request")
+			return
+		}
+		expiresAt = &parsed
+	}
+
 	key, err := h.Keys.Update(r.Context(), id, body.Name, body.Scopes)
 	if err != nil {
 		writeKeyStoreError(w, err)
@@ -229,17 +239,12 @@ func (h *Handlers) updateKey(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		key.ExpiresAt = nil
-	} else if body.ExpiresAt != "" {
-		expiresAt, parseErr := time.Parse(time.RFC3339, body.ExpiresAt)
-		if parseErr != nil {
-			writeError(w, http.StatusBadRequest, "invalid expires_at: must be RFC3339 format", "invalid_request_error", "invalid_request")
-			return
-		}
-		if err := h.Keys.SetExpiration(r.Context(), id, &expiresAt); err != nil {
+	} else if expiresAt != nil {
+		if err := h.Keys.SetExpiration(r.Context(), id, expiresAt); err != nil {
 			writeKeyStoreError(w, err)
 			return
 		}
-		t := expiresAt
+		t := *expiresAt
 		key.ExpiresAt = &t
 	}
 

--- a/internal/admin/handlers_keys_test.go
+++ b/internal/admin/handlers_keys_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -240,7 +241,10 @@ func TestUpdateKeyInvalidExpiration(t *testing.T) {
 	if !ok {
 		t.Fatal("expected key to remain present")
 	}
-	if fresh.Name != target.Name || len(fresh.Scopes) != len(target.Scopes) {
+	// Compare the scope values, not just the count: the request body swaps
+	// scopes for a different set of the same length, so a length check alone
+	// would pass even if the rejected update had been applied.
+	if fresh.Name != target.Name || !slices.Equal(fresh.Scopes, target.Scopes) {
 		t.Fatalf("invalid expiration partially mutated key: before=%+v after=%+v", target, fresh)
 	}
 }

--- a/internal/admin/handlers_keys_test.go
+++ b/internal/admin/handlers_keys_test.go
@@ -228,13 +228,20 @@ func TestUpdateKeyInvalidExpiration(t *testing.T) {
 	adminKey := createAdminKey(t, h)
 	target := createTestKey(t, h, "expirable", nil, nil)
 
-	body := `{"expires_at":"not-a-timestamp"}`
+	body := `{"name":"must-not-apply","scopes":["admin"],"expires_at":"not-a-timestamp"}`
 	req := authedRequest(http.MethodPut, "/admin/keys/"+target.ID, body, adminKey)
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
 
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+	fresh, ok := h.Keys.Get(context.Background(), target.ID)
+	if !ok {
+		t.Fatal("expected key to remain present")
+	}
+	if fresh.Name != target.Name || len(fresh.Scopes) != len(target.Scopes) {
+		t.Fatalf("invalid expiration partially mutated key: before=%+v after=%+v", target, fresh)
 	}
 }
 

--- a/internal/handler/chatrequest.go
+++ b/internal/handler/chatrequest.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 
 	"github.com/ferro-labs/ai-gateway/providers"
+	"github.com/ferro-labs/ai-gateway/providers/core"
 )
 
 type routeChatCompletionRequest struct {
@@ -29,9 +30,16 @@ type routeChatCompletionRequest struct {
 	LogProbs            bool                      `json:"logprobs,omitempty"`
 	TopLogProbs         *int                      `json:"top_logprobs,omitempty"`
 	Stream              bool                      `json:"stream,omitempty"`
-	User                string                    `json:"user,omitempty"`
-	LogitBias           map[string]float64        `json:"logit_bias,omitempty"`
-	ParallelToolCalls   *bool                     `json:"parallel_tool_calls,omitempty"`
+	// StreamOptions is decoded here but deliberately mapped to
+	// providers.Request.ClientStreamOptions below, NOT to
+	// providers.Request.StreamOptions — see the field doc on
+	// ClientStreamOptions in providers/core/chat.go for why the two must
+	// stay separate (an explicit include_usage:false must never reach the
+	// verbatim-forwarding path shared by the OpenAI-compatible providers).
+	StreamOptions     *core.StreamOptions `json:"stream_options,omitempty"`
+	User              string              `json:"user,omitempty"`
+	LogitBias         map[string]float64  `json:"logit_bias,omitempty"`
+	ParallelToolCalls *bool               `json:"parallel_tool_calls,omitempty"`
 }
 
 type routeChatMessage struct {
@@ -60,7 +68,7 @@ func putRouteChatCompletionRequest(r *routeChatCompletionRequest) {
 	chatRequestPool.Put(r)
 }
 
-// reset clears all 20 fields before returning to the pool.
+// reset clears all 21 fields before returning to the pool.
 // SECURITY: every field must be listed explicitly. Missing a field
 // leaks one tenant's data to another in the multi-tenant gateway.
 func (r *routeChatCompletionRequest) reset() {
@@ -81,9 +89,10 @@ func (r *routeChatCompletionRequest) reset() {
 	r.LogProbs = false          // field 15: bool
 	r.TopLogProbs = nil         // field 16: *int
 	r.Stream = false            // field 17: bool
-	r.User = ""                 // field 18: string
-	r.LogitBias = nil           // field 19: map[string]float64
-	r.ParallelToolCalls = nil   // field 20: *bool
+	r.StreamOptions = nil       // field 18: *core.StreamOptions
+	r.User = ""                 // field 19: string
+	r.LogitBias = nil           // field 20: map[string]float64
+	r.ParallelToolCalls = nil   // field 21: *bool
 }
 
 // DecodeChatCompletionRequest decodes the JSON body into a providers.Request.
@@ -128,6 +137,7 @@ func DecodeChatCompletionRequest(r io.Reader) (providers.Request, error) {
 		LogProbs:            wire.LogProbs,
 		TopLogProbs:         wire.TopLogProbs,
 		Stream:              wire.Stream,
+		ClientStreamOptions: wire.StreamOptions,
 		User:                wire.User,
 		LogitBias:           wire.LogitBias,
 		ParallelToolCalls:   wire.ParallelToolCalls,

--- a/internal/handler/chatrequest_streamoptions_test.go
+++ b/internal/handler/chatrequest_streamoptions_test.go
@@ -1,0 +1,93 @@
+package handler
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestDecodeChatCompletionRequest_StreamOptions verifies the three distinct
+// client-visible behaviours for stream_options.include_usage: explicit
+// false, explicit true, and omitted entirely. The decoded value lands on
+// ClientStreamOptions, never on StreamOptions — see the field doc in
+// providers/core/chat.go for why the two must stay separate.
+func TestDecodeChatCompletionRequest_StreamOptions(t *testing.T) {
+	tests := []struct {
+		name           string
+		body           string
+		wantNil        bool
+		wantIncludeVal bool
+	}{
+		{
+			name:    "omitted stream_options decodes to nil",
+			body:    `{"model":"gpt-4","messages":[{"role":"user","content":"hi"}],"stream":true}`,
+			wantNil: true,
+		},
+		{
+			name:           "explicit include_usage:false decodes distinctly from omitted",
+			body:           `{"model":"gpt-4","messages":[{"role":"user","content":"hi"}],"stream":true,"stream_options":{"include_usage":false}}`,
+			wantNil:        false,
+			wantIncludeVal: false,
+		},
+		{
+			name:           "explicit include_usage:true decodes",
+			body:           `{"model":"gpt-4","messages":[{"role":"user","content":"hi"}],"stream":true,"stream_options":{"include_usage":true}}`,
+			wantNil:        false,
+			wantIncludeVal: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, err := DecodeChatCompletionRequest(strings.NewReader(tt.body))
+			if err != nil {
+				t.Fatalf("decode: %v", err)
+			}
+
+			// The wire-forwarding field must never be populated from the
+			// client's request — that is the field ~20 OpenAI-compatible
+			// providers marshal verbatim upstream, and an explicit false
+			// there would silently disable their usage reporting.
+			if req.StreamOptions != nil {
+				t.Errorf("StreamOptions = %+v, want nil (client intent must not reach the verbatim-forward field)", req.StreamOptions)
+			}
+
+			if tt.wantNil {
+				if req.ClientStreamOptions != nil {
+					t.Errorf("ClientStreamOptions = %+v, want nil", req.ClientStreamOptions)
+				}
+				return
+			}
+			if req.ClientStreamOptions == nil {
+				t.Fatal("ClientStreamOptions is nil, want a decoded value")
+			}
+			if req.ClientStreamOptions.IncludeUsage != tt.wantIncludeVal {
+				t.Errorf("IncludeUsage = %v, want %v", req.ClientStreamOptions.IncludeUsage, tt.wantIncludeVal)
+			}
+		})
+	}
+}
+
+// TestDecodeChatCompletionRequest_StreamOptions_PoolReset verifies the
+// sync.Pool-backed wire struct does not leak a previous request's
+// stream_options into the next decode that omits it — the same
+// cross-tenant-leak class of bug the reset() SECURITY comment already guards
+// every other field against.
+func TestDecodeChatCompletionRequest_StreamOptions_PoolReset(t *testing.T) {
+	first, err := DecodeChatCompletionRequest(strings.NewReader(
+		`{"model":"gpt-4","messages":[{"role":"user","content":"hi"}],"stream":true,"stream_options":{"include_usage":false}}`))
+	if err != nil {
+		t.Fatalf("decode first: %v", err)
+	}
+	if first.ClientStreamOptions == nil || first.ClientStreamOptions.IncludeUsage {
+		t.Fatalf("first.ClientStreamOptions = %+v, want include_usage:false", first.ClientStreamOptions)
+	}
+
+	second, err := DecodeChatCompletionRequest(strings.NewReader(
+		`{"model":"gpt-4","messages":[{"role":"user","content":"hi"}],"stream":true}`))
+	if err != nil {
+		t.Fatalf("decode second: %v", err)
+	}
+	if second.ClientStreamOptions != nil {
+		t.Fatalf("second.ClientStreamOptions = %+v, want nil (leaked from pooled first request)", second.ClientStreamOptions)
+	}
+}

--- a/internal/handler/completions.go
+++ b/internal/handler/completions.go
@@ -214,6 +214,17 @@ func Completions(registry *providers.Registry) http.HandlerFunc {
 			return
 		}
 
+		stopSeqs, ok := shimStop(legacyReq.Stop)
+		if !ok {
+			apierror.WriteOpenAI(w,
+				http.StatusBadRequest,
+				"stop must be a string or an array of strings",
+				"invalid_request_error",
+				"invalid_request",
+			)
+			return
+		}
+
 		// Wrap the prompt as a user message and call through the chat path,
 		// then re-wrap the response in the legacy completions envelope.
 		// echo/best_of/logprobs/suffix are decoded above but intentionally
@@ -227,7 +238,7 @@ func Completions(registry *providers.Registry) http.HandlerFunc {
 			Temperature:      legacyReq.Temperature,
 			TopP:             legacyReq.TopP,
 			N:                legacyReq.N,
-			Stop:             shimStop(legacyReq.Stop),
+			Stop:             stopSeqs,
 			PresencePenalty:  legacyReq.PresencePenalty,
 			FrequencyPenalty: legacyReq.FrequencyPenalty,
 			Seed:             legacyReq.Seed,
@@ -304,22 +315,27 @@ func isJSONNull(raw json.RawMessage) bool {
 // shimStop normalizes the `stop` field (a bare string or an array of up to 4
 // strings, per the OpenAI spec) into the slice form providers.Request wants.
 // Both forms are representable, so this never rejects.
-func shimStop(raw json.RawMessage) []string {
+func shimStop(raw json.RawMessage) ([]string, bool) {
 	// "stop": null means no stop sequences. Decoding it into a string succeeds
 	// and yields "", which would send a single empty stop sequence upstream —
 	// a different request from sending none at all.
 	if len(raw) == 0 || isJSONNull(raw) {
-		return nil
+		return nil, true
 	}
 	var s string
 	if err := json.Unmarshal(raw, &s); err == nil {
-		return []string{s}
+		return []string{s}, true
 	}
+	// A null inside the array decodes to "", which is the behaviour this
+	// endpoint has always had. Anything else — a number, an object, a boolean,
+	// or an array holding one — is not a stop sequence. Reporting it beats
+	// silently continuing with no stop sequences at all, which is what the
+	// caller would otherwise get for what is plainly a mistake on their side.
 	var arr []string
 	if err := json.Unmarshal(raw, &arr); err == nil {
-		return arr
+		return arr, true
 	}
-	return nil
+	return nil, false
 }
 
 // CompletionsEndpointURL resolves the upstream /v1/completions URL from a provider base URL.

--- a/internal/handler/completions.go
+++ b/internal/handler/completions.go
@@ -216,9 +216,9 @@ func Completions(registry *providers.Registry) http.HandlerFunc {
 		// Wrap the prompt as a user message and call through the chat path,
 		// then re-wrap the response in the legacy completions envelope.
 		// echo/best_of/logprobs/suffix are decoded above but intentionally
-		// not forwarded or rejected here — v1.3.0 silently ignored them and
-		// that behavior is unchanged; rejecting them is a /v1 breaking
-		// change deferred to a later minor release.
+		// neither forwarded nor rejected: the chat shim cannot express them,
+		// and refusing a request that previously succeeded would change the
+		// endpoint's behaviour for callers already sending them.
 		chatReq := providers.Request{
 			Model:            legacyReq.Model,
 			Messages:         []providers.Message{{Role: "user", Content: promptText}},

--- a/internal/handler/completions.go
+++ b/internal/handler/completions.go
@@ -22,15 +22,23 @@ import (
 // LegacyCompletionRequest mirrors the OpenAI /v1/completions request body.
 // This is the non-chat (text-only) completion format supported by models
 // like gpt-3.5-turbo-instruct, deepseek-chat, etc.
+//
+// Prompt and Stop are decoded as json.RawMessage because OpenAI accepts both
+// of them in more than one JSON shape (prompt: string | []string | []int |
+// [][]int; stop: string | []string). Typing them as bare Go string/[]string
+// would hard-fail json.Unmarshal for the other valid shapes before Path 1
+// (the native proxy, which forwards the body verbatim) ever gets a chance to
+// forward them untouched. Path 2 (the chat shim) decodes them via
+// shimPrompt/shimStop.
 type LegacyCompletionRequest struct {
 	Model            string             `json:"model"`
-	Prompt           string             `json:"prompt"`
+	Prompt           json.RawMessage    `json:"prompt"`
 	MaxTokens        *int               `json:"max_tokens,omitempty"`
 	Temperature      *float64           `json:"temperature,omitempty"`
 	TopP             *float64           `json:"top_p,omitempty"`
 	N                *int               `json:"n,omitempty"`
 	Stream           bool               `json:"stream,omitempty"`
-	Stop             []string           `json:"stop,omitempty"`
+	Stop             json.RawMessage    `json:"stop,omitempty"`
 	PresencePenalty  *float64           `json:"presence_penalty,omitempty"`
 	FrequencyPenalty *float64           `json:"frequency_penalty,omitempty"`
 	Seed             *int64             `json:"seed,omitempty"`
@@ -40,6 +48,30 @@ type LegacyCompletionRequest struct {
 	Echo             bool               `json:"echo,omitempty"`
 	BestOf           *int               `json:"best_of,omitempty"`
 	Suffix           string             `json:"suffix,omitempty"`
+}
+
+// legacyChoice is a single choice in the Path 2 (chat shim) legacy response
+// envelope.
+type legacyChoice struct {
+	Text  string `json:"text"`
+	Index int    `json:"index"`
+	// Logprobs is always present and explicitly null when not requested —
+	// real OpenAI never omits the key, so no omitempty here. The shim never
+	// computes logprobs (LogProbs/Echo/BestOf/Suffix are decoded and
+	// ignored, unchanged from v1.3.0), so this is always nil.
+	Logprobs     any    `json:"logprobs"`
+	FinishReason string `json:"finish_reason"`
+}
+
+// legacyResponse is the Path 2 (chat shim) legacy /v1/completions response
+// envelope, translated from a chat completion response.
+type legacyResponse struct {
+	ID      string          `json:"id"`
+	Object  string          `json:"object"`
+	Created int64           `json:"created"`
+	Model   string          `json:"model"`
+	Choices []legacyChoice  `json:"choices"`
+	Usage   providers.Usage `json:"usage"`
 }
 
 // Completions handles POST /v1/completions (legacy text completion API).
@@ -82,7 +114,12 @@ func Completions(registry *providers.Registry) http.HandlerFunc {
 		if pp, canProxy := p.(providers.ProxiableProvider); canProxy {
 			target, err := CompletionsEndpointURL(pp.BaseURL())
 			if err != nil {
-				apierror.WriteOpenAI(w, http.StatusInternalServerError, err.Error(), "server_error", "internal_error")
+				// The error embeds the operator-configured base URL verbatim,
+				// which may carry a credential in a query string (self-hosted
+				// OpenAI-compatible proxies). Log it server-side only; the
+				// client gets a generic message.
+				logging.FromContext(r.Context()).Error("invalid provider completions URL", "provider", p.Name(), "error", err)
+				apierror.WriteOpenAI(w, http.StatusInternalServerError, "invalid provider configuration", "server_error", "internal_error")
 				return
 			}
 			// Streaming clears http.Server's WriteTimeout per write, so an idle
@@ -159,16 +196,37 @@ func Completions(registry *providers.Registry) http.HandlerFunc {
 			return
 		}
 
+		// promptText is the only prompt shape the shim can represent as a
+		// single chat message. A multi-element batch, a token-id array, or an
+		// array of token-id arrays cannot be represented and must be
+		// rejected — at v1.3.0 these shapes already failed with a 400 (a
+		// json.Unmarshal error against the old string-typed field), so this
+		// is the same status with a clearer message, not a new break.
+		promptText, ok := shimPrompt(legacyReq.Prompt)
+		if !ok {
+			apierror.WriteOpenAI(w,
+				http.StatusBadRequest,
+				"prompt must be a string or single-element array for this provider (no native /v1/completions support); batch, token-id, and nested-array prompts are not supported",
+				"invalid_request_error",
+				"unsupported_parameter",
+			)
+			return
+		}
+
 		// Wrap the prompt as a user message and call through the chat path,
 		// then re-wrap the response in the legacy completions envelope.
+		// echo/best_of/logprobs/suffix are decoded above but intentionally
+		// not forwarded or rejected here — v1.3.0 silently ignored them and
+		// that behavior is unchanged; rejecting them is a /v1 breaking
+		// change deferred to a later minor release.
 		chatReq := providers.Request{
 			Model:            legacyReq.Model,
-			Messages:         []providers.Message{{Role: "user", Content: legacyReq.Prompt}},
+			Messages:         []providers.Message{{Role: "user", Content: promptText}},
 			MaxTokens:        legacyReq.MaxTokens,
 			Temperature:      legacyReq.Temperature,
 			TopP:             legacyReq.TopP,
 			N:                legacyReq.N,
-			Stop:             legacyReq.Stop,
+			Stop:             shimStop(legacyReq.Stop),
 			PresencePenalty:  legacyReq.PresencePenalty,
 			FrequencyPenalty: legacyReq.FrequencyPenalty,
 			Seed:             legacyReq.Seed,
@@ -182,22 +240,10 @@ func Completions(registry *providers.Registry) http.HandlerFunc {
 		}
 
 		// Translate chat response → legacy completions response.
-		type legacyChoice struct {
-			Text         string `json:"text"`
-			Index        int    `json:"index"`
-			FinishReason string `json:"finish_reason"`
-		}
-		type legacyResponse struct {
-			ID      string          `json:"id"`
-			Object  string          `json:"object"`
-			Model   string          `json:"model"`
-			Choices []legacyChoice  `json:"choices"`
-			Usage   providers.Usage `json:"usage"`
-		}
-
 		legacy := legacyResponse{
 			ID:      chatResp.ID,
 			Object:  "text_completion",
+			Created: chatResp.Created,
 			Model:   chatResp.Model,
 			Usage:   chatResp.Usage,
 			Choices: make([]legacyChoice, 0, len(chatResp.Choices)),
@@ -214,6 +260,47 @@ func Completions(registry *providers.Registry) http.HandlerFunc {
 		w.Header().Set("X-Gateway-Provider", p.Name())
 		json.NewEncoder(w).Encode(legacy) //nolint:errcheck,gosec // response headers already committed; an encode error to the client cannot be reported
 	}
+}
+
+// shimPrompt decodes the `prompt` field for Path 2 (the chat shim), which can
+// only represent a single text prompt. It accepts a bare string or a
+// single-element string array (equivalent to a bare string) and returns
+// ok=false for shapes it cannot represent: a multi-element string array
+// (batch), token-id arrays, and arrays of token-id arrays. Path 1 (the native
+// proxy) never calls this — it forwards the raw prompt bytes verbatim.
+func shimPrompt(raw json.RawMessage) (string, bool) {
+	if len(raw) == 0 {
+		return "", true
+	}
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		return s, true
+	}
+	var arr []json.RawMessage
+	if err := json.Unmarshal(raw, &arr); err == nil && len(arr) == 1 {
+		if err := json.Unmarshal(arr[0], &s); err == nil {
+			return s, true
+		}
+	}
+	return "", false
+}
+
+// shimStop normalizes the `stop` field (a bare string or an array of up to 4
+// strings, per the OpenAI spec) into the slice form providers.Request wants.
+// Both forms are representable, so this never rejects.
+func shimStop(raw json.RawMessage) []string {
+	if len(raw) == 0 {
+		return nil
+	}
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		return []string{s}
+	}
+	var arr []string
+	if err := json.Unmarshal(raw, &arr); err == nil {
+		return arr
+	}
+	return nil
 }
 
 // CompletionsEndpointURL resolves the upstream /v1/completions URL from a provider base URL.

--- a/internal/handler/completions.go
+++ b/internal/handler/completions.go
@@ -114,11 +114,12 @@ func Completions(registry *providers.Registry) http.HandlerFunc {
 		if pp, canProxy := p.(providers.ProxiableProvider); canProxy {
 			target, err := CompletionsEndpointURL(pp.BaseURL())
 			if err != nil {
-				// The error embeds the operator-configured base URL verbatim,
-				// which may carry a credential in a query string (self-hosted
-				// OpenAI-compatible proxies). Log it server-side only; the
-				// client gets a generic message.
-				logging.FromContext(r.Context()).Error("invalid provider completions URL", "provider", p.Name(), "error", err)
+				// The error embeds the configured base URL verbatim, which can
+				// carry a credential in its query string, so it is not written
+				// anywhere — not to the client, and not to the log, which is
+				// routinely shipped off-host. The provider name is enough to
+				// locate the offending entry in the gateway's own config.
+				logging.FromContext(r.Context()).Error("invalid provider completions URL", "provider", p.Name())
 				apierror.WriteOpenAI(w, http.StatusInternalServerError, "invalid provider configuration", "server_error", "internal_error")
 				return
 			}
@@ -273,11 +274,19 @@ func shimPrompt(raw json.RawMessage) (string, bool) {
 		return "", true
 	}
 	var s string
+	// A bare JSON null decodes into a string as a no-op, leaving "". That is
+	// what "prompt": null has always produced here, so it stays accepted.
 	if err := json.Unmarshal(raw, &s); err == nil {
 		return s, true
 	}
 	var arr []json.RawMessage
 	if err := json.Unmarshal(raw, &arr); err == nil && len(arr) == 1 {
+		// A null element would decode to "" by the same no-op, silently
+		// turning ["prompt", null] into an empty prompt. There is no text to
+		// send, so treat it as unrepresentable rather than inventing one.
+		if isJSONNull(arr[0]) {
+			return "", false
+		}
 		if err := json.Unmarshal(arr[0], &s); err == nil {
 			return s, true
 		}
@@ -285,11 +294,21 @@ func shimPrompt(raw json.RawMessage) (string, bool) {
 	return "", false
 }
 
+// isJSONNull reports whether raw is the JSON literal null. Decoding null into a
+// string or a slice succeeds and leaves the zero value, so callers that must
+// distinguish "absent" from "present but empty" have to check the bytes.
+func isJSONNull(raw json.RawMessage) bool {
+	return bytes.Equal(bytes.TrimSpace(raw), []byte("null"))
+}
+
 // shimStop normalizes the `stop` field (a bare string or an array of up to 4
 // strings, per the OpenAI spec) into the slice form providers.Request wants.
 // Both forms are representable, so this never rejects.
 func shimStop(raw json.RawMessage) []string {
-	if len(raw) == 0 {
+	// "stop": null means no stop sequences. Decoding it into a string succeeds
+	// and yields "", which would send a single empty stop sequence upstream —
+	// a different request from sending none at all.
+	if len(raw) == 0 || isJSONNull(raw) {
 		return nil
 	}
 	var s string

--- a/internal/handler/completions_test.go
+++ b/internal/handler/completions_test.go
@@ -309,11 +309,10 @@ func TestCompletionsHandler_NativeProxyAcceptsAllPromptAndStopForms(t *testing.T
 	}
 }
 
-// TestCompletionsHandler_ShimIgnoresLegacyOnlyParams is the deferral guard:
-// echo/best_of/logprobs/suffix must keep the v1.3.0 behavior of being
-// decoded and silently ignored on the chat-shim path. Turning them into a
-// 400 is a /v1 breaking change deferred to a later minor release — this
-// test fails if that rejection creeps back in.
+// TestCompletionsHandler_ShimIgnoresLegacyOnlyParams pins the compatibility
+// contract for echo/best_of/logprobs/suffix: they are decoded and ignored on
+// the chat-shim path, never rejected. Refusing them would turn a request that
+// callers send today into a 400, so this test fails if that creeps in.
 func TestCompletionsHandler_ShimIgnoresLegacyOnlyParams(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/internal/handler/completions_test.go
+++ b/internal/handler/completions_test.go
@@ -4,9 +4,11 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"io"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -18,10 +20,11 @@ import (
 )
 
 type nonProxyProvider struct {
-	name   string
-	models []string
-	resp   *providers.Response
-	calls  int
+	name    string
+	models  []string
+	resp    *providers.Response
+	calls   int
+	lastReq providers.Request
 }
 
 func (m *nonProxyProvider) Name() string                  { return m.name }
@@ -35,8 +38,9 @@ func (m *nonProxyProvider) SupportsModel(model string) bool {
 	}
 	return false
 }
-func (m *nonProxyProvider) Complete(_ context.Context, _ providers.Request) (*providers.Response, error) {
+func (m *nonProxyProvider) Complete(_ context.Context, req providers.Request) (*providers.Response, error) {
 	m.calls++
+	m.lastReq = req
 	if m.resp != nil {
 		return m.resp, nil
 	}
@@ -50,6 +54,17 @@ func (m *nonProxyProvider) Complete(_ context.Context, _ providers.Request) (*pr
 		}},
 	}, nil
 }
+
+// proxiableBadURLProvider is a ProxiableProvider whose BaseURL is deliberately
+// malformed, used to exercise the CompletionsEndpointURL error path without
+// depending on a real provider constructor's own URL validation.
+type proxiableBadURLProvider struct {
+	nonProxyProvider
+	baseURL string
+}
+
+func (p *proxiableBadURLProvider) BaseURL() string                { return p.baseURL }
+func (p *proxiableBadURLProvider) AuthHeaders() map[string]string { return nil }
 
 func TestCompletionsEndpointURL(t *testing.T) {
 	tests := []struct {
@@ -145,6 +160,264 @@ func TestCompletionsHandler_ShimsStreamRequest_ReturnsExplicitError(t *testing.T
 	}
 	if np.calls != 0 {
 		t.Fatalf("provider should not be called for unsupported stream shim, got %d calls", np.calls)
+	}
+}
+
+// TestCompletionsHandler_ShimPromptForms covers every OpenAI-valid `prompt`
+// shape through the chat shim (Path 2): a bare string and a single-element
+// array are representable as one text message and must be accepted; a
+// multi-element array (batch), token-id arrays, and arrays of token-id
+// arrays cannot be represented as a single chat message and must be
+// rejected with a 400, not silently mangled.
+func TestCompletionsHandler_ShimPromptForms(t *testing.T) {
+	tests := []struct {
+		name       string
+		promptJSON string
+		wantOK     bool
+		wantText   string
+	}{
+		{"bare string", `"hi"`, true, "hi"},
+		{"single-element array", `["hi"]`, true, "hi"},
+		{"multi-element array batch", `["hi","there"]`, false, ""},
+		{"token ids", `[1,2,3]`, false, ""},
+		{"array of token-id arrays", `[[1,2],[3,4]]`, false, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &nonProxyProvider{name: "shim", models: []string{"legacy-model"}}
+			reg := providers.NewRegistry()
+			reg.Register(p)
+			body := `{"model":"legacy-model","prompt":` + tt.promptJSON + `}`
+			w := httptest.NewRecorder()
+			Completions(reg)(w, httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/v1/completions", strings.NewReader(body)))
+
+			if !tt.wantOK {
+				if w.Code != http.StatusBadRequest {
+					t.Fatalf("status = %d, want 400: %s", w.Code, w.Body.String())
+				}
+				var payload struct {
+					Error struct {
+						Code string `json:"code"`
+					} `json:"error"`
+				}
+				if err := json.Unmarshal(w.Body.Bytes(), &payload); err != nil {
+					t.Fatalf("decode error response: %v", err)
+				}
+				if payload.Error.Code != "unsupported_parameter" {
+					t.Fatalf("error code = %q, want unsupported_parameter", payload.Error.Code)
+				}
+				if p.calls != 0 {
+					t.Fatalf("provider called despite unsupported prompt shape")
+				}
+				return
+			}
+
+			if w.Code != http.StatusOK {
+				t.Fatalf("status = %d, want 200: %s", w.Code, w.Body.String())
+			}
+			if p.calls != 1 {
+				t.Fatalf("provider calls = %d, want 1", p.calls)
+			}
+			if len(p.lastReq.Messages) != 1 || p.lastReq.Messages[0].Content != tt.wantText {
+				t.Fatalf("shim message = %+v, want content %q", p.lastReq.Messages, tt.wantText)
+			}
+		})
+	}
+}
+
+// TestCompletionsHandler_ShimStopForms covers both OpenAI-valid `stop` shapes
+// (bare string, array of strings) through the chat shim, asserting they
+// normalize into the []string form providers.Request expects.
+func TestCompletionsHandler_ShimStopForms(t *testing.T) {
+	tests := []struct {
+		name     string
+		stopJSON string
+		want     []string
+	}{
+		{"bare string", `"\n\n"`, []string{"\n\n"}},
+		{"array of strings", `["a","b"]`, []string{"a", "b"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &nonProxyProvider{name: "shim", models: []string{"legacy-model"}}
+			reg := providers.NewRegistry()
+			reg.Register(p)
+			body := `{"model":"legacy-model","prompt":"hi","stop":` + tt.stopJSON + `}`
+			w := httptest.NewRecorder()
+			Completions(reg)(w, httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/v1/completions", strings.NewReader(body)))
+
+			if w.Code != http.StatusOK {
+				t.Fatalf("status = %d, want 200: %s", w.Code, w.Body.String())
+			}
+			if !reflect.DeepEqual(p.lastReq.Stop, tt.want) {
+				t.Fatalf("stop = %#v, want %#v", p.lastReq.Stop, tt.want)
+			}
+		})
+	}
+}
+
+// TestCompletionsHandler_NativeProxyAcceptsAllPromptAndStopForms is the
+// regression test for the shipped bug: Path 1 forwards the request body
+// verbatim to a provider that natively supports every OpenAI prompt/stop
+// shape, so json.Unmarshal into LegacyCompletionRequest must never reject a
+// valid body before the proxy ever sees it.
+func TestCompletionsHandler_NativeProxyAcceptsAllPromptAndStopForms(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{"bare string prompt", `{"model":"gpt-4o","prompt":"hi"}`},
+		{"single-element array prompt", `{"model":"gpt-4o","prompt":["hi"]}`},
+		{"multi-element array prompt batch", `{"model":"gpt-4o","prompt":["hi","there"]}`},
+		{"token id prompt", `{"model":"gpt-4o","prompt":[1,2,3]}`},
+		{"array of token-id arrays prompt", `{"model":"gpt-4o","prompt":[[1,2],[3,4]]}`},
+		{"bare string stop", `{"model":"gpt-4o","prompt":"hi","stop":"\n\n"}`},
+		{"array stop", `{"model":"gpt-4o","prompt":"hi","stop":["a","b"]}`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotBody []byte
+			upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotBody, _ = io.ReadAll(r.Body)
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`{"id":"cmpl-1","object":"text_completion","model":"gpt-4o","choices":[{"text":"ok","index":0,"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`))
+			}))
+			defer upstream.Close()
+
+			reg := providers.NewRegistry()
+			op, err := openaipkg.New("sk-test", upstream.URL+"/v1")
+			if err != nil {
+				t.Fatalf("failed to build openai provider: %v", err)
+			}
+			reg.Register(op)
+
+			h := Completions(reg)
+			req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/v1/completions", strings.NewReader(tt.body))
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+
+			h(w, req)
+
+			if w.Code != http.StatusOK {
+				t.Fatalf("status = %d, want 200 (verbatim forward must accept every valid prompt/stop shape): %s", w.Code, w.Body.String())
+			}
+			if string(gotBody) != tt.body {
+				t.Fatalf("upstream body = %s, want verbatim %s", gotBody, tt.body)
+			}
+		})
+	}
+}
+
+// TestCompletionsHandler_ShimIgnoresLegacyOnlyParams is the deferral guard:
+// echo/best_of/logprobs/suffix must keep the v1.3.0 behavior of being
+// decoded and silently ignored on the chat-shim path. Turning them into a
+// 400 is a /v1 breaking change deferred to a later minor release — this
+// test fails if that rejection creeps back in.
+func TestCompletionsHandler_ShimIgnoresLegacyOnlyParams(t *testing.T) {
+	tests := []struct {
+		name  string
+		field string
+	}{
+		{"logprobs", `"logprobs":2`},
+		{"echo", `"echo":true`},
+		{"best_of", `"best_of":2`},
+		{"suffix", `"suffix":"done"`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &nonProxyProvider{name: "shim", models: []string{"legacy-model"}}
+			reg := providers.NewRegistry()
+			reg.Register(p)
+			body := `{"model":"legacy-model","prompt":"hi",` + tt.field + `}`
+			w := httptest.NewRecorder()
+			Completions(reg)(w, httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/v1/completions", strings.NewReader(body)))
+			if w.Code != http.StatusOK {
+				t.Fatalf("status = %d, want 200 (this field must remain ignored, not rejected): %s", w.Code, w.Body.String())
+			}
+			if p.calls != 1 {
+				t.Fatalf("provider calls = %d, want 1", p.calls)
+			}
+		})
+	}
+}
+
+// TestCompletionsHandler_ShimResponseIncludesCreatedAndNullLogprobs asserts
+// the shim response envelope matches the real OpenAI completions object:
+// `created` populated from the underlying chat response, and `logprobs`
+// present as an explicit null (not an omitted key) on every choice.
+func TestCompletionsHandler_ShimResponseIncludesCreatedAndNullLogprobs(t *testing.T) {
+	p := &nonProxyProvider{
+		name:   "shim",
+		models: []string{"legacy-model"},
+		resp: &providers.Response{
+			ID:      "cmpl-created",
+			Model:   "legacy-model",
+			Created: 1234567890,
+			Choices: []providers.Choice{{
+				Index:        0,
+				Message:      providers.Message{Role: providers.RoleAssistant, Content: "ok"},
+				FinishReason: "stop",
+			}},
+		},
+	}
+	reg := providers.NewRegistry()
+	reg.Register(p)
+
+	w := httptest.NewRecorder()
+	Completions(reg)(w, httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/v1/completions", strings.NewReader(
+		`{"model":"legacy-model","prompt":"hi"}`)))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d: %s", w.Code, w.Body.String())
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if got, want := payload["created"], float64(1234567890); got != want {
+		t.Fatalf("created = %v, want %v", got, want)
+	}
+	choices, ok := payload["choices"].([]any)
+	if !ok || len(choices) != 1 {
+		t.Fatalf("unexpected choices: %v", payload["choices"])
+	}
+	choice, ok := choices[0].(map[string]any)
+	if !ok {
+		t.Fatalf("unexpected choice shape: %v", choices[0])
+	}
+	logprobs, hasKey := choice["logprobs"]
+	if !hasKey {
+		t.Fatal("choice missing logprobs key, want explicit null")
+	}
+	if logprobs != nil {
+		t.Fatalf("logprobs = %v, want null", logprobs)
+	}
+}
+
+// TestCompletionsHandler_NativeProxyURLErrorDoesNotLeakBaseURL is the
+// regression test for the base-URL credential leak: a malformed operator-
+// configured base URL (which may carry a secret in a query string on a
+// self-hosted OpenAI-compatible proxy) must never reach the client verbatim.
+func TestCompletionsHandler_NativeProxyURLErrorDoesNotLeakBaseURL(t *testing.T) {
+	secret := "sk-" + strings.Repeat("b", 48)
+	p := &proxiableBadURLProvider{
+		nonProxyProvider: nonProxyProvider{name: "bad-url", models: []string{"bad-url-model"}},
+		baseURL:          "not-a-url?api_key=" + secret,
+	}
+	reg := providers.NewRegistry()
+	reg.Register(p)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/v1/completions", strings.NewReader(`{"model":"bad-url-model","prompt":"hi"}`))
+	w := httptest.NewRecorder()
+	Completions(reg)(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500: %s", w.Code, w.Body.String())
+	}
+	if strings.Contains(w.Body.String(), secret) {
+		t.Fatalf("completions URL error leaked provider base URL secret: %s", w.Body.String())
 	}
 }
 

--- a/internal/handler/completions_test.go
+++ b/internal/handler/completions_test.go
@@ -251,6 +251,33 @@ func TestCompletionsHandler_ShimStopForms(t *testing.T) {
 		// alone; changing it would alter a request the gateway already accepts.
 		{"array containing null", `["a",null]`, []string{"a", ""}},
 	}
+	// Shapes that are not stop sequences at all. Each of these was refused
+	// before the field became json.RawMessage, and silently becoming "no stop
+	// sequences" would hand the caller a longer completion than they asked for
+	// with nothing to indicate why.
+	rejected := []struct {
+		name     string
+		stopJSON string
+	}{
+		{"number", `42`},
+		{"boolean", `true`},
+		{"object", `{"a":1}`},
+		{"array holding a number", `["a",7]`},
+	}
+	for _, tt := range rejected {
+		t.Run("rejects "+tt.name, func(t *testing.T) {
+			p := &nonProxyProvider{name: "shim", models: []string{"legacy-model"}}
+			reg := providers.NewRegistry()
+			reg.Register(p)
+			body := `{"model":"legacy-model","prompt":"hi","stop":` + tt.stopJSON + `}`
+			w := httptest.NewRecorder()
+			Completions(reg)(w, httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/v1/completions", strings.NewReader(body)))
+
+			if w.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want 400 for stop=%s: %s", w.Code, tt.stopJSON, w.Body.String())
+			}
+		})
+	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			p := &nonProxyProvider{name: "shim", models: []string{"legacy-model"}}

--- a/internal/handler/completions_test.go
+++ b/internal/handler/completions_test.go
@@ -181,6 +181,13 @@ func TestCompletionsHandler_ShimPromptForms(t *testing.T) {
 		{"multi-element array batch", `["hi","there"]`, false, ""},
 		{"token ids", `[1,2,3]`, false, ""},
 		{"array of token-id arrays", `[[1,2],[3,4]]`, false, ""},
+		// A bare null decodes into a string as a no-op, which is the behaviour
+		// this endpoint has always had for "prompt": null.
+		{"explicit null", `null`, true, ""},
+		// A null element would decode to "" the same way, silently turning the
+		// request into an empty prompt rather than reporting that there is no
+		// text to send.
+		{"single-element array holding null", `[null]`, false, ""},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -236,6 +243,13 @@ func TestCompletionsHandler_ShimStopForms(t *testing.T) {
 	}{
 		{"bare string", `"\n\n"`, []string{"\n\n"}},
 		{"array of strings", `["a","b"]`, []string{"a", "b"}},
+		// null means "no stop sequences". Decoding it into a string yields ""
+		// and would send a single empty stop sequence upstream, which is a
+		// different request. Must stay nil.
+		{"explicit null", `null`, nil},
+		// A null inside the array has always decoded to "", so that is left
+		// alone; changing it would alter a request the gateway already accepts.
+		{"array containing null", `["a",null]`, []string{"a", ""}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -398,7 +412,9 @@ func TestCompletionsHandler_ShimResponseIncludesCreatedAndNullLogprobs(t *testin
 // TestCompletionsHandler_NativeProxyURLErrorDoesNotLeakBaseURL is the
 // regression test for the base-URL credential leak: a malformed operator-
 // configured base URL (which may carry a secret in a query string on a
-// self-hosted OpenAI-compatible proxy) must never reach the client verbatim.
+// self-hosted OpenAI-compatible proxy) must reach neither the client nor the
+// log. Logs are routinely shipped off-host, so writing the secret there is a
+// disclosure too, just a narrower one than answering the caller with it.
 func TestCompletionsHandler_NativeProxyURLErrorDoesNotLeakBaseURL(t *testing.T) {
 	secret := "sk-" + strings.Repeat("b", 48)
 	p := &proxiableBadURLProvider{
@@ -408,6 +424,11 @@ func TestCompletionsHandler_NativeProxyURLErrorDoesNotLeakBaseURL(t *testing.T) 
 	reg := providers.NewRegistry()
 	reg.Register(p)
 
+	var logs bytes.Buffer
+	prevLogger := logging.Logger
+	logging.Logger = slog.New(slog.NewTextHandler(&logs, nil))
+	t.Cleanup(func() { logging.Logger = prevLogger })
+
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/v1/completions", strings.NewReader(`{"model":"bad-url-model","prompt":"hi"}`))
 	w := httptest.NewRecorder()
 	Completions(reg)(w, req)
@@ -416,7 +437,14 @@ func TestCompletionsHandler_NativeProxyURLErrorDoesNotLeakBaseURL(t *testing.T) 
 		t.Fatalf("status = %d, want 500: %s", w.Code, w.Body.String())
 	}
 	if strings.Contains(w.Body.String(), secret) {
-		t.Fatalf("completions URL error leaked provider base URL secret: %s", w.Body.String())
+		t.Fatalf("completions URL error leaked provider base URL secret to the client: %s", w.Body.String())
+	}
+	if strings.Contains(logs.String(), secret) {
+		t.Fatalf("completions URL error leaked provider base URL secret to the log: %s", logs.String())
+	}
+	// The operator still needs to know which provider is misconfigured.
+	if !strings.Contains(logs.String(), "bad-url") {
+		t.Fatalf("log should name the offending provider so it can be found in config: %s", logs.String())
 	}
 }
 

--- a/internal/plugins/budget/plugin.go
+++ b/internal/plugins/budget/plugin.go
@@ -39,8 +39,8 @@
 //
 // All spend data is in-memory and does not survive process restarts. This
 // makes the budget plugin suitable for session-scoped soft limits and
-// development quotas. For durable billing enforcement use FerroCloud's
-// server-side budget controls which persist to PostgreSQL.
+// development quotas. Durable, cross-restart billing enforcement needs spend
+// state in a shared store, which this plugin deliberately does not implement.
 //
 // The store caps tracked keys at max_keys (default 10,000). When the cap is
 // reached on a new key insertion, the key with the lowest accumulated spend is

--- a/internal/strategies/fallback.go
+++ b/internal/strategies/fallback.go
@@ -25,6 +25,20 @@ type targetRetry struct {
 // defaultBackoffMs is used when RetryConfig.InitialBackoffMs is zero.
 const defaultBackoffMs = 100
 
+// NormalizeBackoffMs returns the effective initial backoff in milliseconds,
+// substituting defaultBackoffMs when ms is unset (<= 0). It is exported so
+// every retry surface shares one normalisation rule instead of re-deriving
+// the guard: Fallback.Execute applies it via resolveRetry below, and the
+// streaming start-phase retry helper in the root package applies it via
+// WaitBeforeRetry. Without a single source, an unset InitialBackoffMs can
+// silently mean "0ms backoff" on one surface and "100ms backoff" on another.
+func NormalizeBackoffMs(ms int) int {
+	if ms <= 0 {
+		return defaultBackoffMs
+	}
+	return ms
+}
+
 // Fallback tries each target in order, moving to the next on failure.
 // Per-target retry policies (attempts, status code filtering, backoff) are
 // configured via WithTargetRetry.
@@ -75,9 +89,7 @@ func (f *Fallback) resolveRetry(virtualKey string) targetRetry {
 	if !ok || r.attempts <= 0 {
 		r.attempts = 1
 	}
-	if r.initialBackoffMs <= 0 {
-		r.initialBackoffMs = defaultBackoffMs
-	}
+	r.initialBackoffMs = NormalizeBackoffMs(r.initialBackoffMs)
 	return r
 }
 
@@ -120,6 +132,15 @@ func shouldRetry(err error, onStatusCodes []int) bool {
 	return slices.Contains(onStatusCodes, code)
 }
 
+// ShouldRetry reports whether err is eligible for another configured attempt
+// against the same target. It exposes the fallback strategy's retry
+// classification to the streaming start-phase retry helper in the root
+// package so every routing surface follows one retry policy instead of
+// growing a second, possibly-diverging one.
+func ShouldRetry(err error, onStatusCodes []int) bool {
+	return shouldRetry(err, onStatusCodes)
+}
+
 // retryDelay returns how long to wait before a retry attempt (attempt >= 1). It
 // honors an upstream Retry-After hint from the previous failure when present —
 // the provider knows when it will be ready better than any local guess.
@@ -145,6 +166,25 @@ func retryDelay(attempt, initialBackoffMs int, prevErr error) time.Duration {
 	// clients, not resist prediction. A CSPRNG would buy nothing here and cost
 	// entropy on every retry.
 	return rand.N(exponential)
+}
+
+// WaitBeforeRetry blocks for the configured retry delay ahead of attempt
+// (attempt >= 1), normalising initialBackoffMs through NormalizeBackoffMs so
+// callers never have to re-derive the <=0 default themselves. The returned
+// bool is false when an upstream Retry-After hint exceeds maxRetryAfter and
+// the caller should abandon this target rather than wait; ctx cancellation is
+// returned as an error, matching Execute's own wait below.
+func WaitBeforeRetry(ctx context.Context, attempt, initialBackoffMs int, prevErr error) (bool, error) {
+	delay := retryDelay(attempt, NormalizeBackoffMs(initialBackoffMs), prevErr)
+	if delay < 0 {
+		return false, nil
+	}
+	select {
+	case <-ctx.Done():
+		return false, ctx.Err()
+	case <-time.After(delay):
+		return true, nil
+	}
 }
 
 // Execute attempts each provider in order, retrying according to the per-target

--- a/internal/strategies/fallback_test.go
+++ b/internal/strategies/fallback_test.go
@@ -15,6 +15,80 @@ import (
 
 // ── Retry hygiene: default retryable set, full jitter, Retry-After (#278) ──────
 
+func TestNormalizeBackoffMs(t *testing.T) {
+	tests := []struct {
+		name string
+		ms   int
+		want int
+	}{
+		{"zero falls back to the default", 0, defaultBackoffMs},
+		{"negative falls back to the default", -5, defaultBackoffMs},
+		{"positive value passes through unchanged", 250, 250},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := NormalizeBackoffMs(tt.ms); got != tt.want {
+				t.Errorf("NormalizeBackoffMs(%d) = %d, want %d", tt.ms, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestWaitBeforeRetry_NormalizesUnsetBackoff guards the single-source fix for
+// the streaming retry regression: an unset InitialBackoffMs (0) must produce
+// the same non-zero, jittered-exponential wait that resolveRetry already
+// applies for /v1/chat/completions — not an immediate retry.
+func TestWaitBeforeRetry_NormalizesUnsetBackoff(t *testing.T) {
+	start := time.Now()
+	proceed, err := WaitBeforeRetry(context.Background(), 1, 0, errors.New("transient"))
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("WaitBeforeRetry error = %v, want nil", err)
+	}
+	if !proceed {
+		t.Fatal("WaitBeforeRetry proceed = false, want true for a plain transient error")
+	}
+	// attempt=1, normalized backoff=defaultBackoffMs ⇒ exponential ceiling of
+	// 100ms; full jitter picks uniformly from [0, ceiling), so this can be 0,
+	// but it must never be anywhere near the immediate-retry regression this
+	// guards (hundreds of retries with 0ms backoff).
+	if elapsed >= 200*time.Millisecond {
+		t.Fatalf("WaitBeforeRetry with unset InitialBackoffMs took %v, want within the jittered 100ms ceiling", elapsed)
+	}
+}
+
+func TestWaitBeforeRetry_AbandonsWhenRetryAfterExceedsCap(t *testing.T) {
+	prev := &core.HTTPStatusError{StatusCode: 503, Message: "unavailable", RetryAfter: maxRetryAfter + time.Second}
+	proceed, err := WaitBeforeRetry(context.Background(), 1, 0, prev)
+	if err != nil {
+		t.Fatalf("WaitBeforeRetry error = %v, want nil", err)
+	}
+	if proceed {
+		t.Fatal("WaitBeforeRetry proceed = true, want false when Retry-After exceeds the cap")
+	}
+}
+
+func TestWaitBeforeRetry_ContextCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	proceed, err := WaitBeforeRetry(ctx, 1, 1000, nil)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("WaitBeforeRetry error = %v, want context.Canceled", err)
+	}
+	if proceed {
+		t.Fatal("WaitBeforeRetry proceed = true, want false on cancellation")
+	}
+}
+
+func TestShouldRetry_ExportedMatchesInternal(t *testing.T) {
+	if !ShouldRetry(errors.New("provider error (503): unavailable"), nil) {
+		t.Error("ShouldRetry(503, nil) = false, want true")
+	}
+	if ShouldRetry(circuitbreaker.ErrCircuitOpen, nil) {
+		t.Error("ShouldRetry(ErrCircuitOpen, nil) = true, want false")
+	}
+}
+
 func TestShouldRetry_DefaultPolicy(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/streamwrap/wrap.go
+++ b/internal/streamwrap/wrap.go
@@ -80,6 +80,20 @@ type MeterMeta struct {
 	// CircuitBreakerOutcome, if non-nil, is invoked once when the stream
 	// finishes. err is nil on success; non-nil on provider/stream failure.
 	CircuitBreakerOutcome func(err error)
+	// SuppressUsageForClient, when true, means the client explicitly opted
+	// out of the usage chunk (stream_options.include_usage=false on the
+	// incoming request — see providers/core.Request.ClientStreamOptions).
+	// Meter clears the Usage field on the copy of each chunk forwarded to
+	// out when this is set; it never affects accounting — the usage/cost
+	// seen by CompletionFn, PublishFn, SpanFinisher, and Prometheus metrics
+	// is always the real value the provider reported, captured before the
+	// client-facing copy is stripped.
+	//
+	// The zero value (false) preserves pre-existing behaviour: the usage
+	// chunk reaches the client whenever the provider sends one, matching
+	// every caller that predates this field. Callers should set it to
+	// `req.ClientStreamOptions != nil && !req.ClientStreamOptions.IncludeUsage`.
+	SuppressUsageForClient bool
 }
 
 // metricLabelModel returns the bounded Prometheus label for this request.
@@ -120,8 +134,12 @@ type SpanFinisherFunc func(StreamOutcome)
 // Finish implements SpanFinisher.
 func (f SpanFinisherFunc) Finish(o StreamOutcome) { f(o) }
 
-// Meter wraps src and returns a new channel that forwards every StreamChunk
-// unchanged. When a chunk carrying a non-nil Error is received, or when src
+// Meter wraps src and returns a new channel that forwards every StreamChunk,
+// with one exception: when MeterMeta.SuppressUsageForClient is set, the Usage
+// field is cleared on the forwarded copy of any chunk that carries it (the
+// rest of the chunk — content, finish_reason, error — is untouched). Internal
+// accounting always sees the real usage regardless. When a chunk carrying a
+// non-nil Error is received, or when src
 // closes, the goroutine emits request duration, token, and cost metrics then
 // closes the returned channel. On an error chunk the loop exits immediately
 // after forwarding it; any further chunks queued in src are not consumed.
@@ -189,9 +207,18 @@ func Meter(ctx context.Context, src <-chan providers.StreamChunk, start time.Tim
 				}
 
 				// Forward the chunk, but stop blocking if the consumer
-				// disconnects mid-send.
+				// disconnects mid-send. When the client opted out of usage
+				// reporting, forward a copy with Usage cleared instead of
+				// dropping the chunk outright — it may still carry content
+				// or a finish_reason that must reach the client. Accounting
+				// above already captured the real usage from the
+				// unmodified chunk, so this never affects metrics/cost/plugins.
+				forward := chunk
+				if meta.SuppressUsageForClient && forward.Usage != nil {
+					forward.Usage = nil
+				}
 				select {
-				case out <- chunk:
+				case out <- forward:
 				case <-ctx.Done():
 					clientCanceled = true
 					streamErr = drainSrc(ctx, src, streamErr)

--- a/internal/streamwrap/wrap_streamoptions_test.go
+++ b/internal/streamwrap/wrap_streamoptions_test.go
@@ -1,0 +1,145 @@
+package streamwrap
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/ferro-labs/ai-gateway/models"
+	"github.com/ferro-labs/ai-gateway/providers"
+)
+
+// TestMeter_SuppressUsageForClient_AccountingSeesRealUsage is the bypass
+// regression guard for the A11/B1 fix: a client that sends
+// stream_options.include_usage=false must still be metered on real usage.
+// Before this fix existed, the only way to honor the client's false was to
+// stop requesting usage upstream entirely, which zeroed accounting and let a
+// budget plugin's soft cap never trip (unlimited spend on demand). This test
+// asserts the opposite of that failure mode directly: the after-request
+// plugin stage (CompletionFn) sees the REAL, non-zero usage, while the
+// client-facing stream carries no usage chunk at all.
+func TestMeter_SuppressUsageForClient_AccountingSeesRealUsage(t *testing.T) {
+	const promptTokens, completionTokens, totalTokens = 123, 45, 168
+
+	src := feed(
+		providers.StreamChunk{ID: "1", Choices: []providers.StreamChoice{{
+			Delta: providers.MessageDelta{Content: "hello"},
+		}}},
+		providers.StreamChunk{
+			ID:    "2",
+			Usage: &providers.Usage{PromptTokens: promptTokens, CompletionTokens: completionTokens, TotalTokens: totalTokens},
+		},
+	)
+
+	var pluginSawUsage providers.Usage
+	var completionFnCalled bool
+	out := Meter(context.Background(), src, time.Now(), MeterMeta{
+		Provider:               "openai",
+		Model:                  "gpt-4o",
+		MetricModel:            "gpt-4o",
+		Catalog:                models.Catalog{},
+		SuppressUsageForClient: true, // client sent include_usage:false
+		CompletionFn: func(_ context.Context, resp *providers.Response) error {
+			completionFnCalled = true
+			pluginSawUsage = resp.Usage
+			return nil
+		},
+	})
+
+	var forwarded []providers.StreamChunk
+	for c := range out {
+		forwarded = append(forwarded, c)
+	}
+
+	if !completionFnCalled {
+		t.Fatal("CompletionFn was never called")
+	}
+	if pluginSawUsage.TotalTokens != totalTokens || pluginSawUsage.PromptTokens != promptTokens || pluginSawUsage.CompletionTokens != completionTokens {
+		t.Fatalf("plugin stage saw usage %+v, want real usage {Prompt:%d Completion:%d Total:%d} — a budget plugin reading zero usage here is exactly the spend-cap bypass this test guards against",
+			pluginSawUsage, promptTokens, completionTokens, totalTokens)
+	}
+
+	if len(forwarded) != 2 {
+		t.Fatalf("forwarded %d chunks, want 2", len(forwarded))
+	}
+	for _, c := range forwarded {
+		if c.Usage != nil {
+			t.Fatalf("client-facing chunk %+v carries usage, want it stripped (client asked for include_usage:false)", c)
+		}
+	}
+}
+
+// TestMeter_SuppressUsageForClient_PreservesContentOnUsageChunk verifies the
+// design note "prefer clearing Usage over dropping the chunk": a chunk that
+// carries both content/finish_reason AND usage must still deliver the
+// content to the client — only the Usage field is cleared, not the whole
+// chunk.
+func TestMeter_SuppressUsageForClient_PreservesContentOnUsageChunk(t *testing.T) {
+	src := feed(providers.StreamChunk{
+		ID: "1",
+		Choices: []providers.StreamChoice{{
+			Delta:        providers.MessageDelta{Content: "final words"},
+			FinishReason: "stop",
+		}},
+		Usage: &providers.Usage{PromptTokens: 10, CompletionTokens: 2, TotalTokens: 12},
+	})
+
+	out := Meter(context.Background(), src, time.Now(), MeterMeta{
+		Provider:               "openai",
+		Model:                  "gpt-4o",
+		MetricModel:            "gpt-4o",
+		Catalog:                models.Catalog{},
+		SuppressUsageForClient: true,
+	})
+
+	var forwarded []providers.StreamChunk
+	for c := range out {
+		forwarded = append(forwarded, c)
+	}
+
+	if len(forwarded) != 1 {
+		t.Fatalf("forwarded %d chunks, want 1", len(forwarded))
+	}
+	got := forwarded[0]
+	if got.Usage != nil {
+		t.Errorf("Usage = %+v, want nil (stripped)", got.Usage)
+	}
+	if len(got.Choices) != 1 || got.Choices[0].Delta.Content != "final words" {
+		t.Fatalf("content was dropped along with usage: %+v, want content preserved", got)
+	}
+	if got.Choices[0].FinishReason != "stop" {
+		t.Errorf("finish_reason = %q, want %q", got.Choices[0].FinishReason, "stop")
+	}
+}
+
+// TestMeter_SuppressUsageForClient_ZeroValueKeepsUsage locks in the "zero
+// /v1 breaking changes" requirement: MeterMeta.SuppressUsageForClient
+// defaults to false, so every existing caller that does not set it
+// (including every caller that predates this field) keeps delivering the
+// usage chunk to the client exactly as before.
+func TestMeter_SuppressUsageForClient_ZeroValueKeepsUsage(t *testing.T) {
+	src := feed(providers.StreamChunk{
+		ID:    "1",
+		Usage: &providers.Usage{PromptTokens: 3, CompletionTokens: 1, TotalTokens: 4},
+	})
+
+	out := Meter(context.Background(), src, time.Now(), MeterMeta{
+		Provider:    "openai",
+		Model:       "gpt-4o",
+		MetricModel: "gpt-4o",
+		Catalog:     models.Catalog{},
+		// SuppressUsageForClient intentionally left unset.
+	})
+
+	var forwarded []providers.StreamChunk
+	for c := range out {
+		forwarded = append(forwarded, c)
+	}
+
+	if len(forwarded) != 1 || forwarded[0].Usage == nil {
+		t.Fatalf("forwarded %+v, want the usage chunk delivered unchanged (default behaviour)", forwarded)
+	}
+	if forwarded[0].Usage.TotalTokens != 4 {
+		t.Errorf("TotalTokens = %d, want 4", forwarded[0].Usage.TotalTokens)
+	}
+}

--- a/models/calculator.go
+++ b/models/calculator.go
@@ -3,7 +3,7 @@ package models
 // Usage carries all token and media counts from a completed provider response.
 // This is intentionally a separate type from providers.Usage so the models
 // package has no dependency on the providers package and can be imported
-// independently (e.g. by FerroCloud).
+// independently.
 type Usage struct {
 	PromptTokens     int
 	CompletionTokens int

--- a/models/catalog.go
+++ b/models/catalog.go
@@ -30,6 +30,14 @@ var bundledCatalog []byte
 // Useful for air-gapped deployments or enterprise custom pricing.
 const CatalogURLEnv = "FERRO_MODEL_CATALOG_URL"
 
+// CatalogFetchTimeoutEnv overrides how long the remote fetch may take, as a Go
+// duration (e.g. "2s"). The default suits a normal internet connection; a
+// deployment whose egress is blocked or heavily filtered would otherwise wait
+// the whole budget on every start before falling back to the embedded catalog.
+// Setting it to "0" skips the remote fetch entirely and uses the embedded
+// snapshot immediately.
+const CatalogFetchTimeoutEnv = "FERRO_MODEL_CATALOG_TIMEOUT"
+
 const defaultCatalogURL = "https://github.com/ferro-labs/model-catalog/releases/latest/download/catalog.json"
 
 // LoadSource identifies where a catalog load came from.
@@ -175,7 +183,8 @@ type Lifecycle struct {
 	Successor       *string `json:"successor"`
 }
 
-// Load fetches the model catalog from a remote URL (1s timeout).
+// Load fetches the model catalog from a remote URL, bounded by
+// [CatalogFetchTimeoutEnv] or a 10s default.
 // On any failure it falls back to the embedded catalog_backup.json.
 // The gateway never fails to start due to catalog unavailability.
 // Equivalent to LoadContext(context.Background()).
@@ -267,7 +276,46 @@ func catalogLoadErrorForLog(err error, catalogURL string) string {
 // larger than any realistic catalog file.
 const maxCatalogResponseBytes = 8 * 1024 * 1024
 
+// catalogFetchTimeout bounds the whole remote fetch: DNS, TLS, the two redirects
+// GitHub release downloads go through, and the ~3.4 MB body itself. The previous
+// 1s budget was below the real cost of that transfer (measured ~1.2s on a home
+// connection, ~0.6s from a datacenter), so the fetch usually failed and the
+// gateway silently served the embedded snapshot — which goes stale between
+// releases and prices unknown models at zero. Callers that need a tighter bound
+// pass their own deadline via LoadWithInfoContext.
+const catalogFetchTimeout = 10 * time.Second
+
+// resolveCatalogFetchTimeout returns the effective fetch budget. An unset or
+// unparseable FERRO_MODEL_CATALOG_TIMEOUT leaves the default in place rather
+// than failing the load: the catalog is best-effort, and a typo in an optional
+// tuning knob should not change how long startup takes in a way nobody expects.
+// A non-positive value means "do not fetch at all".
+func resolveCatalogFetchTimeout() time.Duration {
+	raw := strings.TrimSpace(os.Getenv(CatalogFetchTimeoutEnv))
+	if raw == "" {
+		return catalogFetchTimeout
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil {
+		slog.Warn("invalid catalog fetch timeout; using the default", //nolint:gosec // values are CR/LF-sanitized before logging.
+			"env", CatalogFetchTimeoutEnv, "value", safeLogValue(raw), "default", catalogFetchTimeout)
+		return catalogFetchTimeout
+	}
+	if d <= 0 {
+		return 0
+	}
+	return d
+}
+
+// ErrCatalogFetchDisabled reports that the remote fetch was skipped because the
+// configured timeout is zero. Callers fall back to the embedded catalog.
+var ErrCatalogFetchDisabled = fmt.Errorf("catalog fetch: disabled by %s", CatalogFetchTimeoutEnv)
+
 func fetchRemote(ctx context.Context, rawURL string) ([]byte, error) {
+	timeout := resolveCatalogFetchTimeout()
+	if timeout <= 0 {
+		return nil, ErrCatalogFetchDisabled
+	}
 	u, err := url.Parse(rawURL)
 	if err != nil || (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
 		return nil, fmt.Errorf("invalid catalog URL %q: must be http or https with a host", rawURL)
@@ -276,7 +324,7 @@ func fetchRemote(ctx context.Context, rawURL string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	client := &http.Client{Timeout: time.Second}
+	client := &http.Client{Timeout: timeout}
 	resp, err := client.Do(req) //nolint:gosec // URL scheme and host validated above
 	if err != nil {
 		return nil, err

--- a/models/catalog_test.go
+++ b/models/catalog_test.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 )
 
 // TestCatalogBackupParseable verifies the embedded catalog_backup.json is
@@ -735,5 +736,62 @@ func BenchmarkGetBareModelID(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		c.Get(bareID)
+	}
+}
+
+// TestCatalogFetchTimeoutEnv_DisablesRemoteFetch covers the escape hatch for
+// deployments whose egress is blocked. Without it, every start would wait the
+// full default budget for a fetch that cannot succeed — and it waits before the
+// gateway binds its listener, so nothing answers a readiness probe meanwhile.
+func TestCatalogFetchTimeoutEnv_DisablesRemoteFetch(t *testing.T) {
+	var reached atomic.Bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		reached.Store(true)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"test/remote":{"provider":"test","model_id":"remote","mode":"chat"}}`))
+	}))
+	t.Cleanup(server.Close)
+	t.Setenv(CatalogURLEnv, server.URL)
+	t.Setenv(CatalogFetchTimeoutEnv, "0")
+
+	result, err := LoadWithInfo()
+	if err != nil {
+		t.Fatalf("LoadWithInfo returned error: %v", err)
+	}
+	if reached.Load() {
+		t.Fatal("remote catalog was fetched despite the fetch being disabled")
+	}
+	if result.Source != LoadSourceFallback {
+		t.Fatalf("Source = %q, want %q", result.Source, LoadSourceFallback)
+	}
+	if len(result.Catalog) == 0 {
+		t.Fatal("expected the embedded catalog to be served when the fetch is disabled")
+	}
+}
+
+// TestResolveCatalogFetchTimeout covers the parsing of the override. An
+// unparseable value keeps the default rather than failing the load: the catalog
+// is best-effort, and a typo in an optional knob must not silently change how
+// long startup blocks.
+func TestResolveCatalogFetchTimeout(t *testing.T) {
+	tests := []struct {
+		name string
+		env  string
+		want time.Duration
+	}{
+		{"unset keeps the default", "", catalogFetchTimeout},
+		{"explicit shorter budget", "250ms", 250 * time.Millisecond},
+		{"zero disables the fetch", "0", 0},
+		{"negative disables the fetch", "-1s", 0},
+		{"unparseable keeps the default", "soon", catalogFetchTimeout},
+		{"surrounding whitespace tolerated", "  2s  ", 2 * time.Second},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(CatalogFetchTimeoutEnv, tt.env)
+			if got := resolveCatalogFetchTimeout(); got != tt.want {
+				t.Fatalf("resolveCatalogFetchTimeout() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }

--- a/providers/core/chat.go
+++ b/providers/core/chat.go
@@ -187,6 +187,21 @@ type Request struct {
 	Stream        bool           `json:"stream,omitempty"`
 	StreamOptions *StreamOptions `json:"stream_options,omitempty"`
 
+	// ClientStreamOptions is the client's stream_options exactly as sent on
+	// the incoming request, decoded by internal/handler. It is kept separate
+	// from StreamOptions above (which providers/internal/openaicompat
+	// forwards verbatim upstream for ~20 OpenAI-compatible providers) so that
+	// a client's explicit include_usage:false can never leak into that
+	// verbatim forward and silently disable a provider's usage reporting —
+	// doing so would zero out cost/token accounting for the request without
+	// the gateway ever finding out. The only readers are
+	// providers/openai.Provider.CompleteStream (to decide whether to strip
+	// the client-facing usage chunk one layer up) and callers of
+	// internal/streamwrap.Meter (to set MeterMeta.SuppressUsageForClient).
+	// Never marshaled (json:"-"): it exists purely for gateway-internal
+	// bookkeeping, never for any provider wire body.
+	ClientStreamOptions *StreamOptions `json:"-"`
+
 	// Tools
 	ParallelToolCalls *bool `json:"parallel_tool_calls,omitempty"`
 
@@ -197,8 +212,12 @@ type Request struct {
 
 // StreamOptions carries the OpenAI stream_options object. IncludeUsage requests a
 // terminal usage chunk on the stream so cost and metrics tracking work.
+//
+// No omitempty on IncludeUsage: an explicit false must round-trip distinctly
+// from an omitted object wherever this type is marshaled, or a client's
+// opt-out becomes indistinguishable from never having asked at all.
 type StreamOptions struct {
-	IncludeUsage bool `json:"include_usage,omitempty"`
+	IncludeUsage bool `json:"include_usage"`
 }
 
 // NormalizeCompletionTokenLimits fills max_tokens from max_completion_tokens

--- a/providers/core/contracts.go
+++ b/providers/core/contracts.go
@@ -1,9 +1,9 @@
 // Package core defines the stable public contracts for the providers layer:
 // interfaces, shared data types, and supporting helpers.
 //
-// All provider implementations and consumer packages (gateway, admin, ferrocloud)
-// should import this package for type definitions rather than the root
-// providers package when operating from a sub-package context.
+// Provider implementations and consumer packages should import this package for
+// type definitions rather than the root providers package when operating from a
+// sub-package context.
 //
 // The root providers package re-exports everything here as type aliases so
 // existing code using providers.Provider, providers.Request, etc. continues

--- a/providers/core/streamoptions_test.go
+++ b/providers/core/streamoptions_test.go
@@ -1,0 +1,44 @@
+package core
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestRequest_ClientStreamOptions_NeverMarshaled locks in the invariant the
+// whole A11/B1 fix depends on: ClientStreamOptions (the client's raw
+// stream_options) must never appear on any wire body built by marshaling a
+// core.Request directly — that is exactly how the ~20 OpenAI-compatible
+// providers in providers/internal/openaicompat build their upstream request,
+// and forwarding a client's explicit include_usage:false there would disable
+// their usage reporting silently. Only providers/openai builds its own
+// separate wire type that always forces include_usage:true.
+func TestRequest_ClientStreamOptions_NeverMarshaled(t *testing.T) {
+	req := Request{
+		Model:               "gpt-4o",
+		Messages:            []Message{{Role: "user", Content: "hi"}},
+		ClientStreamOptions: &StreamOptions{IncludeUsage: false},
+	}
+	b, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(b), "ClientStreamOptions") || strings.Contains(string(b), "include_usage") {
+		t.Fatalf("marshaled request leaked ClientStreamOptions onto the wire: %s", b)
+	}
+}
+
+// TestStreamOptions_IncludeUsageFalse_RoundTrips verifies an explicit false
+// is distinguishable from an omitted stream_options object wherever
+// StreamOptions itself (not embedded in Request) is marshaled directly —
+// the classic omitempty-swallows-false footgun the reference fix flagged.
+func TestStreamOptions_IncludeUsageFalse_RoundTrips(t *testing.T) {
+	b, err := json.Marshal(StreamOptions{IncludeUsage: false})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if string(b) != `{"include_usage":false}` {
+		t.Fatalf("marshaled = %s, want explicit false (not swallowed by omitempty)", b)
+	}
+}

--- a/providers/factory.go
+++ b/providers/factory.go
@@ -39,8 +39,8 @@ func ProviderConfigFromEnv(entry ProviderEntry) ProviderConfig {
 // init modes that cover every deployment scenario:
 //
 //   - OSS self-hosted: populate from environment variables via ProviderConfigFromEnv.
-//   - Cloud / tenant injection: populate from an encrypted credential store
-//     (e.g. FerroCloud's credentials domain) without touching env vars.
+//   - Programmatic injection: populate from an encrypted credential store or a
+//     per-tenant secret source without touching env vars.
 //
 // Standard key names are defined as CfgKey* constants below.
 type ProviderConfig map[string]string

--- a/providers/openai/openai.go
+++ b/providers/openai/openai.go
@@ -313,16 +313,32 @@ func (p *Provider) Complete(ctx context.Context, req core.Request) (*core.Respon
 	}, nil
 }
 
-// streamOptions carries the OpenAI stream_options object. The gateway always
-// requests usage so cost and metrics tracking work regardless of what the client
-// sent.
+// streamOptions carries the OpenAI stream_options object sent upstream. The
+// gateway always requests usage here — deliberately ignoring
+// req.StreamOptions / req.ClientStreamOptions — so cost and metrics tracking
+// never depend on what the client asked for.
+//
+// DO NOT thread req.ClientStreamOptions (the client's real include_usage
+// choice, see providers/core.Request) into this struct. That field exists so
+// the gateway can honor an explicit include_usage:false on the *client-facing*
+// stream, one layer up in internal/streamwrap.Meter (MeterMeta.
+// SuppressUsageForClient), while this provider keeps requesting the real
+// usage from OpenAI unconditionally. Making IncludeUsage here depend on the
+// client's choice would stop OpenAI from ever sending the terminal usage
+// chunk when a client sets include_usage:false — zeroing cost/token
+// accounting for that request without any error, which for a soft spend cap
+// means unlimited spend on demand.
 type streamOptions struct {
 	IncludeUsage bool `json:"include_usage"`
 }
 
 // streamingRequest is a core.Request forwarded verbatim (so no field can be
 // dropped, unlike a rebuilt param struct) plus the stream_options the streaming
-// path always sets.
+// path always sets. The outer StreamOptions field here has JSON-encoding
+// priority over the core.Request.StreamOptions field embedded through
+// core.Request (shallower field wins on a tag collision), so
+// core.Request.StreamOptions is never actually written to the wire by this
+// struct — only IncludeUsage: true below is.
 type streamingRequest struct {
 	core.Request
 	StreamOptions streamOptions `json:"stream_options"`
@@ -332,8 +348,11 @@ type streamingRequest struct {
 // forwards the same raw core.Request body as Complete (adding stream:true and
 // stream_options.include_usage), so streaming and non-streaming cannot diverge
 // on forwarded fields such as logit_bias and multimodal image content. Usage is
-// always requested so the final SSE chunk carries token statistics for cost and
-// metrics tracking.
+// always requested upstream — unconditionally, regardless of what the client
+// asked for in its own stream_options — so the final SSE chunk always carries
+// token statistics for cost and metrics tracking; a client that opted out of
+// the usage chunk still gets it upstream here, but has it stripped from the
+// forwarded stream one layer up by internal/streamwrap.Meter instead.
 func (p *Provider) CompleteStream(ctx context.Context, req core.Request) (<-chan core.StreamChunk, error) {
 	// o-series reasoning models reject max_tokens; keep only the modern field.
 	req.PreferCompletionTokens()

--- a/providers/openai/openai_streamoptions_test.go
+++ b/providers/openai/openai_streamoptions_test.go
@@ -1,0 +1,67 @@
+package openai
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	core "github.com/ferro-labs/ai-gateway/providers/core"
+)
+
+// TestOpenAIProvider_CompleteStream_AlwaysRequestsUsageUpstream is the
+// provider-side half of the A11/B1 fix: the gateway must always ask OpenAI
+// for the terminal usage chunk, regardless of what the client's own
+// stream_options said (including an explicit include_usage:false), because
+// downstream accounting (cost, metrics, budget plugin) depends on it. Honoring
+// the client's opt-out happens one layer up, in internal/streamwrap.Meter —
+// never here.
+func TestOpenAIProvider_CompleteStream_AlwaysRequestsUsageUpstream(t *testing.T) {
+	tests := []struct {
+		name                string
+		clientStreamOptions *core.StreamOptions
+	}{
+		{name: "client omitted stream_options", clientStreamOptions: nil},
+		{name: "client explicitly set include_usage:false", clientStreamOptions: &core.StreamOptions{IncludeUsage: false}},
+		{name: "client explicitly set include_usage:true", clientStreamOptions: &core.StreamOptions{IncludeUsage: true}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var capturedBody map[string]any
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if err := json.NewDecoder(r.Body).Decode(&capturedBody); err != nil {
+					t.Errorf("decode captured request body: %v", err)
+				}
+				w.Header().Set("Content-Type", "text/event-stream")
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte("data: [DONE]\n\n"))
+			}))
+			defer srv.Close()
+
+			provider, _ := New("sk-test-key", srv.URL)
+			ch, err := provider.CompleteStream(context.Background(), core.Request{
+				Model:               "gpt-4o",
+				Messages:            []core.Message{{Role: "user", Content: "hi"}},
+				ClientStreamOptions: tt.clientStreamOptions,
+			})
+			if err != nil {
+				t.Fatalf("CompleteStream() error: %v", err)
+			}
+			for c := range ch {
+				if c.Error != nil {
+					t.Fatalf("stream error: %v", c.Error)
+				}
+			}
+
+			so, ok := capturedBody["stream_options"].(map[string]any)
+			if !ok {
+				t.Fatalf("upstream request body missing stream_options: %+v", capturedBody)
+			}
+			if includeUsage, _ := so["include_usage"].(bool); !includeUsage {
+				t.Fatalf("upstream stream_options.include_usage = %v, want true unconditionally (client's own choice is %+v)", so["include_usage"], tt.clientStreamOptions)
+			}
+		})
+	}
+}

--- a/providers/registry.go
+++ b/providers/registry.go
@@ -5,6 +5,7 @@ import "fmt"
 // Registry manages a collection of providers for lookup by name.
 type Registry struct {
 	providers map[string]Provider
+	order     []string
 }
 
 // NewRegistry creates a new empty provider registry.
@@ -16,6 +17,9 @@ func NewRegistry() *Registry {
 
 // Register adds a provider to the registry.
 func (r *Registry) Register(p Provider) {
+	if _, exists := r.providers[p.Name()]; !exists {
+		r.order = append(r.order, p.Name())
+	}
 	r.providers[p.Name()] = p
 }
 
@@ -36,25 +40,27 @@ func (r *Registry) MustGet(name string) Provider {
 
 // List returns the names of all registered providers.
 func (r *Registry) List() []string {
-	names := make([]string, 0, len(r.providers))
-	for name := range r.providers {
-		names = append(names, name)
-	}
+	names := make([]string, len(r.order))
+	copy(names, r.order)
 	return names
 }
 
 // AllModels returns ModelInfo from all registered providers.
 func (r *Registry) AllModels() []ModelInfo {
 	var models []ModelInfo
-	for _, p := range r.providers {
+	for _, name := range r.order {
+		p := r.providers[name]
 		models = append(models, p.Models()...)
 	}
 	return models
 }
 
-// FindByModel returns the first provider that supports the given model.
+// FindByModel returns the first registered provider that supports the given
+// model. Registration order is retained explicitly so overlapping/wildcard
+// providers resolve deterministically rather than following Go map iteration.
 func (r *Registry) FindByModel(model string) (Provider, bool) {
-	for _, p := range r.providers {
+	for _, name := range r.order {
+		p := r.providers[name]
 		if p.SupportsModel(model) {
 			return p, true
 		}

--- a/providers/registry_test.go
+++ b/providers/registry_test.go
@@ -79,6 +79,19 @@ func TestRegistry_FindByModel(t *testing.T) {
 	}
 }
 
+func TestRegistry_FindByModelUsesRegistrationOrder(t *testing.T) {
+	r := NewRegistry()
+	r.Register(&stubProvider{name: "first", models: []string{"shared"}})
+	r.Register(&stubProvider{name: "second", models: []string{"shared"}})
+
+	for range 100 {
+		p, ok := r.FindByModel("shared")
+		if !ok || p.Name() != "first" {
+			t.Fatalf("FindByModel = %v,%v, want first registered provider", p, ok)
+		}
+	}
+}
+
 func TestRegistry_AllModels(t *testing.T) {
 	r := NewRegistry()
 	r.Register(&stubProvider{name: "a", models: []string{"m1", "m2"}})


### PR DESCRIPTION
Seven defects reported against `v1.3.0`, plus one pulled forward from the next
patch. Every one is reachable from ordinary YAML or JSON configuration.

**No breaking changes to `/v1`.** No request the gateway accepted is now
refused, no response shape changes, and authentication is untouched. Requests
that were wrongly refused now succeed.

## What was wrong

Much of this is configuration that was quietly not applied:

- A `retry` block worked on `/v1/chat/completions` and was ignored the moment
  `stream: true` was set. A target returning 503 failed the request outright
  instead of falling back.
- `strategy.mode` and the `targets` list were ignored entirely by
  `/v1/embeddings` and `/v1/images/generations`, which always used the first
  capable provider — no fallback, no retry, no request timeout.
- Backoff between retries was zero on every surface except chat, turning three
  configured attempts into three immediate retries against a provider that had
  just asked for a pause.

The rest are plain defects:

- `/v1/completions` refused a `prompt` sent as an array and a `stop` sent as a
  bare string. Both are documented OpenAI shapes, and both failed to decode
  before the handler chose its path — so they were refused even when the request
  was being forwarded verbatim to an upstream that accepts them.
- Provider lookup iterated a map, so which provider served a model available
  from several could differ between two consecutive requests in one process.
- A panic inside a provider call left the circuit breaker's half-open probe
  held. Nothing releases it, so that target was rejected until the process
  restarted.
- `stream_options.include_usage` was discarded and a usage chunk always
  requested.
- An API-key update wrote the new name and scopes before validating the
  expiration timestamp, leaving the key modified by a request that returned 400.
- The model catalog was bounded at one second — below the real cost of fetching
  a multi-megabyte asset through a redirecting CDN — so the gateway served the
  snapshot embedded at build time on essentially every start, pricing anything
  newer at zero.

## Notes for review

**Usage is always requested upstream, regardless of what the caller asks.**
Honouring `include_usage: false` on its own would mean no usage chunk arrives,
so metering records nothing and per-key spend limits never increment — any
caller could then spend without limit on streaming. The caller's preference is
held in a field tagged `json:"-"` so it cannot reach a provider request body,
and the usage chunk is dropped from the client-facing stream instead.

**Nothing narrowed.** Streaming and the non-chat surfaces still fall back to any
registered capable provider when no configured target can serve the model, as
before.

**`echo`, `best_of`, `logprobs` and `suffix` remain decoded and ignored** on the
completions chat shim. Refusing them would turn a request that callers send
today into a 400; a test pins the current behaviour.

## Operator-visible changes

None require action, but three are worth knowing before upgrading:

- **Which provider serves a request may change** on embeddings and image
  generation, since they now follow the configured strategy rather than always
  using the first capable provider. Cost, latency and data-residency
  implications are worth a look.
- **Dashboards will show new traffic and cost.** Embedding and image requests
  now report metrics for the first time, which can look like a step change with
  no change in usage. Reported costs may also move, because the gateway now
  reaches the current catalog instead of a build-time snapshot.
- **Startup can take up to ten seconds longer where egress to the catalog host
  is blocked**, since the fetch precedes the listener binding.
  `FERRO_MODEL_CATALOG_TIMEOUT` shortens it, or `0` skips the fetch entirely.

## Verification

```
gofmt -l                    clean
go build ./...              exit 0
go vet ./...                exit 0
golangci-lint run ./...     0 issues
go test -short -race ./...  0 failures
coverage                    80.6%   (CI floor 75%)
```

`make test-integration` has not been run here — it needs Docker for
testcontainers. This patch touches no migration or store schema.

Every defect ships with a regression test that fails without its fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable model-catalog startup/refresh timeout (`FERRO_MODEL_CATALOG_TIMEOUT`), including a way to skip remote fetch.
  * Added strategy-based routing, retries, and fallback for embeddings and image generation, with improved request metrics, tracing, cost reporting, and lifecycle events.
  * Enhanced streaming and completions compatibility for OpenAI-style `stream_options`, including legacy prompt/stop handling.

* **Bug Fixes**
  * Fixed circuit-breaker behavior on panics for both stream and target execution, preventing stuck/stranded states and improving fallback correctness.
  * Improved streaming start timeout handling (bounds only the start phase) and strengthened sensitive-data redaction.
  * Applied configuration gaps and clarified upgrade behavior in release docs.

* **Tests**
  * Expanded multimodal and streaming regression coverage for routing, retries, timeouts, and observability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->