### PR TITLE
test(mistral): pin the outbound model id for open-mistral-nemo

### DIFF
--- a/gateway_mistral_model_id_test.go
+++ b/gateway_mistral_model_id_test.go
@@ -1,0 +1,75 @@
+package aigateway
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/ferro-labs/ai-gateway/config"
+	"github.com/ferro-labs/ai-gateway/models"
+	"github.com/ferro-labs/ai-gateway/providers"
+	"github.com/ferro-labs/ai-gateway/providers/mistral"
+)
+
+// TestRoute_MistralServedModelIDReachesUpstreamVerbatim pins the model id the
+// gateway puts on the wire for a Mistral model whose name carries a
+// vendor-family prefix ("open-mistral-nemo").
+//
+// The adapter's own guard lives in providers/mistral; this one covers the whole
+// routing path — alias resolution, the model index, and the target walk — because
+// the id a caller sends and the id a provider is handed pass through gateway code
+// that could rewrite either. The assertion is on the serialized body the stub
+// upstream received, so it holds regardless of what any intermediate struct says.
+func TestRoute_MistralServedModelIDReachesUpstreamVerbatim(t *testing.T) {
+	const servedModel = "open-mistral-nemo"
+
+	var raw []byte
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read request body: %v", err)
+		}
+		raw = body
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"chatcmpl-1","model":"` + servedModel + `","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`))
+	}))
+	defer upstream.Close()
+
+	// Pin the catalog to the embedded copy so the test neither reaches the
+	// network nor changes behaviour when the remote catalog does.
+	t.Setenv(models.CatalogURLEnv, "file:///ferro-tests-use-embedded-catalog")
+
+	gw, err := New(config.Config{
+		Strategy: config.StrategyConfig{Mode: config.ModeSingle},
+		Targets:  []config.Target{{VirtualKey: mistral.Name}},
+	})
+	if err != nil {
+		t.Fatalf("create gateway: %v", err)
+	}
+	defer func() { _ = gw.Close() }()
+
+	p, err := mistral.New("test-key", upstream.URL)
+	if err != nil {
+		t.Fatalf("create mistral provider: %v", err)
+	}
+	gw.RegisterProvider(p)
+
+	if _, err := gw.Route(context.Background(), providers.Request{
+		Model:    servedModel,
+		Messages: []providers.Message{{Role: "user", Content: "Hi"}},
+	}); err != nil {
+		t.Fatalf("Route() error: %v", err)
+	}
+
+	var body map[string]any
+	if err := json.Unmarshal(raw, &body); err != nil {
+		t.Fatalf("decode outbound body: %v (body=%s)", err, raw)
+	}
+	if got := body["model"]; got != servedModel {
+		t.Errorf("upstream received model %#v, want %q (the gateway remapped the served model id)", got, servedModel)
+	}
+}

--- a/providers/mistral/mistral_model_id_test.go
+++ b/providers/mistral/mistral_model_id_test.go
@@ -1,0 +1,122 @@
+package mistral
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/ferro-labs/ai-gateway/providers/core"
+)
+
+// servedModel is a Mistral model id whose name carries a vendor-family prefix
+// ("open-mistral-") rather than the plain "mistral-" one. A remap that stripped
+// or normalised the prefix would still produce a model this provider claims to
+// support, so the defect it would cause is invisible to SupportsModel and only
+// observable on the wire.
+const servedModel = "open-mistral-nemo"
+
+// captureOutboundModel decodes the model id from a serialized chat request body
+// and reports it alongside the raw bytes. The raw bytes are kept so a caller can
+// assert on the encoded form, not just on a decoded map: this test exists to pin
+// what actually leaves the process.
+func captureOutboundModel(t *testing.T, raw []byte) string {
+	t.Helper()
+	var body map[string]any
+	if err := json.Unmarshal(raw, &body); err != nil {
+		t.Fatalf("decode outbound body: %v (body=%s)", err, raw)
+	}
+	model, ok := body["model"]
+	if !ok {
+		t.Fatalf("outbound body carries no %q field: %s", "model", raw)
+	}
+	got, ok := model.(string)
+	if !ok {
+		t.Fatalf("outbound model = %#v, want a string: %s", model, raw)
+	}
+	return got
+}
+
+// TestMistralProvider_OutboundModelID_PassesThroughVerbatim asserts that the
+// model id a caller asks for is the model id Mistral is asked for, on both chat
+// surfaces. The assertion is on the serialized request body the stub upstream
+// received — not on core.Request or any provider field — because the wire body
+// is the only thing the upstream reads.
+func TestMistralProvider_OutboundModelID_PassesThroughVerbatim(t *testing.T) {
+	chatResponse := `{"id":"chatcmpl-1","model":"` + servedModel + `","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`
+	streamResponse := "data: {\"id\":\"chatcmpl-1\",\"model\":\"" + servedModel + "\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"ok\"},\"finish_reason\":\"stop\"}]}\n\ndata: [DONE]\n\n"
+
+	tests := []struct {
+		name string
+		// respond writes the stub upstream's reply for this surface.
+		respond func(w http.ResponseWriter)
+		// call drives the provider surface under test and drains any stream so
+		// the request has completed by the time the body is inspected.
+		call func(t *testing.T, p *Provider, req core.Request)
+	}{
+		{
+			name: "Complete",
+			respond: func(w http.ResponseWriter) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(chatResponse))
+			},
+			call: func(t *testing.T, p *Provider, req core.Request) {
+				t.Helper()
+				if _, err := p.Complete(context.Background(), req); err != nil {
+					t.Fatalf("Complete() error: %v", err)
+				}
+			},
+		},
+		{
+			name: "CompleteStream",
+			respond: func(w http.ResponseWriter) {
+				w.Header().Set("Content-Type", "text/event-stream")
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(streamResponse))
+			},
+			call: func(t *testing.T, p *Provider, req core.Request) {
+				t.Helper()
+				ch, err := p.CompleteStream(context.Background(), req)
+				if err != nil {
+					t.Fatalf("CompleteStream() error: %v", err)
+				}
+				for chunk := range ch {
+					if chunk.Error != nil {
+						t.Fatalf("stream chunk error: %v", chunk.Error)
+					}
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var raw []byte
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				body, err := io.ReadAll(r.Body)
+				if err != nil {
+					t.Errorf("read request body: %v", err)
+				}
+				raw = body
+				tt.respond(w)
+			}))
+			defer srv.Close()
+
+			p, err := New("test-key", srv.URL)
+			if err != nil {
+				t.Fatalf("New() error: %v", err)
+			}
+			tt.call(t, p, core.Request{
+				Model:    servedModel,
+				Messages: []core.Message{{Role: "user", Content: "Hi"}},
+			})
+
+			if got := captureOutboundModel(t, raw); got != servedModel {
+				t.Errorf("outbound model = %q, want %q (the provider remapped the served model id)", got, servedModel)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Adds deterministic regression coverage pinning the **outbound** model id the gateway sends upstream for `open-mistral-nemo`, asserted on the serialized request body a stub upstream receives rather than on any internal struct. **No defect was found** — the id already passes through verbatim on every surface covered, so this PR is tests only, with no production code change.

## Type of change

- [x] Refactor / code quality  <!-- test-only: regression coverage, no behaviour change -->

## Related issues

Verifies PE2E-025 (FerroCloud beta goal P0C — Mistral served-model fidelity). Base: v1.4.2 (`1a2017f`).

## Changes

- `providers/mistral/mistral_model_id_test.go` — adapter-level guard. Table-driven over `Complete` and `CompleteStream`; reads the raw request body off an `httptest` upstream and asserts `model == "open-mistral-nemo"`.
- `gateway_mistral_model_id_test.go` — end-to-end guard through `Gateway.Route`, covering alias resolution, the model index, and the target walk. Catalog pinned to the embedded copy (`FERRO_MODEL_CATALOG_URL=file:///…`) so the test is offline and does not move when the remote catalog does.

No `CHANGELOG.md` entry: there is no user-facing behaviour change to document.

## Testing

- [x] `make test` passes (unit tests, race detector) — exit 0, 87 packages `ok`, no `FAIL`
- [x] `make lint` passes — see note below
- [x] New tests added for the change
- [ ] `make test-integration` passes (not applicable — no integration surface touched)
- [ ] Manually tested against a live provider (out of scope: no live paid calls)

`make lint` reports 84 issues (17 `nolintlint`, 67 `prealloc`). These are **pre-existing and unchanged**: stashing this branch's files and re-running produces the identical 84/17/67 counts on the base commit, and neither new file appears in the lint output.

---

## Evidence packet

### Finding: already correct — not a defect

`open-mistral-nemo` reaches the Mistral API unmodified. No adapter change was required and none was made.

### Why this id specifically

It carries a vendor-family prefix (`open-mistral-`) rather than the plain `mistral-` one. `providers/mistral.Provider.SupportsModel` accepts both prefixes, so a remap that stripped or normalised `open-` would still yield a model the provider claims to support — the defect would be **invisible to internal state** and observable only on the wire. That is why both tests assert on the encoded body.

### What was inspected

| Path | Result |
|---|---|
| `mistralChatTransform` (`providers/mistral/mistral.go`) | Rewrites `seed` → `random_seed` only. `core.Request` is embedded, so `model` is forwarded unchanged. |
| `openaicompat.BuildBody` | Sets `stream` and marshals; no model rewriting. |
| `Gateway.resolveModelAlias` (`gateway_alias.go`) | Returns the model unchanged when no alias is configured. |
| `req.Model = …` assignments repo-wide | The only provider that remaps a model id is `vertex_ai` (`vertexAIChatModelID`). Mistral has no equivalent. |
| Model catalog | `models/catalog_backup.json` keys the entry `mistral/open-mistral-nemo` with `model_id: open-mistral-nemo`; the provider-scoped key prefix is not what travels. |

### Verification

Both tests pass against unmodified adapter code:

```
=== RUN   TestMistralProvider_OutboundModelID_PassesThroughVerbatim
=== RUN   TestMistralProvider_OutboundModelID_PassesThroughVerbatim/Complete
=== RUN   TestMistralProvider_OutboundModelID_PassesThroughVerbatim/CompleteStream
--- PASS: TestMistralProvider_OutboundModelID_PassesThroughVerbatim (0.01s)
ok  	github.com/ferro-labs/ai-gateway/providers/mistral

=== RUN   TestRoute_MistralServedModelIDReachesUpstreamVerbatim
--- PASS: TestRoute_MistralServedModelIDReachesUpstreamVerbatim (0.05s)
ok  	github.com/ferro-labs/ai-gateway
```

### Negative control

A passing test proves nothing unless it can fail. Injecting a remap into the adapter (`req.Model = strings.TrimPrefix(req.Model, "open-")` in `mistralChatTransform`) fails both surfaces:

```
--- FAIL: TestMistralProvider_OutboundModelID_PassesThroughVerbatim/Complete
    mistral_model_id_test.go:118: outbound model = "mistral-nemo", want "open-mistral-nemo"
--- FAIL: TestMistralProvider_OutboundModelID_PassesThroughVerbatim/CompleteStream
    mistral_model_id_test.go:118: outbound model = "mistral-nemo", want "open-mistral-nemo"
```

The mutation was reverted before committing; `providers/mistral/mistral.go` is byte-identical to base.

### Scope and constraints

- FerroCloud untouched — it consumes this repo as a tagged module.
- No new providers, no live paid calls (both tests use `httptest` stubs).
- Feature branch + PR; nothing pushed to `main`. Any release ships as a `v1.4.x` tag.

### Coverage ceiling

The tests cover chat and streaming, on the adapter and through `Gateway.Route`. They do not cover the `/v1/*` pass-through proxy, which forwards an opaque body and so cannot remap a model id by construction. Embeddings, transcription and speech are out of scope: `open-mistral-nemo` is not served on those surfaces.

### One caveat on the request

Section 11 of `docs/FERROCLOUD-BETA-EXECUTION-MASTER-PLAN.md` defines the evidence-packet format, but that document is not present in this repository (searched the full filesystem — no match). The packet above follows the shape the goal describes — finding, inspection, verification, negative control, scope, ceiling — but has not been checked against the canonical section 11 headings. Worth a reviewer confirming it lines up.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PMUSsk8qiDJhzHVjB3Qxjc)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage confirming Mistral model identifiers are preserved exactly when requests are sent.
  * Added end-to-end routing validation to ensure the selected model reaches the upstream service unchanged.
  * Verified both standard and streaming completions, including successful responses and complete stream handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds deterministic regression coverage confirming that `open-mistral-nemo` is preserved in the serialized request sent upstream.
- Covers both `Complete` and `CompleteStream` at the Mistral provider boundary.
- Covers the full `Gateway.Route` path with the embedded catalog and a local stub upstream.

<h3>Confidence Score: 5/5</h3>

The test-only PR appears safe to merge.

The new tests use deterministic embedded-catalog fallback and local HTTP stubs, and no concrete correctness, concurrency, security, or repository-rule issue remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| gateway_mistral_model_id_test.go | Adds an end-to-end route test that verifies the served model ID reaches the Mistral upstream unchanged. |
| providers/mistral/mistral_model_id_test.go | Adds provider-level request-body assertions for both synchronous and streaming chat requests. |

<sub>Reviews (1): Last reviewed commit: ["test(mistral): pin the outbound model id..."](https://github.com/ferro-labs/ai-gateway/commit/c77a06eb9327246012af613c243c22500ecdc5a6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52646339)</sub>

<!-- /greptile_comment -->