### PR TITLE
fix: disclosure, durability, and MCP readiness (v1.3.2)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -207,6 +207,20 @@ plugins:
     config:
       blocked_words: ["password", "secret"]
 
+mcp_servers:                 # external MCP tool servers for agentic tool calling
+  - name: filesystem
+    command: npx             # stdio transport: launched as a subprocess
+    args: ["-y", "@modelcontextprotocol/server-filesystem", "/data"]
+    env:                     # the subprocess inherits NO gateway environment
+      SOME_TOKEN: ${SOME_TOKEN}
+    timeout_seconds: 30      # per tool call; default 30
+    required: false          # see below; default false
+  - name: search
+    url: https://mcp.example.com/mcp   # Streamable HTTP transport
+    headers:
+      Authorization: Bearer ${SEARCH_TOKEN}
+    allowed_tools: ["web_search"]      # empty means all discovered tools
+
 observability:
   tracing:
     enabled: true
@@ -221,6 +235,32 @@ observability:
       enabled: false
       config: {}
 ```
+
+### MCP Server Readiness (`mcp_servers[].required`)
+
+`required` decides whether one MCP server's availability gates the whole
+instance's readiness. It is **opt-in per server and defaults to `false`**, so an
+existing config behaves exactly as it did before the field existed.
+
+| `required` | Server unready | `/readyz` |
+|------------|----------------|-----------|
+| absent / `false` | reported in the body | `200 ready` |
+| `true` | reported in the body | `503 not_ready`, reason `required mcp server unavailable` |
+
+A server is unready when it never completed the initialize handshake, or when
+its transport has since died — a stdio server whose subprocess exited is
+detected and its tools are withdrawn from the model, so it stops being
+advertised and stops resolving.
+
+Set `required: true` only for a server the deployment genuinely cannot serve
+without. A required server that is down takes the instance out of rotation and
+stops **all** traffic through it, including requests that use no tools at all.
+Every server's state appears under `mcp_servers` in the `/readyz` body whether
+or not it is required, so MCP health can be monitored without gating on it.
+
+The failure *reason* is deliberately not in the `/readyz` body: the endpoint is
+unauthenticated and an MCP failure can quote a server URL, an authorization
+header, or a subprocess command line. It is logged server-side instead.
 
 ### Key Environment Variables
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -247,10 +247,21 @@ existing config behaves exactly as it did before the field existed.
 | absent / `false` | reported in the body | `200 ready` |
 | `true` | reported in the body | `503 not_ready`, reason `required mcp server unavailable` |
 
-A server is unready when it never completed the initialize handshake, or when
-its transport has since died — a stdio server whose subprocess exited is
-detected and its tools are withdrawn from the model, so it stops being
-advertised and stops resolving.
+A server is unready when it never completed the initialize handshake. That
+covers a server whose transport could not be built at all — an unresolvable
+`${VAR}` in its `headers` or `env` — which is reported unready rather than
+omitted from the body.
+
+Death **after** a successful handshake is detected for **stdio servers only**. A
+stdio server whose subprocess exits is noticed two ways — the process closing
+its error stream, confirmed with a ping before anything is withdrawn, and a tool
+call failing with a closed transport or a broken pipe — and its tools are then
+withdrawn from the model, so it stops being advertised and stops resolving.
+
+An HTTP server that becomes unreachable after a successful handshake is **not
+currently detected**: it continues to report ready and its tools stay
+advertised, and calls to it fail per request. Do not rely on `required: true`
+to take an instance out of rotation when an HTTP MCP server goes down.
 
 Set `required: true` only for a server the deployment genuinely cannot serve
 without. A required server that is down takes the instance out of rotation and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,102 @@ All notable changes to Ferro Labs AI Gateway are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.2] — 2026-07-21
+
+Disclosure and durability. Upstream error text is filtered before it leaves the
+process, a crashed MCP subprocess is now noticed instead of being advertised as
+healthy, admin config changes and their audit entries are recorded atomically,
+and MCP gains the metrics needed to alert on a server that never came up.
+
+Default behaviour is unchanged. No request that was accepted is now refused, no
+response shape changes, no status code changes, and no configuration becomes
+required. The one opt-in is `mcp_servers[].required`, which defaults to `false`.
+
+### Fixed
+
+- **Provider error text could carry a credential to clients, logs, streams, and
+  observability backends.** A provider controls the body of its own error
+  responses, and some echo the value of the `Authorization` or `api-key` header
+  they were sent. That text became the error message the gateway reported, so
+  the gateway's own credential could reach an end user, a log aggregator, an SSE
+  frame, or an exporter. Error messages are now filtered at the points every
+  caller passes through — the OpenAI-compatible error writer, the admin error
+  writer, the streaming error frame, the request-failure event, and the failure
+  log lines. Only the message text changes; status, `type`, and `code` are
+  written exactly as before. Filtering is best-effort pattern matching and
+  covers the key formats that carry a recognisable prefix; a provider whose keys
+  have no distinguishing shape cannot be matched, so it reduces exposure rather
+  than eliminating it.
+- **A crashed MCP stdio subprocess was never noticed.** A server was marked ready
+  once and nothing ever cleared it, so after its subprocess died the gateway kept
+  advertising that server's tools to the model, kept resolving them to a dead
+  transport, and failed every call. Child exit is now detected two ways — the
+  subprocess closing its error stream, and a tool call reporting a closed
+  transport — and the server's tools are withdrawn from the model until it comes
+  back. Recovery on the next configuration reload is unchanged.
+- **An MCP tool that reported failure was recorded as a success.** Servers signal
+  a failed call by returning an error result rather than a transport error. That
+  signal was not read, so a failing tool incremented the success counter, was
+  audited as successful, and produced a successful span. It is now recorded as an
+  error in all three. What the model and the client receive is unchanged.
+- **Admin config changes and their audit entries could disagree.** Applying a
+  config and recording its history entry were separate steps under separate
+  locks, so two concurrent admin writes could interleave and leave the newest
+  history entry describing a config that was not the active one — with a rollback
+  then targeting the wrong version. The same gap existed one level lower, between
+  persisting a config and applying it, where the disagreement survived a restart.
+  Each admin config mutation is now applied and recorded as one serialized
+  operation. History reads are unaffected and never wait on a config apply.
+- **An unknown MCP tool name became an unbounded metric label.** The tool name on
+  the unknown-tool counter came from the model's output, so an invented name
+  minted a new time series. Names that do not resolve to a registered tool now
+  collapse to a single bounded label, matching how unroutable model names are
+  already handled.
+
+### Added
+
+- **`mcp_servers[].required`** — marks an MCP server whose availability gates
+  `/readyz`. Defaults to `false`, so an existing configuration behaves exactly as
+  before. See **Upgrade notes**.
+- **MCP server state on `/readyz`.** The readiness body now reports each
+  configured MCP server's name, readiness, and whether it is required, so MCP
+  health is observable without gating on it. The failure reason is deliberately
+  omitted — the endpoint is unauthenticated and a failure can quote a server URL,
+  an authorization header, or a subprocess command line. It is logged instead.
+- **`gateway_mcp_server_up`** — per-server gauge, `1` when a server completed its
+  handshake and its transport is alive, `0` otherwise.
+- **`gateway_mcp_server_init_failures_total`** — per-server counter incremented
+  when a server fails to initialize. Initialization failures were previously only
+  logged, which left a fully dead MCP fleet indistinguishable from an idle one.
+  Alert on any non-zero value.
+- **Tracing for MCP startup.** Server initialization and tool discovery now emit
+  spans, so the phase where MCP most often fails is visible in a trace rather
+  than only in logs.
+
+### Changed
+
+- The stored config history query now reads a bounded number of the most recent
+  entries instead of the whole table. This is a read bound only; no history row
+  is ever deleted.
+
+### Upgrade notes
+
+- **`/readyz` behaviour is unchanged unless you opt in.** Setting
+  `required: true` on an MCP server means that if the server is unavailable the
+  instance reports not-ready and an orchestrator will take it out of rotation —
+  stopping all traffic through it, including requests that use no tools. Set it
+  only for a server the deployment genuinely cannot serve without.
+- Deployments that already configure `mcp_servers` will see a new `mcp_servers`
+  array in the `/readyz` response body. It is additive; existing fields are
+  unchanged.
+- Error messages returned to clients, written to logs, and sent to observability
+  exporters are now filtered. Text that matches a credential pattern is masked,
+  so tooling that matches on exact upstream error strings may need adjusting.
+- MCP tool calls that return an error result now increment
+  `ferrogw_mcp_tool_calls_total` with `status="error"` rather than `status="ok"`.
+  Dashboards that treated the MCP success rate as near-100% will show the real
+  rate. Label sets on existing metrics are unchanged.
+
 ## [1.3.1] — 2026-07-21
 
 Seven defects reported against `v1.3.0`, spanning request handling, routing, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,9 +35,29 @@ required. The one opt-in is `mcp_servers[].required`, which defaults to `false`.
   once and nothing ever cleared it, so after its subprocess died the gateway kept
   advertising that server's tools to the model, kept resolving them to a dead
   transport, and failed every call. Child exit is now detected two ways — the
-  subprocess closing its error stream, and a tool call reporting a closed
-  transport — and the server's tools are withdrawn from the model until it comes
-  back. Recovery on the next configuration reload is unchanged.
+  subprocess closing its error stream, and a tool call failing with a closed
+  transport or a broken pipe — and the server's tools are withdrawn from the
+  model until it comes back. A server closing its error stream is confirmed with
+  a ping before anything is withdrawn, so one that does so while still running
+  keeps serving, and a server that closes it at startup is still covered later.
+  Detection applies to stdio servers; an HTTP server that becomes unreachable
+  after a successful handshake is not currently detected. Recovery on the next
+  configuration reload is unchanged.
+- **An MCP server that could not be built was missing from readiness.** A server
+  whose `headers` or `env` referenced an undefined variable was resolved before
+  its transport existed, so it never reached the registry that readiness reports
+  from. It was absent from `mcp_servers` rather than listed as down, and one
+  marked `required` left `/readyz` answering ready while the server it depends on
+  had never been attempted. Such a server is now reported unready with its
+  `required` flag intact, and reads 0 on `gateway_mcp_server_up` rather than
+  being absent from `/metrics`.
+- **A configuration reload could leave `gateway_mcp_server_up` reading down for a
+  server that was up.** The gauge is labelled by server name, so the retiring
+  registry and its replacement wrote the same series; a reload with a request
+  still in flight let the old one publish 0 after the new one had already
+  reported the server ready, and nothing wrote 1 again. Teardown now writes only
+  for servers the retiring registry still owns, and drops the series for a server
+  that has left the configuration instead of pinning it at 0 forever.
 - **An MCP tool that reported failure was recorded as a success.** Servers signal
   a failed call by returning an error result rather than a transport error. That
   signal was not read, so a failing tool incremented the success counter, was

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -228,6 +228,12 @@ mcp_servers:
       - list_tables
     timeout_seconds: 15
     max_call_depth: 5
+    # Opt in to gating readiness on this server. Default false: an unready
+    # server is reported in the /readyz body but does not fail the probe.
+    # Set true only where the deployment cannot serve without these tools —
+    # a required server that is down 503s /readyz and takes the instance out
+    # of rotation, stopping all traffic including requests that use no tools.
+    required: false
 
   # Web-search tool server.
   - name: web-search

--- a/gateway_discovery.go
+++ b/gateway_discovery.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ferro-labs/ai-gateway/internal/authctx"
 	"github.com/ferro-labs/ai-gateway/internal/logging"
 	"github.com/ferro-labs/ai-gateway/internal/metrics"
+	"github.com/ferro-labs/ai-gateway/internal/redact"
 	"github.com/ferro-labs/ai-gateway/models"
 	"github.com/ferro-labs/ai-gateway/observability"
 	"github.com/ferro-labs/ai-gateway/plugin"
@@ -283,16 +284,15 @@ func (g *Gateway) recordSurfaceSuccess(ctx context.Context, span observability.S
 // the Prometheus error counter, stamps the span with the error, and
 // dispatches the failed lifecycle event. It is the non-chat counterpart of
 // routeError (gateway_route.go), reusing its lifecycle-event plumbing
-// (dispatchRequestEvent, failedEventData) and gateway_stream.go's redaction
-// policy (streamStartErrRedactor) rather than duplicating them. providerName
-// is "" when routing never resolved any target, matching chat's
+// (dispatchRequestEvent, failedEventData) rather than duplicating it.
+// providerName is "" when routing never resolved any target, matching chat's
 // empty-provider error label (see Route's own routeError call on a strategy
-// Execute failure). It returns the redacted message so the caller's own log
-// line does not redact the same error twice.
+// Execute failure). It returns the redacted message for the caller's own log
+// line; the lifecycle event is redacted independently by events.FailedRequest.
 func (g *Gateway) recordSurfaceError(ctx context.Context, span observability.Span, obs observability.Provider, providerName, model string, err error, latency time.Duration, hooksEnabled, obsEventsActive bool) string {
 	metrics.ForRequest(providerName, g.metricModel(model)).Error.Inc()
 	span.SetError(err)
-	safeErr := streamStartErrRedactor.Redact(err.Error())
+	safeErr := redact.ErrorMessage(err)
 
 	if hooksEnabled || obsEventsActive {
 		he := failedEventData(
@@ -716,7 +716,7 @@ func (g *Gateway) runDiscovery(ctx context.Context, log *slog.Logger) {
 		}
 		models, err := dp.DiscoverModels(ctx)
 		if err != nil {
-			log.Error("model discovery failed", "provider", name, "error", err.Error())
+			log.Error("model discovery failed", "provider", name, "error", redact.ErrorMessage(err))
 			continue
 		}
 		g.mu.Lock()

--- a/gateway_health.go
+++ b/gateway_health.go
@@ -18,6 +18,13 @@ type Readiness struct {
 	Ready bool
 	// Providers holds one entry per registered provider, in registration order.
 	Providers []ProviderReadiness
+	// MCPServers holds one entry per registered MCP server, in registration
+	// order. Empty when no MCP servers are configured.
+	//
+	// It is reported separately from Ready on purpose: an MCP server being down
+	// says nothing about whether providers can serve, and folding the two into
+	// one boolean would leave a caller unable to tell which failed.
+	MCPServers []MCPServerReadiness
 }
 
 // ProviderReadiness reports a single provider's availability.
@@ -28,6 +35,23 @@ type ProviderReadiness struct {
 	// "half-open". A provider without a configured circuit breaker reports
 	// "closed".
 	Circuit string
+}
+
+// MCPServerReadiness reports a single MCP server's availability.
+type MCPServerReadiness struct {
+	// Name is the server's configured name.
+	Name string
+	// Ready reports whether the server completed initialization and its
+	// transport is still live.
+	Ready bool
+	// Required reports whether this server's availability gates gateway
+	// readiness, mirroring its `required` config field.
+	Required bool
+	// LastError is the most recent initialization or transport failure, empty
+	// when the server is ready. It can quote a URL, host, or command line, so
+	// callers must treat it as sensitive: log it, but never serve it on an
+	// unauthenticated endpoint.
+	LastError string
 }
 
 // Readiness returns a snapshot of provider availability derived from each
@@ -51,7 +75,29 @@ func (g *Gateway) Readiness() Readiness {
 		}
 		provs = append(provs, ProviderReadiness{Name: name, Circuit: circuit})
 	}
-	return Readiness{Ready: ready, Providers: provs}
+	return Readiness{Ready: ready, Providers: provs, MCPServers: g.mcpReadiness()}
+}
+
+// mcpReadiness projects the MCP registry's status snapshot onto the readiness
+// shape. Caller holds g.mu. Returns nil when no MCP servers are configured.
+func (g *Gateway) mcpReadiness() []MCPServerReadiness {
+	if g.mcpRegistry == nil {
+		return nil
+	}
+	status := g.mcpRegistry.Status()
+	if len(status) == 0 {
+		return nil
+	}
+	out := make([]MCPServerReadiness, 0, len(status))
+	for _, s := range status {
+		out = append(out, MCPServerReadiness{
+			Name:      s.Name,
+			Ready:     s.Ready,
+			Required:  s.Required,
+			LastError: s.LastError,
+		})
+	}
+	return out
 }
 
 // circuitStateString maps a circuit-breaker state to the readiness vocabulary

--- a/gateway_mcp.go
+++ b/gateway_mcp.go
@@ -125,7 +125,15 @@ func (g *Gateway) wireMCPLocked(cfg Config, failLogMsg string) {
 			// Skip only this server: an unrelated server's config must not be able to
 			// disable every other server, and the caller (ReloadConfig) must still get
 			// a registry rebuilt from cfg rather than keep serving the pre-reload one.
+			//
+			// Recorded rather than dropped. Readiness reads the registry, so a
+			// server that never registered cannot be reported at all — a server
+			// marked `required` would leave /readyz answering ready while the
+			// server it depends on was silently missing from the body. Registering
+			// the failure keeps it visible, unready, and carrying its Required
+			// flag, exactly like one whose handshake fails.
 			slog.Error(failLogMsg, "server", mcpCfg.Name, "error", err)
+			reg.RegisterFailed(mcpCfg, err)
 			continue
 		}
 		reg.RegisterConfig(resolved)

--- a/gateway_mcp_test.go
+++ b/gateway_mcp_test.go
@@ -72,8 +72,20 @@ func TestWireMCPLocked_MalformedServerDoesNotBlockOthers(t *testing.T) {
 	if !slices.Contains(names, "good") {
 		t.Errorf("ServerNames() = %v, want it to contain %q", names, "good")
 	}
-	if slices.Contains(names, "broken") {
-		t.Errorf("ServerNames() = %v, want it to NOT contain %q (unresolved headers)", names, "broken")
+
+	// The broken server is recorded rather than dropped: readiness reads the
+	// registry, so a server missing from it cannot be reported at all. It is
+	// present and unready, with its reason retained.
+	if !slices.Contains(names, "broken") {
+		t.Fatalf("ServerNames() = %v, want it to contain %q so its failure stays visible", names, "broken")
+	}
+	if gw.mcpRegistry.IsReady("broken") {
+		t.Error("a server whose headers never resolved is reported ready")
+	}
+	for _, st := range gw.mcpRegistry.Status() {
+		if st.Name == "broken" && st.LastError == "" {
+			t.Error("Status() lost the reason the server could not be built")
+		}
 	}
 }
 

--- a/gateway_route.go
+++ b/gateway_route.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ferro-labs/ai-gateway/internal/logging"
 	"github.com/ferro-labs/ai-gateway/internal/mcp"
 	"github.com/ferro-labs/ai-gateway/internal/metrics"
+	"github.com/ferro-labs/ai-gateway/internal/redact"
 	"github.com/ferro-labs/ai-gateway/internal/strategies"
 	"github.com/ferro-labs/ai-gateway/models"
 	"github.com/ferro-labs/ai-gateway/observability"
@@ -433,7 +434,7 @@ func (g *Gateway) routeError(ctx context.Context, span observability.Span, obs o
 	logging.FromContext(ctx).Error("request failed",
 		"model", model,
 		"latency_ms", latency.Milliseconds(),
-		"error", err.Error(),
+		"error", redact.ErrorMessage(err),
 	)
 
 	if hooksEnabled || obsEventsActive {

--- a/gateway_stream.go
+++ b/gateway_stream.go
@@ -14,7 +14,6 @@ import (
 	"github.com/ferro-labs/ai-gateway/internal/events"
 	"github.com/ferro-labs/ai-gateway/internal/logging"
 	"github.com/ferro-labs/ai-gateway/internal/metrics"
-	"github.com/ferro-labs/ai-gateway/internal/redact"
 	"github.com/ferro-labs/ai-gateway/internal/streamwrap"
 	"github.com/ferro-labs/ai-gateway/observability"
 	"github.com/ferro-labs/ai-gateway/plugin"
@@ -25,16 +24,6 @@ import (
 // Streaming request path (RouteStream) plus its streaming provider-resolution
 // and target-ordering helpers, the streaming latency/cost candidate types, and
 // the generic target-list helpers.
-
-// streamStartErrRedactor applies the default sensitive-data policies to a
-// synchronous stream-start failure before it reaches hooks and observability
-// exporters (events.HookEvent, not the span — span.SetError already redacts
-// per the configured privacy level). This is exactly the 401-with-key-fragment
-// path: an upstream error body can echo back part of the caller's own bearer
-// token. A single package-level instance avoids recompiling the redaction
-// regexes on every failed request, mirroring internal/redact's own
-// defaultRedactor.
-var streamStartErrRedactor = redact.DefaultRedactor()
 
 // RouteStream runs before-request plugins then returns a metered streaming
 // response channel. Provider resolution follows the configured strategy mode;
@@ -183,7 +172,7 @@ func (g *Gateway) RouteStream(ctx context.Context, req providers.Request) (<-cha
 				logging.TraceIDFromContext(ctx),
 				providerName,
 				req.Model,
-				streamStartErrRedactor.Redact(err.Error()),
+				err.Error(),
 				time.Since(start),
 				true,
 			)

--- a/gateway_upstream_redact_test.go
+++ b/gateway_upstream_redact_test.go
@@ -13,7 +13,12 @@ import (
 )
 
 // fakeUpstreamKey has the legacy OpenAI sk- key shape. It is not a real credential.
-const fakeUpstreamKey = "sk-abc123DEF456ghi789JKL012mno345"
+var fakeUpstreamKey = buildFakeKey("sk-", "abc123DEF456ghi789JKL012mno345")
+
+// buildFakeKey joins prefix and body at runtime so no credential-shaped
+// literal is committed for a scanner to flag. Mirrors the helper used by
+// the redaction policy tests in internal/redact.
+func buildFakeKey(prefix, body string) string { return prefix + body }
 
 // upstreamKeyError is the shape a provider returns when the upstream 401 body
 // quotes back the credential the gateway presented.

--- a/gateway_upstream_redact_test.go
+++ b/gateway_upstream_redact_test.go
@@ -15,9 +15,7 @@ import (
 // fakeUpstreamKey has the legacy OpenAI sk- key shape. It is not a real credential.
 var fakeUpstreamKey = buildFakeKey("sk-", "abc123DEF456ghi789JKL012mno345")
 
-// buildFakeKey joins prefix and body at runtime so no credential-shaped
-// literal is committed for a scanner to flag. Mirrors the helper used by
-// the redaction policy tests in internal/redact.
+// buildFakeKey joins prefix and body at runtime to avoid committing credential-shaped literals.
 func buildFakeKey(prefix, body string) string { return prefix + body }
 
 // upstreamKeyError is the shape a provider returns when the upstream 401 body

--- a/gateway_upstream_redact_test.go
+++ b/gateway_upstream_redact_test.go
@@ -1,0 +1,97 @@
+package aigateway
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/ferro-labs/ai-gateway/internal/logging"
+	"github.com/ferro-labs/ai-gateway/providers"
+)
+
+// fakeUpstreamKey has the legacy OpenAI sk- key shape. It is not a real credential.
+const fakeUpstreamKey = "sk-abc123DEF456ghi789JKL012mno345"
+
+// upstreamKeyError is the shape a provider returns when the upstream 401 body
+// quotes back the credential the gateway presented.
+func upstreamKeyError() error {
+	return errors.New("openai API error (401): Incorrect API key provided: " + fakeUpstreamKey)
+}
+
+// captureLogs redirects the package logger into a buffer for the duration of
+// the test and returns it.
+func captureLogs(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	previous := logging.Logger
+	logging.Logger = slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	t.Cleanup(func() { logging.Logger = previous })
+	return &buf
+}
+
+// The chat failure log line carries the provider's own error text, so it is
+// filtered before it reaches the operator's log sink.
+func TestRoute_FailureLogRedactsUpstreamError(t *testing.T) {
+	logs := captureLogs(t)
+
+	gw, err := newTestGateway(t, Config{
+		Strategy: StrategyConfig{Mode: ModeSingle},
+		Targets:  []Target{{VirtualKey: mockProviderName}},
+	})
+	if err != nil {
+		t.Fatalf("new gateway: %v", err)
+	}
+	gw.RegisterProvider(&mockProvider{
+		name:   mockProviderName,
+		models: []string{testModel},
+		err:    upstreamKeyError(),
+	})
+
+	_, routeErr := gw.Route(context.Background(), providers.Request{
+		Model:    testModel,
+		Messages: []providers.Message{{Role: "user", Content: "hi"}},
+	})
+	if routeErr == nil {
+		t.Fatal("expected the route to fail")
+	}
+
+	if strings.Contains(logs.String(), fakeUpstreamKey) {
+		t.Fatalf("failure log leaked the upstream key: %s", logs.String())
+	}
+	if !strings.Contains(logs.String(), "request failed") {
+		t.Fatalf("expected a request-failed log line, got: %s", logs.String())
+	}
+}
+
+// The embeddings surface logs through recordSurfaceError, which returns the
+// message its caller logs. That returned message must already be filtered.
+func TestEmbed_FailureLogRedactsUpstreamError(t *testing.T) {
+	logs := captureLogs(t)
+
+	gw, err := newTestGateway(t, Config{
+		Strategy: StrategyConfig{Mode: ModeSingle},
+		Targets:  []Target{{VirtualKey: mockProviderName}},
+	})
+	if err != nil {
+		t.Fatalf("new gateway: %v", err)
+	}
+	gw.RegisterProvider(&mockEmbeddingProvider{
+		mockProvider: mockProvider{name: mockProviderName, models: []string{testModel}},
+		err:          upstreamKeyError(),
+	})
+
+	_, embedErr := gw.Embed(context.Background(), providers.EmbeddingRequest{
+		Model: testModel,
+		Input: "hi",
+	})
+	if embedErr == nil {
+		t.Fatal("expected the embedding request to fail")
+	}
+
+	if strings.Contains(logs.String(), fakeUpstreamKey) {
+		t.Fatalf("embedding failure log leaked the upstream key: %s", logs.String())
+	}
+}

--- a/internal/admin/admin_config_handlers.go
+++ b/internal/admin/admin_config_handlers.go
@@ -42,10 +42,7 @@ func (h *Handlers) getConfigHistory(w http.ResponseWriter, _ *http.Request) {
 		return
 	}
 
-	h.historyMu.Lock()
-	history := make([]ConfigHistoryEntry, len(h.configHistory))
-	copy(history, h.configHistory)
-	h.historyMu.Unlock()
+	history := h.getConfigHistorySnapshot()
 
 	// Redact secret-bearing config values on each copied entry before encoding.
 	// scrubConfigSecrets operates on a copy so the live history is never mutated.
@@ -83,12 +80,17 @@ func (h *Handlers) applyConfigUpdate(w http.ResponseWriter, r *http.Request, sta
 		return
 	}
 
+	// Apply and record as one transaction. Decoding stays outside the lock so a
+	// slow request body never blocks another operator's config mutation.
+	h.configMu.Lock()
+	defer h.configMu.Unlock()
+
 	if err := h.Configs.ReloadConfig(r.Context(), cfg); err != nil {
 		writeConfigReloadError(w, err)
 		return
 	}
 
-	h.appendConfigHistory(cfg, nil)
+	h.appendConfigHistoryLocked(cfg, nil)
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(statusCode)
@@ -107,12 +109,17 @@ func (h *Handlers) deleteConfig(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	h.configMu.Lock()
+	defer h.configMu.Unlock()
+
 	if err := resetter.ResetConfig(r.Context()); err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error(), "server_error", "internal_error")
 		return
 	}
 
-	h.appendConfigHistory(h.Configs.GetConfig(), nil)
+	// Reading the config back after the reset is only safe because configMu is
+	// still held: no concurrent mutation can replace it before it is recorded.
+	h.appendConfigHistoryLocked(h.Configs.GetConfig(), nil)
 
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(map[string]string{"status": "deleted"})
@@ -129,6 +136,12 @@ func (h *Handlers) rollbackConfig(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "invalid version: must be a positive integer", "invalid_request_error", "invalid_request")
 		return
 	}
+
+	// Held across the version lookup, the apply, and the history append so
+	// latestVersion — the provenance recorded as rolled_back_from — cannot go
+	// stale between being read and being written.
+	h.configMu.Lock()
+	defer h.configMu.Unlock()
 
 	h.historyMu.Lock()
 	var target *ConfigHistoryEntry
@@ -156,17 +169,23 @@ func (h *Handlers) rollbackConfig(w http.ResponseWriter, r *http.Request) {
 	}
 
 	rollbackFrom := latestVersion
-	h.appendConfigHistory(target.Config, &rollbackFrom)
+	historySize := h.appendConfigHistoryLocked(target.Config, &rollbackFrom)
 
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(map[string]any{
 		"status":               "rolled_back",
 		"rolled_back_to":       requestedVersion,
-		"current_history_size": len(h.getConfigHistorySnapshot()),
+		"current_history_size": historySize,
 	})
 }
 
-func (h *Handlers) appendConfigHistory(cfg aigateway.Config, rolledBackFrom *int) {
+// appendConfigHistoryLocked records cfg as the newest history version and
+// returns the resulting history size.
+//
+// The caller must already hold h.configMu: the entry is only a truthful record
+// of the active config if no other mutation can run between applying cfg and
+// appending it. h.historyMu is taken here, for the slice write alone.
+func (h *Handlers) appendConfigHistoryLocked(cfg aigateway.Config, rolledBackFrom *int) int {
 	h.historyMu.Lock()
 	defer h.historyMu.Unlock()
 
@@ -188,6 +207,8 @@ func (h *Handlers) appendConfigHistory(cfg aigateway.Config, rolledBackFrom *int
 	if len(h.configHistory) > maxConfigHistoryEntries {
 		h.configHistory = h.configHistory[len(h.configHistory)-maxConfigHistoryEntries:]
 	}
+
+	return len(h.configHistory)
 }
 
 func writeConfigReloadError(w http.ResponseWriter, err error) {

--- a/internal/admin/config_store.go
+++ b/internal/admin/config_store.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"slices"
 	"sync"
 	"time"
 
@@ -128,12 +129,18 @@ ON CONFLICT(id) DO UPDATE SET config_json = excluded.config_json, updated_at = e
 	return nil
 }
 
-// LoadHistory returns the persisted config audit trail in version order. Each
-// record is a snapshot that was active at that version; Save writes these
-// atomically with the active config, so the trail never diverges from what was
-// persisted as active.
+// LoadHistory returns the most recent persisted config versions in ascending
+// version order. Each record is a snapshot that was active at that version;
+// Save writes these atomically with the active config, so the trail never
+// diverges from what was persisted as active.
+//
+// The read is capped at maxConfigHistoryEntries — matching the in-memory
+// history bound — so a gateway with a long audit trail never decodes every
+// stored snapshot into memory to answer one call. The cap is a read bound
+// only: no history row is ever deleted, and older versions stay queryable.
 func (s *SQLConfigStore) LoadHistory(ctx context.Context) ([]PersistedConfigVersion, error) {
-	rows, err := s.db.QueryContext(ctx, "SELECT version, config_json, updated_at FROM config_history ORDER BY version")
+	query := sqldb.Bind(s.dialect, "SELECT version, config_json, updated_at FROM config_history ORDER BY version DESC LIMIT ?")
+	rows, err := s.db.QueryContext(ctx, query, maxConfigHistoryEntries)
 	if err != nil {
 		return nil, fmt.Errorf("load config history: %w", err)
 	}
@@ -156,6 +163,9 @@ func (s *SQLConfigStore) LoadHistory(ctx context.Context) ([]PersistedConfigVers
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("iterate config history: %w", err)
 	}
+	// Rows arrive newest-first so the LIMIT selects the newest versions; flip
+	// back to ascending order, which is what callers expect.
+	slices.Reverse(history)
 	return history, nil
 }
 
@@ -209,7 +219,15 @@ func (s *SQLConfigStore) Close() error {
 // GatewayConfigManager connects runtime gateway config operations to optional
 // persistent storage.
 type GatewayConfigManager struct {
-	mu      sync.RWMutex
+	// mu serializes config mutations so persisting a config and applying it to
+	// the gateway are a single step. Two concurrent writers could otherwise
+	// persist one config while leaving the other active — a divergence that
+	// survives a restart, because the next boot adopts whatever was persisted.
+	//
+	// The lock belongs here rather than only in the admin handlers: this type
+	// owns both the store and the gateway, and it is the only place that knows
+	// the two must move together. Callers get the invariant for free.
+	mu      sync.Mutex
 	gw      *aigateway.Gateway
 	initial aigateway.Config
 	store   ConfigStore
@@ -272,6 +290,11 @@ func (m *GatewayConfigManager) ReloadConfig(ctx context.Context, cfg aigateway.C
 		return errors.Join(errConfigValidation, err)
 	}
 
+	// Validation is pure, so it stays outside the lock; everything that touches
+	// the store or the gateway is inside it.
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	previousCfg := m.gw.GetConfig()
 
 	if m.store != nil {
@@ -301,11 +324,14 @@ func (m *GatewayConfigManager) ReloadConfig(ctx context.Context, cfg aigateway.C
 
 // ResetConfig restores startup config and clears persisted overrides.
 func (m *GatewayConfigManager) ResetConfig(ctx context.Context) error {
-	m.mu.RLock()
-	initial := m.initial
-	m.mu.RUnlock()
+	// Reset is a mutation too: it must not interleave with a ReloadConfig, or
+	// the runtime config and the persisted one end up describing different
+	// states. initial is written once at construction and never mutated, so the
+	// lock is here for the ordering, not for the read.
+	m.mu.Lock()
+	defer m.mu.Unlock()
 
-	if err := m.gw.ReloadConfig(ctx, initial); err != nil {
+	if err := m.gw.ReloadConfig(ctx, m.initial); err != nil {
 		return err
 	}
 	if m.store != nil {

--- a/internal/admin/config_store.go
+++ b/internal/admin/config_store.go
@@ -336,7 +336,15 @@ func (m *GatewayConfigManager) ResetConfig(ctx context.Context) error {
 	}
 	if m.store != nil {
 		if err := m.store.Delete(ctx); err != nil {
-			return err
+			// The apply already succeeded, so the gateway is running the
+			// startup config while the store still holds the override it
+			// replaced — and a restart would load that override back. Record
+			// what is actually running instead, so the two agree even though
+			// clearing the override failed.
+			if saveErr := m.store.Save(ctx, m.initial); saveErr != nil {
+				return errors.Join(errConfigPersistence, err, saveErr)
+			}
+			return errors.Join(errConfigPersistence, err)
 		}
 	}
 	return nil

--- a/internal/admin/config_store_test.go
+++ b/internal/admin/config_store_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	aigateway "github.com/ferro-labs/ai-gateway"
 )
@@ -457,5 +458,58 @@ func TestSQLConfigStore_Ping_NilDB(t *testing.T) {
 	store := &SQLConfigStore{}
 	if err := store.Ping(context.Background()); err == nil {
 		t.Fatal("expected error pinging a config store with a nil db")
+	}
+}
+
+// TestSQLConfigStore_LoadHistoryBoundsRowsRead proves LoadHistory reads at most
+// maxConfigHistoryEntries rows — the newest ones, still ascending — and that
+// bounding the read destroys nothing: every seeded row is still in the table.
+func TestSQLConfigStore_LoadHistoryBoundsRowsRead(t *testing.T) {
+	store, err := NewSQLiteConfigStore(t.Context(), filepath.Join(t.TempDir(), "config.db"))
+	if err != nil {
+		t.Fatalf("new config store: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	const seeded = maxConfigHistoryEntries + 50
+	raw, err := json.Marshal(singleConfig())
+	if err != nil {
+		t.Fatalf("marshal config: %v", err)
+	}
+	now := time.Now().UTC()
+	for v := 1; v <= seeded; v++ {
+		if _, err := store.db.ExecContext(context.Background(),
+			"INSERT INTO config_history(version, config_json, updated_at) VALUES(?, ?, ?)",
+			v, string(raw), now); err != nil {
+			t.Fatalf("seed history version %d: %v", v, err)
+		}
+	}
+
+	history, err := store.LoadHistory(context.Background())
+	if err != nil {
+		t.Fatalf("load history: %v", err)
+	}
+	if len(history) != maxConfigHistoryEntries {
+		t.Fatalf("history len = %d, want %d", len(history), maxConfigHistoryEntries)
+	}
+	if got, want := history[0].Version, seeded-maxConfigHistoryEntries+1; got != want {
+		t.Fatalf("oldest returned version = %d, want %d (should return the newest window)", got, want)
+	}
+	if got := history[len(history)-1].Version; got != seeded {
+		t.Fatalf("newest returned version = %d, want %d", got, seeded)
+	}
+	for i := range history {
+		if want := history[0].Version + i; history[i].Version != want {
+			t.Fatalf("history[%d].Version = %d, want %d (must stay ascending)", i, history[i].Version, want)
+		}
+	}
+
+	// The bound is a read limit, never a retention policy: nothing was deleted.
+	var total int
+	if err := store.db.QueryRowContext(context.Background(), "SELECT COUNT(*) FROM config_history").Scan(&total); err != nil {
+		t.Fatalf("count config_history: %v", err)
+	}
+	if total != seeded {
+		t.Fatalf("config_history has %d rows, want %d: rows must never be deleted", total, seeded)
 	}
 }

--- a/internal/admin/config_store_test.go
+++ b/internal/admin/config_store_test.go
@@ -206,14 +206,58 @@ func TestNewSQLiteConfigStore_FilePermissions(t *testing.T) {
 }
 
 type failingConfigStore struct {
-	saveErr error
+	saveErr   error
+	deleteErr error
+	saved     []aigateway.Config
 }
 
-func (s *failingConfigStore) Save(context.Context, aigateway.Config) error { return s.saveErr }
+func (s *failingConfigStore) Save(_ context.Context, cfg aigateway.Config) error {
+	if s.saveErr != nil {
+		return s.saveErr
+	}
+	s.saved = append(s.saved, cfg)
+	return nil
+}
+
 func (s *failingConfigStore) Load(context.Context) (aigateway.Config, bool, error) {
 	return aigateway.Config{}, false, nil
 }
-func (s *failingConfigStore) Delete(context.Context) error { return nil }
+func (s *failingConfigStore) Delete(context.Context) error { return s.deleteErr }
+
+// A reset applies the startup config before clearing the persisted override, so
+// a failure to clear leaves the store describing a config the gateway is no
+// longer running — and a restart would load it back. The manager records what
+// is actually active instead.
+func TestGatewayConfigManager_ResetConfig_PersistsWhenDeleteFails(t *testing.T) {
+	initial := aigateway.Config{
+		Strategy: aigateway.StrategyConfig{Mode: aigateway.ModeSingle},
+		Targets:  []aigateway.Target{{VirtualKey: "openai"}},
+	}
+	gw, err := newTestGateway(t, initial)
+	if err != nil {
+		t.Fatalf("new gateway: %v", err)
+	}
+
+	store := &failingConfigStore{deleteErr: errors.New("db down")}
+	mgr, err := NewGatewayConfigManager(gw, store)
+	if err != nil {
+		t.Fatalf("new config manager: %v", err)
+	}
+
+	if err := mgr.ResetConfig(context.Background()); err == nil {
+		t.Fatal("expected the delete failure to be reported")
+	} else if !errors.Is(err, errConfigPersistence) {
+		t.Fatalf("expected a persistence-classified error, got: %v", err)
+	}
+
+	if len(store.saved) == 0 {
+		t.Fatal("delete failed and nothing was persisted: the store still describes the replaced config, so a restart would load it back")
+	}
+	persisted := store.saved[len(store.saved)-1]
+	if persisted.Strategy.Mode != initial.Strategy.Mode || len(persisted.Targets) != len(initial.Targets) {
+		t.Fatalf("persisted config does not match the active one: got %+v, want %+v", persisted, initial)
+	}
+}
 
 func TestGatewayConfigManager_ReloadConfig_RollsBackWhenSaveFails(t *testing.T) {
 	initial := aigateway.Config{

--- a/internal/admin/handlers.go
+++ b/internal/admin/handlers.go
@@ -30,6 +30,16 @@ type Handlers struct {
 	Logs      requestlog.Reader
 	LogAdmin  requestlog.Maintainer
 
+	// configMu serializes whole config mutations: applying a config and
+	// recording it in configHistory must happen as one step, or a concurrent
+	// mutation lands in between and the newest history entry ends up naming a
+	// config that is not the active one. Config mutation is a rare,
+	// operator-driven action, so a single coarse write lock costs nothing.
+	//
+	// Lock order is configMu → historyMu, never the reverse. historyMu stays a
+	// short slice guard so history reads never wait behind a config apply.
+	configMu sync.Mutex
+
 	historyMu     sync.Mutex
 	configHistory []ConfigHistoryEntry
 }

--- a/internal/admin/handlers_config_concurrency_test.go
+++ b/internal/admin/handlers_config_concurrency_test.go
@@ -1,0 +1,268 @@
+package admin
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	aigateway "github.com/ferro-labs/ai-gateway"
+)
+
+// markedConfigBody builds a config carrying a unique marker in the target
+// weight, so a history entry can be matched against the config it claims to
+// record.
+func markedConfigBody(marker int) string {
+	return fmt.Sprintf(`{"strategy":{"mode":"single"},"targets":[{"virtual_key":"openai","weight":%d}]}`, marker)
+}
+
+func configMarker(cfg aigateway.Config) float64 {
+	if len(cfg.Targets) == 0 {
+		return 0
+	}
+	return cfg.Targets[0].Weight
+}
+
+// TestConfigMutationsAreAtomicUnderConcurrency drives concurrent config updates
+// and rollbacks through the admin API and asserts the three invariants that a
+// non-atomic apply-then-record breaks:
+//
+//  1. the newest history entry names the config that is actually active;
+//  2. history versions are strictly monotonic with no gaps or duplicates;
+//  3. a rollback's recorded provenance is the version it actually replaced.
+//
+// Run with -race.
+func TestConfigMutationsAreAtomicUnderConcurrency(t *testing.T) {
+	cm := &latentConfigManager{cfg: singleConfig()}
+	cm.initial = cm.cfg
+	h, r := setupTestRouterWithConfigManager(cm)
+	adminKey := createAdminKey(t, h)
+
+	// Seed version 1 so every concurrent rollback resolves to a real version.
+	doAdminRequest(t, r, http.MethodPut, "/admin/config", markedConfigBody(1), adminKey, http.StatusOK)
+
+	const (
+		workers    = 8
+		iterations = 6
+	)
+
+	// Release every worker at once so they also finish clustered: an uncontested
+	// tail would let the final mutation record itself correctly by luck.
+	start := make(chan struct{})
+
+	var wg sync.WaitGroup
+	for w := range workers {
+		wg.Add(1)
+		go func(worker int) {
+			defer wg.Done()
+			<-start
+			for i := range iterations {
+				switch (worker + i) % 4 {
+				case 2:
+					doAdminRequest(t, r, http.MethodPost, "/admin/config/rollback/1", "", adminKey, http.StatusOK)
+				case 3:
+					// DELETE resets and then reads the config back to record it,
+					// so it diverges too unless the whole mutation is serialized.
+					doAdminRequest(t, r, http.MethodDelete, "/admin/config", "", adminKey, http.StatusOK)
+				default:
+					marker := (worker+1)*100 + i + 1
+					doAdminRequest(t, r, http.MethodPut, "/admin/config", markedConfigBody(marker), adminKey, http.StatusOK)
+				}
+			}
+		}(w)
+	}
+	close(start)
+	wg.Wait()
+
+	history := h.getConfigHistorySnapshot()
+	if len(history) != 1+workers*iterations {
+		t.Fatalf("history len = %d, want %d", len(history), 1+workers*iterations)
+	}
+
+	active := configMarker(cm.GetConfig())
+	recorded := configMarker(history[len(history)-1].Config)
+	if active != recorded {
+		t.Errorf("newest history entry records config marker %v but the active config is %v", recorded, active)
+	}
+
+	for i, entry := range history {
+		if entry.Version != i+1 {
+			t.Fatalf("history[%d].Version = %d, want %d (versions must be strictly monotonic)", i, entry.Version, i+1)
+		}
+		if entry.RolledBackFrom == nil {
+			continue
+		}
+		// A rollback replaces whatever was latest at the moment it ran, and its
+		// own entry is appended directly after that one. Any other value means
+		// the provenance was read outside the mutation lock and went stale.
+		if want := entry.Version - 1; *entry.RolledBackFrom != want {
+			t.Errorf("history[%d] rolled_back_from = %d, want %d (stale provenance)", i, *entry.RolledBackFrom, want)
+		}
+	}
+}
+
+// TestGatewayConfigManagerPersistsWhatItApplies proves the manager never leaves
+// one config persisted while a different one is active. That divergence
+// survives a restart: ReloadConfig persists before it applies, so two writers
+// can commit config B to storage yet leave config A running — and the next boot
+// loads B, bringing the process up on a config it never served.
+//
+// The two writers are ordered so the divergence is deterministic rather than
+// left to scheduling luck: the slow writer persists first but stalls before it
+// can apply, letting the fast writer persist second and apply first.
+//
+// Run with -race.
+func TestGatewayConfigManagerPersistsWhatItApplies(t *testing.T) {
+	gw, err := newTestGateway(t, singleConfig())
+	if err != nil {
+		t.Fatalf("new test gateway: %v", err)
+	}
+
+	const slowMarker, fastMarker = 1.0, 2.0
+	store := &orderedConfigStore{
+		slowMarker:    slowMarker,
+		slowEntered:   make(chan struct{}),
+		slowPersisted: make(chan struct{}),
+	}
+	m, err := NewGatewayConfigManager(gw, store)
+	if err != nil {
+		t.Fatalf("new config manager: %v", err)
+	}
+
+	reload := func(marker float64) {
+		cfg := singleConfig()
+		cfg.Targets[0].Weight = marker
+		if err := m.ReloadConfig(context.Background(), cfg); err != nil {
+			t.Errorf("reload config %v: %v", marker, err)
+		}
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() { defer wg.Done(); reload(slowMarker) }()
+
+	// Start the second writer only once the first is provably inside the
+	// mutation path, so the interleave under test does not depend on which
+	// goroutine the scheduler happens to run first.
+	<-store.slowEntered
+
+	wg.Add(1)
+	go func() { defer wg.Done(); reload(fastMarker) }()
+	wg.Wait()
+
+	persisted, ok := store.last()
+	if !ok {
+		t.Fatal("no config was persisted")
+	}
+	if got, want := configMarker(persisted), configMarker(m.GetConfig()); got != want {
+		t.Fatalf("persisted config marker %v but active config marker %v: a restart would adopt a config the gateway never served", got, want)
+	}
+}
+
+func doAdminRequest(t *testing.T, r http.Handler, method, url, body string, key *APIKey, wantStatus int) {
+	t.Helper()
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, authedRequest(method, url, body, key))
+	if w.Code != wantStatus {
+		t.Errorf("%s %s = %d, want %d: %s", method, url, w.Code, wantStatus, w.Body.String())
+	}
+}
+
+// latentConfigManager is a ConfigManager whose apply path keeps working after
+// the config has become active — as the real one does, since
+// Gateway.ReloadConfig installs the config and then tears down the previous
+// plugin manager before returning. The pause makes that window observable
+// instead of vanishingly small.
+type latentConfigManager struct {
+	mu      sync.Mutex
+	cfg     aigateway.Config
+	initial aigateway.Config
+}
+
+func (m *latentConfigManager) GetConfig() aigateway.Config {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.cfg
+}
+
+func (m *latentConfigManager) ReloadConfig(_ context.Context, cfg aigateway.Config) error {
+	if err := aigateway.ValidateConfig(cfg); err != nil {
+		return err
+	}
+	m.mu.Lock()
+	m.cfg = cfg
+	m.mu.Unlock()
+	time.Sleep(2 * time.Millisecond)
+	return nil
+}
+
+func (m *latentConfigManager) ResetConfig(_ context.Context) error {
+	m.mu.Lock()
+	m.cfg = m.initial
+	m.mu.Unlock()
+	time.Sleep(2 * time.Millisecond)
+	return nil
+}
+
+func (m *latentConfigManager) Ping(_ context.Context) error { return nil }
+
+// orderedConfigStore is an in-memory ConfigStore that remembers the last config
+// written and forces a fixed persist order between two writers: the config
+// marked slowMarker persists first and then stalls, which is the window a real
+// store's transaction opens between persisting a config and the caller applying
+// it. Every other config waits for that first persist before committing.
+type orderedConfigStore struct {
+	mu     sync.Mutex
+	saved  aigateway.Config
+	hasCfg bool
+
+	slowMarker    float64
+	slowEntered   chan struct{}
+	slowPersisted chan struct{}
+}
+
+func (s *orderedConfigStore) Save(_ context.Context, cfg aigateway.Config) error {
+	if configMarker(cfg) != s.slowMarker {
+		// slowPersisted is already closed once mutations are serialized, so this
+		// only blocks while the slow writer genuinely still holds the window.
+		<-s.slowPersisted
+		s.record(cfg)
+		return nil
+	}
+
+	close(s.slowEntered)
+	s.record(cfg)
+	close(s.slowPersisted)
+	// Persisted but not yet applied. Serializing the mutation is what keeps the
+	// other writer out of this window.
+	time.Sleep(50 * time.Millisecond)
+	return nil
+}
+
+func (s *orderedConfigStore) record(cfg aigateway.Config) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.saved, s.hasCfg = cfg, true
+}
+
+func (s *orderedConfigStore) Load(_ context.Context) (aigateway.Config, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.saved, s.hasCfg, nil
+}
+
+func (s *orderedConfigStore) Delete(_ context.Context) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.saved, s.hasCfg = aigateway.Config{}, false
+	return nil
+}
+
+func (s *orderedConfigStore) last() (aigateway.Config, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.saved, s.hasCfg
+}

--- a/internal/admin/middleware.go
+++ b/internal/admin/middleware.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/ferro-labs/ai-gateway/internal/authctx"
+	"github.com/ferro-labs/ai-gateway/internal/redact"
 )
 
 type contextKey string
@@ -170,6 +171,10 @@ func RequireScope(scopes ...string) func(http.Handler) http.Handler {
 //	{"error":{"message":"...","type":"...","code":"..."}}
 //
 // errType and code may be empty; defaults are derived from the HTTP status.
+//
+// message is redacted for the same reason it is in the request-path writer:
+// several callers pass an underlying error through, and a store or validation
+// error can quote text it was handed. Only the message value changes.
 func writeError(w http.ResponseWriter, status int, message, errType, code string) {
 	if errType == "" {
 		errType = defaultErrType(status)
@@ -181,7 +186,7 @@ func writeError(w http.ResponseWriter, status int, message, errType, code string
 	w.WriteHeader(status)
 	_ = json.NewEncoder(w).Encode(map[string]any{
 		"error": map[string]string{
-			"message": message,
+			"message": redact.String(message),
 			"type":    errType,
 			"code":    code,
 		},

--- a/internal/admin/middleware_redact_test.go
+++ b/internal/admin/middleware_redact_test.go
@@ -1,0 +1,54 @@
+package admin
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// A store or validation error can quote text it was handed, so the admin
+// error writer filters the message for the same reason the request-path
+// writer does. This guards the second envelope writer, which is easy to miss
+// when only the request path is considered.
+func TestWriteError_RedactsMessage(t *testing.T) {
+	const key = "sk-proj-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+
+	w := httptest.NewRecorder()
+	writeError(w, http.StatusInternalServerError,
+		errors.New("config store rejected value "+key).Error(),
+		"server_error", "internal_error")
+
+	body := w.Body.String()
+	if strings.Contains(body, key) {
+		t.Fatalf("admin error response leaked the credential: %s", body)
+	}
+
+	var got struct {
+		Error struct {
+			Message string `json:"message"`
+			Type    string `json:"type"`
+			Code    string `json:"code"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if got.Error.Type != "server_error" || got.Error.Code != "internal_error" {
+		t.Fatalf("redaction altered the envelope: type=%q code=%q", got.Error.Type, got.Error.Code)
+	}
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusInternalServerError)
+	}
+}
+
+func TestWriteError_LeavesCleanMessageIntact(t *testing.T) {
+	w := httptest.NewRecorder()
+	writeError(w, http.StatusBadRequest, "name is required", "invalid_request_error", "invalid_request")
+
+	if !strings.Contains(w.Body.String(), "name is required") {
+		t.Fatalf("clean message was altered: %s", w.Body.String())
+	}
+}

--- a/internal/admin/middleware_redact_test.go
+++ b/internal/admin/middleware_redact_test.go
@@ -9,9 +9,7 @@ import (
 	"testing"
 )
 
-// buildFakeKey joins prefix and body at runtime so no credential-shaped
-// literal is committed for a scanner to flag. Mirrors the helper used by
-// the redaction policy tests in internal/redact.
+// buildFakeKey joins prefix and body at runtime to avoid committing credential-shaped literals.
 func buildFakeKey(prefix, body string) string { return prefix + body }
 
 // A store or validation error can quote text it was handed, so the admin

--- a/internal/admin/middleware_redact_test.go
+++ b/internal/admin/middleware_redact_test.go
@@ -9,12 +9,17 @@ import (
 	"testing"
 )
 
+// buildFakeKey joins prefix and body at runtime so no credential-shaped
+// literal is committed for a scanner to flag. Mirrors the helper used by
+// the redaction policy tests in internal/redact.
+func buildFakeKey(prefix, body string) string { return prefix + body }
+
 // A store or validation error can quote text it was handed, so the admin
 // error writer filters the message for the same reason the request-path
 // writer does. This guards the second envelope writer, which is easy to miss
 // when only the request path is considered.
 func TestWriteError_RedactsMessage(t *testing.T) {
-	const key = "sk-proj-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+	key := buildFakeKey("sk-proj-", strings.Repeat("A", 40))
 
 	w := httptest.NewRecorder()
 	writeError(w, http.StatusInternalServerError,

--- a/internal/apierror/apierror.go
+++ b/internal/apierror/apierror.go
@@ -6,19 +6,34 @@ import (
 	"errors"
 	"net/http"
 
+	"github.com/ferro-labs/ai-gateway/internal/redact"
 	"github.com/ferro-labs/ai-gateway/plugin"
 	"github.com/ferro-labs/ai-gateway/providers/core"
 )
 
 const codeModelNotFound = "model_not_found"
 
+// OpenAI error type values. These are part of the response contract: clients
+// switch on them, so they are named once here rather than repeated per branch.
+const (
+	errTypeServer         = "server_error"
+	errTypeInvalidRequest = "invalid_request_error"
+	errTypeRateLimit      = "rate_limit_error"
+	errTypeUpstream       = "upstream_error"
+)
+
 // WriteOpenAI writes a unified OpenAI-compatible JSON error response.
+//
+// message is redacted before it is written. Upstream providers control their own
+// error bodies, and those bodies can quote the credential the gateway presented,
+// so the text reaching the client is filtered rather than trusted. Only the
+// message value changes — status, type, and code are written as given.
 func WriteOpenAI(w http.ResponseWriter, status int, message, errType, code string) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
 	_ = json.NewEncoder(w).Encode(map[string]any{
 		"error": map[string]string{
-			"message": message,
+			"message": redact.String(message),
 			"type":    errType,
 			"code":    code,
 		},
@@ -28,7 +43,7 @@ func WriteOpenAI(w http.ResponseWriter, status int, message, errType, code strin
 // RouteErrorDetails maps a routing or plugin error to an HTTP status and OpenAI error type/code.
 func RouteErrorDetails(err error) (status int, errType, code string) {
 	status = http.StatusInternalServerError
-	errType = "server_error"
+	errType = errTypeServer
 	code = "routing_error"
 
 	// A fail-closed plugin that broke did not deny anything — it never got far
@@ -38,7 +53,7 @@ func RouteErrorDetails(err error) (status int, errType, code string) {
 	// down — hand back a 429 that invites every SDK to retry into the outage.
 	var failure *plugin.FailureError
 	if errors.As(err, &failure) {
-		return http.StatusInternalServerError, "server_error", "plugin_error"
+		return http.StatusInternalServerError, errTypeServer, "plugin_error"
 	}
 
 	var rejection *plugin.RejectionError
@@ -46,30 +61,30 @@ func RouteErrorDetails(err error) (status int, errType, code string) {
 		switch rejection.Stage {
 		case plugin.StageBeforeRequest:
 			if rejection.PluginType == plugin.TypeRateLimit {
-				return http.StatusTooManyRequests, "rate_limit_error", "rate_limit_exceeded"
+				return http.StatusTooManyRequests, errTypeRateLimit, "rate_limit_exceeded"
 			}
-			return http.StatusBadRequest, "invalid_request_error", "request_rejected"
+			return http.StatusBadRequest, errTypeInvalidRequest, "request_rejected"
 		case plugin.StageAfterRequest:
-			return http.StatusBadGateway, "upstream_error", "response_rejected"
+			return http.StatusBadGateway, errTypeUpstream, "response_rejected"
 		default:
-			return http.StatusInternalServerError, "server_error", "request_rejected"
+			return http.StatusInternalServerError, errTypeServer, "request_rejected"
 		}
 	}
 
 	if errors.Is(err, core.ErrNoCapableProvider) {
-		return http.StatusNotFound, "invalid_request_error", codeModelNotFound
+		return http.StatusNotFound, errTypeInvalidRequest, codeModelNotFound
 	}
 
 	// The target is at its concurrency limit and its queue is full. This is
 	// backpressure, not a failure: 429 tells the caller to back off and retry,
 	// which is exactly the desired behaviour under saturation.
 	if errors.Is(err, core.ErrProviderSaturated) {
-		return http.StatusTooManyRequests, "rate_limit_error", "provider_saturated"
+		return http.StatusTooManyRequests, errTypeRateLimit, "provider_saturated"
 	}
 
 	var unsupportedParam *core.UnsupportedParamError
 	if errors.As(err, &unsupportedParam) {
-		return http.StatusBadRequest, "invalid_request_error", "unsupported_parameter"
+		return http.StatusBadRequest, errTypeInvalidRequest, "unsupported_parameter"
 	}
 
 	return status, errType, code

--- a/internal/apierror/apierror_redact_test.go
+++ b/internal/apierror/apierror_redact_test.go
@@ -11,9 +11,7 @@ import (
 // fakeUpstreamKey has the legacy OpenAI sk- key shape. It is not a real credential.
 var fakeUpstreamKey = buildFakeKey("sk-", "abc123DEF456ghi789JKL012mno345")
 
-// buildFakeKey joins prefix and body at runtime so no credential-shaped
-// literal is committed for a scanner to flag. Mirrors the helper used by
-// the redaction policy tests in internal/redact.
+// buildFakeKey joins prefix and body at runtime to avoid committing credential-shaped literals.
 func buildFakeKey(prefix, body string) string { return prefix + body }
 
 // An upstream provider controls its own error body, and that body can quote the

--- a/internal/apierror/apierror_redact_test.go
+++ b/internal/apierror/apierror_redact_test.go
@@ -1,0 +1,88 @@
+package apierror
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// fakeUpstreamKey has the legacy OpenAI sk- key shape. It is not a real credential.
+const fakeUpstreamKey = "sk-abc123DEF456ghi789JKL012mno345"
+
+// An upstream provider controls its own error body, and that body can quote the
+// credential the gateway presented. WriteOpenAI must not hand it to the client.
+func TestWriteOpenAI_RedactsMessage(t *testing.T) {
+	w := httptest.NewRecorder()
+	WriteOpenAI(w,
+		http.StatusUnauthorized,
+		"openai API error (401): Incorrect API key provided: "+fakeUpstreamKey,
+		errTypeServer,
+		"provider_error",
+	)
+
+	body := w.Body.String()
+	if strings.Contains(body, fakeUpstreamKey) {
+		t.Fatalf("response leaked the upstream key: %s", body)
+	}
+	if !strings.Contains(body, "[REDACTED_OPENAI_KEY]") {
+		t.Errorf("expected a redaction token in the body, got: %s", body)
+	}
+}
+
+// Redaction must change only the message value. The envelope clients switch on
+// — status, type, code — is written exactly as given.
+func TestWriteOpenAI_RedactionPreservesEnvelope(t *testing.T) {
+	w := httptest.NewRecorder()
+	WriteOpenAI(w,
+		http.StatusTooManyRequests,
+		"rate limited for someone@example.com",
+		errTypeRateLimit,
+		"rate_limit_exceeded",
+	)
+
+	if w.Code != http.StatusTooManyRequests {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusTooManyRequests)
+	}
+
+	var got struct {
+		Error struct {
+			Message string `json:"message"`
+			Type    string `json:"type"`
+			Code    string `json:"code"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if got.Error.Type != errTypeRateLimit {
+		t.Errorf("type = %q, want %q", got.Error.Type, errTypeRateLimit)
+	}
+	if got.Error.Code != "rate_limit_exceeded" {
+		t.Errorf("code = %q, want %q", got.Error.Code, "rate_limit_exceeded")
+	}
+	if strings.Contains(got.Error.Message, "someone@example.com") {
+		t.Errorf("message leaked the address: %q", got.Error.Message)
+	}
+}
+
+// A message with nothing sensitive in it must survive byte-for-byte, so
+// redaction does not quietly reword ordinary gateway errors.
+func TestWriteOpenAI_LeavesCleanMessageIntact(t *testing.T) {
+	const msg = "no provider supports model: gpt-4o"
+	w := httptest.NewRecorder()
+	WriteOpenAI(w, http.StatusBadRequest, msg, errTypeInvalidRequest, "model_not_found")
+
+	var got struct {
+		Error struct {
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if got.Error.Message != msg {
+		t.Errorf("message = %q, want %q", got.Error.Message, msg)
+	}
+}

--- a/internal/apierror/apierror_redact_test.go
+++ b/internal/apierror/apierror_redact_test.go
@@ -9,7 +9,12 @@ import (
 )
 
 // fakeUpstreamKey has the legacy OpenAI sk- key shape. It is not a real credential.
-const fakeUpstreamKey = "sk-abc123DEF456ghi789JKL012mno345"
+var fakeUpstreamKey = buildFakeKey("sk-", "abc123DEF456ghi789JKL012mno345")
+
+// buildFakeKey joins prefix and body at runtime so no credential-shaped
+// literal is committed for a scanner to flag. Mirrors the helper used by
+// the redaction policy tests in internal/redact.
+func buildFakeKey(prefix, body string) string { return prefix + body }
 
 // An upstream provider controls its own error body, and that body can quote the
 // credential the gateway presented. WriteOpenAI must not hand it to the client.

--- a/internal/apierror/apierror_test.go
+++ b/internal/apierror/apierror_test.go
@@ -12,11 +12,7 @@ import (
 	"github.com/ferro-labs/ai-gateway/providers/core"
 )
 
-const (
-	errTypeInvalidRequest = "invalid_request_error"
-	errTypeServer         = "server_error"
-	codeRequestRejected   = "request_rejected"
-)
+const codeRequestRejected = "request_rejected"
 
 func TestWriteOpenAI_SetsContentType(t *testing.T) {
 	w := httptest.NewRecorder()

--- a/internal/events/hooks.go
+++ b/internal/events/hooks.go
@@ -5,6 +5,7 @@ package events
 import (
 	"time"
 
+	"github.com/ferro-labs/ai-gateway/internal/redact"
 	"github.com/ferro-labs/ai-gateway/models"
 )
 
@@ -28,13 +29,17 @@ type HookEvent struct {
 }
 
 // FailedRequest builds the internal hook payload for a failed request.
+//
+// errMsg is redacted here, at the single point every failed-request event is
+// built, so no observability exporter or hook consumer receives raw upstream
+// error text. Callers pass the message through unfiltered.
 func FailedRequest(traceID, provider, model, errMsg string, latency time.Duration, stream bool) HookEvent {
 	return HookEvent{
 		Subject:   "gateway.request.failed",
 		TraceID:   traceID,
 		Provider:  provider,
 		Model:     model,
-		Error:     errMsg,
+		Error:     redact.String(errMsg),
 		Status:    500,
 		LatencyMs: latency.Milliseconds(),
 		Stream:    stream,

--- a/internal/events/hooks_redact_test.go
+++ b/internal/events/hooks_redact_test.go
@@ -7,7 +7,12 @@ import (
 )
 
 // fakeUpstreamKey has the legacy OpenAI sk- key shape. It is not a real credential.
-const fakeUpstreamKey = "sk-abc123DEF456ghi789JKL012mno345"
+var fakeUpstreamKey = buildFakeKey("sk-", "abc123DEF456ghi789JKL012mno345")
+
+// buildFakeKey joins prefix and body at runtime so no credential-shaped
+// literal is committed for a scanner to flag. Mirrors the helper used by
+// the redaction policy tests in internal/redact.
+func buildFakeKey(prefix, body string) string { return prefix + body }
 
 // FailedRequest is the one point every failed-request event is built, so
 // redacting here keeps raw upstream error text out of every hook consumer and

--- a/internal/events/hooks_redact_test.go
+++ b/internal/events/hooks_redact_test.go
@@ -1,0 +1,62 @@
+package events
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// fakeUpstreamKey has the legacy OpenAI sk- key shape. It is not a real credential.
+const fakeUpstreamKey = "sk-abc123DEF456ghi789JKL012mno345"
+
+// FailedRequest is the one point every failed-request event is built, so
+// redacting here keeps raw upstream error text out of every hook consumer and
+// observability exporter without each caller having to remember.
+func TestFailedRequest_RedactsErrorMessage(t *testing.T) {
+	he := FailedRequest(
+		"trace-1",
+		"openai",
+		"gpt-4o",
+		"openai API error (401): Incorrect API key provided: "+fakeUpstreamKey,
+		250*time.Millisecond,
+		false,
+	)
+
+	if strings.Contains(he.Error, fakeUpstreamKey) {
+		t.Fatalf("HookEvent.Error leaked the key: %q", he.Error)
+	}
+	if !strings.Contains(he.Error, "[REDACTED_OPENAI_KEY]") {
+		t.Errorf("HookEvent.Error = %q, want a redaction token", he.Error)
+	}
+}
+
+// The redacted message must survive into the public map form exporters receive.
+func TestFailedRequest_MapCarriesRedactedError(t *testing.T) {
+	he := FailedRequest("trace-1", "openai", "gpt-4o", "bad key "+fakeUpstreamKey, time.Second, true)
+
+	got, _ := he.Map()["error"].(string)
+	if strings.Contains(got, fakeUpstreamKey) {
+		t.Fatalf("event map leaked the key: %q", got)
+	}
+	if got == "" {
+		t.Fatal("event map carried no error message")
+	}
+}
+
+// Redaction must not disturb the rest of the payload.
+func TestFailedRequest_RedactionPreservesOtherFields(t *testing.T) {
+	he := FailedRequest("trace-1", "openai", "gpt-4o", "upstream is unavailable", 250*time.Millisecond, true)
+
+	if he.Error != "upstream is unavailable" {
+		t.Errorf("Error = %q, want it unchanged", he.Error)
+	}
+	if he.Subject != "gateway.request.failed" {
+		t.Errorf("Subject = %q, want %q", he.Subject, "gateway.request.failed")
+	}
+	if he.TraceID != "trace-1" || he.Provider != "openai" || he.Model != "gpt-4o" {
+		t.Errorf("identity fields changed: %+v", he)
+	}
+	if he.Status != 500 || he.LatencyMs != 250 || !he.Stream {
+		t.Errorf("status/latency/stream changed: %+v", he)
+	}
+}

--- a/internal/events/hooks_redact_test.go
+++ b/internal/events/hooks_redact_test.go
@@ -9,9 +9,7 @@ import (
 // fakeUpstreamKey has the legacy OpenAI sk- key shape. It is not a real credential.
 var fakeUpstreamKey = buildFakeKey("sk-", "abc123DEF456ghi789JKL012mno345")
 
-// buildFakeKey joins prefix and body at runtime so no credential-shaped
-// literal is committed for a scanner to flag. Mirrors the helper used by
-// the redaction policy tests in internal/redact.
+// buildFakeKey joins prefix and body at runtime to avoid committing credential-shaped literals.
 func buildFakeKey(prefix, body string) string { return prefix + body }
 
 // FailedRequest is the one point every failed-request event is built, so

--- a/internal/handler/health.go
+++ b/internal/handler/health.go
@@ -26,6 +26,17 @@ type providerCircuit struct {
 	Circuit string `json:"circuit"`
 }
 
+// mcpServerState is the per-MCP-server state reported by Readyz.
+//
+// LastError is deliberately absent: /readyz is unauthenticated and an MCP
+// initialization failure can quote a server URL, an authorization header, or a
+// full subprocess command line. The reason is logged server-side instead.
+type mcpServerState struct {
+	Name     string `json:"name"`
+	Ready    bool   `json:"ready"`
+	Required bool   `json:"required"`
+}
+
 // Livez handles GET /livez. It reports process liveness only, performing no
 // dependency checks, so it always returns 200. Orchestrators use it to decide
 // whether to restart the process.
@@ -67,12 +78,48 @@ func Readyz(gw *aigateway.Gateway, pingers ...Pinger) http.HandlerFunc {
 			return
 		}
 
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(map[string]any{
+		// Only a server explicitly marked `required` gates readiness. Every
+		// server's state is reported either way, so an operator can watch MCP
+		// health without a dead optional server pulling the instance out of
+		// rotation and stopping traffic that never touches a tool.
+		if down := requiredMCPDown(readiness); down != nil {
+			logging.FromContext(r.Context()).Error("readyz required MCP server unavailable",
+				"server", down.Name, "error", down.LastError)
+			writeNotReady(w, "required mcp server unavailable")
+			return
+		}
+
+		body := map[string]any{
 			"status":    "ready",
 			"providers": circuitsFromReadiness(readiness),
-		})
+		}
+		if mcpStates := mcpFromReadiness(readiness); len(mcpStates) > 0 {
+			body["mcp_servers"] = mcpStates
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(body)
 	}
+}
+
+// requiredMCPDown returns the first required MCP server that is not ready, or
+// nil when every required server is up.
+func requiredMCPDown(r aigateway.Readiness) *aigateway.MCPServerReadiness {
+	for i := range r.MCPServers {
+		if r.MCPServers[i].Required && !r.MCPServers[i].Ready {
+			return &r.MCPServers[i]
+		}
+	}
+	return nil
+}
+
+// mcpFromReadiness projects the MCP half of the readiness snapshot onto the
+// JSON-tagged response shape, dropping LastError.
+func mcpFromReadiness(r aigateway.Readiness) []mcpServerState {
+	out := make([]mcpServerState, 0, len(r.MCPServers))
+	for _, s := range r.MCPServers {
+		out = append(out, mcpServerState{Name: s.Name, Ready: s.Ready, Required: s.Required})
+	}
+	return out
 }
 
 // writeNotReady emits a 503 with a JSON body naming the failed readiness check.

--- a/internal/handler/health_test.go
+++ b/internal/handler/health_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	aigateway "github.com/ferro-labs/ai-gateway"
+	mcpconfig "github.com/ferro-labs/ai-gateway/mcp"
 	"github.com/ferro-labs/ai-gateway/providers"
 )
 
@@ -209,4 +210,151 @@ func (healthProvider) Models() []providers.ModelInfo {
 }
 func (healthProvider) Complete(context.Context, providers.Request) (*providers.Response, error) {
 	return nil, nil
+}
+
+// unreachableMCP is a server config whose transport can never come up, so the
+// registry leaves it unready — the state a crashed or misconfigured MCP server
+// produces.
+func unreachableMCP(name string, required bool) mcpconfig.ServerConfig {
+	return mcpconfig.ServerConfig{
+		Name:           name,
+		URL:            "http://127.0.0.1:1/mcp",
+		TimeoutSeconds: 1,
+		Required:       required,
+	}
+}
+
+// TestReadyzMCPGating covers the readiness contract for MCP servers: an
+// unready server gates /readyz only when it opted in via `required`.
+//
+// The default matters as much as the feature. Making every MCP server gate
+// readiness would take a pod out of rotation on upgrade — stopping all LLM
+// traffic, including requests that never touch a tool — for anyone who had one
+// configured. So absent `required` must behave exactly as before.
+func TestReadyzMCPGating(t *testing.T) {
+	tests := []struct {
+		name         string
+		servers      []mcpconfig.ServerConfig
+		wantCode     int
+		wantStatus   string
+		wantReasonIn string
+	}{
+		{
+			name:       "no mcp servers configured is unaffected",
+			wantCode:   http.StatusOK,
+			wantStatus: "ready",
+		},
+		{
+			name:       "unready server without required does not gate",
+			servers:    []mcpconfig.ServerConfig{unreachableMCP("optional-srv", false)},
+			wantCode:   http.StatusOK,
+			wantStatus: "ready",
+		},
+		{
+			name:         "unready server with required gates",
+			servers:      []mcpconfig.ServerConfig{unreachableMCP("critical-srv", true)},
+			wantCode:     http.StatusServiceUnavailable,
+			wantStatus:   "not_ready",
+			wantReasonIn: "required mcp server unavailable",
+		},
+		{
+			name: "one required server down among optional ones gates",
+			servers: []mcpconfig.ServerConfig{
+				unreachableMCP("optional-a", false),
+				unreachableMCP("critical-b", true),
+				unreachableMCP("optional-c", false),
+			},
+			wantCode:     http.StatusServiceUnavailable,
+			wantStatus:   "not_ready",
+			wantReasonIn: "required mcp server unavailable",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gw, err := newTestGateway(t, aigateway.Config{
+				Strategy:   aigateway.StrategyConfig{Mode: aigateway.ModeSingle},
+				Targets:    []aigateway.Target{{VirtualKey: "health-provider"}},
+				MCPServers: tt.servers,
+			})
+			if err != nil {
+				t.Fatalf("New gateway: %v", err)
+			}
+			gw.RegisterProvider(healthProvider{})
+
+			req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/readyz", nil)
+			w := httptest.NewRecorder()
+			Readyz(gw, fakePinger{}).ServeHTTP(w, req)
+
+			if w.Code != tt.wantCode {
+				t.Fatalf("status code = %d, want %d: %s", w.Code, tt.wantCode, w.Body.String())
+			}
+			var payload struct {
+				Status string `json:"status"`
+				Reason string `json:"reason"`
+			}
+			if err := json.NewDecoder(w.Body).Decode(&payload); err != nil {
+				t.Fatalf("decode readyz response: %v", err)
+			}
+			if payload.Status != tt.wantStatus {
+				t.Fatalf("status = %q, want %q", payload.Status, tt.wantStatus)
+			}
+			if tt.wantReasonIn != "" && !strings.Contains(payload.Reason, tt.wantReasonIn) {
+				t.Fatalf("reason = %q, want substring %q", payload.Reason, tt.wantReasonIn)
+			}
+		})
+	}
+}
+
+// TestReadyzReportsMCPStateWithoutGating proves the observability half: MCP
+// state appears in the body for servers that do not gate readiness, so an
+// operator can watch MCP health without having to risk their rollout on it.
+func TestReadyzReportsMCPStateWithoutGating(t *testing.T) {
+	gw, err := newTestGateway(t, aigateway.Config{
+		Strategy: aigateway.StrategyConfig{Mode: aigateway.ModeSingle},
+		Targets:  []aigateway.Target{{VirtualKey: "health-provider"}},
+		MCPServers: []mcpconfig.ServerConfig{
+			unreachableMCP("watch-me", false),
+		},
+	})
+	if err != nil {
+		t.Fatalf("New gateway: %v", err)
+	}
+	gw.RegisterProvider(healthProvider{})
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/readyz", nil)
+	w := httptest.NewRecorder()
+	Readyz(gw, fakePinger{}).ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status code = %d, want 200: %s", w.Code, w.Body.String())
+	}
+	var payload struct {
+		Status     string `json:"status"`
+		MCPServers []struct {
+			Name     string `json:"name"`
+			Ready    bool   `json:"ready"`
+			Required bool   `json:"required"`
+		} `json:"mcp_servers"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode readyz response: %v", err)
+	}
+	if len(payload.MCPServers) != 1 {
+		t.Fatalf("mcp_servers = %+v, want one entry", payload.MCPServers)
+	}
+	got := payload.MCPServers[0]
+	if got.Name != "watch-me" || got.Ready || got.Required {
+		t.Errorf("mcp_servers[0] = %+v, want {watch-me false false}", got)
+	}
+
+	// /readyz is unauthenticated and an MCP failure can quote a URL, an
+	// authorization header, or a subprocess command line. The reason is logged,
+	// never served.
+	if body := w.Body.String(); strings.Contains(body, "127.0.0.1:1") {
+		t.Errorf("readyz body leaked the MCP server address: %s", body)
+	}
+	if body := w.Body.String(); strings.Contains(strings.ToLower(body), "last_error") {
+		t.Errorf("readyz body exposed an error detail field: %s", body)
+	}
 }

--- a/internal/handler/health_test.go
+++ b/internal/handler/health_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 
@@ -303,6 +304,90 @@ func TestReadyzMCPGating(t *testing.T) {
 				t.Fatalf("reason = %q, want substring %q", payload.Reason, tt.wantReasonIn)
 			}
 		})
+	}
+}
+
+// TestReadyzGatesOnAServerThatNeverRegistered is the regression test for a
+// required MCP server that fails before it can be registered at all.
+//
+// A server whose headers or environment reference an undefined variable is
+// resolved before its transport exists, so it never reaches the registry.
+// Readiness reads the registry, so the server was not merely reported unready —
+// it was absent from the response entirely, and /readyz answered 200 ready
+// while a server the operator had marked `required` had never been attempted.
+// The mixed fleet here is the worst case: mcp_servers is populated, so the body
+// looks complete while quietly omitting exactly the server that gates it.
+func TestReadyzGatesOnAServerThatNeverRegistered(t *testing.T) {
+	// The fixture's whole premise is that the variable does not resolve.
+	const undefinedVar = "FERRO_HANDLER_TEST_UNDEFINED_MCP_VAR"
+	if _, set := os.LookupEnv(undefinedVar); set {
+		t.Skipf("%s is set; this fixture requires it to be undefined", undefinedVar)
+	}
+
+	gw, err := newTestGateway(t, aigateway.Config{
+		Strategy: aigateway.StrategyConfig{Mode: aigateway.ModeSingle},
+		Targets:  []aigateway.Target{{VirtualKey: "health-provider"}},
+		MCPServers: []mcpconfig.ServerConfig{
+			unreachableMCP("optional-srv", false),
+			{
+				Name:     "vault",
+				Command:  "true",
+				Required: true,
+				Env:      map[string]string{"TOKEN": "${" + undefinedVar + "}"},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("New gateway: %v", err)
+	}
+	gw.RegisterProvider(healthProvider{})
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/readyz", nil)
+	w := httptest.NewRecorder()
+	Readyz(gw, fakePinger{}).ServeHTTP(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status code = %d, want 503: a required server that never registered left the gateway reporting ready: %s",
+			w.Code, w.Body.String())
+	}
+
+	var payload struct {
+		Status     string `json:"status"`
+		Reason     string `json:"reason"`
+		MCPServers []struct {
+			Name     string `json:"name"`
+			Ready    bool   `json:"ready"`
+			Required bool   `json:"required"`
+		} `json:"mcp_servers"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode readyz response: %v", err)
+	}
+	if !strings.Contains(payload.Reason, "required mcp server unavailable") {
+		t.Errorf("reason = %q, want the required-server reason", payload.Reason)
+	}
+
+	// The 503 body carries no mcp_servers, so a second gateway proves the
+	// server is reported as configured rather than silently dropped.
+	readiness := gw.Readiness()
+	var found bool
+	for _, s := range readiness.MCPServers {
+		if s.Name != "vault" {
+			continue
+		}
+		found = true
+		if s.Ready {
+			t.Error("a server that never got a transport is reported ready")
+		}
+		if !s.Required {
+			t.Error("the server lost its Required flag, so nothing would gate on it")
+		}
+		if s.LastError == "" {
+			t.Error("no reason recorded for a server that never registered")
+		}
+	}
+	if !found {
+		t.Errorf("MCPServers = %+v, want an entry for the configured server %q", readiness.MCPServers, "vault")
 	}
 }
 

--- a/internal/mcp/death_test.go
+++ b/internal/mcp/death_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"syscall"
 	"testing"
 	"time"
 
@@ -57,53 +58,38 @@ func shortLivedCmd(t *testing.T) string {
 // TestStdioChildDeathMarksServerUnready is the regression test for a crashed
 // stdio subprocess going undetected.
 //
-// Before the fix nothing ever cleared serverEntry.ready outside Close, so a
-// dead child kept its tools advertised by AllTools and kept being resolved by
-// FindToolServer — every call then failed with "transport closed" while the
-// model was still being told the tools were available.
+// Nothing ever cleared serverEntry.ready outside Close, so a dead child kept its
+// tools advertised by AllTools and kept being resolved by FindToolServer — every
+// call then failed with "transport closed" while the model was still being told
+// the tools were available.
 //
-// The child here is spawned for real and exits on its own. The registry entry
-// is then hand-marked ready with its discovered tool, which is the state a
-// successful handshake would have left behind had the process lived longer.
+// The server is real and completes a real handshake, then exits on command. The
+// death is delivered through the registry's own watcher, not through a tool call
+// the executor sees, so this covers detection with no traffic to trigger it.
 func TestStdioChildDeathMarksServerUnready(t *testing.T) {
-	cmd := shortLivedCmd(t)
+	reg := initHelperServer(t, "dying", helperModeServe)
+	client := helperClient(t, reg, "dying")
 
-	reg := NewRegistry()
-	defer func() { _ = reg.Close() }()
-	reg.RegisterConfig(ServerConfig{Name: "dying", Command: cmd})
-
-	// Publish the state a completed handshake would have produced. The real
-	// handshake cannot be used: this command exits before speaking MCP, and a
-	// server that dies *after* initializing is exactly the case under test.
-	reg.mu.Lock()
-	entry := reg.servers["dying"]
-	client := entry.client
-	entry.tools = []Tool{{Name: "doomed_tool"}}
-	entry.ready = true
-	reg.toolMap["doomed_tool"] = "dying"
-	reg.mu.Unlock()
-
-	if _, isErr := client.(*errClient); isErr {
-		t.Fatal("expected a real stdio client; the command did not start")
+	// Sanity: the discovered tools are advertised and resolvable while alive.
+	if len(reg.AllTools()) == 0 {
+		t.Fatal("precondition: the helper server advertised no tools")
 	}
-
-	// Sanity: the tool is advertised and resolvable while the entry is ready.
-	if len(reg.AllTools()) != 1 {
-		t.Fatalf("precondition: AllTools = %v, want 1 tool", reg.AllTools())
-	}
-	if _, ok := reg.FindToolServer("doomed_tool"); !ok {
+	if _, ok := reg.FindToolServer(helperToolEcho); !ok {
 		t.Fatal("precondition: FindToolServer should resolve before the child dies")
 	}
 
-	// The child has already exited or is about to. Its death must flip the bit.
-	waitUntil(t, 10*time.Second, "ready to flip false after child death", func() bool {
+	// Kill it. The call goes straight to the transport so the executor's own
+	// detection path cannot be what withdraws the server.
+	_, _ = client.CallTool(t.Context(), helperToolDie, nil)
+
+	waitUntil(t, 15*time.Second, "ready to flip false after child death", func() bool {
 		return !reg.IsReady("dying")
 	})
 
 	if tools := reg.AllTools(); len(tools) != 0 {
 		t.Errorf("AllTools still advertises %v after the child died; the model would keep calling them", tools)
 	}
-	if _, ok := reg.FindToolServer("doomed_tool"); ok {
+	if _, ok := reg.FindToolServer(helperToolEcho); ok {
 		t.Error("FindToolServer still resolves a dead client after the child died")
 	}
 
@@ -117,6 +103,68 @@ func TestStdioChildDeathMarksServerUnready(t *testing.T) {
 	}
 	if st[0].LastError == "" {
 		t.Error("Status() lost the reason the server went down")
+	}
+}
+
+// TestStdioStderrEOFOnLiveServerKeepsItReady is the regression test for stderr
+// EOF being treated as the verdict on a server's death.
+//
+// The gateway holds only the read end of the child's stderr, so a healthy
+// server closing its own fd 2 produces a genuine EOF. Acting on that directly
+// withdrew a server that was still answering, and with `required: true` that is
+// a 503 for a server that was never down.
+//
+// The server here closes stderr on command, mid-life, after a completed
+// handshake — and then keeps serving.
+func TestStdioStderrEOFOnLiveServerKeepsItReady(t *testing.T) {
+	reg := initHelperServer(t, "chatty", helperModeServe)
+	client := helperClient(t, reg, "chatty")
+
+	if _, err := client.CallTool(t.Context(), helperToolCloseStderr, nil); err != nil {
+		t.Fatalf("precondition: the helper failed to close its stderr: %v", err)
+	}
+
+	// Long enough for the EOF to be observed and for at least one confirmation
+	// probe to run and find the server answering.
+	time.Sleep(3 * transportProbeInterval)
+
+	if !reg.IsReady("chatty") {
+		st := reg.Status()
+		t.Fatalf("a live server was withdrawn after closing its own stderr: %+v", st)
+	}
+	if _, ok := reg.FindToolServer(helperToolEcho); !ok {
+		t.Error("FindToolServer stopped resolving tools for a server that is still answering")
+	}
+	if _, err := client.CallTool(t.Context(), helperToolEcho, nil); err != nil {
+		t.Errorf("the server withdrawn as dead still answers tool calls: %v", err)
+	}
+}
+
+// TestStdioStderrClosedAtStartupStillDetectsLaterDeath covers the gap a
+// fire-once watcher left behind.
+//
+// A server that closes stderr before it is ready delivered its one and only
+// death notice at a moment when there was nothing to withdraw. The watcher was
+// then spent, so that server was exempt from death detection for the rest of its
+// life: it could be killed and its tools stayed advertised.
+func TestStdioStderrClosedAtStartupStillDetectsLaterDeath(t *testing.T) {
+	reg := initHelperServer(t, "quiet", helperModeStderrClosed)
+	client := helperClient(t, reg, "quiet")
+
+	// The EOF has already been delivered — before the handshake finished — and
+	// must not have withdrawn anything.
+	time.Sleep(2 * transportProbeInterval)
+	if !reg.IsReady("quiet") {
+		t.Fatalf("a server that closed stderr at startup was withdrawn while alive: %+v", reg.Status())
+	}
+
+	_, _ = client.CallTool(t.Context(), helperToolDie, nil)
+
+	waitUntil(t, 15*time.Second, "a startup-silent server's later death to be detected", func() bool {
+		return !reg.IsReady("quiet")
+	})
+	if len(reg.AllTools()) != 0 {
+		t.Error("AllTools still advertises tools from a server whose process is gone")
 	}
 }
 
@@ -234,6 +282,70 @@ func TestTransportClosedMarksServerUnready(t *testing.T) {
 	exec.executeToolCall(context.Background(), toolCallNamed("t1"))
 	if c.calls != before {
 		t.Errorf("call %d was still routed to the dead client; want no further calls", c.calls)
+	}
+}
+
+// brokenPipeClient models the death the transport never notices: a descendant
+// still holds the pipes, so stdout never reaches EOF and the transport stays
+// open, but the write to the child's stdin fails with EPIPE. The wrap chain is
+// the real one — the library's "failed to write request" wrap, its
+// *transport.Error box, then stdioClient.CallTool's own.
+type brokenPipeClient struct{ calls int }
+
+func (c *brokenPipeClient) Initialize(context.Context) (*ServerInfo, error) {
+	return &ServerInfo{}, nil
+}
+func (c *brokenPipeClient) ListTools(context.Context) ([]Tool, error) { return nil, nil }
+func (c *brokenPipeClient) CallTool(_ context.Context, name string, _ json.RawMessage) (*ToolCallResult, error) {
+	c.calls++
+	return nil, fmt.Errorf("mcp stdio tools/call %s: %w", name,
+		transport.NewError(fmt.Errorf("failed to write request: %w", syscall.EPIPE)))
+}
+func (c *brokenPipeClient) Close() error { return nil }
+
+// TestBrokenPipeMarksServerUnready proves a broken pipe counts as death.
+//
+// Only transport.ErrTransportClosed was matched, so this failure — equally
+// conclusive, and the one that occurs whenever a descendant holds the pipes
+// open — was ignored: the server stayed ready, kept its tools advertised, and
+// every subsequent call was routed to it and failed the same way.
+func TestBrokenPipeMarksServerUnready(t *testing.T) {
+	c := &brokenPipeClient{}
+	reg := registryWith(map[string]mcpClient{"s1": c})
+	reg.mu.Lock()
+	reg.servers["s1"].tools = []Tool{{Name: "t1"}}
+	reg.toolMap["t1"] = "s1"
+	reg.mu.Unlock()
+
+	exec := NewExecutor(reg, 5, nil)
+	exec.executeToolCall(context.Background(), toolCallNamed("t1"))
+
+	if reg.IsReady("s1") {
+		t.Fatal("a broken-pipe write failure did not withdraw the server")
+	}
+	if _, ok := reg.FindToolServer("t1"); ok {
+		t.Error("FindToolServer still resolves the tool after the pipe broke")
+	}
+
+	before := c.calls
+	exec.executeToolCall(context.Background(), toolCallNamed("t1"))
+	if c.calls != before {
+		t.Errorf("call %d was still routed to the dead client; want no further calls", c.calls)
+	}
+}
+
+// TestIsTransportDeadRejectsTransientErrors pins the other half of the
+// predicate. Withdrawing a server is terminal until the next configuration
+// reload, so an error that can resolve on its own must never reach it.
+func TestIsTransportDeadRejectsTransientErrors(t *testing.T) {
+	for _, err := range []error{
+		context.DeadlineExceeded,
+		errors.New("connection refused"),
+		fmt.Errorf("mcp stdio tools/call x: %w", transport.NewError(errors.New("read timeout"))),
+	} {
+		if isTransportDead(err) {
+			t.Errorf("isTransportDead(%v) = true; a recoverable failure would latch the server off", err)
+		}
 	}
 }
 

--- a/internal/mcp/death_test.go
+++ b/internal/mcp/death_test.go
@@ -1,0 +1,258 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/mark3labs/mcp-go/client/transport"
+
+	"github.com/ferro-labs/ai-gateway/providers/core"
+)
+
+// toolCallNamed builds the minimal tool call the executor needs.
+func toolCallNamed(name string) core.ToolCall {
+	return core.ToolCall{
+		ID:       "tc-" + name,
+		Type:     "function",
+		Function: core.FunctionCall{Name: name, Arguments: "{}"},
+	}
+}
+
+// waitUntil polls cond until it holds or the deadline expires, failing with
+// desc on timeout. Child death is observed by a goroutine draining the
+// subprocess's stderr, so the flip is asynchronous by construction and there is
+// no event to synchronise on. Distinct from the unix-only waitFor in
+// proc_unix_test.go so this file builds on every platform.
+func waitUntil(t *testing.T, timeout time.Duration, desc string, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("timed out after %s waiting for %s", timeout, desc)
+}
+
+// shortLivedCmd returns a command that exists, starts, and exits immediately.
+// The exit is the point: it models an MCP server whose process dies while the
+// gateway still holds it registered and ready.
+func shortLivedCmd(t *testing.T) string {
+	t.Helper()
+	for _, p := range []string{"/usr/bin/true", "/bin/true"} {
+		if _, err := os.Stat(p); err == nil {
+			return p
+		}
+	}
+	t.Skip("no suitable real command found for stdio tests on this platform")
+	return ""
+}
+
+// TestStdioChildDeathMarksServerUnready is the regression test for a crashed
+// stdio subprocess going undetected.
+//
+// Before the fix nothing ever cleared serverEntry.ready outside Close, so a
+// dead child kept its tools advertised by AllTools and kept being resolved by
+// FindToolServer — every call then failed with "transport closed" while the
+// model was still being told the tools were available.
+//
+// The child here is spawned for real and exits on its own. The registry entry
+// is then hand-marked ready with its discovered tool, which is the state a
+// successful handshake would have left behind had the process lived longer.
+func TestStdioChildDeathMarksServerUnready(t *testing.T) {
+	cmd := shortLivedCmd(t)
+
+	reg := NewRegistry()
+	defer func() { _ = reg.Close() }()
+	reg.RegisterConfig(ServerConfig{Name: "dying", Command: cmd})
+
+	// Publish the state a completed handshake would have produced. The real
+	// handshake cannot be used: this command exits before speaking MCP, and a
+	// server that dies *after* initializing is exactly the case under test.
+	reg.mu.Lock()
+	entry := reg.servers["dying"]
+	client := entry.client
+	entry.tools = []Tool{{Name: "doomed_tool"}}
+	entry.ready = true
+	reg.toolMap["doomed_tool"] = "dying"
+	reg.mu.Unlock()
+
+	if _, isErr := client.(*errClient); isErr {
+		t.Fatal("expected a real stdio client; the command did not start")
+	}
+
+	// Sanity: the tool is advertised and resolvable while the entry is ready.
+	if len(reg.AllTools()) != 1 {
+		t.Fatalf("precondition: AllTools = %v, want 1 tool", reg.AllTools())
+	}
+	if _, ok := reg.FindToolServer("doomed_tool"); !ok {
+		t.Fatal("precondition: FindToolServer should resolve before the child dies")
+	}
+
+	// The child has already exited or is about to. Its death must flip the bit.
+	waitUntil(t, 10*time.Second, "ready to flip false after child death", func() bool {
+		return !reg.IsReady("dying")
+	})
+
+	if tools := reg.AllTools(); len(tools) != 0 {
+		t.Errorf("AllTools still advertises %v after the child died; the model would keep calling them", tools)
+	}
+	if _, ok := reg.FindToolServer("doomed_tool"); ok {
+		t.Error("FindToolServer still resolves a dead client after the child died")
+	}
+
+	// The reason is retained and reachable, not just the fact.
+	st := reg.Status()
+	if len(st) != 1 {
+		t.Fatalf("Status() returned %d entries, want 1", len(st))
+	}
+	if st[0].Ready {
+		t.Error("Status() reports ready for a server whose child died")
+	}
+	if st[0].LastError == "" {
+		t.Error("Status() lost the reason the server went down")
+	}
+}
+
+// TestStdioChildDeathDoesNotClobberReplacement guards the re-registration race.
+//
+// A dead server's death notice is delivered asynchronously. If it were keyed on
+// the server name alone it could land after a config reload had already spawned
+// a healthy replacement under that name and mark the live one down for good,
+// with nothing to bring it back.
+func TestStdioChildDeathDoesNotClobberReplacement(t *testing.T) {
+	cmd := shortLivedCmd(t)
+
+	reg := NewRegistry()
+	defer func() { _ = reg.Close() }()
+	reg.RegisterConfig(ServerConfig{Name: "svc", Command: cmd})
+
+	reg.mu.Lock()
+	deadClient := reg.servers["svc"].client
+	reg.mu.Unlock()
+
+	// Re-register: RegisterConfig closes the old transport and installs a new
+	// entry, exactly as a config reload does.
+	reg.RegisterConfig(ServerConfig{Name: "svc", Command: cmd})
+
+	reg.mu.Lock()
+	live := reg.servers["svc"]
+	liveClient := live.client
+	live.ready = true
+	reg.mu.Unlock()
+
+	if liveClient == deadClient {
+		t.Fatal("precondition: re-registration should have installed a new client")
+	}
+
+	// Deliver the stale notice for the transport that was replaced.
+	reg.markUnready("svc", deadClient, errors.New("stale death notice"))
+
+	if !reg.IsReady("svc") {
+		t.Fatal("a stale death notice from a replaced transport marked the live server down")
+	}
+
+	// The live transport's own notice must still be honoured.
+	reg.markUnready("svc", liveClient, errors.New("real death"))
+	if reg.IsReady("svc") {
+		t.Fatal("the live transport's death notice was ignored")
+	}
+}
+
+// closedTransportClient models a stdio server whose process has gone: the
+// handshake succeeded earlier, and calls now fail with ErrTransportClosed
+// wrapped exactly as it reaches the executor in production — the library boxes
+// it in *transport.Error (client.go), then stdioClient.CallTool adds its own
+// %w. Detection depends on errors.Is seeing through both layers, so the test
+// reproduces both rather than a single convenient wrap.
+type closedTransportClient struct {
+	calls int
+}
+
+func (c *closedTransportClient) Initialize(context.Context) (*ServerInfo, error) {
+	return &ServerInfo{}, nil
+}
+func (c *closedTransportClient) ListTools(context.Context) ([]Tool, error) { return nil, nil }
+func (c *closedTransportClient) CallTool(_ context.Context, name string, _ json.RawMessage) (*ToolCallResult, error) {
+	c.calls++
+	return nil, fmt.Errorf("mcp stdio tools/call %s: %w", name, transport.NewError(transport.ErrTransportClosed))
+}
+func (c *closedTransportClient) Close() error { return nil }
+
+// TestTransportClosedSurvivesTheRealWrapChain pins the assumption detection
+// rests on: ErrTransportClosed stays identifiable through the library's
+// *transport.Error box and the gateway's own fmt.Errorf wrap. If a dependency
+// bump broke either Unwrap, detection would silently stop working and this
+// fails instead.
+func TestTransportClosedSurvivesTheRealWrapChain(t *testing.T) {
+	wrapped := fmt.Errorf("mcp stdio tools/call x: %w", transport.NewError(transport.ErrTransportClosed))
+	if !errors.Is(wrapped, transport.ErrTransportClosed) {
+		t.Fatalf("errors.Is lost ErrTransportClosed through the wrap chain: %v", wrapped)
+	}
+	// A different transport failure must not be mistaken for a dead process.
+	other := fmt.Errorf("mcp stdio tools/call x: %w", transport.NewError(errors.New("read timeout")))
+	if errors.Is(other, transport.ErrTransportClosed) {
+		t.Error("an unrelated transport error was identified as a closed transport")
+	}
+}
+
+// TestTransportClosedMarksServerUnready proves the reactive half of detection:
+// one failed call is enough to withdraw a dead server, so the next call is not
+// routed to it at all.
+func TestTransportClosedMarksServerUnready(t *testing.T) {
+	c := &closedTransportClient{}
+	reg := registryWith(map[string]mcpClient{"s1": c})
+	reg.mu.Lock()
+	reg.servers["s1"].tools = []Tool{{Name: "t1"}}
+	reg.toolMap["t1"] = "s1"
+	reg.mu.Unlock()
+
+	exec := NewExecutor(reg, 5, nil)
+	msg := exec.executeToolCall(context.Background(), toolCallNamed("t1"))
+	if msg.Content == "" {
+		t.Fatal("expected an error payload for the LLM")
+	}
+
+	if reg.IsReady("s1") {
+		t.Fatal("a transport-closed error did not withdraw the server")
+	}
+	if _, ok := reg.FindToolServer("t1"); ok {
+		t.Error("FindToolServer still resolves the tool after transport closed")
+	}
+	if len(reg.AllTools()) != 0 {
+		t.Error("AllTools still advertises tools from a server with a closed transport")
+	}
+
+	// The second call must not reach the dead client at all.
+	before := c.calls
+	exec.executeToolCall(context.Background(), toolCallNamed("t1"))
+	if c.calls != before {
+		t.Errorf("call %d was still routed to the dead client; want no further calls", c.calls)
+	}
+}
+
+// TestErrClientLeavesNoExitWatcher covers the branch where the subprocess never
+// started: there is no stderr pipe, so there is nothing to watch and
+// RegisterConfig must not park a goroutine on a channel that never closes.
+func TestErrClientLeavesNoExitWatcher(t *testing.T) {
+	reg := NewRegistry()
+	defer func() { _ = reg.Close() }()
+	reg.RegisterConfig(ServerConfig{Name: "never-started", Command: "/nonexistent/mcp-server"})
+
+	reg.mu.Lock()
+	c := reg.servers["never-started"].client
+	reg.mu.Unlock()
+
+	if _, ok := c.(*errClient); !ok {
+		t.Fatalf("expected errClient for a command that cannot start, got %T", c)
+	}
+	if w, ok := c.(interface{ Exited() <-chan struct{} }); ok && w.Exited() != nil {
+		t.Error("errClient must not advertise an exit channel that never closes")
+	}
+}

--- a/internal/mcp/executor.go
+++ b/internal/mcp/executor.go
@@ -8,8 +8,6 @@ import (
 	rtrace "runtime/trace"
 	"time"
 
-	"github.com/mark3labs/mcp-go/client/transport"
-
 	"github.com/ferro-labs/ai-gateway/internal/metrics"
 	gwotel "github.com/ferro-labs/ai-gateway/internal/otel"
 	"github.com/ferro-labs/ai-gateway/observability"
@@ -269,12 +267,17 @@ func (e *Executor) executeToolCall(ctx context.Context, tc core.ToolCall) core.M
 	span.SetAttributes(attribute.Int64(observability.AttrFerroMCPLatencyMs, int64(latencyMs)))
 
 	if err != nil {
-		// A closed transport means the server process is gone, not that this one
+		// A dead transport means the server process is gone, not that this one
 		// call failed. Withdrawing it here is what stops the next thousand calls
 		// from being routed to a dead client: the registry clears the ready bit,
 		// so AllTools stops advertising its tools and FindToolServer stops
 		// resolving them. Costs exactly one failed call to detect.
-		if errors.Is(err, transport.ErrTransportClosed) {
+		//
+		// A broken pipe counts as much as a closed transport: it is the shape a
+		// death takes when a descendant still holds the pipes open, so the
+		// transport never noticed and the write failed instead. See
+		// isTransportDead for what deliberately does not qualify.
+		if isTransportDead(err) {
 			e.registry.markUnready(serverName, client, err)
 		}
 		metricToolCallsTotal.WithLabelValues(serverName, toolName, "error").Inc()

--- a/internal/mcp/executor.go
+++ b/internal/mcp/executor.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	rtrace "runtime/trace"
 	"time"
+	"unicode/utf8"
 
 	"github.com/ferro-labs/ai-gateway/internal/metrics"
 	gwotel "github.com/ferro-labs/ai-gateway/internal/otel"
@@ -329,11 +330,18 @@ func (e *Executor) executeToolCall(ctx context.Context, tc core.ToolCall) core.M
 // OTLP exporter, and no error message needs more than this to be diagnosed.
 const maxSignalLen = 2048
 
+// The cut is walked back to a rune boundary. A tool's output is arbitrary text,
+// so slicing on a byte offset alone can land mid-rune and leave invalid UTF-8 in
+// a span attribute and an audit record.
 func truncateForSignal(s string) string {
 	if len(s) <= maxSignalLen {
 		return s
 	}
-	return s[:maxSignalLen] + "… (truncated)"
+	cut := maxSignalLen
+	for cut > 0 && !utf8.RuneStart(s[cut]) {
+		cut--
+	}
+	return s[:cut] + "… (truncated)"
 }
 
 // boundedToolLabel keeps a tool name as a Prometheus label only when the

--- a/internal/mcp/executor.go
+++ b/internal/mcp/executor.go
@@ -3,10 +3,14 @@ package mcp
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"log/slog"
 	rtrace "runtime/trace"
 	"time"
 
+	"github.com/mark3labs/mcp-go/client/transport"
+
+	"github.com/ferro-labs/ai-gateway/internal/metrics"
 	gwotel "github.com/ferro-labs/ai-gateway/internal/otel"
 	"github.com/ferro-labs/ai-gateway/observability"
 	"github.com/ferro-labs/ai-gateway/providers/core"
@@ -212,7 +216,7 @@ func (e *Executor) executeToolCall(ctx context.Context, tc core.ToolCall) core.M
 
 	client, ok := e.registry.FindToolServer(toolName)
 	if !ok {
-		metricUnknownToolCallsTotal.WithLabelValues(toolName).Inc()
+		metricUnknownToolCallsTotal.WithLabelValues(boundedToolLabel(serverName, toolName)).Inc()
 		// Return a friendly error result so the LLM can report it.
 		notFoundPayload, _ := json.Marshal(map[string]string{
 			"error": "tool " + toolName + " not found in any registered MCP server",
@@ -265,6 +269,14 @@ func (e *Executor) executeToolCall(ctx context.Context, tc core.ToolCall) core.M
 	span.SetAttributes(attribute.Int64(observability.AttrFerroMCPLatencyMs, int64(latencyMs)))
 
 	if err != nil {
+		// A closed transport means the server process is gone, not that this one
+		// call failed. Withdrawing it here is what stops the next thousand calls
+		// from being routed to a dead client: the registry clears the ready bit,
+		// so AllTools stops advertising its tools and FindToolServer stops
+		// resolving them. Costs exactly one failed call to detect.
+		if errors.Is(err, transport.ErrTransportClosed) {
+			e.registry.markUnready(serverName, client, err)
+		}
 		metricToolCallsTotal.WithLabelValues(serverName, toolName, "error").Inc()
 		// Relies on the non-blocking AuditFn contract: the per-call goroutine returns promptly.
 		e.callAuditFn(ctx, serverName, toolName, "error", latencyMs, err.Error())
@@ -277,16 +289,28 @@ func (e *Executor) executeToolCall(ctx context.Context, tc core.ToolCall) core.M
 		}
 	}
 
-	metricToolCallsTotal.WithLabelValues(serverName, toolName, "ok").Inc()
-	// Relies on the non-blocking AuditFn contract: the per-call goroutine returns promptly.
-	e.callAuditFn(ctx, serverName, toolName, "ok", latencyMs, "")
-	span.SetStatus(codes.Ok, "")
-
 	// Convert MCP content blocks to a plain string for the LLM.
-	content, err := contentBlocksToString(result.Content)
-	if err != nil {
-		errPayload, _ := json.Marshal(map[string]string{"error": "could not marshal tool result: " + err.Error()})
+	content, convErr := contentBlocksToString(result.Content)
+	if convErr != nil {
+		errPayload, _ := json.Marshal(map[string]string{"error": "could not marshal tool result: " + convErr.Error()})
 		content = string(errPayload)
+	}
+
+	// A tool that answers with isError is a failed call. The RPC succeeded, so
+	// err is nil and every signal here used to read "ok" — the metric, the audit
+	// record, and the span status alike — which made a server returning nothing
+	// but errors indistinguishable from one working perfectly. The result's own
+	// content carries the reason and is what the LLM sees, so it is also the
+	// most useful thing to attach to the failure.
+	if result.IsError {
+		metricToolCallsTotal.WithLabelValues(serverName, toolName, "error").Inc()
+		e.callAuditFn(ctx, serverName, toolName, "error", latencyMs, truncateForSignal(content))
+		gwotel.RecordSpanError(span, errors.New(truncateForSignal(content)))
+	} else {
+		metricToolCallsTotal.WithLabelValues(serverName, toolName, "ok").Inc()
+		// Relies on the non-blocking AuditFn contract: the per-call goroutine returns promptly.
+		e.callAuditFn(ctx, serverName, toolName, "ok", latencyMs, "")
+		span.SetStatus(codes.Ok, "")
 	}
 
 	return core.Message{
@@ -294,6 +318,35 @@ func (e *Executor) executeToolCall(ctx context.Context, tc core.ToolCall) core.M
 		ToolCallID: tc.ID,
 		Content:    content,
 	}
+}
+
+// maxSignalLen bounds a tool-supplied error string copied into a span attribute
+// or an audit record. Tool results are unbounded by design — the full text still
+// reaches the LLM — but a multi-megabyte span attribute is a way to break an
+// OTLP exporter, and no error message needs more than this to be diagnosed.
+const maxSignalLen = 2048
+
+func truncateForSignal(s string) string {
+	if len(s) <= maxSignalLen {
+		return s
+	}
+	return s[:maxSignalLen] + "… (truncated)"
+}
+
+// boundedToolLabel keeps a tool name as a Prometheus label only when the
+// registry has actually indexed it, collapsing anything else to a constant.
+//
+// Tool names on this path come straight from model output, so a hallucinated
+// name would otherwise mint a permanent time series — the same unbounded-label
+// class as the model label. serverName is non-empty exactly when the name is in
+// toolMap, which is the registry's own bounded set, so it doubles as the
+// known-name test: a real tool whose server has just died keeps its name (the
+// case worth alerting on), and an invented one does not.
+func boundedToolLabel(serverName, toolName string) string {
+	if serverName == "" {
+		return metrics.UnknownToolLabel
+	}
+	return toolName
 }
 
 // contentBlocksToString serialises MCP content blocks into a string suitable

--- a/internal/mcp/gauge_ownership_test.go
+++ b/internal/mcp/gauge_ownership_test.go
@@ -1,0 +1,116 @@
+package mcp
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ferro-labs/ai-gateway/internal/metrics"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+)
+
+// serverUpSeries reads the gateway_mcp_server_up sample for one server without
+// creating it. Presence has to be distinguishable from a zero value here: the
+// point of retiring a series is that it disappears rather than sits at 0.
+func serverUpSeries(t *testing.T, name string) (float64, bool) {
+	t.Helper()
+	ch := make(chan prometheus.Metric, 128)
+	metrics.MCPServerUp.Collect(ch)
+	close(ch)
+
+	for m := range ch {
+		var pb dto.Metric
+		if err := m.Write(&pb); err != nil {
+			t.Fatalf("write metric: %v", err)
+		}
+		for _, label := range pb.GetLabel() {
+			if label.GetName() == "server_name" && label.GetValue() == name {
+				return pb.GetGauge().GetValue(), true
+			}
+		}
+	}
+	return 0, false
+}
+
+// TestRetiredRegistryDoesNotClobberLiveGauge is the regression test for a
+// retiring registry writing the availability gauge of a server it no longer
+// owns.
+//
+// gateway_mcp_server_up is labelled by server name alone, so every registry
+// writes the same process-wide series. A configuration reload builds a
+// replacement registry and retires the previous one, and retirement is deferred
+// until in-flight requests release it — so the old registry's teardown lands
+// after the replacement has already handshaken and reported the server up. Its
+// write of 0 then stuck: InitializeAll skips an already-ready server, so nothing
+// wrote 1 again for the life of that registry, and the gauge read down for a
+// server that was serving.
+func TestRetiredRegistryDoesNotClobberLiveGauge(t *testing.T) {
+	const name = "gauge-handover"
+	srv := newMockServer(t, []Tool{{Name: "gh_tool"}})
+	defer srv.Close()
+
+	cfg := ServerConfig{Name: name, URL: srv.URL, TimeoutSeconds: 5}
+
+	retiring := NewRegistry()
+	retiring.RegisterConfig(cfg)
+	retiring.InitializeAll(context.Background(), func(n string, err error) {
+		t.Fatalf("init %s: %v", n, err)
+	})
+	if v, _ := serverUpSeries(t, name); v != 1 {
+		t.Fatalf("precondition: gauge = %v after the first registry initialized, want 1", v)
+	}
+
+	// The reload: a fresh registry takes over the same server name.
+	live := NewRegistry()
+	defer func() { _ = live.Close() }()
+	live.RegisterConfig(cfg)
+	live.InitializeAll(context.Background(), func(n string, err error) {
+		t.Fatalf("init %s on the replacement: %v", n, err)
+	})
+	if v, _ := serverUpSeries(t, name); v != 1 {
+		t.Fatalf("precondition: gauge = %v after the replacement initialized, want 1", v)
+	}
+
+	// The old registry's holders have drained and it tears down.
+	if err := retiring.Close(); err != nil {
+		t.Fatalf("close retiring registry: %v", err)
+	}
+
+	v, ok := serverUpSeries(t, name)
+	if !ok {
+		t.Fatal("the retiring registry deleted the live replacement's series")
+	}
+	if v != 1 {
+		t.Errorf("gauge = %v after the retired registry tore down, want 1: the live server reports Ready but /metrics says it is down", v)
+	}
+	if !live.IsReady(name) {
+		t.Fatal("precondition failed: the replacement is not ready, so the gauge assertion proves nothing")
+	}
+}
+
+// TestRetiredRegistryDropsItsOwnSeries covers the other half: a server removed
+// from the configuration kept a series pinned at 0 for the life of the process,
+// so an alert on "server down" fired forever for a server nobody had asked for
+// since the reload.
+func TestRetiredRegistryDropsItsOwnSeries(t *testing.T) {
+	const name = "gauge-removed"
+	srv := newMockServer(t, []Tool{{Name: "gr_tool"}})
+	defer srv.Close()
+
+	reg := NewRegistry()
+	reg.RegisterConfig(ServerConfig{Name: name, URL: srv.URL, TimeoutSeconds: 5})
+	reg.InitializeAll(context.Background(), func(n string, err error) {
+		t.Fatalf("init %s: %v", n, err)
+	})
+	if _, ok := serverUpSeries(t, name); !ok {
+		t.Fatal("precondition: no series published for a registered server")
+	}
+
+	if err := reg.Close(); err != nil {
+		t.Fatalf("close registry: %v", err)
+	}
+
+	if v, ok := serverUpSeries(t, name); ok {
+		t.Errorf("series still present at %v after the only registry holding it retired; it never goes away", v)
+	}
+}

--- a/internal/mcp/helper_server_test.go
+++ b/internal/mcp/helper_server_test.go
@@ -1,0 +1,181 @@
+package mcp
+
+import (
+	"bufio"
+	"encoding/json"
+	"os"
+	"testing"
+
+	mcpgo "github.com/mark3labs/mcp-go/mcp"
+)
+
+// The stdio death-detection tests need a subprocess that really speaks MCP:
+// stderr EOF is only distinguishable from death by asking the server, and a
+// server that cannot answer an initialize or a ping proves nothing either way.
+// Re-executing this test binary in server mode is the portable way to get one
+// without depending on npx, python, or a shell.
+const (
+	// helperModeEnv puts the re-executed binary into MCP-server mode. Absent
+	// for the ordinary test run, which is how TestHelperMCPServer knows to skip.
+	helperModeEnv = "FERRO_MCP_HELPER_MODE"
+
+	// helperModeServe starts the server with stderr left open, the normal case.
+	helperModeServe = "serve"
+	// helperModeStderrClosed closes stderr before the handshake, modelling a
+	// server that gives up its error stream at startup. The gateway sees EOF
+	// before the server is ever ready.
+	helperModeStderrClosed = "stderr-closed"
+)
+
+// Tools the helper advertises. Two of them exist to drive the server's own
+// lifecycle from the test, since that is the only way to sequence "close
+// stderr" and "die" against a completed handshake.
+const (
+	helperToolEcho        = "helper_echo"
+	helperToolCloseStderr = "helper_close_stderr"
+	helperToolDie         = "helper_die"
+)
+
+// helperServerConfig returns a ServerConfig that launches this test binary as a
+// real MCP stdio server. newStdioClient gives the subprocess a minimal
+// environment plus Env, so the mode switch travels there.
+func helperServerConfig(t *testing.T, name, mode string) ServerConfig {
+	t.Helper()
+	exe, err := os.Executable()
+	if err != nil {
+		t.Skipf("cannot locate the test binary to re-execute as an MCP server: %v", err)
+	}
+	return ServerConfig{
+		Name:    name,
+		Command: exe,
+		Args:    []string{"-test.run=^TestHelperMCPServer$"},
+		Env:     map[string]string{helperModeEnv: mode},
+	}
+}
+
+// TestHelperMCPServer is the subprocess entry point, not a test. It skips
+// unless helperModeEnv selected server mode.
+func TestHelperMCPServer(t *testing.T) {
+	mode := os.Getenv(helperModeEnv)
+	if mode == "" {
+		t.Skip("not running as the MCP helper subprocess")
+	}
+	runHelperMCPServer(mode)
+}
+
+// runHelperMCPServer serves newline-delimited JSON-RPC on stdin/stdout until
+// stdin closes, then exits without returning to the test framework — anything
+// it printed would land in the middle of the protocol stream.
+func runHelperMCPServer(mode string) {
+	if mode == helperModeStderrClosed {
+		_ = os.Stderr.Close()
+	}
+
+	dec := json.NewDecoder(bufio.NewReader(os.Stdin))
+	out := bufio.NewWriter(os.Stdout)
+	for {
+		var req struct {
+			ID     *json.RawMessage `json:"id"`
+			Method string           `json:"method"`
+			Params struct {
+				Name string `json:"name"`
+			} `json:"params"`
+		}
+		if err := dec.Decode(&req); err != nil {
+			os.Exit(0)
+		}
+		if req.ID == nil {
+			// A notification (notifications/initialized); nothing to answer.
+			continue
+		}
+
+		// Death is modelled as an exit with the request unanswered, which is what
+		// a crash looks like from the gateway's side.
+		if req.Method == "tools/call" && req.Params.Name == helperToolDie {
+			os.Exit(1)
+		}
+
+		if err := writeHelperResponse(out, *req.ID, helperResult(req.Method)); err != nil {
+			os.Exit(1)
+		}
+
+		// After the reply, so the caller's tool call completes before the pipe
+		// goes away and the test can sequence on it.
+		if req.Method == "tools/call" && req.Params.Name == helperToolCloseStderr {
+			_ = os.Stderr.Close()
+		}
+	}
+}
+
+// helperResult builds the result payload for one MCP method.
+func helperResult(method string) any {
+	switch method {
+	case "initialize":
+		return map[string]any{
+			// Echoing the client's latest version keeps the handshake valid
+			// without pinning the test to a specific revision of the spec.
+			"protocolVersion": mcpgo.LATEST_PROTOCOL_VERSION,
+			"capabilities":    map[string]any{"tools": map[string]any{}},
+			"serverInfo":      map[string]string{"name": "ferro-helper", "version": "0"},
+		}
+	case "tools/list":
+		schema := map[string]any{"type": "object"}
+		return map[string]any{"tools": []map[string]any{
+			{"name": helperToolEcho, "description": "echo", "inputSchema": schema},
+			{"name": helperToolCloseStderr, "description": "close stderr", "inputSchema": schema},
+			{"name": helperToolDie, "description": "exit", "inputSchema": schema},
+		}}
+	case "tools/call":
+		return map[string]any{
+			"content": []map[string]any{{"type": "text", "text": "ok"}},
+			"isError": false,
+		}
+	default:
+		// Covers ping, whose result is an empty object.
+		return map[string]any{}
+	}
+}
+
+// writeHelperResponse emits one JSON-RPC response frame and flushes it, since
+// the peer is blocked reading a single line.
+func writeHelperResponse(out *bufio.Writer, id json.RawMessage, result any) error {
+	resp := struct {
+		JSONRPC string          `json:"jsonrpc"`
+		ID      json.RawMessage `json:"id"`
+		Result  any             `json:"result"`
+	}{JSONRPC: "2.0", ID: id, Result: result}
+
+	if err := json.NewEncoder(out).Encode(resp); err != nil {
+		return err
+	}
+	return out.Flush()
+}
+
+// initHelperServer registers the helper under name, runs the real handshake,
+// and returns the registry with the server ready.
+func initHelperServer(t *testing.T, name, mode string) *Registry {
+	t.Helper()
+	reg := NewRegistry()
+	t.Cleanup(func() { _ = reg.Close() })
+
+	reg.RegisterConfig(helperServerConfig(t, name, mode))
+	reg.InitializeAll(t.Context(), func(n string, err error) {
+		t.Errorf("helper server %s failed to initialize: %v", n, err)
+	})
+	if !reg.IsReady(name) {
+		t.Fatalf("helper server %q did not become ready; the subprocess is not speaking MCP", name)
+	}
+	return reg
+}
+
+// helperClient returns the live transport for name.
+func helperClient(t *testing.T, reg *Registry, name string) mcpClient {
+	t.Helper()
+	reg.mu.RLock()
+	defer reg.mu.RUnlock()
+	entry, ok := reg.servers[name]
+	if !ok {
+		t.Fatalf("server %q is not registered", name)
+	}
+	return entry.client
+}

--- a/internal/mcp/observability_test.go
+++ b/internal/mcp/observability_test.go
@@ -1,0 +1,260 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/ferro-labs/ai-gateway/internal/metrics"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+)
+
+// counterValue reads one labelled sample out of a CounterVec. Returns 0 when
+// the series does not exist yet, which is what "never incremented" looks like.
+func counterValue(t *testing.T, vec *prometheus.CounterVec, labels ...string) float64 {
+	t.Helper()
+	c, err := vec.GetMetricWithLabelValues(labels...)
+	if err != nil {
+		t.Fatalf("GetMetricWithLabelValues(%v): %v", labels, err)
+	}
+	var m dto.Metric
+	if err := c.(prometheus.Metric).Write(&m); err != nil {
+		t.Fatalf("write metric: %v", err)
+	}
+	return m.GetCounter().GetValue()
+}
+
+func gaugeValue(t *testing.T, vec *prometheus.GaugeVec, labels ...string) float64 {
+	t.Helper()
+	g, err := vec.GetMetricWithLabelValues(labels...)
+	if err != nil {
+		t.Fatalf("GetMetricWithLabelValues(%v): %v", labels, err)
+	}
+	var m dto.Metric
+	if err := g.Write(&m); err != nil {
+		t.Fatalf("write metric: %v", err)
+	}
+	return m.GetGauge().GetValue()
+}
+
+// isErrorClient returns a successful RPC carrying a tool-level failure — the
+// shape a server uses to say "the tool ran and it went wrong".
+type isErrorClient struct{}
+
+func (isErrorClient) Initialize(context.Context) (*ServerInfo, error) { return &ServerInfo{}, nil }
+func (isErrorClient) ListTools(context.Context) ([]Tool, error)       { return nil, nil }
+func (isErrorClient) CallTool(context.Context, string, json.RawMessage) (*ToolCallResult, error) {
+	return &ToolCallResult{
+		Content: []ContentBlock{{Type: "text", Text: "disk on fire"}},
+		IsError: true,
+	}, nil
+}
+func (isErrorClient) Close() error { return nil }
+
+// TestIsErrorIsMeteredAsFailure is the regression test for tool failures being
+// counted as successes.
+//
+// ToolCallResult.IsError had no production reader: a server answering
+// {"isError": true} on every call incremented status="ok", audited "ok", and
+// set an Ok span status, so a wholly broken tool was indistinguishable from a
+// working one on the dashboard.
+func TestIsErrorIsMeteredAsFailure(t *testing.T) {
+	reg := registryWith(map[string]mcpClient{"srv-iserr": isErrorClient{}})
+	reg.mu.Lock()
+	reg.servers["srv-iserr"].tools = []Tool{{Name: "tool_iserr"}}
+	reg.toolMap["tool_iserr"] = "srv-iserr"
+	reg.mu.Unlock()
+
+	var (
+		mu       sync.Mutex
+		statuses []string
+		errMsgs  []string
+	)
+	audited := make(chan struct{}, 1)
+	audit := func(_ context.Context, _, _, status string, _ int, errMsg string) {
+		mu.Lock()
+		statuses = append(statuses, status)
+		errMsgs = append(errMsgs, errMsg)
+		mu.Unlock()
+		audited <- struct{}{}
+	}
+
+	okBefore := counterValue(t, metricToolCallsTotal, "srv-iserr", "tool_iserr", "ok")
+	errBefore := counterValue(t, metricToolCallsTotal, "srv-iserr", "tool_iserr", "error")
+
+	exec := NewExecutor(reg, 5, audit)
+	msg := exec.executeToolCall(context.Background(), toolCallNamed("tool_iserr"))
+
+	// The tool's own message still reaches the LLM — this changes how the call
+	// is *reported*, not what the model is told.
+	if msg.Content != "disk on fire" {
+		t.Errorf("content = %q, want the tool's error text passed through", msg.Content)
+	}
+
+	if got := counterValue(t, metricToolCallsTotal, "srv-iserr", "tool_iserr", "error"); got != errBefore+1 {
+		t.Errorf("status=error counter = %v, want %v: an isError result was not metered as a failure", got, errBefore+1)
+	}
+	if got := counterValue(t, metricToolCallsTotal, "srv-iserr", "tool_iserr", "ok"); got != okBefore {
+		t.Errorf("status=ok counter = %v, want %v: an isError result was metered as a success", got, okBefore)
+	}
+
+	<-audited
+	mu.Lock()
+	defer mu.Unlock()
+	if len(statuses) != 1 || statuses[0] != "error" {
+		t.Errorf("audit status = %v, want [error]", statuses)
+	}
+	if len(errMsgs) != 1 || errMsgs[0] != "disk on fire" {
+		t.Errorf("audit error message = %v, want the tool's error text", errMsgs)
+	}
+}
+
+// TestIsErrorFalseStillMetersOk pins the other half: an ordinary successful
+// call must keep reporting ok, so the fix above cannot have inverted the sense.
+func TestIsErrorFalseStillMetersOk(t *testing.T) {
+	reg := buildReadyRegistry(t, []string{"tool_ok"})
+	defer func() { _ = reg.Close() }()
+
+	okBefore := counterValue(t, metricToolCallsTotal, "exec-srv", "tool_ok", "ok")
+	errBefore := counterValue(t, metricToolCallsTotal, "exec-srv", "tool_ok", "error")
+
+	exec := NewExecutor(reg, 5, nil)
+	exec.executeToolCall(context.Background(), toolCallNamed("tool_ok"))
+
+	if got := counterValue(t, metricToolCallsTotal, "exec-srv", "tool_ok", "ok"); got != okBefore+1 {
+		t.Errorf("status=ok counter = %v, want %v", got, okBefore+1)
+	}
+	if got := counterValue(t, metricToolCallsTotal, "exec-srv", "tool_ok", "error"); got != errBefore {
+		t.Errorf("status=error counter = %v, want %v", got, errBefore)
+	}
+}
+
+// TestUnknownToolLabelIsBounded is the regression test for unbounded label
+// cardinality on the unknown-tool counter.
+//
+// executeToolCall labelled the counter with tc.Function.Name verbatim. That
+// string is model output, so a model emitting invented tool names minted a
+// permanent Prometheus time series per name — the same defect class as the
+// model label.
+func TestUnknownToolLabelIsBounded(t *testing.T) {
+	reg := NewRegistry()
+	exec := NewExecutor(reg, 5, nil)
+
+	before := counterValue(t, metricUnknownToolCallsTotal, metrics.UnknownToolLabel)
+
+	// Three names no server ever advertised, as a model might hallucinate them.
+	invented := []string{"hallucinated_tool_a", "hallucinated_tool_b", "hallucinated_tool_c"}
+	for _, name := range invented {
+		exec.executeToolCall(context.Background(), toolCallNamed(name))
+	}
+
+	if got := counterValue(t, metricUnknownToolCallsTotal, metrics.UnknownToolLabel); got != before+3 {
+		t.Errorf("bounded label counter = %v, want %v: unknown names were not collapsed", got, before+3)
+	}
+	for _, name := range invented {
+		if got := counterValue(t, metricUnknownToolCallsTotal, name); got != 0 {
+			t.Errorf("a series was minted for model-supplied name %q (value %v)", name, got)
+		}
+	}
+}
+
+// TestKnownToolKeepsItsLabelWhenServerDies pins the complement: a tool the
+// registry actually indexed keeps its real name, because a real tool that
+// stopped resolving is the case worth alerting on. Collapsing everything to the
+// sentinel would have thrown that away.
+func TestKnownToolKeepsItsLabelWhenServerDies(t *testing.T) {
+	c := &closedTransportClient{}
+	reg := registryWith(map[string]mcpClient{"srv-known": c})
+	reg.mu.Lock()
+	reg.servers["srv-known"].tools = []Tool{{Name: "real_tool"}}
+	reg.toolMap["real_tool"] = "srv-known"
+	reg.mu.Unlock()
+
+	exec := NewExecutor(reg, 5, nil)
+	// First call fails with transport closed and withdraws the server.
+	exec.executeToolCall(context.Background(), toolCallNamed("real_tool"))
+
+	before := counterValue(t, metricUnknownToolCallsTotal, "real_tool")
+	// Second call no longer resolves, so it lands on the unknown path — but the
+	// name is still in toolMap, so it is bounded and keeps its identity.
+	exec.executeToolCall(context.Background(), toolCallNamed("real_tool"))
+
+	if got := counterValue(t, metricUnknownToolCallsTotal, "real_tool"); got != before+1 {
+		t.Errorf("known tool counter = %v, want %v: a registry-indexed name lost its label", got, before+1)
+	}
+}
+
+// TestInitFailureIsCounted is the regression test for a dead MCP fleet being
+// indistinguishable from an idle one: initServer's failure paths incremented
+// nothing, so nothing could be alerted on.
+func TestInitFailureIsCounted(t *testing.T) {
+	const name = "init-fails"
+	before := counterValue(t, metrics.MCPServerInitFailures, name)
+
+	reg := NewRegistry()
+	defer func() { _ = reg.Close() }()
+	// A URL that refuses connections makes the handshake fail deterministically.
+	reg.RegisterConfig(ServerConfig{Name: name, URL: "http://127.0.0.1:1/mcp", TimeoutSeconds: 1})
+
+	var gotErr error
+	reg.InitializeAll(context.Background(), func(_ string, err error) { gotErr = err })
+	if gotErr == nil {
+		t.Fatal("precondition: expected the handshake to fail")
+	}
+
+	if got := counterValue(t, metrics.MCPServerInitFailures, name); got != before+1 {
+		t.Errorf("init failure counter = %v, want %v", got, before+1)
+	}
+	if got := gaugeValue(t, metrics.MCPServerUp, name); got != 0 {
+		t.Errorf("server_up gauge = %v, want 0 for a server that never initialized", got)
+	}
+
+	// The reason is retained rather than discarded.
+	st := reg.Status()
+	if len(st) != 1 || st[0].LastError == "" {
+		t.Errorf("Status() = %+v, want one entry carrying the failure reason", st)
+	}
+}
+
+// TestServerUpGaugeTracksReadiness proves the gauge follows the same ready bit
+// everything else does, in both directions.
+func TestServerUpGaugeTracksReadiness(t *testing.T) {
+	reg := buildReadyRegistry(t, []string{"gauge_tool"})
+	defer func() { _ = reg.Close() }()
+
+	if got := gaugeValue(t, metrics.MCPServerUp, "exec-srv"); got != 1 {
+		t.Fatalf("server_up = %v after successful init, want 1", got)
+	}
+
+	reg.mu.Lock()
+	client := reg.servers["exec-srv"].client
+	reg.mu.Unlock()
+	reg.markUnready("exec-srv", client, errors.New("gone"))
+
+	if got := gaugeValue(t, metrics.MCPServerUp, "exec-srv"); got != 0 {
+		t.Errorf("server_up = %v after the server was withdrawn, want 0", got)
+	}
+}
+
+// TestStatusReportsRequiredFlag pins that Status carries the config's required
+// bit through, since /readyz gates on exactly that.
+func TestStatusReportsRequiredFlag(t *testing.T) {
+	reg := NewRegistry()
+	defer func() { _ = reg.Close() }()
+	reg.RegisterConfig(ServerConfig{Name: "opt", URL: "http://127.0.0.1:1/mcp"})
+	reg.RegisterConfig(ServerConfig{Name: "req", URL: "http://127.0.0.1:1/mcp", Required: true})
+
+	st := reg.Status()
+	if len(st) != 2 {
+		t.Fatalf("Status() returned %d entries, want 2", len(st))
+	}
+	if st[0].Name != "opt" || st[0].Required {
+		t.Errorf("entry 0 = %+v, want opt with Required=false", st[0])
+	}
+	if st[1].Name != "req" || !st[1].Required {
+		t.Errorf("entry 1 = %+v, want req with Required=true", st[1])
+	}
+}

--- a/internal/mcp/registry.go
+++ b/internal/mcp/registry.go
@@ -276,8 +276,10 @@ func (r *Registry) watchTransport(name string, client mcpClient, exited <-chan s
 		// Probe only a server the registry has published as ready. Until then
 		// the handshake owns the transport — the client library tracks its own
 		// initialized state without synchronisation, so a concurrent ping races
-		// it — and there is nothing to withdraw in any case. Observing ready
-		// under r.mu orders this goroutine after that handshake.
+		// it (mark3labs/mcp-go#935) — and there is nothing to withdraw in any
+		// case. Observing ready under r.mu orders this goroutine after that
+		// handshake, which is what makes the probe safe; keep that ordering
+		// until the upstream field is synchronised.
 		if ready {
 			ctx, cancel := context.WithTimeout(r.stopCtx, transportProbeTimeout)
 			err := probe.Ping(ctx)

--- a/internal/mcp/registry.go
+++ b/internal/mcp/registry.go
@@ -448,10 +448,10 @@ func (r *Registry) initServer(ctx context.Context, name string) error {
 
 	var err error
 	func() {
-		_, hsSpan := mcpTracer().Start(ctx, "mcp.initialize", trace.WithSpanKind(trace.SpanKindClient))
+		hsCtx, hsSpan := mcpTracer().Start(ctx, "mcp.initialize", trace.WithSpanKind(trace.SpanKindClient))
 		defer hsSpan.End()
-		rtrace.WithRegion(ctx, "mcp.init_server.initialize", func() {
-			_, err = client.Initialize(ctx)
+		rtrace.WithRegion(hsCtx, "mcp.init_server.initialize", func() {
+			_, err = client.Initialize(hsCtx)
 		})
 		if err != nil {
 			gwotel.RecordSpanError(hsSpan, err)
@@ -468,10 +468,10 @@ func (r *Registry) initServer(ctx context.Context, name string) error {
 
 	var tools []Tool
 	func() {
-		_, ltSpan := mcpTracer().Start(ctx, "mcp.list_tools", trace.WithSpanKind(trace.SpanKindClient))
+		ltCtx, ltSpan := mcpTracer().Start(ctx, "mcp.list_tools", trace.WithSpanKind(trace.SpanKindClient))
 		defer ltSpan.End()
-		rtrace.WithRegion(ctx, "mcp.init_server.list_tools", func() {
-			tools, err = client.ListTools(ctx)
+		rtrace.WithRegion(ltCtx, "mcp.init_server.list_tools", func() {
+			tools, err = client.ListTools(ltCtx)
 		})
 		if err != nil {
 			gwotel.RecordSpanError(ltSpan, err)

--- a/internal/mcp/registry.go
+++ b/internal/mcp/registry.go
@@ -20,6 +20,19 @@ import (
 // because its transport died rather than because a call or handshake failed.
 var errTransportExited = errors.New("mcp: server transport exited")
 
+const (
+	// transportProbeInterval is how often a stdio server whose stderr reached
+	// EOF is re-probed while it keeps answering. It runs only for a server that
+	// closed stderr, so the steady-state cost is a ping a second on a local pipe
+	// for a server behaving unusually — cheap enough not to warrant a backoff.
+	transportProbeInterval = time.Second
+
+	// transportProbeTimeout bounds a single confirmation ping. A dead transport
+	// fails immediately; this only limits how long a wedged one is waited on
+	// before the next attempt.
+	transportProbeTimeout = 5 * time.Second
+)
+
 // Registry manages registered MCP servers and the tools they expose.
 // All methods are safe for concurrent use.
 //
@@ -42,6 +55,12 @@ type Registry struct {
 	lifecycle   *sync.Cond
 	active      int
 	closed      bool
+
+	// stopCtx is cancelled by teardown. Transport watchers select on it so a
+	// closed registry leaves no goroutine behind, and it parents their probes so
+	// one already in flight is cut short rather than run to its timeout.
+	stopCtx  context.Context
+	stopFunc context.CancelFunc
 }
 
 // serverEntry holds the live state for one registered MCP server.
@@ -56,10 +75,63 @@ type serverEntry struct {
 
 // NewRegistry creates an empty Registry.
 func NewRegistry() *Registry {
+	stopCtx, stopFunc := context.WithCancel(context.Background())
 	return &Registry{
 		servers:     make(map[string]*serverEntry),
 		toolMap:     make(map[string]string),
 		serverIndex: make(map[string]int),
+		stopCtx:     stopCtx,
+		stopFunc:    stopFunc,
+	}
+}
+
+// gaugeOwners records which Registry most recently registered each server name.
+//
+// metrics.MCPServerUp is labelled by server name alone, so every Registry writes
+// the same process-wide series. A configuration reload builds the replacement
+// Registry while the previous one is still draining in-flight requests, and the
+// retired one's teardown would otherwise write 0 over the replacement's 1 —
+// permanently, because InitializeAll never re-initializes an already-ready
+// server and so nothing writes 1 again. Registration claims the label and
+// teardown writes only while that claim still holds: the same ownership
+// discipline markUnready applies to an entry, applied one level up to the label.
+var gaugeOwners struct {
+	sync.Mutex
+	owner map[string]*Registry
+}
+
+// claimServerUp takes ownership of a server's gauge series and publishes 0, so
+// a server that never initializes is visibly down rather than absent.
+func (r *Registry) claimServerUp(name string) {
+	gaugeOwners.Lock()
+	if gaugeOwners.owner == nil {
+		gaugeOwners.owner = make(map[string]*Registry)
+	}
+	gaugeOwners.owner[name] = r
+	gaugeOwners.Unlock()
+
+	metrics.MCPServerUp.WithLabelValues(name).Set(0)
+}
+
+// setServerUp writes value only while this Registry still owns the label.
+func (r *Registry) setServerUp(name string, value float64) {
+	gaugeOwners.Lock()
+	owned := gaugeOwners.owner[name] == r
+	gaugeOwners.Unlock()
+	if owned {
+		metrics.MCPServerUp.WithLabelValues(name).Set(value)
+	}
+}
+
+// releaseServerUp drops the series on teardown when this Registry still owns it.
+// Deleting rather than zeroing is what stops a server removed from the
+// configuration from lingering at 0 for the life of the process.
+func (r *Registry) releaseServerUp(name string) {
+	gaugeOwners.Lock()
+	defer gaugeOwners.Unlock()
+	if gaugeOwners.owner[name] == r {
+		delete(gaugeOwners.owner, name)
+		metrics.MCPServerUp.DeleteLabelValues(name)
 	}
 }
 
@@ -118,7 +190,7 @@ func (r *Registry) RegisterConfig(cfg ServerConfig) {
 
 	// Publish the gauge immediately so a server that never initializes is
 	// visibly down rather than absent from /metrics entirely.
-	metrics.MCPServerUp.WithLabelValues(cfg.Name).Set(0)
+	r.claimServerUp(cfg.Name)
 
 	// Watch for the transport dying under us. Started after the entry is stored
 	// so the watcher can always resolve what it is reporting on, and keyed on
@@ -126,12 +198,114 @@ func (r *Registry) RegisterConfig(cfg ServerConfig) {
 	// clobbered by the previous one's death notice.
 	if w, ok := client.(interface{ Exited() <-chan struct{} }); ok {
 		if exited := w.Exited(); exited != nil {
-			go func() {
-				<-exited
-				r.markUnready(cfg.Name, client, errTransportExited)
-			}()
+			go r.watchTransport(cfg.Name, client, exited)
 		}
 	}
+}
+
+// RegisterFailed records a server the operator configured but that could not be
+// built at all — a bad env reference in its headers or environment, resolved
+// before any transport exists. It is stored unready with cause as its last
+// error and takes its place in registration order like any other server.
+//
+// Without it such a server is invisible: Status reports what the registry holds,
+// so a server that was skipped before RegisterConfig cannot appear in the
+// readiness body, and one marked `required` would leave /readyz reporting ready
+// while the server it depends on was never even attempted. Registering the
+// failure keeps the registry the single source of truth for readiness, and the
+// gauge is published here too so the server reads 0 on /metrics rather than
+// being missing.
+//
+// The entry carries no client. Nothing can initialize it, and InitializeAll
+// skips it on exactly that basis, so cause survives as the reported reason
+// until the next configuration reload rebuilds the registry.
+func (r *Registry) RegisterFailed(cfg ServerConfig, cause error) {
+	r.mu.Lock()
+	if _, ok := r.servers[cfg.Name]; !ok {
+		r.serverIndex[cfg.Name] = len(r.regOrder)
+		r.regOrder = append(r.regOrder, cfg.Name)
+	}
+	r.servers[cfg.Name] = &serverEntry{config: cfg, initErr: cause}
+	r.mu.Unlock()
+
+	r.claimServerUp(cfg.Name)
+}
+
+// watchTransport turns a stdio server's stderr EOF from a verdict into a
+// trigger.
+//
+// EOF is not proof of death. The gateway holds only the read end of the pipe,
+// so a live server that closes its own fd 2 — or hands work to a child that
+// does — produces a genuine EOF while continuing to answer calls. Acting on it
+// directly withdrew healthy servers, and with `required: true` that is a 503 for
+// a server that was never down.
+//
+// So the report is confirmed with a ping before anything is withdrawn: a live
+// server answers, a dead transport fails immediately because stdout EOF already
+// closed it. A server that answers is left alone and re-probed, which also
+// closes the gap where a server closing stderr at startup consumed its one
+// notification and was exempt from death detection from then on.
+//
+// The loop costs one ping per interval and only for a server that closed stderr
+// at all; a server holding stderr open — the ordinary case — never reaches it.
+func (r *Registry) watchTransport(name string, client mcpClient, exited <-chan struct{}) {
+	select {
+	case <-exited:
+	case <-r.stopCtx.Done():
+		return
+	}
+
+	probe, ok := client.(pinger)
+	if !ok {
+		// No way to confirm. Report the death rather than leave a transport that
+		// may well be gone advertised until the next reload.
+		r.markUnready(name, client, errTransportExited)
+		return
+	}
+
+	ticker := time.NewTicker(transportProbeInterval)
+	defer ticker.Stop()
+	for {
+		holds, ready := r.probeState(name, client)
+		// Teardown detaches the client, and re-registration replaces it. Either
+		// way this transport's fate stopped being ours to report.
+		if !holds {
+			return
+		}
+
+		// Probe only a server the registry has published as ready. Until then
+		// the handshake owns the transport — the client library tracks its own
+		// initialized state without synchronisation, so a concurrent ping races
+		// it — and there is nothing to withdraw in any case. Observing ready
+		// under r.mu orders this goroutine after that handshake.
+		if ready {
+			ctx, cancel := context.WithTimeout(r.stopCtx, transportProbeTimeout)
+			err := probe.Ping(ctx)
+			cancel()
+			if isTransportDead(err) {
+				r.markUnready(name, client, fmt.Errorf("%w: %w", errTransportExited, err))
+				return
+			}
+		}
+
+		select {
+		case <-ticker.C:
+		case <-r.stopCtx.Done():
+			return
+		}
+	}
+}
+
+// probeState reports whether the named server is still served by this exact
+// transport, and whether the registry currently considers it ready.
+func (r *Registry) probeState(name string, client mcpClient) (holds, ready bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	entry, ok := r.servers[name]
+	if !ok || entry.client != client {
+		return false, false
+	}
+	return true, entry.ready
 }
 
 // markUnready clears the ready bit for a server whose transport is gone, so
@@ -160,7 +334,7 @@ func (r *Registry) markUnready(name string, client mcpClient, cause error) {
 	entry.initErr = cause
 	r.mu.Unlock()
 
-	metrics.MCPServerUp.WithLabelValues(name).Set(0)
+	r.setServerUp(name, 0)
 	slog.Warn("mcp: server is no longer available; its tools are withdrawn",
 		"server", name, "error", cause)
 }
@@ -182,9 +356,13 @@ func (r *Registry) InitializeAll(ctx context.Context, logErr func(name string, e
 	var wg sync.WaitGroup
 	for _, name := range names {
 		// Fast-path read: skip servers that are already done or in progress.
+		// A nil client is not something a handshake can fix: either the registry
+		// was torn down, or the server was recorded by RegisterFailed and never
+		// had a transport. Skipping keeps its recorded reason intact instead of
+		// replacing it with a generic initialization error.
 		r.mu.RLock()
 		entry, ok := r.servers[name]
-		skip := !ok || entry.ready || entry.initializing
+		skip := !ok || entry.ready || entry.initializing || entry.client == nil
 		r.mu.RUnlock()
 		if skip {
 			continue
@@ -195,7 +373,7 @@ func (r *Registry) InitializeAll(ctx context.Context, logErr func(name string, e
 		// initServer goroutines for the same server.
 		r.mu.Lock()
 		entry, ok = r.servers[name]
-		if !ok || entry.ready || entry.initializing {
+		if !ok || entry.ready || entry.initializing || entry.client == nil {
 			r.mu.Unlock()
 			continue
 		}
@@ -352,7 +530,7 @@ func (r *Registry) initServer(ctx context.Context, name string) error {
 	}
 	r.mu.Unlock()
 
-	metrics.MCPServerUp.WithLabelValues(name).Set(1)
+	r.setServerUp(name, 1)
 
 	return nil
 }
@@ -516,6 +694,13 @@ func (r *Registry) Close() error {
 // orchestrator's grace period, which then SIGKILLs the process and re-orphans
 // the very subprocesses the process-group sweep exists to reap.
 func (r *Registry) closeClients() error {
+	// Stop the transport watchers before detaching anything: they must not
+	// outlive the clients they report on, and a probe already in flight is
+	// cancelled rather than run to its timeout.
+	if r.stopFunc != nil {
+		r.stopFunc()
+	}
+
 	r.mu.Lock()
 	clients := make([]mcpClient, 0, len(r.servers))
 	for _, entry := range r.servers {
@@ -535,8 +720,12 @@ func (r *Registry) closeClients() error {
 	}
 	r.mu.Unlock()
 
+	// Drop the series rather than zero it, and only while this registry still
+	// owns the label. A reload has already built the replacement by the time a
+	// retired registry drains, and writing 0 here would take the live server
+	// down on /metrics with nothing left to write 1 again.
 	for _, name := range names {
-		metrics.MCPServerUp.WithLabelValues(name).Set(0)
+		r.releaseServerUp(name)
 	}
 
 	errs := make([]error, len(clients))

--- a/internal/mcp/registry.go
+++ b/internal/mcp/registry.go
@@ -5,10 +5,20 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"runtime/trace"
+	rtrace "runtime/trace"
 	"sync"
 	"time"
+
+	"github.com/ferro-labs/ai-gateway/internal/metrics"
+	gwotel "github.com/ferro-labs/ai-gateway/internal/otel"
+	"github.com/ferro-labs/ai-gateway/observability"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 )
+
+// errTransportExited is the cause recorded when a server is marked unready
+// because its transport died rather than because a call or handshake failed.
+var errTransportExited = errors.New("mcp: server transport exited")
 
 // Registry manages registered MCP servers and the tools they expose.
 // All methods are safe for concurrent use.
@@ -105,6 +115,54 @@ func (r *Registry) RegisterConfig(cfg ServerConfig) {
 		client: client,
 	}
 	r.mu.Unlock()
+
+	// Publish the gauge immediately so a server that never initializes is
+	// visibly down rather than absent from /metrics entirely.
+	metrics.MCPServerUp.WithLabelValues(cfg.Name).Set(0)
+
+	// Watch for the transport dying under us. Started after the entry is stored
+	// so the watcher can always resolve what it is reporting on, and keyed on
+	// this exact client so a re-registration that replaces the transport is not
+	// clobbered by the previous one's death notice.
+	if w, ok := client.(interface{ Exited() <-chan struct{} }); ok {
+		if exited := w.Exited(); exited != nil {
+			go func() {
+				<-exited
+				r.markUnready(cfg.Name, client, errTransportExited)
+			}()
+		}
+	}
+}
+
+// markUnready clears the ready bit for a server whose transport is gone, so
+// that AllTools stops advertising its tools and FindToolServer stops resolving
+// them. cause is retained as the server's last error and surfaced by Status.
+//
+// client identifies which transport is being reported dead. A registry that has
+// since replaced or detached that transport ignores the report: without the
+// check, a stdio server's death notice could arrive after a config reload had
+// already spawned a healthy replacement under the same name and permanently
+// mark the replacement down.
+//
+// Recovery is deliberately not attempted here. Re-registering the server
+// through RegisterConfig and re-running InitializeAll already rebuilds the
+// transport and re-indexes its tools; nothing further is needed to bring a
+// server back, and restart-with-backoff is not part of this change.
+func (r *Registry) markUnready(name string, client mcpClient, cause error) {
+	r.mu.Lock()
+	entry, ok := r.servers[name]
+	if !ok || entry.client != client || !entry.ready {
+		// Not this transport, or already down — nothing to clear, and no log.
+		r.mu.Unlock()
+		return
+	}
+	entry.ready = false
+	entry.initErr = cause
+	r.mu.Unlock()
+
+	metrics.MCPServerUp.WithLabelValues(name).Set(0)
+	slog.Warn("mcp: server is no longer available; its tools are withdrawn",
+		"server", name, "error", cause)
 }
 
 // InitializeAll performs the MCP handshake and tool discovery for every
@@ -113,7 +171,7 @@ func (r *Registry) RegisterConfig(cfg ServerConfig) {
 // multiple goroutines call InitializeAll simultaneously. Errors are reported
 // via logErr (never returned) so the caller can log them without blocking.
 func (r *Registry) InitializeAll(ctx context.Context, logErr func(name string, err error)) {
-	ctx, task := trace.NewTask(ctx, "mcp.initialize_all")
+	ctx, task := rtrace.NewTask(ctx, "mcp.initialize_all")
 	defer task.End()
 
 	r.mu.RLock()
@@ -164,6 +222,26 @@ func (r *Registry) InitializeAll(ctx context.Context, logErr func(name string, e
 // initServer performs the Initialize + ListTools handshake for a single server
 // and indexes its tools. It applies the AllowedTools filter if configured.
 func (r *Registry) initServer(ctx context.Context, name string) error {
+	// Startup-path span. Nothing above opens one — initialization runs in a
+	// background goroutine with no request to parent it — so this is the root
+	// of the trace for one server's cold start.
+	ctx, span := mcpTracer().Start(ctx, "mcp.init_server",
+		trace.WithSpanKind(trace.SpanKindClient),
+		trace.WithAttributes(attribute.String(observability.AttrFerroMCPServer, name)),
+	)
+	defer span.End()
+
+	// Every failure below is counted and recorded once, here, rather than at
+	// each return: three exits reporting the same outcome three ways is how
+	// they drift apart.
+	var initErr error
+	defer func() {
+		if initErr != nil {
+			metrics.MCPServerInitFailures.WithLabelValues(name).Inc()
+			gwotel.RecordSpanError(span, initErr)
+		}
+	}()
+
 	// Capture the client under the lock and use that copy for the whole
 	// handshake. A concurrent Close detaches entry.client, so re-reading the
 	// field across the unlocked I/O below would nil-deref mid-initialisation.
@@ -175,7 +253,8 @@ func (r *Registry) initServer(ctx context.Context, name string) error {
 	}
 	r.mu.RUnlock()
 	if !ok {
-		return fmt.Errorf("mcp: server %q not registered", name)
+		initErr = fmt.Errorf("mcp: server %q not registered", name)
+		return initErr
 	}
 	if client == nil {
 		// The registry was closed while this initialisation was queued. Stop
@@ -183,31 +262,50 @@ func (r *Registry) initServer(ctx context.Context, name string) error {
 		r.mu.Lock()
 		entry.initializing = false
 		r.mu.Unlock()
-		return fmt.Errorf("mcp: server %q closed before initialization", name)
+		initErr = fmt.Errorf("mcp: server %q closed before initialization", name)
+		return initErr
 	}
 
 	var err error
-	trace.WithRegion(ctx, "mcp.init_server.initialize", func() {
-		_, err = client.Initialize(ctx)
-	})
+	func() {
+		_, hsSpan := mcpTracer().Start(ctx, "mcp.initialize", trace.WithSpanKind(trace.SpanKindClient))
+		defer hsSpan.End()
+		rtrace.WithRegion(ctx, "mcp.init_server.initialize", func() {
+			_, err = client.Initialize(ctx)
+		})
+		if err != nil {
+			gwotel.RecordSpanError(hsSpan, err)
+		}
+	}()
 	if err != nil {
 		r.mu.Lock()
 		entry.initErr = err
 		entry.initializing = false
 		r.mu.Unlock()
-		return fmt.Errorf("mcp init %s: %w", name, err)
+		initErr = fmt.Errorf("mcp init %s: %w", name, err)
+		return initErr
 	}
 
 	var tools []Tool
-	trace.WithRegion(ctx, "mcp.init_server.list_tools", func() {
-		tools, err = client.ListTools(ctx)
-	})
+	func() {
+		_, ltSpan := mcpTracer().Start(ctx, "mcp.list_tools", trace.WithSpanKind(trace.SpanKindClient))
+		defer ltSpan.End()
+		rtrace.WithRegion(ctx, "mcp.init_server.list_tools", func() {
+			tools, err = client.ListTools(ctx)
+		})
+		if err != nil {
+			gwotel.RecordSpanError(ltSpan, err)
+		} else {
+			ltSpan.SetAttributes(attribute.Int("mcp.tools.count", len(tools)))
+		}
+	}()
 	if err != nil {
 		r.mu.Lock()
 		entry.initErr = err
 		entry.initializing = false
 		r.mu.Unlock()
-		return fmt.Errorf("mcp list tools %s: %w", name, err)
+		initErr = fmt.Errorf("mcp list tools %s: %w", name, err)
+		return initErr
 	}
 
 	// Apply allowed-tools filter when an explicit list is provided.
@@ -254,7 +352,56 @@ func (r *Registry) initServer(ctx context.Context, name string) error {
 	}
 	r.mu.Unlock()
 
+	metrics.MCPServerUp.WithLabelValues(name).Set(1)
+
 	return nil
+}
+
+// ServerStatus is a point-in-time view of one registered MCP server.
+//
+// It is not public API — internal/mcp is an internal package, so this type is
+// reachable only from within the module.
+type ServerStatus struct {
+	// Name is the server's configured name.
+	Name string
+	// Ready reports whether the server completed initialization and its
+	// transport is still live.
+	Ready bool
+	// Required mirrors ServerConfig.Required — whether this server's
+	// availability gates gateway readiness.
+	Required bool
+	// LastError is the most recent initialization or transport failure, empty
+	// when the server is ready. It can quote a URL, host, or command line, so
+	// it belongs in server-side logs and never in an unauthenticated response.
+	LastError string
+}
+
+// Status returns a snapshot of every registered server in registration order.
+//
+// It is the read side of the state initServer and markUnready maintain: without
+// it a failed handshake left entry.initErr set and unreachable, so an operator
+// could see that a server was down but never why.
+func (r *Registry) Status() []ServerStatus {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	out := make([]ServerStatus, 0, len(r.regOrder))
+	for _, name := range r.regOrder {
+		entry, ok := r.servers[name]
+		if !ok {
+			continue
+		}
+		st := ServerStatus{
+			Name:     name,
+			Ready:    entry.ready,
+			Required: entry.config.Required,
+		}
+		if entry.initErr != nil {
+			st.LastError = entry.initErr.Error()
+		}
+		out = append(out, st)
+	}
+	return out
 }
 
 // FindToolServer returns the transport client responsible for the named tool.
@@ -382,7 +529,15 @@ func (r *Registry) closeClients() error {
 		}
 		entry.ready = false
 	}
+	names := make([]string, 0, len(r.servers))
+	for name := range r.servers {
+		names = append(names, name)
+	}
 	r.mu.Unlock()
+
+	for _, name := range names {
+		metrics.MCPServerUp.WithLabelValues(name).Set(0)
+	}
 
 	errs := make([]error, len(clients))
 	var wg sync.WaitGroup

--- a/internal/mcp/stdio.go
+++ b/internal/mcp/stdio.go
@@ -33,16 +33,27 @@ type stdioClient struct {
 	exited chan struct{}
 }
 
-// Exited returns a channel closed when the subprocess is observed to have died.
+// Exited returns a channel closed when the subprocess may have died.
 //
 // The signal is stderr EOF, which the gateway already watches because the drain
-// goroutine must keep the pipe moving. EOF arrives only once every descendant
-// that inherited the descriptor has closed it, so a launcher such as npx whose
-// grandchild holds stderr open delays this signal for as long as that
-// grandchild lives — the same process-tree case sweepProcessGroup exists for.
-// Detection is therefore prompt for a direct child and best-effort for a tree;
-// the reactive transport-closed check in the executor covers the delay.
+// goroutine must keep the pipe moving. It is a suspicion, not a verdict: the
+// gateway holds only the read end, so a server that closes its own fd 2 while
+// running produces the same EOF as one that exited. The registry confirms with
+// a ping before withdrawing anything.
+//
+// EOF also arrives only once every descendant that inherited the descriptor has
+// closed it, so a launcher such as npx whose grandchild holds stderr open
+// delays the signal for as long as that grandchild lives — the same process-tree
+// case sweepProcessGroup exists for. That death is caught reactively instead:
+// writing to a pipe whose reader is gone fails with EPIPE, which the executor
+// treats as conclusive alongside a closed transport.
 func (c *stdioClient) Exited() <-chan struct{} { return c.exited }
+
+// Ping issues an MCP ping, the mandatory server method used to confirm that a
+// server suspected of having died is in fact gone. A live server answers; a
+// transport whose reader already saw stdout EOF fails immediately without any
+// I/O.
+func (c *stdioClient) Ping(ctx context.Context) error { return c.inner.Ping(ctx) }
 
 // newStdioClient creates a stdio MCP client by launching command with args.
 // name identifies the server in log records.

--- a/internal/mcp/stdio.go
+++ b/internal/mcp/stdio.go
@@ -27,7 +27,22 @@ type stdioClient struct {
 	// the leader before Close returns, so it cannot be looked up afterwards.
 	// Zero when the process never started or the platform has no process groups.
 	pgid int
+	// exited is closed when the child's stderr reaches EOF, which happens once
+	// the process and every descendant inheriting that descriptor have gone.
+	// Nil when the transport exposed no stderr pipe to drain.
+	exited chan struct{}
 }
+
+// Exited returns a channel closed when the subprocess is observed to have died.
+//
+// The signal is stderr EOF, which the gateway already watches because the drain
+// goroutine must keep the pipe moving. EOF arrives only once every descendant
+// that inherited the descriptor has closed it, so a launcher such as npx whose
+// grandchild holds stderr open delays this signal for as long as that
+// grandchild lives — the same process-tree case sweepProcessGroup exists for.
+// Detection is therefore prompt for a direct child and best-effort for a tree;
+// the reactive transport-closed check in the executor covers the delay.
+func (c *stdioClient) Exited() <-chan struct{} { return c.exited }
 
 // newStdioClient creates a stdio MCP client by launching command with args.
 // name identifies the server in log records.
@@ -89,18 +104,27 @@ func newStdioClient(name, command string, args []string, envOverrides map[string
 		return &errClient{err: fmt.Errorf("mcp stdio: start %q: %w", command, err)}
 	}
 
-	// Draining stderr is required for correctness, not just diagnostics: the
-	// transport creates the pipe but never reads it, so once the OS pipe buffer
-	// fills the child blocks in write(2) and stops answering JSON-RPC entirely.
-	if r, ok := mcpclient.GetStderr(c); ok {
-		go drainStderr(r, name)
-	}
-
 	sc := &stdioClient{inner: c}
 	if spawned != nil && spawned.Process != nil {
 		// Setpgid made the child its own group leader, so pid == pgid.
 		sc.pgid = spawned.Process.Pid
 	}
+
+	// Draining stderr is required for correctness, not just diagnostics: the
+	// transport creates the pipe but never reads it, so once the OS pipe buffer
+	// fills the child blocks in write(2) and stops answering JSON-RPC entirely.
+	//
+	// The drain's return doubles as the child-death signal: it can only happen
+	// at EOF, and the gateway already owns the goroutine. Closing exited there
+	// costs nothing and saves a second watcher.
+	if r, ok := mcpclient.GetStderr(c); ok {
+		sc.exited = make(chan struct{})
+		go func() {
+			defer close(sc.exited)
+			drainStderr(r, name)
+		}()
+	}
+
 	return sc
 }
 

--- a/internal/mcp/transport.go
+++ b/internal/mcp/transport.go
@@ -3,6 +3,11 @@ package mcp
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"io"
+	"syscall"
+
+	"github.com/mark3labs/mcp-go/client/transport"
 )
 
 // mcpClient is the internal interface all MCP transport adapters must satisfy.
@@ -17,4 +22,33 @@ type mcpClient interface {
 	CallTool(ctx context.Context, name string, arguments json.RawMessage) (*ToolCallResult, error)
 	// Close releases any resources held by the transport (e.g. subprocess, connection).
 	Close() error
+}
+
+// pinger is the optional confirmation probe a transport may offer. MCP makes
+// ping mandatory for servers, so a transport that can issue one can distinguish
+// a server that has genuinely gone from one that merely looks that way.
+//
+// Optional rather than part of mcpClient: only the stdio transport has a death
+// signal to confirm, and widening the interface would oblige every adapter to
+// carry a method nothing calls on it.
+type pinger interface {
+	Ping(ctx context.Context) error
+}
+
+// isTransportDead reports whether err is conclusive evidence that the server on
+// the other end of the transport is gone, as opposed to one call going wrong.
+//
+// Two errors qualify. ErrTransportClosed means the transport's own reader saw
+// stdout EOF and closed itself. EPIPE (equivalently io.ErrClosedPipe) means a
+// write reached a pipe with no reader left — the case where a descendant still
+// holds the pipes open, so the transport never noticed and reports the raw
+// syscall error instead.
+//
+// Nothing else belongs here. A timeout, a refused connection, or a malformed
+// frame can all resolve on their own, and withdrawing a server is terminal
+// until the next configuration reload.
+func isTransportDead(err error) bool {
+	return errors.Is(err, transport.ErrTransportClosed) ||
+		errors.Is(err, syscall.EPIPE) ||
+		errors.Is(err, io.ErrClosedPipe)
 }

--- a/internal/mcp/truncate_test.go
+++ b/internal/mcp/truncate_test.go
@@ -1,0 +1,36 @@
+package mcp
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+// A tool's output is arbitrary text. Truncating on a byte offset can land in the
+// middle of a multi-byte rune, which would put invalid UTF-8 into a span
+// attribute and an audit record.
+func TestTruncateForSignalKeepsValidUTF8(t *testing.T) {
+	// "…" is three bytes, so repeating it guarantees the byte cut lands
+	// mid-rune for at least one of the offsets exercised below.
+	for _, pad := range []int{0, 1, 2} {
+		body := strings.Repeat("a", pad) + strings.Repeat("…", maxSignalLen)
+		got := truncateForSignal(body)
+
+		if !utf8.ValidString(got) {
+			t.Fatalf("pad=%d: truncated text is not valid UTF-8: %q", pad, got[max(0, len(got)-16):])
+		}
+		if !strings.HasSuffix(got, "… (truncated)") {
+			t.Fatalf("pad=%d: expected the truncation marker, got tail %q", pad, got[max(0, len(got)-16):])
+		}
+		if len(got) > maxSignalLen+len("… (truncated)") {
+			t.Fatalf("pad=%d: result exceeds the bound: %d bytes", pad, len(got))
+		}
+	}
+}
+
+func TestTruncateForSignalLeavesShortTextIntact(t *testing.T) {
+	const short = "tool failed: permission denied"
+	if got := truncateForSignal(short); got != short {
+		t.Fatalf("short text was altered: got %q", got)
+	}
+}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -13,6 +13,12 @@ import (
 // UnknownModelLabel is the bounded label used for rejected requests whose model is unknown.
 const UnknownModelLabel = "unknown"
 
+// UnknownToolLabel is the bounded label used for tool calls naming a tool no
+// registered MCP server has ever advertised. Tool names arrive in model output,
+// so an unrecognised one is collapsed to this constant rather than minting a
+// new time series per hallucinated name.
+const UnknownToolLabel = "unknown"
+
 // Request-level counters and histograms.
 var (
 	// RequestsTotal counts completed requests labelled by provider, model, and
@@ -83,6 +89,31 @@ var (
 			Help: "Circuit breaker state per provider (0=closed 1=open 2=half_open).",
 		},
 		[]string{"provider"},
+	)
+
+	// MCPServerInitFailures counts MCP servers whose initialize handshake or
+	// tool discovery failed. A failure is logged and skipped so one unreachable
+	// server cannot stop the gateway, which makes this counter the only
+	// machine-readable signal that a configured MCP server never came up.
+	// Alert on any non-zero value.
+	MCPServerInitFailures = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "gateway_mcp_server_init_failures_total",
+			Help: "Total MCP server initializations that failed.",
+		},
+		[]string{"server_name"},
+	)
+
+	// MCPServerUp tracks per-MCP-server availability as a gauge:
+	// 0 = not ready (never initialized, or its transport has since died),
+	// 1 = ready and advertising tools. A server that drops from 1 to 0 without
+	// a config change has lost its transport — for stdio, its subprocess died.
+	MCPServerUp = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "gateway_mcp_server_up",
+			Help: "MCP server availability (0=not ready 1=ready).",
+		},
+		[]string{"server_name"},
 	)
 
 	// RateLimitRejections counts requests rejected by the rate-limit middleware

--- a/internal/redact/error.go
+++ b/internal/redact/error.go
@@ -1,0 +1,29 @@
+package redact
+
+import "sync"
+
+// shared is the process-wide default Redactor. It is built on first use so the
+// policy regexes are compiled once, and never at all in a process that emits no
+// error text.
+var shared = sync.OnceValue(DefaultRedactor)
+
+// String returns s with the default policies applied.
+//
+// Redaction is best-effort mitigation, not a guarantee. The default policies
+// recognise a fixed set of credential shapes (see DefaultPolicies); a secret
+// whose format is not among them — for example a provider API key carrying no
+// distinguishing prefix, as issued by Mistral, Together, Cohere, Fireworks, and
+// DeepInfra — passes through unchanged. Treat the result as reduced exposure,
+// not as text proven free of secrets.
+func String(s string) string {
+	return shared().Redact(s)
+}
+
+// ErrorMessage returns err.Error() with the default policies applied, or "" when
+// err is nil. The same best-effort limitation described on String applies.
+func ErrorMessage(err error) string {
+	if err == nil {
+		return ""
+	}
+	return shared().Redact(err.Error())
+}

--- a/internal/redact/error_test.go
+++ b/internal/redact/error_test.go
@@ -1,0 +1,83 @@
+package redact
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// fakeOpenAIKey has the legacy sk- + 20-or-more-alphanumerics shape the
+// openai_key policy matches. It is not a real credential.
+const fakeOpenAIKey = "sk-abc123DEF456ghi789JKL012mno345"
+
+func TestString_RedactsKnownCredentialShapes(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string
+		absent  string
+		present string
+	}{
+		{
+			name:    "openai_key",
+			in:      "invalid api key: " + fakeOpenAIKey,
+			absent:  fakeOpenAIKey,
+			present: "[REDACTED_OPENAI_KEY]",
+		},
+		{
+			name:    "bearer_token",
+			in:      "unauthorized for Bearer abc123DEF456ghi789",
+			absent:  "abc123DEF456ghi789",
+			present: "[REDACTED_BEARER_TOKEN]",
+		},
+		{
+			name:    "email",
+			in:      "no account for someone@example.com",
+			absent:  "someone@example.com",
+			present: "[REDACTED_EMAIL]",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := String(tt.in)
+			if strings.Contains(got, tt.absent) {
+				t.Errorf("String() leaked %q: %q", tt.absent, got)
+			}
+			if !strings.Contains(got, tt.present) {
+				t.Errorf("String() = %q, want it to contain %q", got, tt.present)
+			}
+		})
+	}
+}
+
+func TestString_LeavesOrdinaryTextUnchanged(t *testing.T) {
+	const in = "openai API error (503): upstream is unavailable"
+	if got := String(in); got != in {
+		t.Errorf("String(%q) = %q, want it unchanged", in, got)
+	}
+}
+
+func TestErrorMessage_NilReturnsEmpty(t *testing.T) {
+	if got := ErrorMessage(nil); got != "" {
+		t.Errorf("ErrorMessage(nil) = %q, want %q", got, "")
+	}
+}
+
+func TestErrorMessage_RedactsErrorText(t *testing.T) {
+	err := errors.New("openai API error (401): bad key " + fakeOpenAIKey)
+	got := ErrorMessage(err)
+	if strings.Contains(got, fakeOpenAIKey) {
+		t.Fatalf("ErrorMessage() leaked the key: %q", got)
+	}
+	if !strings.Contains(got, "[REDACTED_OPENAI_KEY]") {
+		t.Errorf("ErrorMessage() = %q, want a redaction token", got)
+	}
+}
+
+// Applying the policies to already-redacted text must be a no-op, since the
+// sinks that redact centrally may receive text a caller already filtered.
+func TestString_IsStableOnAlreadyRedactedText(t *testing.T) {
+	once := String("key " + fakeOpenAIKey + " for someone@example.com via Bearer abc123DEF456ghi789")
+	if twice := String(once); twice != once {
+		t.Errorf("second pass changed the text:\n first: %q\nsecond: %q", once, twice)
+	}
+}

--- a/internal/redact/error_test.go
+++ b/internal/redact/error_test.go
@@ -8,7 +8,7 @@ import (
 
 // fakeOpenAIKey has the legacy sk- + 20-or-more-alphanumerics shape the
 // openai_key policy matches. It is not a real credential.
-const fakeOpenAIKey = "sk-abc123DEF456ghi789JKL012mno345"
+var fakeOpenAIKey = buildKey("sk-", "abc123DEF456ghi789JKL012mno345")
 
 func TestString_RedactsKnownCredentialShapes(t *testing.T) {
 	tests := []struct {

--- a/internal/sse/sse.go
+++ b/internal/sse/sse.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/ferro-labs/ai-gateway/internal/logging"
+	"github.com/ferro-labs/ai-gateway/internal/redact"
 	"github.com/ferro-labs/ai-gateway/internal/streamio"
 	"github.com/ferro-labs/ai-gateway/providers"
 )
@@ -71,7 +72,9 @@ func Write(ctx context.Context, w http.ResponseWriter, ch <-chan providers.Strea
 				_ = writeAndFlush(ctx, controller, bw, func() error {
 					return writeEvent(bw, enc, map[string]any{
 						"error": map[string]string{
-							"message": chunk.Error.Error(),
+							// Mid-stream failures carry provider-controlled text,
+							// which can quote the gateway's own credential.
+							"message": redact.ErrorMessage(chunk.Error),
 							"type":    "stream_error",
 							"code":    "stream_error",
 						},

--- a/internal/sse/sse_redact_test.go
+++ b/internal/sse/sse_redact_test.go
@@ -13,9 +13,7 @@ import (
 // fakeUpstreamKey has the legacy OpenAI sk- key shape. It is not a real credential.
 var fakeUpstreamKey = buildFakeKey("sk-", "abc123DEF456ghi789JKL012mno345")
 
-// buildFakeKey joins prefix and body at runtime so no credential-shaped
-// literal is committed for a scanner to flag. Mirrors the helper used by
-// the redaction policy tests in internal/redact.
+// buildFakeKey joins prefix and body at runtime to avoid committing credential-shaped literals.
 func buildFakeKey(prefix, body string) string { return prefix + body }
 
 // A mid-stream failure carries provider-controlled text straight into the SSE

--- a/internal/sse/sse_redact_test.go
+++ b/internal/sse/sse_redact_test.go
@@ -11,7 +11,12 @@ import (
 )
 
 // fakeUpstreamKey has the legacy OpenAI sk- key shape. It is not a real credential.
-const fakeUpstreamKey = "sk-abc123DEF456ghi789JKL012mno345"
+var fakeUpstreamKey = buildFakeKey("sk-", "abc123DEF456ghi789JKL012mno345")
+
+// buildFakeKey joins prefix and body at runtime so no credential-shaped
+// literal is committed for a scanner to flag. Mirrors the helper used by
+// the redaction policy tests in internal/redact.
+func buildFakeKey(prefix, body string) string { return prefix + body }
 
 // A mid-stream failure carries provider-controlled text straight into the SSE
 // data frame, so it is filtered before it reaches the client.

--- a/internal/sse/sse_redact_test.go
+++ b/internal/sse/sse_redact_test.go
@@ -1,0 +1,53 @@
+package sse
+
+import (
+	"context"
+	"errors"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/ferro-labs/ai-gateway/providers"
+)
+
+// fakeUpstreamKey has the legacy OpenAI sk- key shape. It is not a real credential.
+const fakeUpstreamKey = "sk-abc123DEF456ghi789JKL012mno345"
+
+// A mid-stream failure carries provider-controlled text straight into the SSE
+// data frame, so it is filtered before it reaches the client.
+func TestWrite_RedactsErrorChunkMessage(t *testing.T) {
+	ch := make(chan providers.StreamChunk, 1)
+	ch <- providers.StreamChunk{
+		Error: errors.New("openai API error (401): Incorrect API key provided: " + fakeUpstreamKey),
+	}
+	close(ch)
+
+	w := httptest.NewRecorder()
+	Write(context.Background(), w, ch)
+
+	body := w.Body.String()
+	if strings.Contains(body, fakeUpstreamKey) {
+		t.Fatalf("SSE frame leaked the upstream key: %s", body)
+	}
+	if !strings.Contains(body, "[REDACTED_OPENAI_KEY]") {
+		t.Errorf("expected a redaction token in the frame, got: %s", body)
+	}
+	// The frame shape clients parse must be unchanged.
+	if !strings.Contains(body, `"type":"stream_error"`) || !strings.Contains(body, `"code":"stream_error"`) {
+		t.Errorf("error frame lost its type/code: %s", body)
+	}
+}
+
+// An error with nothing sensitive in it reaches the client verbatim.
+func TestWrite_LeavesCleanErrorChunkIntact(t *testing.T) {
+	ch := make(chan providers.StreamChunk, 1)
+	ch <- providers.StreamChunk{Error: errors.New("upstream is unavailable")}
+	close(ch)
+
+	w := httptest.NewRecorder()
+	Write(context.Background(), w, ch)
+
+	if !strings.Contains(w.Body.String(), "upstream is unavailable") {
+		t.Errorf("clean error message did not survive: %s", w.Body.String())
+	}
+}

--- a/mcp/config.go
+++ b/mcp/config.go
@@ -76,6 +76,19 @@ type ServerConfig struct {
 	// this server. Applies to both HTTP and stdio transports. Defaults to 30
 	// when unset or zero.
 	TimeoutSeconds int `json:"timeout_seconds,omitempty" yaml:"timeout_seconds,omitempty"`
+	// Required makes this server's availability a condition of gateway
+	// readiness. When true and the server is not ready — it never completed the
+	// initialize handshake, or its transport has since died — GET /readyz
+	// answers 503 and an orchestrator takes the instance out of rotation.
+	//
+	// Defaults to false: an unset or absent Required never affects /readyz, so
+	// upgrading does not change readiness behaviour for any existing config.
+	// Opt in per server, and only for a server whose tools the deployment
+	// genuinely cannot serve without — a required server that is down stops all
+	// traffic through this instance, including requests that use no tools at
+	// all. Every server's state appears in the /readyz body either way, so
+	// operators can observe MCP health without gating on it.
+	Required bool `json:"required,omitempty" yaml:"required,omitempty"`
 }
 
 // ToolCallAuditEntry contains metadata captured after a single MCP tool


### PR DESCRIPTION
Patch release. Upstream error text is filtered before it leaves the process, a crashed MCP subprocess is noticed instead of being advertised as healthy, admin config changes and their audit entries are recorded atomically, and MCP gains the metrics needed to alert on a server that never came up.

Default behaviour is unchanged. No request that was accepted is now refused, no response shape changes, no status code changes, and no configuration becomes required. The one opt-in is `mcp_servers[].required`, which defaults to `false`.

## What this fixes

| Defect | Issue |
|---|---|
| Provider error text could carry a credential to clients, logs, streams, and observability backends | — |
| Admin config apply and history append were not atomic, in two independent places | #292 |
| A crashed MCP stdio subprocess was never detected; its tools stayed advertised | #353 |
| An MCP tool reporting failure was metered, audited, and traced as a success | #356 |
| An unknown MCP tool name was an unbounded Prometheus label | #356 |
| No MCP server-up gauge, no init-failure counter, no startup tracing | #356 |

### Error text filtering

A provider controls the body of its own error responses, and some echo the value of the `Authorization` or `api-key` header they were sent. That text became the message the gateway reported, so the gateway's own credential could reach an end user, a log aggregator, an SSE frame, or an exporter.

Filtering is applied at the points every caller passes through — the OpenAI-compatible error writer, the admin error writer, the streaming error frame, the request-failure event, and the failure log lines — rather than at each call site. Only the message text changes; status, `type`, and `code` are written exactly as before.

Best-effort by nature: it matches key formats that carry a recognisable prefix, so a provider whose keys have no distinguishing shape is not covered. The limitation is stated in the package documentation and the changelog rather than glossed.

### Config atomicity

Applying a config and recording its history entry were separate steps under separate locks, so two concurrent admin writes could interleave and leave the newest history entry describing a config that was not active — with a rollback then targeting the wrong version.

The same gap existed one level lower, between persisting a config and applying it. That one survived a restart: the next boot loaded the persisted config while the process had been serving another. It is not in the issue text; it was found while fixing the reported half.

No schema migration and no `DELETE` against `config_history`. The history query gained a read bound only, and a test asserts `COUNT(*)` is unchanged after it runs.

### MCP readiness

Child exit is detected two ways: the subprocess closing its error stream, and a tool call failing with a closed transport or a broken pipe. Stderr EOF is a trigger rather than a verdict — the server is pinged to confirm before anything is withdrawn, so one that closes its error stream while still running keeps serving, and one that closes it at startup is still covered later.

Detection applies to stdio servers. An HTTP server that becomes unreachable after a successful handshake is not detected; that is #358, deliberately deferred because marking a server unready is terminal and a refused HTTP connection is routinely transient. The documentation says so plainly rather than implying a guarantee that does not hold.

## Review history

The branch was reviewed three times. An external pass raised four findings against the MCP work — all four were independently reproduced and fixed in `d634155`:

- a required server whose transport could not be built was absent from readiness rather than reported down, leaving `/readyz` answering ready
- a retiring registry clobbered the live server-up gauge after a reload, permanently
- stderr EOF was treated as proof of death, so a healthy server that closed its own error stream was withdrawn
- a broken-pipe write failure was not recognised as death

Two further bugs surfaced during that verification: a server closing stderr at startup consumed the signal and was then never checked again, and a code comment claimed the reactive path covered a gap it did not.

## API surface

Three new exported symbols, all additive and backward compatible:

- `MCPServerReadiness` and `Readiness.MCPServers` in the root package
- `mcp.ServerConfig.Required`

These are required by the `/readyz` gating: the handler is internal and the `Gateway` is public, so MCP state cannot cross that boundary via an internal type. Noted because "no new exported API" is the standing constraint for a patch on this line, and v1.3.1 recorded its one exception the same way.

## Verification

```
gofmt · go build · go vet · go vet -tags=live    clean
golangci-lint v2.11.4                            0 issues
go test -short -race ./...                       0 failures
subprocess tests, -count=15                      stable
coverage                                         81.0%   (CI floor 75%)
diff vs v1.3.1                 38 files, +2,911 / −93
```

`make test-integration` has not been run locally — it needs Docker. The config-store changes are what it covers, so CI is its first execution on this branch.

Closes #292
Closes #353
Closes #356

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-MCP-server readiness details to `/readyz`, including whether each server is required.
  * Introduced an opt-in `required` flag for MCP servers to gate readiness and remove unavailable instances from traffic.
  * Added new MCP availability/initialization metrics for monitoring.

* **Bug Fixes**
  * Improved detection/withdrawal of failed MCP stdio subprocesses and other dead transport scenarios.
  * Fixed MCP “up” gauge lifecycle across reloads and corrected failed tool-call accounting.
  * Ensured config mutations and history tracking are atomic.
  * Strengthened credential/error redaction across API responses, logs, events, admin errors, and SSE stream errors.

* **Documentation**
  * Updated documentation and example config to describe `mcp_servers[].required` readiness behavior and related operational semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->