### PR TITLE
feat: preserve provider capabilities across aliases and add httpgateway surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _Nothing yet._
 
-## [1.4.2] — 2026-08-07
+## [1.4.2] — 2026-08-10
 
-A documentation correction for the v1.4.0 configuration-package move.
+### Added — registration aliases preserve provider capabilities
+
+`Gateway.RegisterProviderAs` registers one provider under a distinct routing target,
+so deployments can bind multiple credentials for the same canonical provider. The
+alias now resolves every optional provider capability through the original provider;
+streaming, embeddings, images, rerank, moderation, audio, discovery, batch,
+Responses, and generic pass-through no longer disappear behind an identity wrapper.
+
+### Added — embedding HTTP surface facade
+
+The public `httpgateway` package exposes the OSS-owned Files/Batches, Responses,
+and generic pass-through handlers to embedding applications. Embedders can keep
+their own authentication and tenant policy middleware while reusing the same
+provider resolution, credential injection, traversal protection, governance, and
+usage capture as the standalone server.
+
+### Added — build provenance on the health endpoint
+
+`GET /health` now reports the binary's `version`, `commit`, and `built` build
+metadata alongside provider status, so an operator or embedding application can
+confirm which build is serving traffic. Values come from `internal/version` and
+default to `dev` / `none` / `unknown` for an unstamped local build.
 
 ### Changed — the configuration schema lives in the config package
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _Nothing yet._
 
+## [1.4.2] — 2026-08-07
+
+A documentation correction for the v1.4.0 configuration-package move.
+
+### Changed — the configuration schema lives in the config package
+
+v1.4.0 moved the configuration schema — `Config` and its sub-types — and the
+loader and validator out of the root package and into the `config` package
+(`github.com/ferro-labs/ai-gateway/config`). Two code comments still referred to
+a root-package alias file that was never shipped; they now point at the `config`
+package, which is the single home for these types.
+
+For an embedder this remains a breaking change from the pre-v1.4.0 API, and the
+migration is a one-line import: reference `config.Config`, `config.ValidateConfig`,
+`config.ModeFallback` and the rest instead of the former `aigateway.*` names. The
+gateway is still constructed the same way — `aigateway.New` takes a `config.Config`.
+
 ## [1.4.1] — 2026-08-07
 
 A dependency-security patch for the web toolchain and the embedded dashboard.

--- a/config/config.go
+++ b/config/config.go
@@ -1,7 +1,8 @@
 // Package config defines the AI Gateway configuration schema (Config and its
-// sub-types) and the loader/validator (LoadConfig, ValidateConfig). The root
-// aigateway package re-exports these as aliases (see config_aliases.go) so
-// existing embedders keep compiling; new code may import this package directly.
+// sub-types) and the loader/validator (LoadConfig, ValidateConfig). These types
+// moved here from the root aigateway package in v1.4.0; embedders import this
+// package directly. The gateway is still built with aigateway.New, which takes a
+// config.Config.
 package config
 
 import "github.com/ferro-labs/ai-gateway/mcp"

--- a/gateway.go
+++ b/gateway.go
@@ -316,14 +316,26 @@ const (
 	roleUser = "user"
 )
 
-// RegisterProvider registers a provider with the gateway.
+// RegisterProvider registers a provider with the gateway under its canonical name.
 func (g *Gateway) RegisterProvider(p providers.Provider) {
+	g.RegisterProviderAs(p.Name(), p)
+}
+
+// RegisterProviderAs registers a provider under name while retaining the
+// provider's canonical identity and every optional capability it implements.
+// This is intended for deployments that bind multiple credentials for one
+// canonical provider to distinct routing targets.
+func (g *Gateway) RegisterProviderAs(name string, p providers.Provider) {
+	if name == "" {
+		name = p.Name()
+	}
+	p = providers.WithName(p, name)
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if _, exists := g.providers[p.Name()]; !exists {
-		g.providerNames = append(g.providerNames, p.Name())
+	if _, exists := g.providers[name]; !exists {
+		g.providerNames = append(g.providerNames, name)
 	}
-	g.providers[p.Name()] = p
+	g.providers[name] = p
 	g.rebuildModelIndexesLocked()
 	g.strategy = nil // force strategy rebuild
 }

--- a/gateway_autodiscovery.go
+++ b/gateway_autodiscovery.go
@@ -57,7 +57,7 @@ func (g *Gateway) runDiscovery(ctx context.Context, log *logger.Logger) {
 	g.mu.RLock()
 	discoverable := make(map[string]providers.DiscoveryProvider, len(g.providers))
 	for name, p := range g.providers {
-		if dp, ok := p.(providers.DiscoveryProvider); ok {
+		if dp, ok := providers.As[providers.DiscoveryProvider](p); ok {
 			discoverable[name] = dp
 		}
 	}

--- a/gateway_circuitbreaker.go
+++ b/gateway_circuitbreaker.go
@@ -59,7 +59,7 @@ func (p *cbProvider) CompleteStream(ctx context.Context, req providers.Request) 
 			panic(r)
 		}
 	}()
-	sp, ok := p.Provider.(providers.StreamProvider)
+	sp, ok := providers.As[providers.StreamProvider](p.Provider)
 	if !ok {
 		p.cb.ReleaseProbe()
 		return nil, fmt.Errorf("provider %s does not support streaming", p.name)

--- a/gateway_concurrency.go
+++ b/gateway_concurrency.go
@@ -110,7 +110,7 @@ func (p *limitedProvider) Complete(ctx context.Context, req providers.Request) (
 // once response headers arrive would let unlimited streams run concurrently and
 // defeat the cap entirely.
 func (p *limitedProvider) CompleteStream(ctx context.Context, req providers.Request) (<-chan providers.StreamChunk, error) {
-	sp, ok := p.Provider.(providers.StreamProvider)
+	sp, ok := providers.As[providers.StreamProvider](p.Provider)
 	if !ok {
 		return nil, fmt.Errorf("provider %s does not support streaming", p.name)
 	}

--- a/gateway_concurrency.go
+++ b/gateway_concurrency.go
@@ -27,8 +27,7 @@ import (
 // in-flight slot when a target sets max_concurrency but omits queue_size.
 const DefaultConcurrencyQueueSize = 1000
 
-// MaxTargetConcurrency moved to the config package; it is re-exported as an
-// alias in config_aliases.go.
+// MaxTargetConcurrency lives in the config package (config.MaxTargetConcurrency).
 
 // providerLimiter bounds how many requests may be in flight against a single
 // target, and how many may wait for a slot.

--- a/gateway_modelindex.go
+++ b/gateway_modelindex.go
@@ -166,6 +166,27 @@ func (g *Gateway) modelsForRoutingLocked(name string, p providers.Provider) []st
 	return out
 }
 
+// canonicalProviderName returns the name of the provider beneath any identity
+// (aliasing) decorators — the vendor identity the model catalog and price book
+// are keyed on. A provider registered under its own name unwraps to itself, so
+// the routing key (which may be an alias bound to a specific credential) stays
+// separate from the canonical identity used for catalog inventory and pricing.
+// The bounded walk mirrors core.As and cannot hang on a self-referential wrapper.
+func canonicalProviderName(p providers.Provider) string {
+	for range 32 {
+		unwrapper, ok := p.(providers.ProviderUnwrapper)
+		if !ok {
+			break
+		}
+		next := unwrapper.UnwrapProvider()
+		if next == nil {
+			break
+		}
+		p = next
+	}
+	return p.Name()
+}
+
 // rebuildModelIndexesLocked repopulates every exact model→provider index from
 // the current provider set, and drops the built strategy: it selects targets
 // against a snapshot of this index, so leaving it in place would keep routing
@@ -185,7 +206,15 @@ func (g *Gateway) rebuildModelIndexesLocked() {
 	// treats them as read-only.
 	g.catalogModels = make(map[string][]string, len(g.providerNames))
 	for _, name := range g.providerNames {
-		if ids := g.catalog.ModelsForProvider(name); len(ids) > 0 {
+		p, ok := g.providers[name]
+		if !ok {
+			continue
+		}
+		// Key the catalog lookup on the provider's canonical vendor identity, not
+		// the (possibly aliased) routing key it was registered under — otherwise an
+		// alias inherits none of its provider's catalog models and they vanish from
+		// routing and /v1/models.
+		if ids := g.catalog.ModelsForProvider(canonicalProviderName(p)); len(ids) > 0 {
 			g.catalogModels[name] = ids
 		}
 	}

--- a/gateway_modelindex.go
+++ b/gateway_modelindex.go
@@ -80,7 +80,7 @@ type modelLookupIndex struct {
 // an Azure deployment, an OLLAMA_MODELS entry — or nil for the providers whose
 // inventory the catalog supplies. See core.ConfiguredModelProvider.
 func configuredModelsOf(p providers.Provider) []string {
-	cm, ok := p.(providers.ConfiguredModelProvider)
+	cm, ok := providers.As[providers.ConfiguredModelProvider](p)
 	if !ok {
 		return nil
 	}
@@ -245,7 +245,7 @@ func (g *Gateway) publishRoutingLocked() {
 // when p implements the capability interface T. Used to populate the per-capability
 // exact indexes without repeating the type-assert-and-append block per capability.
 func indexModelsIfImplements[T any](p providers.Provider, name string, models []string, index map[string][]string) {
-	if _, ok := any(p).(T); !ok {
+	if _, ok := providers.As[T](p); !ok {
 		return
 	}
 	for _, model := range models {
@@ -269,7 +269,7 @@ func indexModelsIfImplements[T any](p providers.Provider, name string, models []
 func findByModel[T any](s *routingSnapshot, index map[string][]string, model string) (name string, impl T, ok bool) {
 	owners := index[model]
 	for _, n := range owners {
-		if t, is := any(s.providers[n]).(T); is {
+		if t, is := providers.As[T](s.providers[n]); is {
 			return n, t, true
 		}
 	}
@@ -279,7 +279,7 @@ func findByModel[T any](s *routingSnapshot, index map[string][]string, model str
 			if !exists || !servesAnyModel(p) {
 				continue
 			}
-			if t, is := any(p).(T); is {
+			if t, is := providers.As[T](p); is {
 				return n, t, true
 			}
 		}
@@ -292,7 +292,7 @@ func findByModel[T any](s *routingSnapshot, index map[string][]string, model str
 // that its upstream accepts model ids no index can enumerate. It is the ONLY
 // way a target becomes a candidate for a model the index has no owner for.
 func servesAnyModel(p providers.Provider) bool {
-	_, ok := p.(providers.AnyModelProvider)
+	_, ok := providers.As[providers.AnyModelProvider](p)
 	return ok
 }
 
@@ -391,7 +391,7 @@ func (p *indexedStreamProvider) CompleteStream(ctx context.Context, req provider
 // owned, so the view answers for the declared wildcards and nobody else.
 func withIndexedModels(name string, p providers.Provider, index map[string][]string) providers.Provider {
 	view := &indexedProvider{Provider: p, name: name, index: index, anyModel: servesAnyModel(p)}
-	if sp, ok := p.(providers.StreamProvider); ok {
+	if sp, ok := providers.As[providers.StreamProvider](p); ok {
 		return &indexedStreamProvider{indexedProvider: view, stream: sp}
 	}
 	return view

--- a/gateway_pipeline.go
+++ b/gateway_pipeline.go
@@ -674,11 +674,12 @@ func (g *Gateway) routeChat(ctx context.Context, s strategies.Strategy, req prov
 // gate and a leaf call:
 //
 //	func embeddingProvider(p providers.Provider) bool {
-//		_, ok := p.(providers.EmbeddingProvider)
+//		_, ok := providers.As[providers.EmbeddingProvider](p)
 //		return ok
 //	}
 //	func embed(ctx context.Context, p providers.Provider, req providers.EmbeddingRequest) (*providers.EmbeddingResponse, error) {
-//		return p.(providers.EmbeddingProvider).Embed(ctx, req)
+//		provider, _ := providers.As[providers.EmbeddingProvider](p)
+//		return provider.Embed(ctx, req)
 //	}
 //
 // then routeTargets(ctx, g, g.planFor(req.Model, keys), req, embeddingProvider, embed).

--- a/gateway_provider_alias_test.go
+++ b/gateway_provider_alias_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/ferro-labs/ai-gateway/config"
+	"github.com/ferro-labs/ai-gateway/models"
 	"github.com/ferro-labs/ai-gateway/providers"
 )
 
@@ -171,5 +172,51 @@ func TestRegisterProviderAsPreservesEveryOptionalCapability(t *testing.T) {
 	}
 	if _, err := gw.Speech(ctx, providers.SpeechRequest{Model: "alias-model", Input: "hello", Voice: "test"}); err != nil {
 		t.Fatalf("speech through alias: %v", err)
+	}
+}
+
+func sortedModelIDs(infos []providers.ModelInfo) []string {
+	ids := make([]string, len(infos))
+	for i, m := range infos {
+		ids[i] = m.ID
+	}
+	slices.Sort(ids)
+	return ids
+}
+
+// TestRegisterProviderAsPreservesCatalogIdentity guards the routing-key /
+// canonical-identity split: a catalog-backed provider registered under a
+// distinct alias must still inherit its canonical provider's catalog models,
+// without the caller having to re-declare them on targets[].models.
+func TestRegisterProviderAsPreservesCatalogIdentity(t *testing.T) {
+	t.Setenv(models.CatalogURLEnv, "file:///ferro-tests-use-embedded-catalog")
+	entry, ok := providers.GetProviderEntry(providers.NameOpenAI)
+	if !ok {
+		t.Fatal("openai provider entry missing from registry")
+	}
+	provider, err := entry.Build(providers.ProviderConfig{providers.CfgKeyAPIKey: "test-key"})
+	if err != nil {
+		t.Fatalf("build openai provider: %v", err)
+	}
+	gw, err := New(config.Config{
+		Strategy: config.StrategyConfig{Mode: config.ModeSingle},
+		Targets:  []config.Target{{VirtualKey: "openai::credential-1"}}, // no Models declared
+	})
+	if err != nil {
+		t.Fatalf("create gateway: %v", err)
+	}
+	t.Cleanup(func() { _ = gw.Close() })
+
+	gw.RegisterProvider(provider)                           // canonical "openai"
+	gw.RegisterProviderAs("openai::credential-1", provider) // alias of the same provider
+
+	canonical := sortedModelIDs(gw.ModelsFor("openai"))
+	if len(canonical) == 0 {
+		t.Skip("embedded catalog carries no openai models; cannot verify alias identity")
+	}
+	alias := sortedModelIDs(gw.ModelsFor("openai::credential-1"))
+	if !slices.Equal(alias, canonical) {
+		t.Fatalf("alias catalog models (%d) != canonical (%d); alias lost catalog identity",
+			len(alias), len(canonical))
 	}
 }

--- a/gateway_provider_alias_test.go
+++ b/gateway_provider_alias_test.go
@@ -1,0 +1,175 @@
+package aigateway
+
+import (
+	"context"
+	"net/http"
+	"slices"
+	"testing"
+
+	"github.com/ferro-labs/ai-gateway/config"
+	"github.com/ferro-labs/ai-gateway/providers"
+)
+
+type aliasCapabilityProvider struct{}
+
+var (
+	_ providers.Provider                = (*aliasCapabilityProvider)(nil)
+	_ providers.StreamProvider          = (*aliasCapabilityProvider)(nil)
+	_ providers.EmbeddingProvider       = (*aliasCapabilityProvider)(nil)
+	_ providers.ImageProvider           = (*aliasCapabilityProvider)(nil)
+	_ providers.RerankProvider          = (*aliasCapabilityProvider)(nil)
+	_ providers.ModerationProvider      = (*aliasCapabilityProvider)(nil)
+	_ providers.TranscriptionProvider   = (*aliasCapabilityProvider)(nil)
+	_ providers.SpeechProvider          = (*aliasCapabilityProvider)(nil)
+	_ providers.ProxiableProvider       = (*aliasCapabilityProvider)(nil)
+	_ providers.NonOpenAIWireProvider   = (*aliasCapabilityProvider)(nil)
+	_ providers.RequestSigner           = (*aliasCapabilityProvider)(nil)
+	_ providers.BatchProvider           = (*aliasCapabilityProvider)(nil)
+	_ providers.DiscoveryProvider       = (*aliasCapabilityProvider)(nil)
+	_ providers.ConfiguredModelProvider = (*aliasCapabilityProvider)(nil)
+	_ providers.AnyModelProvider        = (*aliasCapabilityProvider)(nil)
+)
+
+func (*aliasCapabilityProvider) Name() string { return "canonical" }
+
+func (*aliasCapabilityProvider) Complete(_ context.Context, req providers.Request) (*providers.Response, error) {
+	return &providers.Response{Model: req.Model}, nil
+}
+
+func (*aliasCapabilityProvider) SupportsModel(string) bool { return true }
+func (*aliasCapabilityProvider) ServesAnyModel()           {}
+
+func (*aliasCapabilityProvider) ConfiguredModels() []string { return []string{"configured-model"} }
+
+func (*aliasCapabilityProvider) CompleteStream(context.Context, providers.Request) (<-chan providers.StreamChunk, error) {
+	ch := make(chan providers.StreamChunk)
+	close(ch)
+	return ch, nil
+}
+
+func (*aliasCapabilityProvider) Embed(_ context.Context, req providers.EmbeddingRequest) (*providers.EmbeddingResponse, error) {
+	return &providers.EmbeddingResponse{Model: req.Model}, nil
+}
+
+func (*aliasCapabilityProvider) GenerateImage(context.Context, providers.ImageRequest) (*providers.ImageResponse, error) {
+	return &providers.ImageResponse{}, nil
+}
+
+func (*aliasCapabilityProvider) Rerank(_ context.Context, req providers.RerankRequest) (*providers.RerankResponse, error) {
+	return &providers.RerankResponse{Model: req.Model}, nil
+}
+
+func (*aliasCapabilityProvider) Moderate(_ context.Context, req providers.ModerationRequest) (*providers.ModerationResponse, error) {
+	return &providers.ModerationResponse{Model: req.Model}, nil
+}
+
+func (*aliasCapabilityProvider) Transcribe(context.Context, providers.TranscriptionRequest) (*providers.TranscriptionResponse, error) {
+	return &providers.TranscriptionResponse{Text: "ok"}, nil
+}
+
+func (*aliasCapabilityProvider) Speech(context.Context, providers.SpeechRequest) (*providers.SpeechResponse, error) {
+	return &providers.SpeechResponse{Audio: []byte("ok"), ContentType: "audio/mpeg"}, nil
+}
+
+func (*aliasCapabilityProvider) BaseURL() string                      { return "https://example.com/v1" }
+func (*aliasCapabilityProvider) AuthHeaders() map[string]string       { return nil }
+func (*aliasCapabilityProvider) NonOpenAIWire()                       {}
+func (*aliasCapabilityProvider) SignProxyRequest(*http.Request) error { return nil }
+func (*aliasCapabilityProvider) BatchBaseURL() string                 { return "https://example.com/v1" }
+func (*aliasCapabilityProvider) BatchAuthHeaders() map[string]string  { return nil }
+
+func (*aliasCapabilityProvider) DiscoverModels(context.Context) ([]providers.ModelInfo, error) {
+	return []providers.ModelInfo{{ID: "discovered-model"}}, nil
+}
+
+func TestRegisterProviderAsPreservesEveryOptionalCapability(t *testing.T) {
+	const alias = "canonical::credential-1"
+	provider := &aliasCapabilityProvider{}
+	gw, err := New(config.Config{
+		Strategy: config.StrategyConfig{Mode: config.ModeSingle},
+		Targets:  []config.Target{{VirtualKey: alias, Models: []string{"alias-model"}}},
+	})
+	if err != nil {
+		t.Fatalf("create gateway: %v", err)
+	}
+	t.Cleanup(func() { _ = gw.Close() })
+	gw.RegisterProvider(provider)
+	gw.RegisterProviderAs(alias, provider)
+
+	if _, ok := gw.GetProvider("canonical"); !ok {
+		t.Fatal("canonical provider was not registered")
+	}
+	registered, ok := gw.GetProvider(alias)
+	if !ok {
+		t.Fatalf("provider %q was not registered", alias)
+	}
+	if registered.Name() != alias {
+		t.Fatalf("registered name = %q, want %q", registered.Name(), alias)
+	}
+	if got := gw.ListProviders(); !slices.Equal(got, []string{"canonical", alias}) {
+		t.Fatalf("registered providers = %v, want [canonical %s]", got, alias)
+	}
+
+	assertCapability := func(name string, ok bool) {
+		t.Helper()
+		if !ok {
+			t.Errorf("alias lost %s", name)
+		}
+	}
+	_, ok = providers.As[providers.StreamProvider](registered)
+	assertCapability("StreamProvider", ok)
+	_, ok = providers.As[providers.EmbeddingProvider](registered)
+	assertCapability("EmbeddingProvider", ok)
+	_, ok = providers.As[providers.ImageProvider](registered)
+	assertCapability("ImageProvider", ok)
+	_, ok = providers.As[providers.RerankProvider](registered)
+	assertCapability("RerankProvider", ok)
+	_, ok = providers.As[providers.ModerationProvider](registered)
+	assertCapability("ModerationProvider", ok)
+	_, ok = providers.As[providers.TranscriptionProvider](registered)
+	assertCapability("TranscriptionProvider", ok)
+	_, ok = providers.As[providers.SpeechProvider](registered)
+	assertCapability("SpeechProvider", ok)
+	_, ok = providers.As[providers.ProxiableProvider](registered)
+	assertCapability("ProxiableProvider", ok)
+	_, ok = providers.As[providers.NonOpenAIWireProvider](registered)
+	assertCapability("NonOpenAIWireProvider", ok)
+	_, ok = providers.As[providers.RequestSigner](registered)
+	assertCapability("RequestSigner", ok)
+	_, ok = providers.As[providers.BatchProvider](registered)
+	assertCapability("BatchProvider", ok)
+	_, ok = providers.As[providers.DiscoveryProvider](registered)
+	assertCapability("DiscoveryProvider", ok)
+	_, ok = providers.As[providers.ConfiguredModelProvider](registered)
+	assertCapability("ConfiguredModelProvider", ok)
+	_, ok = providers.As[providers.AnyModelProvider](registered)
+	assertCapability("AnyModelProvider", ok)
+
+	streamProvider, ok := gw.FindStreamingByModel("alias-model")
+	if !ok {
+		t.Fatal("streaming alias was not indexed")
+	}
+	if _, err := streamProvider.CompleteStream(context.Background(), providers.Request{Model: "alias-model"}); err != nil {
+		t.Fatalf("stream through alias: %v", err)
+	}
+
+	ctx := context.Background()
+	if _, err := gw.Embed(ctx, providers.EmbeddingRequest{Model: "alias-model", Input: "hello"}); err != nil {
+		t.Fatalf("embed through alias: %v", err)
+	}
+	if _, err := gw.GenerateImage(ctx, providers.ImageRequest{Model: "alias-model", Prompt: "hello"}); err != nil {
+		t.Fatalf("image through alias: %v", err)
+	}
+	if _, err := gw.Rerank(ctx, providers.RerankRequest{Model: "alias-model", Query: "q", Documents: []string{"d"}}); err != nil {
+		t.Fatalf("rerank through alias: %v", err)
+	}
+	if _, err := gw.Moderate(ctx, providers.ModerationRequest{Model: "alias-model", Input: "hello"}); err != nil {
+		t.Fatalf("moderation through alias: %v", err)
+	}
+	if _, err := gw.Transcribe(ctx, providers.TranscriptionRequest{Model: "alias-model", File: []byte("audio"), Filename: "test.wav"}); err != nil {
+		t.Fatalf("transcription through alias: %v", err)
+	}
+	if _, err := gw.Speech(ctx, providers.SpeechRequest{Model: "alias-model", Input: "hello", Voice: "test"}); err != nil {
+		t.Fatalf("speech through alias: %v", err)
+	}
+}

--- a/gateway_stream_start.go
+++ b/gateway_stream_start.go
@@ -66,7 +66,7 @@ func (g *Gateway) startStreamWithStrategy(startCtx, streamCtx context.Context, r
 // streamCapable is streaming's candidacy gate: a target whose provider cannot
 // stream is not a candidate and is never called.
 func streamCapable(p providers.Provider) bool {
-	_, ok := p.(providers.StreamProvider)
+	_, ok := providers.As[providers.StreamProvider](p)
 	return ok
 }
 
@@ -91,7 +91,7 @@ func startStreamOn(streamCtx context.Context, admitted **circuitbreaker.CircuitB
 		}
 		// streamCapable already proved this of the undecorated provider, and
 		// both decorators forward CompleteStream, so the assertion cannot fail.
-		sp, ok := p.(providers.StreamProvider)
+		sp, ok := providers.As[providers.StreamProvider](p)
 		if !ok {
 			return nil, fmt.Errorf("provider %s does not support streaming", p.Name())
 		}

--- a/gateway_surface.go
+++ b/gateway_surface.go
@@ -832,27 +832,33 @@ func surfaceGate(surface string) capabilityGate {
 // and the hot path allocates nothing to describe the call. The gate above has
 // already run by the time either executes, so neither assertion can fail.
 func embed(ctx context.Context, p providers.Provider, req providers.EmbeddingRequest) (*providers.EmbeddingResponse, error) {
-	return p.(providers.EmbeddingProvider).Embed(ctx, req) //nolint:forcetypeassert // embeddingCapable gated candidacy
+	provider, _ := providers.As[providers.EmbeddingProvider](p)
+	return provider.Embed(ctx, req) // embeddingCapable gated candidacy
 }
 
 func generateImage(ctx context.Context, p providers.Provider, req providers.ImageRequest) (*providers.ImageResponse, error) {
-	return p.(providers.ImageProvider).GenerateImage(ctx, req) //nolint:forcetypeassert // imageCapable gated candidacy
+	provider, _ := providers.As[providers.ImageProvider](p)
+	return provider.GenerateImage(ctx, req) // imageCapable gated candidacy
 }
 
 func rerank(ctx context.Context, p providers.Provider, req providers.RerankRequest) (*providers.RerankResponse, error) {
-	return p.(providers.RerankProvider).Rerank(ctx, req) //nolint:forcetypeassert // rerankCapable gated candidacy
+	provider, _ := providers.As[providers.RerankProvider](p)
+	return provider.Rerank(ctx, req) // rerankCapable gated candidacy
 }
 
 func moderate(ctx context.Context, p providers.Provider, req providers.ModerationRequest) (*providers.ModerationResponse, error) {
-	return p.(providers.ModerationProvider).Moderate(ctx, req) //nolint:forcetypeassert // moderationCapable gated candidacy
+	provider, _ := providers.As[providers.ModerationProvider](p)
+	return provider.Moderate(ctx, req) // moderationCapable gated candidacy
 }
 
 func transcribe(ctx context.Context, p providers.Provider, req providers.TranscriptionRequest) (*providers.TranscriptionResponse, error) {
-	return p.(providers.TranscriptionProvider).Transcribe(ctx, req) //nolint:forcetypeassert // transcriptionCapable gated candidacy
+	provider, _ := providers.As[providers.TranscriptionProvider](p)
+	return provider.Transcribe(ctx, req) // transcriptionCapable gated candidacy
 }
 
 func speak(ctx context.Context, p providers.Provider, req providers.SpeechRequest) (*providers.SpeechResponse, error) {
-	return p.(providers.SpeechProvider).Speech(ctx, req) //nolint:forcetypeassert // speechCapable gated candidacy
+	provider, _ := providers.As[providers.SpeechProvider](p)
+	return provider.Speech(ctx, req) // speechCapable gated candidacy
 }
 
 // routeEmbedding runs an embedding request through the shared request pipeline

--- a/gateway_surface_ranking.go
+++ b/gateway_surface_ranking.go
@@ -294,22 +294,22 @@ func surfaceHasPrice(catalog models.Catalog, modelKey, surface string) bool {
 func providerSupportsSurface(p providers.Provider, surface string) bool {
 	switch surface {
 	case surfaceEmbeddings:
-		_, ok := p.(providers.EmbeddingProvider)
+		_, ok := providers.As[providers.EmbeddingProvider](p)
 		return ok
 	case surfaceImages:
-		_, ok := p.(providers.ImageProvider)
+		_, ok := providers.As[providers.ImageProvider](p)
 		return ok
 	case surfaceRerank:
-		_, ok := p.(providers.RerankProvider)
+		_, ok := providers.As[providers.RerankProvider](p)
 		return ok
 	case surfaceModeration:
-		_, ok := p.(providers.ModerationProvider)
+		_, ok := providers.As[providers.ModerationProvider](p)
 		return ok
 	case surfaceTranscription:
-		_, ok := p.(providers.TranscriptionProvider)
+		_, ok := providers.As[providers.TranscriptionProvider](p)
 		return ok
 	case surfaceSpeech:
-		_, ok := p.(providers.SpeechProvider)
+		_, ok := providers.As[providers.SpeechProvider](p)
 		return ok
 	default:
 		return false

--- a/gateway_surface_ranking.go
+++ b/gateway_surface_ranking.go
@@ -116,7 +116,7 @@ func (g *Gateway) rankConfiguredSurfaceTargets(targets []config.Target, provider
 		if mode == config.ModeLatency {
 			candidate.latency, candidate.hasLatency = g.latencyTracker.Stats(target.VirtualKey)
 		} else {
-			modelKey := p.Name() + "/" + model
+			modelKey := canonicalProviderName(p) + "/" + model
 			candidate.cost = models.Calculate(catalog, modelKey, usage)
 			candidate.priced = surfaceHasPrice(catalog, modelKey, surface)
 		}

--- a/httpgateway/surfaces.go
+++ b/httpgateway/surfaces.go
@@ -1,0 +1,34 @@
+// Package httpgateway exposes OSS-owned HTTP surfaces to applications that
+// embed an aigateway.Gateway behind their own authentication and policy layer.
+package httpgateway
+
+import (
+	"net/http"
+
+	aigateway "github.com/ferro-labs/ai-gateway"
+	internalproxy "github.com/ferro-labs/ai-gateway/internal/proxy"
+)
+
+// Passthrough exposes the gateway-owned transparent /v1/* fallback. Mount it
+// only after every native/static route the embedding application owns.
+func Passthrough(gw *aigateway.Gateway) http.HandlerFunc {
+	return internalproxy.Handler(gw)
+}
+
+// Batch exposes the fixed-target Files and Batches surface. BatchTarget selects
+// the one configured backend.
+func Batch(gw *aigateway.Gateway) http.HandlerFunc {
+	return internalproxy.BatchHandler(gw)
+}
+
+// ResponsesCreate exposes governed, model-routed POST /v1/responses. The
+// response usage tee keeps this surface priced by the OSS lifecycle.
+func ResponsesCreate(gw *aigateway.Gateway) http.HandlerFunc {
+	return internalproxy.ResponsesCreate(gw)
+}
+
+// ResponsesStateful exposes the fixed-target Responses id sub-routes.
+// ResponsesTarget selects the one configured backend.
+func ResponsesStateful(gw *aigateway.Gateway) http.HandlerFunc {
+	return internalproxy.ResponsesIDs(gw)
+}

--- a/httpgateway/surfaces.go
+++ b/httpgateway/surfaces.go
@@ -1,5 +1,5 @@
-// Package httpgateway exposes OSS-owned HTTP surfaces to applications that
-// embed an aigateway.Gateway behind their own authentication and policy layer.
+// Package httpgateway exposes HTTP handlers for applications that embed an
+// aigateway.Gateway behind their own authentication and policy middleware.
 package httpgateway
 
 import (
@@ -21,8 +21,8 @@ func Batch(gw *aigateway.Gateway) http.HandlerFunc {
 	return internalproxy.BatchHandler(gw)
 }
 
-// ResponsesCreate exposes governed, model-routed POST /v1/responses. The
-// response usage tee keeps this surface priced by the OSS lifecycle.
+// ResponsesCreate handles model-routed POST /v1/responses, pricing the surface
+// from the response usage as it streams through.
 func ResponsesCreate(gw *aigateway.Gateway) http.HandlerFunc {
 	return internalproxy.ResponsesCreate(gw)
 }

--- a/httpgateway/surfaces_test.go
+++ b/httpgateway/surfaces_test.go
@@ -27,11 +27,15 @@ func TestEmbeddingHandlersDelegateToOwnedSurfaces(t *testing.T) {
 		handler http.Handler
 		request *http.Request
 		status  int
+		// wantBody is a token unique to the intended internal handler, so a wrapper
+		// wired to the wrong surface (e.g. Batch and ResponsesStateful both answer
+		// 501) is caught rather than passing on the shared status alone.
+		wantBody string
 	}{
-		{"generic pass-through", Passthrough(gw), httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/v1/fine_tuning/jobs", strings.NewReader(`{}`)), http.StatusBadRequest},
-		{"batch fixed target", Batch(gw), httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/v1/files", nil), http.StatusNotImplemented},
-		{"responses create", ResponsesCreate(gw), httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/v1/responses", strings.NewReader(`{}`)), http.StatusBadRequest},
-		{"responses stateful fixed target", ResponsesStateful(gw), httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/v1/responses/resp_1", nil), http.StatusNotImplemented},
+		{"generic pass-through", Passthrough(gw), httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/v1/fine_tuning/jobs", strings.NewReader(`{}`)), http.StatusBadRequest, "provider_not_resolved"},
+		{"batch fixed target", Batch(gw), httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/v1/files", nil), http.StatusNotImplemented, "batch_not_configured"},
+		{"responses create", ResponsesCreate(gw), httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/v1/responses", strings.NewReader(`{}`)), http.StatusBadRequest, "model is required"},
+		{"responses stateful fixed target", ResponsesStateful(gw), httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/v1/responses/resp_1", nil), http.StatusNotImplemented, "responses_not_configured"},
 	}
 
 	for _, tt := range tests {
@@ -40,6 +44,9 @@ func TestEmbeddingHandlersDelegateToOwnedSurfaces(t *testing.T) {
 			tt.handler.ServeHTTP(rec, tt.request)
 			if rec.Code != tt.status {
 				t.Fatalf("status = %d, want %d: %s", rec.Code, tt.status, rec.Body.String())
+			}
+			if body := rec.Body.String(); !strings.Contains(body, tt.wantBody) {
+				t.Fatalf("body = %q, want it to contain %q (wrapper may delegate to the wrong handler)", body, tt.wantBody)
 			}
 		})
 	}

--- a/httpgateway/surfaces_test.go
+++ b/httpgateway/surfaces_test.go
@@ -1,0 +1,46 @@
+package httpgateway
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	aigateway "github.com/ferro-labs/ai-gateway"
+	"github.com/ferro-labs/ai-gateway/config"
+	"github.com/ferro-labs/ai-gateway/models"
+)
+
+func TestEmbeddingHandlersDelegateToOwnedSurfaces(t *testing.T) {
+	t.Setenv(models.CatalogURLEnv, "file:///ferro-tests-use-embedded-catalog")
+	gw, err := aigateway.New(config.Config{
+		Strategy: config.StrategyConfig{Mode: config.ModeSingle},
+		Targets:  []config.Target{{VirtualKey: "openai"}},
+	})
+	if err != nil {
+		t.Fatalf("create gateway: %v", err)
+	}
+	defer func() { _ = gw.Close() }()
+
+	tests := []struct {
+		name    string
+		handler http.Handler
+		request *http.Request
+		status  int
+	}{
+		{"generic pass-through", Passthrough(gw), httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/v1/fine_tuning/jobs", strings.NewReader(`{}`)), http.StatusBadRequest},
+		{"batch fixed target", Batch(gw), httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/v1/files", nil), http.StatusNotImplemented},
+		{"responses create", ResponsesCreate(gw), httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/v1/responses", strings.NewReader(`{}`)), http.StatusBadRequest},
+		{"responses stateful fixed target", ResponsesStateful(gw), httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/v1/responses/resp_1", nil), http.StatusNotImplemented},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			tt.handler.ServeHTTP(rec, tt.request)
+			if rec.Code != tt.status {
+				t.Fatalf("status = %d, want %d: %s", rec.Code, tt.status, rec.Body.String())
+			}
+		})
+	}
+}

--- a/internal/handler/chat.go
+++ b/internal/handler/chat.go
@@ -10,6 +10,7 @@ import (
 	aigateway "github.com/ferro-labs/ai-gateway"
 	"github.com/ferro-labs/ai-gateway/internal/apierror"
 	"github.com/ferro-labs/ai-gateway/internal/sse"
+	"github.com/ferro-labs/ai-gateway/internal/version"
 )
 
 // ChatCompletions handles POST /v1/chat/completions.
@@ -121,6 +122,9 @@ func Health(gw *aigateway.Gateway) http.HandlerFunc {
 		}
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"status":    status,
+			"version":   version.Version,
+			"commit":    version.Commit,
+			"built":     version.Date,
 			"providers": providerStatuses,
 		})
 	}

--- a/internal/handler/health_test.go
+++ b/internal/handler/health_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/ferro-labs/ai-gateway/config"
+	"github.com/ferro-labs/ai-gateway/internal/version"
 	mcpconfig "github.com/ferro-labs/ai-gateway/mcp"
 	"github.com/ferro-labs/ai-gateway/providers"
 )
@@ -56,8 +57,11 @@ func TestHealthStatusCodes(t *testing.T) {
 			if err := json.NewDecoder(w.Body).Decode(&payload); err != nil {
 				t.Fatalf("decode health response: %v", err)
 			}
-			if payload.Version == "" || payload.Commit == "" || payload.Built == "" {
-				t.Fatalf("health provenance missing: %+v", payload)
+			if payload.Version != version.Version ||
+				payload.Commit != version.Commit ||
+				payload.Built != version.Date {
+				t.Fatalf("health provenance = %+v, want version=%q commit=%q built=%q",
+					payload, version.Version, version.Commit, version.Date)
 			}
 			if payload.Status != tt.wantStatus {
 				t.Fatalf("status = %q, want %q", payload.Status, tt.wantStatus)

--- a/internal/handler/health_test.go
+++ b/internal/handler/health_test.go
@@ -48,10 +48,16 @@ func TestHealthStatusCodes(t *testing.T) {
 				t.Fatalf("status code = %d, want %d: %s", w.Code, tt.wantCode, w.Body.String())
 			}
 			var payload struct {
-				Status string `json:"status"`
+				Status  string `json:"status"`
+				Version string `json:"version"`
+				Commit  string `json:"commit"`
+				Built   string `json:"built"`
 			}
 			if err := json.NewDecoder(w.Body).Decode(&payload); err != nil {
 				t.Fatalf("decode health response: %v", err)
+			}
+			if payload.Version == "" || payload.Commit == "" || payload.Built == "" {
+				t.Fatalf("health provenance missing: %+v", payload)
 			}
 			if payload.Status != tt.wantStatus {
 				t.Fatalf("status = %q, want %q", payload.Status, tt.wantStatus)

--- a/internal/proxy/batch.go
+++ b/internal/proxy/batch.go
@@ -62,7 +62,7 @@ func BatchHandler(src BatchSource) http.HandlerFunc {
 				"invalid_request_error", "batch_not_configured")
 			return
 		}
-		bp, ok := p.(providers.BatchProvider)
+		bp, ok := providers.As[providers.BatchProvider](p)
 		if !ok {
 			apierror.WriteOpenAI(w, http.StatusNotImplemented,
 				"provider "+p.Name()+" does not support the batch and files endpoints",

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -144,7 +144,7 @@ func passThroughHandler(src providers.ProviderSource) http.HandlerFunc {
 			return
 		}
 
-		pp, canProxy := p.(providers.ProxiableProvider)
+		pp, canProxy := providers.As[providers.ProxiableProvider](p)
 		if !canProxy {
 			apierror.WriteOpenAI(w, http.StatusNotImplemented,
 				"provider "+p.Name()+" does not support proxy pass-through",
@@ -159,7 +159,7 @@ func passThroughHandler(src providers.ProviderSource) http.HandlerFunc {
 		// their base URL. Refuse with 501 instead of forwarding a request their
 		// upstream cannot parse; they remain available via their native
 		// translated endpoints. See core.NonOpenAIWireProvider.
-		if _, nativeOnly := p.(providers.NonOpenAIWireProvider); nativeOnly {
+		if _, nativeOnly := providers.As[providers.NonOpenAIWireProvider](p); nativeOnly {
 			apierror.WriteOpenAI(w, http.StatusNotImplemented,
 				"provider "+p.Name()+" is not available for OpenAI-compatible pass-through; use its native chat, embeddings, or images endpoints",
 				"invalid_request_error",
@@ -220,7 +220,7 @@ func passThroughHandler(src providers.ProviderSource) http.HandlerFunc {
 		// transport so the fully-formed outbound request is signed; a signing
 		// failure surfaces via ErrorHandler rather than as an unsigned forward.
 		var transport http.RoundTripper = httpclient.SharedStreamingTransport()
-		if signer, ok := p.(providers.RequestSigner); ok {
+		if signer, ok := providers.As[providers.RequestSigner](p); ok {
 			transport = signingRoundTripper{base: transport, signer: signer}
 		}
 

--- a/internal/proxy/responses.go
+++ b/internal/proxy/responses.go
@@ -56,12 +56,12 @@ func ResponsesCreate(src ResponsesSource) http.HandlerFunc {
 			return
 		}
 
-		pp, canProxy := p.(providers.ProxiableProvider)
+		pp, canProxy := providers.As[providers.ProxiableProvider](p)
 		if !canProxy {
 			apierror.WriteOpenAI(w, http.StatusNotImplemented, "provider "+p.Name()+" does not support the responses endpoint", "invalid_request_error", "responses_not_supported")
 			return
 		}
-		if _, nativeOnly := p.(providers.NonOpenAIWireProvider); nativeOnly {
+		if _, nativeOnly := providers.As[providers.NonOpenAIWireProvider](p); nativeOnly {
 			apierror.WriteOpenAI(w, http.StatusNotImplemented, "provider "+p.Name()+" is not available for the OpenAI-compatible responses endpoint; use its native chat endpoint", "invalid_request_error", "responses_not_supported")
 			return
 		}
@@ -137,7 +137,7 @@ func ResponsesIDs(src ResponsesSource) http.HandlerFunc {
 			apierror.WriteOpenAI(w, http.StatusNotImplemented, "the configured responses target is unavailable", "invalid_request_error", "responses_not_configured")
 			return
 		}
-		pp, canProxy := p.(providers.ProxiableProvider)
+		pp, canProxy := providers.As[providers.ProxiableProvider](p)
 		if !canProxy {
 			apierror.WriteOpenAI(w, http.StatusNotImplemented, "provider "+p.Name()+" does not support the responses endpoint", "invalid_request_error", "responses_not_supported")
 			return

--- a/providers/core/contracts.go
+++ b/providers/core/contracts.go
@@ -38,6 +38,56 @@ type Provider interface {
 	SupportsModel(model string) bool
 }
 
+// ProviderUnwrapper exposes the provider beneath an identity-only decorator.
+// Consumers should normally use As rather than unwrapping directly so nested
+// decorators remain an implementation detail.
+type ProviderUnwrapper interface {
+	UnwrapProvider() Provider
+}
+
+type namedProvider struct {
+	Provider
+	name string
+}
+
+var _ Provider = (*namedProvider)(nil)
+
+func (p *namedProvider) Name() string { return p.name }
+
+func (p *namedProvider) UnwrapProvider() Provider { return p.Provider }
+
+// WithName returns a provider registered under name without copying its
+// optional capability interfaces onto a lossy wrapper. Use As to resolve an
+// optional interface through the returned identity decorator.
+func WithName(p Provider, name string) Provider {
+	if p == nil || name == "" || p.Name() == name {
+		return p
+	}
+	return &namedProvider{Provider: p, name: name}
+}
+
+// As resolves T from p or from an identity decorator beneath it. Every provider
+// in the chain is inspected, including the one reached by the final unwrap. The
+// bounded walk (at most 32 unwraps) prevents a broken third-party decorator that
+// unwraps to itself from hanging capability resolution.
+func As[T any](p Provider) (T, bool) {
+	var zero T
+	for i := 0; ; i++ {
+		if capability, ok := any(p).(T); ok {
+			return capability, true
+		}
+		unwrapper, ok := p.(ProviderUnwrapper)
+		if !ok || i >= 32 {
+			return zero, false
+		}
+		next := unwrapper.UnwrapProvider()
+		if next == nil {
+			return zero, false
+		}
+		p = next
+	}
+}
+
 // AnyModelProvider is the opt-in declaration that a provider's upstream accepts
 // model ids nothing can enumerate in advance — a deployment name chosen at
 // deploy time, a serving endpoint named by a workspace, a model pulled onto the

--- a/providers/facade_aliases.go
+++ b/providers/facade_aliases.go
@@ -12,6 +12,9 @@ import "github.com/ferro-labs/ai-gateway/providers/core"
 // Provider is an alias for core.Provider.
 type Provider = core.Provider
 
+// ProviderUnwrapper is an alias for core.ProviderUnwrapper.
+type ProviderUnwrapper = core.ProviderUnwrapper
+
 // StreamProvider is an alias for core.StreamProvider.
 type StreamProvider = core.StreamProvider
 
@@ -185,3 +188,11 @@ var ParseStatusCode = core.ParseStatusCode
 
 // RetryAfterFrom re-exports core.RetryAfterFrom.
 var RetryAfterFrom = core.RetryAfterFrom
+
+// WithName re-exports core.WithName.
+var WithName = core.WithName
+
+// As resolves an optional capability through identity-only provider wrappers.
+func As[T any](p Provider) (T, bool) {
+	return core.As[T](p)
+}

--- a/providers/registry.go
+++ b/providers/registry.go
@@ -47,7 +47,7 @@ func (r *Registry) ModelsFor(name string) []ModelInfo {
 	if !ok {
 		return nil
 	}
-	cm, ok := p.(ConfiguredModelProvider)
+	cm, ok := As[ConfiguredModelProvider](p)
 	if !ok {
 		return nil
 	}


### PR DESCRIPTION
## Summary

Provider registration aliases that preserve every optional capability, a public `httpgateway`
package for applications that embed the gateway behind their own auth, health-endpoint build
provenance, and a documentation correction for the v1.4.0 configuration-package move. All changes
are additive and backward-compatible. Ships as **v1.4.2** (see `CHANGELOG.md`).

## Changes

### Registration aliases preserve provider capabilities
- New `Gateway.RegisterProviderAs(name, provider)` registers one provider under a distinct routing
  target while keeping its canonical identity and every optional capability. `RegisterProvider` now
  delegates to it, so existing behaviour is unchanged.
- `core.WithName` returns an identity decorator (no lossy capability copying); `core.As[T]` resolves
  an optional interface through the decorator chain with a bounded walk (`core.ProviderUnwrapper`).
  Every capability-resolution site now uses `As[T]`, so streaming, embeddings, images, rerank,
  moderation, audio, discovery, batch, Responses, and generic pass-through all survive an alias.

### Embeddable HTTP surface facade (`httpgateway`)
- New public `httpgateway` package exposes the gateway-owned Files/Batches, Responses, and generic
  pass-through handlers to applications embedding `aigateway.Gateway` behind their own authentication
  and policy middleware — reusing the same provider resolution, traversal protection, governance, and
  usage capture as the standalone server. `internal/proxy` stays internal (implementation detail);
  the facade is the minimal, stable public seam.

### Build provenance on `/health`
- `GET /health` now reports `version`, `commit`, and `built` alongside provider status (from
  `internal/version`; defaults to `dev` / `none` / `unknown` for an unstamped local build), so an
  operator or embedding application can confirm which build is serving traffic.

### Docs
- Two configuration references corrected to point at the `config` package (the v1.4.0 move).

## Compatibility

Additive only. New public API: `Gateway.RegisterProviderAs`, `core.WithName` / `core.As` /
`core.ProviderUnwrapper`, the `httpgateway` package, and the extra `/health` fields. No breaking
changes.

## Test plan

- `go build ./...` · `go vet ./...` · `golangci-lint` — clean.
- `go test -race` across changed packages (root gateway, `providers/...`, `internal/proxy`,
  `internal/handler`, `httpgateway`) — passing, including:
  - `TestRegisterProviderAsPreservesEveryOptionalCapability` — all optional interfaces survive an
    alias, and live calls route through it (stream / embed / image / rerank / moderation /
    transcription / speech).
  - `httpgateway` surface-delegation test (pass-through, batch, responses create/stateful).
  - `/health` build-provenance assertion.
- Provider stability + conformance guards unchanged.

See `CHANGELOG.md` → **[1.4.2]**.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Register providers under alternate names while preserving supported capabilities and catalog model availability.
  - Added HTTP handlers for passthrough requests, files, batches, and Responses workflows.
  - Embedding-related HTTP routes are now available through the public gateway surface.
  - Health responses now include build version, commit, and build date metadata.

- **Improvements**
  - Provider capabilities continue to work reliably when providers are wrapped or decorated.
  - Configuration documentation now reflects the current configuration package and usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds provider aliases that retain canonical catalog identity and optional capabilities, exposes selected gateway HTTP handlers for embedding applications, and adds build provenance to health responses.
- Adds `RegisterProviderAs`, identity decorators, and decorator-aware capability resolution.
- Uses canonical provider identity for alias model inventory and pricing.
- Adds the public `httpgateway` handler facade.
- Reports version, commit, and build date through `/health`.
- Corrects configuration-package documentation and adds focused coverage.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains; the alias model-index rebuild now unwraps the registered identity decorator and queries catalog inventory using the canonical provider name.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| gateway.go | Adds alias registration while retaining the alias as the routing key and preserving the wrapped provider’s canonical identity. |
| gateway_modelindex.go | Resolves catalog inventory through the canonical provider name and stores the resulting models under each routing alias, fixing the previously reported loss. |
| providers/core/contracts.go | Introduces the identity-only name decorator and bounded optional-capability traversal used by aliases. |
| httpgateway/surfaces.go | Adds a small public facade over the existing passthrough, batch, and Responses handlers. |
| internal/handler/chat.go | Extends health responses with version, commit, and build timestamp metadata. |

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    A[RegisterProviderAs alias provider] --> B[WithName identity decorator]
    B --> C[g.providers keyed by alias]
    C --> D[canonicalProviderName unwraps provider]
    D --> E[Catalog lookup by canonical name]
    E --> F[Model inventory stored under alias]
    C --> G[providers.As resolves optional capabilities]
    G --> H[Routing and HTTP surfaces use aliased provider]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: resolve provider catalog identity a..."](https://github.com/ferro-labs/ai-gateway/commit/a3da46b862285d90170054e4f7a264e927187bd9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51857160)</sub>

<!-- /greptile_comment -->