### PR TITLE
fix(web): v1.4.1 — clear every open dependency security advisory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+_Nothing yet._
+
+## [1.4.1] — 2026-08-07
+
+A dependency-security patch for the web toolchain and the embedded dashboard.
+No gateway code changes.
+
 ### Changed — the web toolchain clears every open dependency advisory
 
 The dashboard's router moves to `react-router` 8.3.0 — the package that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,9 @@ No gateway code changes.
 
 The dashboard's router moves to `react-router` 8.3.0 — the package that
 absorbed `react-router-dom`, whose 7.x line advisory scanners flag on an
-uncorrected affected range — together with React 19.2.8, its peer floor. The
-client routing API is unchanged and the rendered browser suites pass
-unmodified.
+uncorrected affected range — together with React 19.2.8 (Router 8's peer
+floor is React 19.2.7). The client routing API is unchanged and the rendered
+browser suites pass unmodified.
 
 Seven build- and tooling-time packages move onto their patched releases:
 `undici`, `ip-address`, `fast-uri`, `postcss`, `@hono/node-server` (reached

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-_Nothing yet._
+### Changed — the web toolchain clears every open dependency advisory
+
+The dashboard's router moves to `react-router` 8.3.0 — the package that
+absorbed `react-router-dom`, whose 7.x line advisory scanners flag on an
+uncorrected affected range — together with React 19.2.8, its peer floor. The
+client routing API is unchanged and the rendered browser suites pass
+unmodified.
+
+Seven build- and tooling-time packages move onto their patched releases:
+`undici`, `ip-address`, `fast-uri`, `postcss`, `@hono/node-server` (reached
+through the component tooling's MCP SDK), `brace-expansion`, and `hono`. None
+of them ships in the embedded bundle. `npm audit` reports zero
+vulnerabilities.
 
 ## [1.4.0] — 2026-08-07
 

--- a/web/AUDIT-NOTES.md
+++ b/web/AUDIT-NOTES.md
@@ -5,28 +5,8 @@ whoever runs it — not a scanner config. There is no `osv-scanner.toml`,
 `.nsprc`, or `audit-ci` allowlist because no tool that reads one runs against
 `web/`.
 
-## GHSA-qwww-vcr4-c8h2 — react-router / react-router-dom — expected, already fixed
-
-**Re-check after 2026-10-31.** If the advisory range has been corrected by then,
-delete this entry. If it has not, confirm the two facts below still hold and
-extend the date — do not extend it unread.
-
-`npm audit` reports this advisory against react-router at any 7.x version. It is
-a false positive here for two independent reasons:
-
-1. **Already patched.** The fix was backported to 7.x by upstream PR #15353 and
-   released as 7.18.2, which is what the lockfile resolves. The advisory's
-   affected range still reads `>=7.12.0 <8.3.0` and has not been corrected for
-   the backport, so the scanner keeps matching a patched version.
-2. **Not reachable.** The vulnerable code ships only under the `react-server`
-   export condition. This is a client-only Vite SPA using `<BrowserRouter>`
-   (`src/App.tsx`), with no RSC server and no custom `resolve.conditions`, so
-   that condition is never set. Diffing the published 7.18.1 and 7.18.2
-   tarballs, the client-reachable module graph is byte-identical apart from the
-   version string; the CSRF hardening appears only in `index-react-server.mjs`.
-
-Verify claim 1 in one command:
-
-```sh
-npm view react-router@7.18.2 dist.tarball   # then read its CHANGELOG.md
-```
+There are currently no exceptions. The last one — GHSA-qwww-vcr4-c8h2, a
+react-router 7.x false positive whose advisory range (`>=7.12.0 <8.3.0`) was
+never corrected for the upstream 7.18.2 backport — was retired when the
+dashboard moved to `react-router@8.3.0`, which sits outside the range and
+carries the fix natively. Its full analysis is in this file's git history.

--- a/web/AUDIT-NOTES.md
+++ b/web/AUDIT-NOTES.md
@@ -5,8 +5,25 @@ whoever runs it — not a scanner config. There is no `osv-scanner.toml`,
 `.nsprc`, or `audit-ci` allowlist because no tool that reads one runs against
 `web/`.
 
-There are currently no exceptions. The last one — GHSA-qwww-vcr4-c8h2, a
-react-router 7.x false positive whose advisory range (`>=7.12.0 <8.3.0`) was
-never corrected for the upstream 7.18.2 backport — was retired when the
-dashboard moved to `react-router@8.3.0`, which sits outside the range and
-carries the fix natively. Its full analysis is in this file's git history.
+There are currently no exceptions.
+
+## GHSA-qwww-vcr4-c8h2 — react-router — retired 2026-08-06
+
+Retired when the dashboard moved to `react-router@8.3.0`, the version the
+advisory lists as patched: the advisory no longer matches the lockfile and
+`npm audit` reports nothing. While the dashboard was on 7.18.2 this was the
+one exception, documented as a false positive for two reasons — both verified,
+and both still true of the 7.x line:
+
+1. **7.18.2 carries the backported fix.** Its published changelog entry reads
+   "Harden RSC CSRF codepaths" (upstream PR #15353). The advisory's affected
+   range (`>=7.12.0 <8.3.0`) was never updated to exclude it, so scanners kept
+   matching a patched version. Verify in one command:
+   `npm pack react-router@7.18.2` and read `package/CHANGELOG.md` — do not
+   trust secondhand summaries of the advisory here; several state that no 7.x
+   patch exists.
+2. **The vulnerable surface is RSC-only.** The hardening lives under the
+   `react-server` export condition. This is a client-only Vite SPA using
+   `<BrowserRouter>` with no RSC server and no custom `resolve.conditions`,
+   so that condition is never set; the client-reachable module graph of
+   7.18.1 and 7.18.2 is byte-identical apart from the version string.

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ferro-labs/ai-gateway-web",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ferro-labs/ai-gateway-web",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "dependencies": {
         "@base-ui/react": "^1.6.0",
         "class-variance-authority": "^0.7.1",

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -12,9 +12,9 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^0.468.0",
-        "react": "^19.1.0",
-        "react-dom": "^19.1.0",
-        "react-router-dom": "^7.6.0",
+        "react": "^19.2.8",
+        "react-dom": "^19.2.8",
+        "react-router": "^8.3.0",
         "tailwind-merge": "^3.6.0",
         "tw-animate-css": "^1.4.0"
       },
@@ -1620,13 +1620,13 @@
       "license": "MIT"
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.14",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.1.0.tgz",
+      "integrity": "sha512-XovyyCCnBzW+zKu+z/zq8hwNs4KOR5rEMAOxo2f40Q5xoOI37IMm6MIg2COOUtUApo0i6850MTBKH2u4QLGIqg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"
@@ -1831,13 +1831,13 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
-      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@hono/node-server": "^1.19.9",
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",
@@ -2788,16 +2788,16 @@
       }
     },
     "node_modules/@ts-morph/common/node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/@ts-morph/common/node_modules/minimatch": {
@@ -2912,9 +2912,9 @@
       }
     },
     "node_modules/@types/react": {
-      "version": "19.2.17",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
-      "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
+      "version": "19.2.18",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.18.tgz",
+      "integrity": "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -2922,9 +2922,9 @@
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "19.2.3",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
-      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.4.tgz",
+      "integrity": "sha512-Bsc+QHgp+P/F02XDzNCY9jnZNCUuLki36KT7VKrTXXLdHf+vHMNZnW1rVu5DNW/rCK+fya3DATySbLM4yhtKUw==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -3137,16 +3137,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
@@ -3701,9 +3701,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4112,18 +4112,11 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/cookie": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
-      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
+    "node_modules/cookie-es": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-3.1.1.tgz",
+      "integrity": "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==",
+      "license": "MIT"
     },
     "node_modules/cookie-signature": {
       "version": "1.2.2",
@@ -5076,9 +5069,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "dev": true,
       "funding": [
         {
@@ -5434,9 +5427,9 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5529,9 +5522,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.31",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.31.tgz",
-      "integrity": "sha512-zJIHFrl6bq3RDd2YusFNCDlM8qUprxKswyi/OPzPyzKDdyBXDqWx8bZlZ7R+saTdSTatUmb3O7K4SspGPaEOQg==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.0.tgz",
+      "integrity": "sha512-jhunvfHWxd7J5EFfSgH4xsYJzSe/lfqbUCxiyyeaQasUsXeEHXtzVid+7EOGByc5JnFa23SSFL3Y2RV/z1T+eQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5685,9 +5678,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6782,9 +6775,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.17",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
       "dev": true,
       "funding": [
         {
@@ -7404,9 +7397,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.21",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.21.tgz",
-      "integrity": "sha512-v4sDNP3fdNiWMfabO7OwOQdOX8TiQSztKyT1Wj0w+j7LDallJThJRBBBmzVGyYj0crMh7jlV4zepPkiNu9UwDQ==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "dev": true,
       "funding": [
         {
@@ -7424,7 +7417,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.16",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -7649,24 +7642,24 @@
       }
     },
     "node_modules/react": {
-      "version": "19.2.7",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
-      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.7",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
-      "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
+      "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.7"
+        "react": "^19.2.8"
       }
     },
     "node_modules/react-is": {
@@ -7688,41 +7681,24 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.2.tgz",
-      "integrity": "sha512-aUVMjFm3GAPTTZL7oYr5E7ETiqfQCHRLH+B+5afnICvf0r7kkK4eR6SMuwbSTJw/7t+12khT/Kahij49fqOCIg==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-8.3.0.tgz",
+      "integrity": "sha512-qyPMvW83jGIct3yiieisxdk9M745anqhpIMKN5m1t6yBMfgVPpt77aHOqs5fUlEJRMCGffg9BaQLH9oPVOL7xQ==",
       "license": "MIT",
       "dependencies": {
-        "cookie": "^1.0.1",
-        "set-cookie-parser": "^2.6.0"
+        "cookie-es": "^3.1.1"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.22.0"
       },
       "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
+        "react": ">=19.2.7",
+        "react-dom": ">=19.2.7"
       },
       "peerDependenciesMeta": {
         "react-dom": {
           "optional": true
         }
-      }
-    },
-    "node_modules/react-router-dom": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.2.tgz",
-      "integrity": "sha512-AIKJ/jgGlFb3EbfCXk5Gzshiwt+l3mqbCrNjmEWMMjqQxNJ3svBa6bgzFyCC2Sw3RA0VWF1kg3uQf2OFhxb8hw==",
-      "license": "MIT",
-      "dependencies": {
-        "react-router": "7.18.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
       }
     },
     "node_modules/recast": {
@@ -8014,12 +7990,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
-    },
-    "node_modules/set-cookie-parser": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
-      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
-      "license": "MIT"
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
@@ -8559,9 +8529,9 @@
       }
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8864,9 +8834,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/web/package.json
+++ b/web/package.json
@@ -21,9 +21,9 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.468.0",
-    "react": "^19.1.0",
-    "react-dom": "^19.1.0",
-    "react-router-dom": "^7.6.0",
+    "react": "^19.2.8",
+    "react-dom": "^19.2.8",
+    "react-router": "^8.3.0",
     "tailwind-merge": "^3.6.0",
     "tw-animate-css": "^1.4.0"
   },

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ferro-labs/ai-gateway-web",
   "private": true,
-  "version": "1.4.0",
+  "version": "1.4.1",
   "type": "module",
   "engines": {
     "node": ">=22.14.0"

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,5 +1,5 @@
 import { lazy, Suspense } from 'react'
-import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom'
+import { BrowserRouter, Navigate, Route, Routes } from 'react-router'
 import { AuthProvider } from './auth/AuthProvider'
 import { AppShell } from './components/AppShell'
 import { ErrorBoundary } from './components/ErrorBoundary'

--- a/web/src/components/AppShell.test.tsx
+++ b/web/src/components/AppShell.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { MemoryRouter, Route, Routes } from 'react-router'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { ROUTES } from '../lib/routes'
 import { memoryStorage, stubMatchMedia } from '../test/stubs'

--- a/web/src/components/AppShell.tsx
+++ b/web/src/components/AppShell.tsx
@@ -23,7 +23,7 @@ import {
   type LucideIcon,
 } from 'lucide-react'
 import { useEffect, useMemo, useState, type ComponentType } from 'react'
-import { NavLink, Outlet, useLocation } from 'react-router-dom'
+import { NavLink, Outlet, useLocation } from 'react-router'
 import { useAuth } from '../auth/AuthProvider'
 import { Logo } from './Logo'
 import { titleForPath } from '../lib/format'

--- a/web/src/components/ProtectedRoute.test.tsx
+++ b/web/src/components/ProtectedRoute.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react'
-import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom'
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { useAuth } from '../auth/AuthProvider'
 import { ProtectedRoute } from './ProtectedRoute'

--- a/web/src/components/ProtectedRoute.tsx
+++ b/web/src/components/ProtectedRoute.tsx
@@ -1,4 +1,4 @@
-import { Navigate, Outlet, useLocation } from 'react-router-dom'
+import { Navigate, Outlet, useLocation } from 'react-router'
 import { useAuth } from '../auth/AuthProvider'
 import { LoadingState } from './ui'
 

--- a/web/src/pages/AnalyticsPage.test.tsx
+++ b/web/src/pages/AnalyticsPage.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { MemoryRouter, useLocation } from 'react-router-dom'
+import { MemoryRouter, useLocation } from 'react-router'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { ApiError } from '../lib/api'
 import type * as ApiModule from '../lib/api'

--- a/web/src/pages/AnalyticsPage.tsx
+++ b/web/src/pages/AnalyticsPage.tsx
@@ -1,6 +1,6 @@
 import { CalendarDays, Filter, RefreshCw } from 'lucide-react'
 import { useEffect, useState, type FormEvent, type ReactNode } from 'react'
-import { useSearchParams } from 'react-router-dom'
+import { useSearchParams } from 'react-router'
 import { Button, EmptyState, LoadingState, Notice, PageHeader } from '../components/ui'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'

--- a/web/src/pages/AuditPage.test.tsx
+++ b/web/src/pages/AuditPage.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom'
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { ApiError, request } from '../lib/api'
 import type * as ApiModule from '../lib/api'

--- a/web/src/pages/AuditPage.tsx
+++ b/web/src/pages/AuditPage.tsx
@@ -1,6 +1,6 @@
 import { ChevronDown, ChevronRight, Filter, RefreshCw } from 'lucide-react'
 import { useCallback, useEffect, useMemo, useState, type FormEvent } from 'react'
-import { Link, useSearchParams } from 'react-router-dom'
+import { Link, useSearchParams } from 'react-router'
 import { DataTable, type DataTableColumn } from '../components/DataTable'
 import { Button, CopyButton, EmptyState, Notice, PageHeader, StatusPill } from '../components/ui'
 import { Input } from '@/components/ui/input'

--- a/web/src/pages/GettingStartedPage.test.tsx
+++ b/web/src/pages/GettingStartedPage.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { MemoryRouter } from 'react-router-dom'
+import { MemoryRouter } from 'react-router'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { DashboardSummary } from '../types'
 import GettingStartedPage from './GettingStartedPage'

--- a/web/src/pages/GettingStartedPage.tsx
+++ b/web/src/pages/GettingStartedPage.tsx
@@ -1,6 +1,6 @@
 import { Check, Circle, ExternalLink, KeyRound, Play, ScrollText, ServerCog, Sparkles } from 'lucide-react'
 import { type ComponentType } from 'react'
-import { Link } from 'react-router-dom'
+import { Link } from 'react-router'
 import { cn } from '@/lib/utils'
 import { Button, LoadingState, Notice, PageHeader } from '../components/ui'
 import { request } from '../lib/api'

--- a/web/src/pages/LoginPage.test.tsx
+++ b/web/src/pages/LoginPage.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom'
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { AuthProvider } from '../auth/AuthProvider'
 import { clearSession, configureGateway, saveSession } from '../lib/api'

--- a/web/src/pages/LoginPage.tsx
+++ b/web/src/pages/LoginPage.tsx
@@ -1,6 +1,6 @@
 import { ArrowRight, Eye, EyeOff, Github, KeyRound } from 'lucide-react'
 import { useEffect, useState, type FormEvent } from 'react'
-import { Navigate, useLocation } from 'react-router-dom'
+import { Navigate, useLocation } from 'react-router'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { useAuth } from '../auth/AuthProvider'

--- a/web/src/pages/LogsPage.test.tsx
+++ b/web/src/pages/LogsPage.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom'
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { ApiError, request } from '../lib/api'
 import type * as ApiModule from '../lib/api'

--- a/web/src/pages/LogsPage.tsx
+++ b/web/src/pages/LogsPage.tsx
@@ -1,7 +1,7 @@
 import { Filter, RefreshCw, Search, Trash2 } from 'lucide-react'
 import { useAuth } from '../auth/AuthProvider'
 import { useEffect, useMemo, useState, type FormEvent } from 'react'
-import { useSearchParams } from 'react-router-dom'
+import { useSearchParams } from 'react-router'
 import { DataTable, type DataTableColumn } from '../components/DataTable'
 import { Button, CopyButton, EmptyState, Modal, Notice, PageHeader, StatusPill } from '../components/ui'
 import { Input } from '@/components/ui/input'

--- a/web/src/pages/OverviewPage.test.tsx
+++ b/web/src/pages/OverviewPage.test.tsx
@@ -1,6 +1,6 @@
 import { act, render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { MemoryRouter, useLocation } from 'react-router-dom'
+import { MemoryRouter, useLocation } from 'react-router'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { AdminHealth, DashboardSummary, LogsStats, Readiness, RequestLog } from '../types'
 import OverviewPage from './OverviewPage'

--- a/web/src/pages/OverviewPage.tsx
+++ b/web/src/pages/OverviewPage.tsx
@@ -1,5 +1,5 @@
 import { CalendarDays, RefreshCw } from 'lucide-react'
-import { Link, useSearchParams } from 'react-router-dom'
+import { Link, useSearchParams } from 'react-router'
 import { SeriesChart } from '../components/SeriesChart'
 import { TRAFFIC_BANDS } from '../lib/chartBands'
 import { Button, EmptyState, LoadingState, Notice, PageHeader, StatusPill } from '../components/ui'

--- a/web/src/pages/PlaygroundPage.test.tsx
+++ b/web/src/pages/PlaygroundPage.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { MemoryRouter } from 'react-router-dom'
+import { MemoryRouter } from 'react-router'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import PlaygroundPage from './PlaygroundPage'
 import type { CatalogModelsResponse } from '../lib/playground'

--- a/web/src/pages/PlaygroundPage.tsx
+++ b/web/src/pages/PlaygroundPage.tsx
@@ -1,6 +1,6 @@
 import { ImageIcon, MessagesSquare, Ruler } from 'lucide-react'
 import { useState } from 'react'
-import { Link } from 'react-router-dom'
+import { Link } from 'react-router'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { useAuth } from '../auth/AuthProvider'
 import { Button, EmptyState, LoadingState, Notice, PageHeader } from '../components/ui'


### PR DESCRIPTION
## Summary

Dependency-security patch for the web toolchain and the embedded dashboard, released as `v1.4.1` (2026-08-07). Resolves **all 12 open Dependabot alerts** plus two findings only local `npm audit` reports; `npm audit` now reports **0 vulnerabilities**. No gateway code changes.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related issues

No open issues — this clears the repository's [Dependabot alerts](https://github.com/ferro-labs/ai-gateway/security/dependabot) (advisories referenced by GHSA id below, since alert numbers would mislink as issue references).

## Changes

- **`react-router-dom` 7.18.2 → `react-router` 8.3.0**, with React/`react-dom` at 19.2.8 (Router 8's peer floor is 19.2.7). Upstream consolidated `react-router-dom` into `react-router`; GHSA-qwww-vcr4-c8h2's affected range (`>=7.12.0 <8.3.0`) was never corrected for the 7.x backport, so any 7.x lockfile keeps matching the advisory. The migration is an import-source swap across 19 files — the client routing API (`BrowserRouter`, `Routes`, `Route`, `Link`, `Navigate`, `MemoryRouter`, `useLocation`) is unchanged, and the rendered browser suites pass unmodified.
- **In-range transitive updates** clearing the remaining Dependabot alerts, all development/build tooling:
  - `undici` 7.28.0 → 7.29.0 — GHSA-4cwx-7wf7-3272 (high) + GHSA-8xcm-r25x-g524, GHSA-v3r7-h72x-cjcm, GHSA-jr45-8vmc-qm54, GHSA-m8rv-5g2x-5cg5
  - `ip-address` 10.2.0 → 10.4.0 — GHSA-mwp4-54f8-5fhr (high) + GHSA-4xrf-jv44-h6hh, GHSA-22jq-vg5j-6vgg
  - `fast-uri` 3.1.4 → 3.1.5 — GHSA-7p8r-x3mc-p8w7 (high)
  - `postcss` 8.5.21 → 8.5.26 — GHSA-fxqj-rqcc-2cmp
  - `@hono/node-server` 1.19.14 → 2.1.0 — GHSA-frvp-7c67-39w9; unlocked without overrides by `@modelcontextprotocol/sdk` 1.30.0, which widened its constraint to `^1.19.9 || ^2.0.5`
- **npm-audit-only findings** (not surfaced by Dependabot) patched in-range: `brace-expansion` (GHSA-mh99-v99m-4gvg, GHSA-rgw5-rvv9-x895) and `hono` (GHSA-8j4g-w8fx-2239)
- `web/AUDIT-NOTES.md`: the react-router false-positive exception is retired — on 8.3.0 the advisory no longer matches at all (analysis preserved in git history)
- `CHANGELOG.md`: `[1.4.1] — 2026-08-07` section added; `[Unreleased]` reset

Only `react-router` and React ship in the embedded bundle; every other updated package is development or build tooling that never reaches the binary.

## Testing

- [x] `make test` passes (full Go suite with race detector — run by the pre-push gate; no Go code changed)
- [x] `make lint` passes (0 issues)
- [x] `npm run check --prefix web` — lint, unit tests, TypeScript, production build all green
- [x] `npm run test:e2e --prefix web` — 82 passed / 0 failed (26 skips are per-viewport project gating, by design)
- [x] `npm audit` — 0 vulnerabilities
- [ ] New tests added — n/a, dependency updates only; existing suites cover the router swap
- [ ] `make test-integration` — n/a, no gateway code changes

## Breaking change notes

None. The dashboard's routing behaviour, URLs, and the gateway API surface are unchanged.

## Merge sequencing

Merge **after** the `v1.4.0` tag is cut from `main` (`134a337`), then tag `v1.4.1` — both dated 2026-08-07. Merging first would sweep this into the `v1.4.0` tag instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Applied security updates to the web toolchain and routing components.
  * Updated React and routing packages to patched versions.
  * Retained existing navigation and client-routing behavior.
  * The release reports zero outstanding npm audit vulnerabilities.

* **Documentation**
  * Added release notes for version 1.4.1.
  * Updated audit documentation to record the resolved security advisory and retired exception.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This dependency-security release upgrades the embedded dashboard to React Router 8 and React 19.2.8, refreshes vulnerable transitive web-tooling packages, and updates release and audit documentation.
- Replaces `react-router-dom` imports with the consolidated `react-router` package across application and test code.
- Updates the web manifest and lockfile to patched direct and transitive dependency versions.
- Adds the v1.4.1 changelog entry and retires the previous audit exception.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete changed-code failure identified in the dependency or import migration.

The application retains its existing routing logic while using the consolidated React Router package, and the patched dependency graph remains pinned through lockfile-enforced build and release workflows.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| web/package.json | Updates the web release version and replaces React Router DOM 7 with React Router 8 alongside its required React versions. |
| web/package-lock.json | Pins the new router and React versions plus patched transitive tooling dependencies with compatible engine and peer constraints. |
| web/src/App.tsx | Changes only the routing import source while preserving the existing BrowserRouter route tree and behavior. |
| web/src/components/AppShell.tsx | Moves navigation hooks and components to the consolidated router package without changing application logic. |
| web/src/components/ProtectedRoute.tsx | Moves authentication-route imports to the consolidated package while preserving redirect and location-state handling. |
| web/AUDIT-NOTES.md | Retires the React Router advisory exception after moving the lockfile outside the advisory range. |
| CHANGELOG.md | Documents the v1.4.1 dependency-security release and its patched web-toolchain packages. |

<sub>Reviews (1): Last reviewed commit: ["fix(web): address review — peer-floor wo..."](https://github.com/ferro-labs/ai-gateway/commit/a54dd56c9d6cd77770e59211e4cfd2b9ccbab6e1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50822036)</sub>

<!-- /greptile_comment -->