### PR TITLE
fix: v1.4.3 - clear every reachable advisory and price registration aliases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ["1.25.12"]
+        go: ["1.25.13"]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -85,7 +85,7 @@ jobs:
         run: go test -v -short -race -timeout 300s ./...
 
       - name: Test coverage
-        if: matrix.go == '1.25.12'
+        if: matrix.go == '1.25.13'
         id: coverage
         run: |
           go test -short -race -coverprofile=coverage.out -covermode=atomic ./...
@@ -100,7 +100,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload coverage artifact
-        if: matrix.go == '1.25.12'
+        if: matrix.go == '1.25.13'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: coverage-go-${{ matrix.go }}
@@ -113,7 +113,7 @@ jobs:
       # fail_ci_if_error would let a Codecov outage block a release. Keeping it
       # off the tag path is also why the reusable call passes no secrets.
       - name: Upload coverage to Codecov
-        if: matrix.go == '1.25.12' && github.ref_type != 'tag'
+        if: matrix.go == '1.25.13' && github.ref_type != 'tag'
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -155,7 +155,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
-          go-version: "1.25.12"
+          go-version: "1.25.13"
           check-latest: true
           cache: true
 
@@ -176,7 +176,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
-          go-version: "1.25.12"
+          go-version: "1.25.13"
           check-latest: true
           cache: true
 
@@ -199,7 +199,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
       with:
-        go-version: '1.25.12'
+        go-version: '1.25.13'
         check-latest: true
 
     - name: Run golangci-lint (v2)

--- a/.github/workflows/code-scanning.yml
+++ b/.github/workflows/code-scanning.yml
@@ -43,7 +43,7 @@ jobs:
         if: matrix.language == 'go'
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
-          go-version: "1.25.12"
+          go-version: "1.25.13"
           check-latest: true
           cache: true
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
-          go-version: "1.25.12"
+          go-version: "1.25.13"
           cache: true
 
       # The dashboard is embedded in the binary, so GoReleaser's before-hooks

--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,5 @@ internal/webui/dist/*
 # Generated at release time by scripts/gen-licenses.sh (kept out of dist/ so
 # GoReleaser's empty-dist guard is satisfied); bundled into archives + image.
 /notices/
+/.agents/
+/.codex/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _Nothing yet._
 
-## [1.4.3] — 2026-08-18
+## [1.4.3] — 2026-08-17
 
 A security patch. Every dependency advisory reachable from gateway code is
 cleared, and registration aliases are priced correctly on the two paths where

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,26 +18,31 @@ breaking changes.
 
 ### Security — the Go toolchain moves to 1.25.13
 
-Seven Go standard-library advisories are reachable from gateway code at the
+Six Go standard-library advisories are reachable from gateway code at the
 pinned 1.25.12 toolchain, and every one is fixed in 1.25.13: quadratic
 complexity in `net/url`'s `resolvePath`, JavaScript regexp context tracking in
 `html/template`, unbounded post-handshake messages in `crypto/tls`,
 `ReadHeaderTimeout` not applied on the unencrypted HTTP/2 check in `net/http`,
-recursion depth during decode in `encoding/xml`, maximum recursion depth in
-`encoding/asn1`, and ASCII-only Punycode labels not rejected in
-`golang.org/x/net/idna`. They are reached through provider HTTP clients, the
-serving path, the request-log store, the streaming reader, the signing proxy,
-Bedrock's XML response stream, and Vertex AI's OAuth token exchange.
+recursion depth during decode in `encoding/xml`, and maximum recursion depth in
+`encoding/asn1`. They are reached through provider HTTP clients, the serving
+path, the request-log store, the streaming reader, the signing proxy, Bedrock's
+XML response stream, and Vertex AI's OAuth token exchange.
+
+A seventh advisory — ASCII-only Punycode labels not rejected in
+`golang.org/x/net/idna`, reached through Vertex AI's OAuth token exchange —
+is **not** a standard-library issue and is not fixed by the toolchain. It lives
+in an external module and is cleared by `golang.org/x/net` v0.55.0, which this
+build already pins. It is listed here for completeness, not as a change in this
+release.
 
 No gateway code changes; the fix is the toolchain version.
 
 ### Security — the dashboard toolchain clears its open advisory
 
 `nanoid` moves to 3.3.18, closing a high-severity advisory where a custom
-generator can loop indefinitely when `size` is zero. It is a build-time tooling
-dependency — reached through the component-scaffolding CLI's own PostCSS — and
-is not present in the dashboard bundle the binary embeds. `npm audit` reports
-zero vulnerabilities.
+generator can loop indefinitely when `size` is zero. It is a build-time
+dependency and is not present in the dashboard bundle the binary embeds, so no
+shipped artifact was affected. `npm audit` reports zero vulnerabilities.
 
 ### Fixed — registration aliases are priced correctly
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,65 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _Nothing yet._
 
+## [1.4.3] — 2026-08-18
+
+A security patch. Every dependency advisory reachable from gateway code is
+cleared, and registration aliases are priced correctly on the two paths where
+the alias reached the catalog instead of the vendor identity behind it. No
+breaking changes.
+
+### Security — the Go toolchain moves to 1.25.13
+
+Seven Go standard-library advisories are reachable from gateway code at the
+pinned 1.25.12 toolchain, and every one is fixed in 1.25.13: quadratic
+complexity in `net/url`'s `resolvePath`, JavaScript regexp context tracking in
+`html/template`, unbounded post-handshake messages in `crypto/tls`,
+`ReadHeaderTimeout` not applied on the unencrypted HTTP/2 check in `net/http`,
+recursion depth during decode in `encoding/xml`, maximum recursion depth in
+`encoding/asn1`, and ASCII-only Punycode labels not rejected in
+`golang.org/x/net/idna`. They are reached through provider HTTP clients, the
+serving path, the request-log store, the streaming reader, the signing proxy,
+Bedrock's XML response stream, and Vertex AI's OAuth token exchange.
+
+No gateway code changes; the fix is the toolchain version.
+
+### Security — the dashboard toolchain clears its open advisory
+
+`nanoid` moves to 3.3.18, closing a high-severity advisory where a custom
+generator can loop indefinitely when `size` is zero. It is a build-time tooling
+dependency — reached through the component-scaffolding CLI's own PostCSS — and
+is not present in the dashboard bundle the binary embeds. `npm audit` reports
+zero vulnerabilities.
+
+### Fixed — registration aliases are priced correctly
+
+`RegisterProviderAs`, added in 1.4.2, registers a provider under a routing
+alias that differs from its canonical vendor identity. 1.4.2 corrected catalog
+inventory and surface ranking to resolve the canonical identity; pricing still
+keyed on the alias in two places, so an aliased target was treated as unpriced:
+
+- **Cost-optimized routing.** The strategy built its price key from the routing
+  alias, so an aliased target ranked as unpriced — dropped from routing entirely
+  under `unpriced_strategy: skip`, and ordered wrongly otherwise. This affected
+  every provider.
+- **Streaming cost.** A streaming response carries no provider identity of its
+  own, so its cost was computed against the routing alias — a key the catalog
+  cannot price. The span cost, request-log cost and budget spend for a streamed
+  request through an aliased target recorded as zero. This also affected every
+  provider.
+
+Both now resolve the canonical identity for the catalog lookup. A third path —
+non-streaming cost recording — is corrected for completeness: it reads the
+provider name off the response, and every built-in provider sets that field to
+its own canonical name, so in practice built-in providers were already priced
+correctly there. A provider implementation that leaves the field unset was not.
+
+Attribution is unchanged. The routing alias, not the canonical name, still
+identifies the target in metrics labels, in the span, and in the `Target` field
+plugins read.
+
+Deployments that register providers under their canonical name are unaffected.
+
 ## [1.4.2] — 2026-08-10
 
 ### Added — registration aliases preserve provider capabilities

--- a/README.md
+++ b/README.md
@@ -125,11 +125,11 @@ Most AI gateways are Python proxies that crack under load or JavaScript services
 
 ## Features
 
-| | | |
+| Capability | What it does | Reference |
 |:---|:---|:---|
 | 🔀 **Routing** | 8 strategies — single, fallback, load balance, least latency, cost-optimized, content-based, A/B test, conditional — with per-target retry, failover, and model aliases | [Docs →](https://docs.ferrolabs.ai/routing/) |
 | 🔌 **30 providers** | Chat and streaming everywhere; embeddings, images, rerank, moderations, speech-to-text, text-to-speech, and batch where the vendor offers them | [Docs →](https://docs.ferrolabs.ai/providers/) |
-| 🛡️ **Guardrails & plugins** | Six built in — word filter, token/message limits, response cache, rate limiting, per-key budgets, request logging — and the framework is public for your own | [Docs →](https://docs.ferrolabs.ai/plugins/) |
+| 🛡️ **Guardrails & plugins** | Six built in — word filter, token/message limits, response cache, rate limiting, per-key budgets, request logging — and the plugin framework is public for writing your own | [Docs →](https://docs.ferrolabs.ai/plugins/) |
 | 🎯 **Capability matrix** | One declarative record of which OpenAI parameters each provider forwards, translates, or cannot express, served by `GET /v1/capabilities` | [Docs →](https://docs.ferrolabs.ai/guides/provider-capabilities/) |
 | 🤖 **MCP** | Connects to stdio and Streamable HTTP tool servers, injects their tools into chat completions, and drives the agentic `tool_calls` loop itself | [Docs →](https://docs.ferrolabs.ai/guides/mcp/) |
 | 📊 **Observability** | OpenTelemetry tracing and Prometheus metrics, one trace ID across logs and spans — a zero-allocation no-op until enabled | [Docs →](https://docs.ferrolabs.ai/guides/observability/) |
@@ -446,7 +446,7 @@ commands below.
 
 At 1,000 VU: **13,925 RPS**, p50 overhead **8.1ms**, memory **135 MB**.
 Against the live OpenAI API, the gateway itself adds **25 microseconds** p50 in
-a typical plugin configuration (2µs bare).
+a typical plugin configuration, and **2 microseconds** with no plugins enabled.
 
 Full methodology, raw results, and flamegraph analysis:
 [ferro-labs/ai-gateway-performance-benchmarks](https://github.com/ferro-labs/ai-gateway-performance-benchmarks)

--- a/README.md
+++ b/README.md
@@ -13,8 +13,6 @@
 
 **High-performance AI gateway in Go. Route LLM requests across 30 providers via a single OpenAI-compatible API.**
 
-**Deploy templates**
-
 [![Deploy on Railway: SQLite](https://railway.com/button.svg)](https://railway.com/deploy/ferro-labs-ai-sqlite-storage?referralCode=KblxKX&utm_medium=integration&utm_source=template&utm_campaign=generic)
 [![Deploy on Railway: PostgreSQL](https://railway.com/button.svg)](https://railway.com/deploy/ferro-labs-ai-postgresql-storage?referralCode=KblxKX&utm_medium=integration&utm_source=template&utm_campaign=generic)
 [![Deploy to Render: PostgreSQL](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/ferro-labs/ai-gateway)
@@ -92,26 +90,6 @@ or secret manager.
   <img src="docs/demo.gif" alt="Ferro Labs AI Gateway — Quick Start Demo" width="720" />
 </div>
 
-### Minimal config
-
-Create `config.yaml` (or use `ferrogw init`), then point the gateway at it with `export GATEWAY_CONFIG=./config.yaml` — a config file is loaded only when that variable names it:
-
-```yaml
-strategy:
-  mode: fallback
-
-targets:
-  - virtual_key: openai
-    retry:
-      attempts: 3
-      on_status_codes: [429, 502, 503]
-  - virtual_key: anthropic
-
-aliases:
-  fast: gpt-4o-mini
-  smart: claude-3-5-sonnet-20241022
-```
-
 ### First request
 
 ```bash
@@ -145,90 +123,17 @@ Most AI gateways are Python proxies that crack under load or JavaScript services
 
 ---
 
-## Performance
-
-Every figure in this section comes from one run: **Ferro Labs v1.0.0, measured
-2026-03-23**. Benchmarked against Kong OSS, Bifrost, LiteLLM, and Portkey on
-**GCP n2-standard-8** (8 vCPU, 32 GB RAM) using a **60ms fixed-latency
-mock upstream** — results reflect gateway overhead only. Later releases have not
-been re-measured; reproduce against the version you intend to run using the
-commands below.
-
-![Throughput comparison — Ferro Labs vs Kong, Bifrost, LiteLLM, Portkey across 150–1,000 VU](docs/benchmarks/throughput-comparison.png)
-
-| VU | RPS | p50 | p99 | Memory |
-|---:|---:|---:|---:|---:|
-| 50 | 813 | 61.3ms | 64.1ms | 36 MB |
-| 150 | 2,447 | 61.2ms | 63.4ms | 47 MB |
-| 300 | 4,890 | 61.2ms | 64.4ms | 72 MB |
-| 500 | 8,014 | 61.5ms | 72.9ms | 89 MB |
-| 1,000 | 13,925 | 68.1ms | 111.9ms | 135 MB |
-
-At 1,000 VU: **13,925 RPS**, p50 overhead **8.1ms**, memory **135 MB**.
-Against the live OpenAI API, the gateway itself adds **25 microseconds** p50 in
-a typical plugin configuration (2µs bare).
-
-Full methodology, raw results, and flamegraph analysis:
-[ferro-labs/ai-gateway-performance-benchmarks](https://github.com/ferro-labs/ai-gateway-performance-benchmarks)
-(`make setup && make bench` reproduces it).
-
----
-
 ## Features
 
-### 🔀 Routing
-
-- **8 routing strategies:** single, fallback, load balance, least latency, cost-optimized, content-based, A/B test, conditional — see [internal/strategies/README.md](internal/strategies/README.md)
-- Provider failover with configurable retry policies and status code filters
-- Cost-optimized routing can explicitly fallback, skip, or allow providers with unknown catalog prices
-- Per-request model aliases (`fast → gpt-4o-mini`, `smart → claude-3-5-sonnet`)
-
-### 🔌 Providers (30)
-
-| OpenAI & Compatible | Anthropic & Google | Cloud & Enterprise | Open Source & Inference |
-|:---|:---|:---|:---|
-| OpenAI | Anthropic | AWS Bedrock | Ollama, Ollama Cloud |
-| Azure OpenAI | Google Gemini | Azure Foundry | Hugging Face |
-| OpenRouter | Vertex AI | Databricks | Replicate |
-| DeepSeek | | Cloudflare Workers AI | Together AI |
-| Perplexity | | | Fireworks |
-| xAI (Grok) | | | DeepInfra |
-| Mistral | | | NVIDIA NIM |
-| Groq | | | SambaNova |
-| Cohere | | | Novita AI |
-| AI21 | | | Cerebras |
-| Moonshot / Kimi | | | Qwen / DashScope |
-
-Beyond chat and streaming, providers serve **embeddings, images, rerank,
-moderations, speech-to-text, text-to-speech, and batch** where the vendor offers
-them — the full per-provider endpoint matrix is
-[providers/README.md](providers/README.md).
-
-### 🛡️ Guardrails & Plugins
-
-Six plugins ship built-in — word filter, token/message limits, response cache,
-rate limiting, per-key budgets, and request logging — and the framework is
-public for writing your own. See [plugin/README.md](plugin/README.md).
-
-### 🎯 Provider Capabilities
-
-- **Capability matrix** — one declarative record of which OpenAI parameters each provider forwards, translates, or cannot express
-- **`GET /v1/capabilities`** — compare providers programmatically before you route to them
-- **Strict mode** — `compatibility.on_unsupported_param: warn | drop | reject`; a parameter the provider cannot honor is no longer silently discarded
-- **Conformance-tested** — every provider is built through the same seam the gateway uses and asserted against its real upstream payload shape
-
-### 🤖 MCP (Model Context Protocol)
-
-The gateway connects to MCP tool servers (stdio and Streamable HTTP), injects
-their tools into chat completions, and drives the agentic `tool_calls` loop
-itself — bounded depth, tool filtering, cross-server dedup. See
-[mcp/README.md](mcp/README.md).
-
-### 📊 Observability
-
-- **OpenTelemetry tracing** — OTLP export, W3C propagation, GenAI semantic conventions plus `ferro.*` cost/routing/MCP attributes; a zero-allocation no-op until enabled. See [observability/README.md](observability/README.md)
-- **Prometheus metrics** at `/metrics` (authenticated) and deep health checks at `/health`, `/livez`, `/readyz`
-- One trace ID threads logs, spans, and the `X-Request-ID` header; request logs persist to SQLite/PostgreSQL
+| | | |
+|:---|:---|:---|
+| 🔀 **Routing** | 8 strategies — single, fallback, load balance, least latency, cost-optimized, content-based, A/B test, conditional — with per-target retry, failover, and model aliases | [Docs →](https://docs.ferrolabs.ai/routing/) |
+| 🔌 **30 providers** | Chat and streaming everywhere; embeddings, images, rerank, moderations, speech-to-text, text-to-speech, and batch where the vendor offers them | [Docs →](https://docs.ferrolabs.ai/providers/) |
+| 🛡️ **Guardrails & plugins** | Six built in — word filter, token/message limits, response cache, rate limiting, per-key budgets, request logging — and the framework is public for your own | [Docs →](https://docs.ferrolabs.ai/plugins/) |
+| 🎯 **Capability matrix** | One declarative record of which OpenAI parameters each provider forwards, translates, or cannot express, served by `GET /v1/capabilities` | [Docs →](https://docs.ferrolabs.ai/guides/provider-capabilities/) |
+| 🤖 **MCP** | Connects to stdio and Streamable HTTP tool servers, injects their tools into chat completions, and drives the agentic `tool_calls` loop itself | [Docs →](https://docs.ferrolabs.ai/guides/mcp/) |
+| 📊 **Observability** | OpenTelemetry tracing and Prometheus metrics, one trace ID across logs and spans — a zero-allocation no-op until enabled | [Docs →](https://docs.ferrolabs.ai/guides/observability/) |
+| 🖥️ **Dashboard** | Operations console compiled into the binary and served at `/` — traffic, spend, provider health, request logs, audit trail | [Docs →](https://docs.ferrolabs.ai/guides/dashboard/) |
 
 ---
 
@@ -517,6 +422,35 @@ with no custom headers in self-hosted mode.
 - No vendor lock-in — Apache 2.0 license
 - MCP support — Portkey self-hosted lacks native MCP
 - FerroCloud (coming soon) for teams that want a managed service
+
+---
+
+## Performance
+
+Every figure in this section comes from one run: **Ferro Labs v1.0.0, measured
+2026-03-23**. Benchmarked against Kong OSS, Bifrost, LiteLLM, and Portkey on
+**GCP n2-standard-8** (8 vCPU, 32 GB RAM) using a **60ms fixed-latency
+mock upstream** — results reflect gateway overhead only. Later releases have not
+been re-measured; reproduce against the version you intend to run using the
+commands below.
+
+![Throughput comparison — Ferro Labs vs Kong, Bifrost, LiteLLM, Portkey across 150–1,000 VU](docs/benchmarks/throughput-comparison.png)
+
+| VU | RPS | p50 | p99 | Memory |
+|---:|---:|---:|---:|---:|
+| 50 | 813 | 61.3ms | 64.1ms | 36 MB |
+| 150 | 2,447 | 61.2ms | 63.4ms | 47 MB |
+| 300 | 4,890 | 61.2ms | 64.4ms | 72 MB |
+| 500 | 8,014 | 61.5ms | 72.9ms | 89 MB |
+| 1,000 | 13,925 | 68.1ms | 111.9ms | 135 MB |
+
+At 1,000 VU: **13,925 RPS**, p50 overhead **8.1ms**, memory **135 MB**.
+Against the live OpenAI API, the gateway itself adds **25 microseconds** p50 in
+a typical plugin configuration (2µs bare).
+
+Full methodology, raw results, and flamegraph analysis:
+[ferro-labs/ai-gateway-performance-benchmarks](https://github.com/ferro-labs/ai-gateway-performance-benchmarks)
+(`make setup && make bench` reproduces it).
 
 ---
 

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -34,7 +34,7 @@ RUN npm run build
 
 # ── Gateway ──────────────────────────────────────────────────────────────────
 
-FROM golang:1.25.12-alpine AS gateway-build
+FROM golang:1.25.13-alpine AS gateway-build
 
 RUN apk add --no-cache git ca-certificates
 

--- a/gateway_alias_pricing_test.go
+++ b/gateway_alias_pricing_test.go
@@ -165,3 +165,91 @@ func TestGateway_AliasPricing_Streaming(t *testing.T) {
 		})
 	}
 }
+
+// TestGateway_AliasPricing_CostOptimizedStrategy is issue 396's third path, and
+// the one the strategy-level unit tests could not reach.
+//
+// internal/strategies exercises SelectTargets against a lookup that hands back
+// the raw providers.WithName wrapper. The gateway does not: getStrategy wraps
+// every provider in the model-index view and then in the concurrency limiter
+// and circuit breaker, and CanonicalName has to survive all three to reach the
+// vendor the catalog is keyed on. It did not, so an aliased target priced as
+// unpriced and `unpriced_strategy: skip` dropped it from routing entirely --
+// exactly the defect 396 reports, passing its own unit test the whole time.
+//
+// This asserts through gateway wiring rather than a hand-built lookup, so a
+// future decorator that forgets core.IdentityUnwrapper fails here.
+func TestGateway_AliasPricing_CostOptimizedStrategy(t *testing.T) {
+	tests := []struct {
+		name       string
+		virtualKey string
+	}{
+		{name: "canonical name", virtualKey: "mock"},
+		{name: "routing alias", virtualKey: "mock--credential-1"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gw, err := newTestGateway(t, config.Config{
+				Strategy: config.StrategyConfig{
+					Mode: config.ModeCostOptimized,
+					// skip is the setting that turns mis-pricing from a
+					// wrong ORDER into a dropped target, so it is the one
+					// that fails loudly when the identity is lost.
+					UnpricedStrategy: config.UnpricedStrategySkip,
+				},
+				Targets: []config.Target{{VirtualKey: tt.virtualKey}},
+			})
+			if err != nil {
+				t.Fatalf("New: %v", err)
+			}
+			gw.catalog = aliasPricingCatalog()
+
+			gw.RegisterProviderAs(tt.virtualKey, &mockProvider{
+				name:   "mock",
+				models: []string{testModel},
+			})
+
+			strategy, err := gw.getStrategy()
+			if err != nil {
+				t.Fatalf("getStrategy: %v", err)
+			}
+
+			keys, err := strategy.SelectTargets(providers.Request{
+				Model:    testModel,
+				Messages: []providers.Message{{Role: "user", Content: "hi"}},
+			})
+			if err != nil {
+				t.Fatalf("SelectTargets: the target is priced through its canonical identity, so skip mode must rank it: %v", err)
+			}
+			if len(keys) == 0 || keys[0] != tt.virtualKey {
+				t.Fatalf("SelectTargets = %v, want %q to lead", keys, tt.virtualKey)
+			}
+		})
+	}
+}
+
+// TestCanonicalNameSurvivesRoutingDecorators pins the seam itself, one layer at
+// a time, so a regression names the decorator that lost the identity rather
+// than surfacing as a mis-priced route several packages away.
+func TestCanonicalNameSurvivesRoutingDecorators(t *testing.T) {
+	const canonical = "mock"
+	raw := &mockProvider{name: canonical, models: []string{testModel}}
+	alias := providers.WithName(raw, "mock--credential-1")
+
+	indexed := withIndexedModels("mock--credential-1", alias, map[string][]string{})
+	limited := &limitedProvider{Provider: indexed, lim: newProviderLimiter(1, 1), name: "mock--credential-1"}
+
+	for _, tc := range []struct {
+		layer string
+		p     providers.Provider
+	}{
+		{"WithName", alias},
+		{"+ indexed view", indexed},
+		{"+ concurrency limiter", limited},
+	} {
+		if got := providers.CanonicalName(tc.p); got != canonical {
+			t.Errorf("%s: CanonicalName = %q, want %q", tc.layer, got, canonical)
+		}
+	}
+}

--- a/gateway_alias_pricing_test.go
+++ b/gateway_alias_pricing_test.go
@@ -3,9 +3,11 @@ package aigateway
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/ferro-labs/ai-gateway/config"
 	"github.com/ferro-labs/ai-gateway/models"
+	"github.com/ferro-labs/ai-gateway/pkg/circuitbreaker"
 	"github.com/ferro-labs/ai-gateway/providers"
 )
 
@@ -232,21 +234,30 @@ func TestGateway_AliasPricing_CostOptimizedStrategy(t *testing.T) {
 // TestCanonicalNameSurvivesRoutingDecorators pins the seam itself, one layer at
 // a time, so a regression names the decorator that lost the identity rather
 // than surfacing as a mis-priced route several packages away.
+// The limiter and breaker layers are composed with decorateProvider rather than
+// built by hand, so the test covers the ORDER production applies as well as the
+// seam itself -- breaker outermost, limiter innermost.
 func TestCanonicalNameSurvivesRoutingDecorators(t *testing.T) {
-	const canonical = "mock"
+	const (
+		canonical = "mock"
+		alias     = "mock--credential-1"
+	)
 	raw := &mockProvider{name: canonical, models: []string{testModel}}
-	alias := providers.WithName(raw, "mock--credential-1")
+	named := providers.WithName(raw, alias)
 
-	indexed := withIndexedModels("mock--credential-1", alias, map[string][]string{})
-	limited := &limitedProvider{Provider: indexed, lim: newProviderLimiter(1, 1), name: "mock--credential-1"}
+	indexed := withIndexedModels(alias, named, map[string][]string{})
+	lim := newProviderLimiter(1, 1)
+	cb := circuitbreaker.New(1, 1, 1, time.Minute)
 
 	for _, tc := range []struct {
 		layer string
 		p     providers.Provider
 	}{
-		{"WithName", alias},
+		{"WithName", named},
 		{"+ indexed view", indexed},
-		{"+ concurrency limiter", limited},
+		{"+ concurrency limiter", decorateProvider(alias, indexed, nil, lim)},
+		{"+ circuit breaker", decorateProvider(alias, indexed, cb, nil)},
+		{"+ both, as getStrategy composes them", decorateProvider(alias, indexed, cb, lim)},
 	} {
 		if got := providers.CanonicalName(tc.p); got != canonical {
 			t.Errorf("%s: CanonicalName = %q, want %q", tc.layer, got, canonical)

--- a/gateway_alias_pricing_test.go
+++ b/gateway_alias_pricing_test.go
@@ -1,0 +1,167 @@
+package aigateway
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ferro-labs/ai-gateway/config"
+	"github.com/ferro-labs/ai-gateway/models"
+	"github.com/ferro-labs/ai-gateway/providers"
+)
+
+// aliasPricingWantCostUSD is 100 prompt tokens at $5/1M plus 50 completion
+// tokens at $15/1M, computed against aliasPricingCatalog's one priced entry.
+const aliasPricingWantCostUSD = 0.0005 + 0.00075
+
+// aliasPricingCatalog prices only the canonical identity "mock", never an
+// alias, so a non-zero cost can only come from a correctly resolved key.
+func aliasPricingCatalog() models.Catalog {
+	return models.Catalog{
+		"mock/" + testModel: {
+			Provider: "mock",
+			ModelID:  testModel,
+			Mode:     models.ModeChat,
+			Pricing: models.Pricing{
+				InputPerMTokens:  ptrFloat64(5.0),
+				OutputPerMTokens: ptrFloat64(15.0),
+			},
+		},
+	}
+}
+
+// TestGateway_AliasPricing is issue 396's non-streaming regression suite.
+//
+// A target registered through RegisterProviderAs under a routing alias
+// distinct from its provider's canonical name ("mock") must be priced
+// identically to the same provider registered under its canonical name.
+//
+// gateway_route.go computes cost once (`cost := g.calculateCost(resp)`) and
+// feeds the same value to the request logger and the budget plugin, so
+// asserting calculateCost's result covers both request-log cost and budget
+// spend; asserting the span cost covers the third. resp.Provider must keep
+// naming the routing key everywhere attribution reads it.
+//
+// The mock leaves Response.Provider unset, matching a provider that does not
+// stamp its own identity: the shape RegisterProviderAs is documented for,
+// and the shape the pipeline's own fallback exists to handle.
+func TestGateway_AliasPricing(t *testing.T) {
+	tests := []struct {
+		name       string
+		virtualKey string
+	}{
+		{name: "canonical name", virtualKey: "mock"},
+		{name: "routing alias", virtualKey: "mock--credential-1"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gw, err := newTestGateway(t, config.Config{
+				Strategy: config.StrategyConfig{Mode: config.ModeSingle},
+				Targets:  []config.Target{{VirtualKey: tt.virtualKey}},
+			})
+			if err != nil {
+				t.Fatalf("New: %v", err)
+			}
+			gw.catalog = aliasPricingCatalog()
+
+			fp := &fakeProvider{}
+			gw.SetObservability(fp)
+
+			gw.RegisterProviderAs(tt.virtualKey, &mockProvider{
+				name:   "mock",
+				models: []string{testModel},
+				resp: &providers.Response{
+					Model: testModel,
+					Usage: providers.Usage{PromptTokens: 100, CompletionTokens: 50},
+				},
+			})
+
+			resp, err := gw.Route(context.Background(), providers.Request{
+				Model:    testModel,
+				Messages: []providers.Message{{Role: "user", Content: "hi"}},
+			})
+			if err != nil {
+				t.Fatalf("Route: %v", err)
+			}
+
+			if resp.Provider != tt.virtualKey {
+				t.Errorf("resp.Provider = %q, want routing key %q", resp.Provider, tt.virtualKey)
+			}
+
+			cost := gw.calculateCost(resp)
+			if !cost.Priced || cost.TotalUSD != aliasPricingWantCostUSD {
+				t.Errorf("calculateCost = %+v, want Priced TotalUSD %.5f", cost, aliasPricingWantCostUSD)
+			}
+
+			sp := fp.rootSpan()
+			if sp == nil {
+				t.Fatal("expected a root span")
+			}
+			if sp.cost.TotalUSD != aliasPricingWantCostUSD {
+				t.Errorf("span cost = %+v, want TotalUSD %.5f", sp.cost, aliasPricingWantCostUSD)
+			}
+		})
+	}
+}
+
+// TestGateway_AliasPricing_Streaming is the streaming counterpart of
+// TestGateway_AliasPricing.
+//
+// The cost there is computed inside internal/streamwrap.Meter from
+// MeterMeta.PriceProvider rather than from a Response the provider built, so
+// this exercises a materially different code path even though the assertion
+// -- the span cost matches the canonical price -- is the same shape.
+func TestGateway_AliasPricing_Streaming(t *testing.T) {
+	tests := []struct {
+		name       string
+		virtualKey string
+	}{
+		{name: "canonical name", virtualKey: "mock"},
+		{name: "routing alias", virtualKey: "mock--credential-1"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gw, err := newTestGateway(t, config.Config{
+				Strategy: config.StrategyConfig{Mode: config.ModeSingle},
+				Targets:  []config.Target{{VirtualKey: tt.virtualKey}},
+			})
+			if err != nil {
+				t.Fatalf("New: %v", err)
+			}
+			gw.catalog = aliasPricingCatalog()
+
+			fp := &fakeProvider{}
+			gw.SetObservability(fp)
+
+			streamCh := make(chan providers.StreamChunk, 1)
+			streamCh <- providers.StreamChunk{
+				Usage: &providers.Usage{PromptTokens: 100, CompletionTokens: 50, TotalTokens: 150},
+			}
+			close(streamCh)
+
+			gw.RegisterProviderAs(tt.virtualKey, &mockStreamProvider{
+				mockProvider: mockProvider{name: "mock", models: []string{testModel}},
+				streamCh:     streamCh,
+			})
+
+			ch, err := gw.RouteStream(context.Background(), providers.Request{
+				Model:    testModel,
+				Stream:   true,
+				Messages: []providers.Message{{Role: "user", Content: "hi"}},
+			})
+			if err != nil {
+				t.Fatalf("RouteStream: %v", err)
+			}
+			drainStream(t, ch)
+
+			sp := fp.rootSpan()
+			if sp == nil {
+				t.Fatal("expected a root span")
+			}
+			if sp.cost.TotalUSD != aliasPricingWantCostUSD {
+				t.Errorf("stream span cost = %+v, want TotalUSD %.5f", sp.cost, aliasPricingWantCostUSD)
+			}
+		})
+	}
+}

--- a/gateway_circuitbreaker.go
+++ b/gateway_circuitbreaker.go
@@ -21,6 +21,13 @@ type cbProvider struct {
 	name string
 }
 
+// UnwrapIdentity exposes the provider beneath the breaker. A circuit breaker
+// adds behaviour without becoming a vendor, so identity is safe to see through
+// while capabilities are not — this type must never implement
+// ProviderUnwrapper, or As would resolve CompleteStream/Embed past the breaker
+// and lose it. See core.IdentityUnwrapper.
+func (p *cbProvider) UnwrapIdentity() providers.Provider { return p.Provider }
+
 func (p *cbProvider) Complete(ctx context.Context, req providers.Request) (resp *providers.Response, err error) {
 	if !p.cb.Allow() {
 		return nil, circuitbreaker.ErrCircuitOpen

--- a/gateway_concurrency.go
+++ b/gateway_concurrency.go
@@ -96,6 +96,12 @@ type limitedProvider struct {
 	name string
 }
 
+// UnwrapIdentity exposes the provider beneath the limiter. Holding a slot does
+// not make this a vendor, so identity is safe to see through — but capabilities
+// are not, which is why this type must never implement ProviderUnwrapper. See
+// core.IdentityUnwrapper.
+func (p *limitedProvider) UnwrapIdentity() providers.Provider { return p.Provider }
+
 // Complete holds an in-flight slot for the duration of the upstream call.
 func (p *limitedProvider) Complete(ctx context.Context, req providers.Request) (*providers.Response, error) {
 	if err := p.lim.acquire(ctx); err != nil {

--- a/gateway_modelindex.go
+++ b/gateway_modelindex.go
@@ -166,27 +166,6 @@ func (g *Gateway) modelsForRoutingLocked(name string, p providers.Provider) []st
 	return out
 }
 
-// canonicalProviderName returns the name of the provider beneath any identity
-// (aliasing) decorators — the vendor identity the model catalog and price book
-// are keyed on. A provider registered under its own name unwraps to itself, so
-// the routing key (which may be an alias bound to a specific credential) stays
-// separate from the canonical identity used for catalog inventory and pricing.
-// The bounded walk mirrors core.As and cannot hang on a self-referential wrapper.
-func canonicalProviderName(p providers.Provider) string {
-	for range 32 {
-		unwrapper, ok := p.(providers.ProviderUnwrapper)
-		if !ok {
-			break
-		}
-		next := unwrapper.UnwrapProvider()
-		if next == nil {
-			break
-		}
-		p = next
-	}
-	return p.Name()
-}
-
 // rebuildModelIndexesLocked repopulates every exact model→provider index from
 // the current provider set, and drops the built strategy: it selects targets
 // against a snapshot of this index, so leaving it in place would keep routing
@@ -214,7 +193,7 @@ func (g *Gateway) rebuildModelIndexesLocked() {
 		// the (possibly aliased) routing key it was registered under — otherwise an
 		// alias inherits none of its provider's catalog models and they vanish from
 		// routing and /v1/models.
-		if ids := g.catalog.ModelsForProvider(canonicalProviderName(p)); len(ids) > 0 {
+		if ids := g.catalog.ModelsForProvider(providers.CanonicalName(p)); len(ids) > 0 {
 			g.catalogModels[name] = ids
 		}
 	}

--- a/gateway_modelindex.go
+++ b/gateway_modelindex.go
@@ -362,6 +362,16 @@ type indexedProvider struct {
 	anyModel bool
 }
 
+// UnwrapIdentity exposes the provider beneath the view. This decorator narrows
+// a model set; it is not a vendor, and it deliberately does NOT implement
+// ProviderUnwrapper — see core.IdentityUnwrapper for why the two are separate.
+//
+// Without this, CanonicalName stops here and returns whatever Name() promotes
+// to, which for a target registered through RegisterProviderAs is the routing
+// alias. The cost-optimized strategy then prices against a key the catalog has
+// never heard of and drops the target as unpriced.
+func (p *indexedProvider) UnwrapIdentity() providers.Provider { return p.Provider }
+
 // SupportsModel answers for routing, and is the same rule
 // supportsModelForRoutingLocked applies: the index decides, and a declared
 // AnyModelProvider is offered only the names the index gives no owner. The

--- a/gateway_route_outcome.go
+++ b/gateway_route_outcome.go
@@ -178,6 +178,22 @@ func cacheServedMeasurements(start time.Time) plugin.Measurements {
 	}
 }
 
+// canonicalPriceKeyLocked resolves routingKey — a resp.Provider or
+// streamwrap.MeterMeta.Provider value, which names the routing target that
+// served the request rather than a vendor — to the canonical vendor identity
+// the model catalog and price book are keyed on. A target registered through
+// RegisterProviderAs is priced as its underlying provider, not the alias the
+// catalog has never heard of. Attribution is untouched: callers keep using
+// routingKey itself for everything except the catalog lookup. Returns
+// routingKey unchanged when no provider is currently registered under it.
+// Caller must hold g.mu (a read lock is sufficient).
+func (g *Gateway) canonicalPriceKeyLocked(routingKey string) string {
+	if p, ok := g.providers[routingKey]; ok {
+		return providers.CanonicalName(p)
+	}
+	return routingKey
+}
+
 // calculateCost prices a response against the current model catalog.
 //
 // Split out because the after-request plugins need the result before
@@ -187,8 +203,9 @@ func cacheServedMeasurements(start time.Time) plugin.Measurements {
 func (g *Gateway) calculateCost(resp *providers.Response) models.CostResult {
 	g.mu.RLock()
 	catalog := g.catalog
+	priceKey := g.canonicalPriceKeyLocked(resp.Provider)
 	g.mu.RUnlock()
-	return models.Calculate(catalog, resp.Provider+"/"+resp.Model, models.Usage{
+	return models.Calculate(catalog, priceKey+"/"+resp.Model, models.Usage{
 		PromptTokens:     resp.Usage.PromptTokens,
 		CompletionTokens: resp.Usage.CompletionTokens,
 		ReasoningTokens:  resp.Usage.ReasoningTokens,

--- a/gateway_stream.go
+++ b/gateway_stream.go
@@ -171,11 +171,18 @@ func (g *Gateway) RouteStream(ctx context.Context, req providers.Request) (<-cha
 	// metrics and event hooks once the stream completes.
 	g.mu.RLock()
 	catalog := g.catalog
+	// Resolved once, alongside the catalog snapshot, from the same live
+	// provider set routing just selected providerName from — see
+	// canonicalPriceKeyLocked. providerName itself keeps naming the routing
+	// target on meta.Provider (attribution: metric labels, the completed/failed
+	// event, resp.Provider); priceProvider exists solely for the cost lookup.
+	priceProvider := g.canonicalPriceKeyLocked(providerName)
 	g.mu.RUnlock()
 
 	meta := streamwrap.MeterMeta{
-		Provider: providerName,
-		Model:    req.Model,
+		Provider:      providerName,
+		PriceProvider: priceProvider,
+		Model:         req.Model,
 		// Model stays raw for cost lookup and event payloads; only the metric
 		// label is bounded, mirroring the non-streaming path's use of the
 		// provider-reported model.

--- a/gateway_surface_ranking.go
+++ b/gateway_surface_ranking.go
@@ -116,7 +116,7 @@ func (g *Gateway) rankConfiguredSurfaceTargets(targets []config.Target, provider
 		if mode == config.ModeLatency {
 			candidate.latency, candidate.hasLatency = g.latencyTracker.Stats(target.VirtualKey)
 		} else {
-			modelKey := canonicalProviderName(p) + "/" + model
+			modelKey := providers.CanonicalName(p) + "/" + model
 			candidate.cost = models.Calculate(catalog, modelKey, usage)
 			candidate.priced = surfaceHasPrice(catalog, modelKey, surface)
 		}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ferro-labs/ai-gateway
 
-go 1.25.12
+go 1.25.13
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.43.3

--- a/internal/cli/colors.go
+++ b/internal/cli/colors.go
@@ -28,6 +28,9 @@ const (
 	SymDASH = "[-]"
 )
 
+// osWindows is runtime.GOOS on Windows.
+const osWindows = "windows"
+
 // stdoutIsTerminal reports whether this process's stdout is an interactive
 // terminal. It is a var because there is no portable way to open a pty just to
 // assert that colour IS emitted in front of one, so the positive case is pinned
@@ -41,7 +44,7 @@ var NoColor = func() bool {
 	}
 	// Disable colors on Windows cmd.exe unless running in Windows Terminal
 	// or another modern terminal that sets WT_SESSION or TERM.
-	if runtime.GOOS == "windows" {
+	if runtime.GOOS == osWindows {
 		if os.Getenv("WT_SESSION") == "" && os.Getenv("TERM") == "" {
 			return true
 		}

--- a/internal/cli/colors_test.go
+++ b/internal/cli/colors_test.go
@@ -27,7 +27,7 @@ func TestClr(t *testing.T) {
 	})
 
 	t.Run("wraps text in ANSI codes when color is enabled", func(t *testing.T) {
-		if runtime.GOOS == "windows" {
+		if runtime.GOOS == osWindows {
 			t.Skip("color is disabled on bare Windows terminals")
 		}
 		t.Setenv("NO_COLOR", "")
@@ -48,7 +48,7 @@ func TestClr(t *testing.T) {
 // whether anything was on the other end. This drives the real check — no seam
 // override — against a stdout that is a pipe, which is what a redirect gives.
 func TestNoColor_NonTerminalStdout(t *testing.T) {
-	if runtime.GOOS == "windows" {
+	if runtime.GOOS == osWindows {
 		t.Skip("the Windows branch already suppresses colour without a TTY check")
 	}
 	t.Setenv("NO_COLOR", "")

--- a/internal/strategies/costoptimized.go
+++ b/internal/strategies/costoptimized.go
@@ -67,10 +67,15 @@ func (c *CostOptimized) SelectTargets(req providers.Request) ([]string, error) {
 	estimatedPromptTokens := estimatePromptTokens(req)
 	candidates := make([]costOrderCandidate, 0, len(c.targets))
 	for _, t := range c.targets {
-		if !routableCandidate(c.lookup, t.VirtualKey, req.Model) {
+		p, ok := c.lookup(t.VirtualKey)
+		if !ok || !p.SupportsModel(req.Model) {
 			continue
 		}
-		result := models.Calculate(c.catalog, t.VirtualKey+"/"+req.Model, models.Usage{
+		// Price against the provider's canonical vendor identity, not the
+		// (possibly aliased) routing key: an alias registered through
+		// RegisterProviderAs shares its provider's catalog price rather than
+		// pricing against a name the catalog has never heard of.
+		result := models.Calculate(c.catalog, providers.CanonicalName(p)+"/"+req.Model, models.Usage{
 			PromptTokens: estimatedPromptTokens,
 		})
 		candidates = append(candidates, costOrderCandidate{

--- a/internal/strategies/costoptimized_test.go
+++ b/internal/strategies/costoptimized_test.go
@@ -232,3 +232,119 @@ func TestCostOptimized_NoTargets(t *testing.T) {
 		t.Errorf("expected no candidates with no targets, got %v", keys)
 	}
 }
+
+// TestCostOptimized_AliasPricing is issue #396's regression suite: a target
+// registered through Gateway.RegisterProviderAs carries a routing alias
+// (e.g. "openai--cred-1") distinct from its provider's canonical vendor
+// identity ("openai"). SelectTargets must price such a target exactly as it
+// would price the same provider registered under its own canonical name --
+// pricing the alias itself finds nothing in the catalog, which used to rank
+// every aliased target as unpriced and, under unpriced_strategy: skip, drop
+// it from routing entirely.
+func TestCostOptimized_AliasPricing(t *testing.T) {
+	aliasCatalog := models.Catalog{
+		"openai/gpt-4o": {
+			Provider: "openai",
+			ModelID:  "gpt-4o",
+			Mode:     models.ModeChat,
+			Pricing: models.Pricing{
+				InputPerMTokens:  ptrF(5.0),
+				OutputPerMTokens: ptrF(15.0),
+			},
+		},
+	}
+
+	tests := []struct {
+		name             string
+		targets          []Target
+		lookup           ProviderLookup
+		catalog          models.Catalog
+		unpricedStrategy string
+		wantLead         string // asserted when wantErr is empty
+		wantKeys         []string
+		wantErr          string // substring; empty means no error expected
+	}{
+		{
+			// Declared order puts the expensive alias first, so only a
+			// correct canonical-keyed price lookup can reorder it behind the
+			// cheap one -- a strategy still pricing the alias name itself
+			// would find both unpriced and leave the declared (wrong) order
+			// standing.
+			name: "ranks cheapest alias first, same as it would unaliased",
+			targets: []Target{
+				{VirtualKey: "expensive--cred-1"},
+				{VirtualKey: "cheap--cred-1"},
+			},
+			lookup: newLookup(
+				providers.WithName(&mockProvider{name: "expensive", models: []string{"gpt-4o"}}, "expensive--cred-1"),
+				providers.WithName(&mockProvider{name: "cheap", models: []string{"gpt-4o"}}, "cheap--cred-1"),
+			),
+			catalog:  buildCatalog(),
+			wantLead: "cheap--cred-1",
+		},
+		{
+			// A provider registered under its own canonical name is the
+			// baseline every alias case above is measured against: WithName
+			// is a no-op here (core.WithName returns p unchanged when
+			// name == p.Name()), so this is unaffected by the fix.
+			name: "provider registered under its canonical name is unaffected",
+			targets: []Target{
+				{VirtualKey: "expensive"},
+				{VirtualKey: "cheap"},
+			},
+			lookup: newLookup(
+				&mockProvider{name: "expensive", models: []string{"gpt-4o"}},
+				&mockProvider{name: "cheap", models: []string{"gpt-4o"}},
+			),
+			catalog:  buildCatalog(),
+			wantLead: "cheap",
+		},
+		{
+			// The acceptance case named explicitly in issue #396: under
+			// unpriced_strategy: skip, an aliased target that IS priced in
+			// the catalog (under its canonical name) must not be dropped
+			// from routing.
+			name: "skip strategy does not drop a priced aliased target",
+			targets: []Target{
+				{VirtualKey: "openai--cred-1"},
+			},
+			lookup: newLookup(
+				providers.WithName(&mockProvider{name: "openai", models: []string{"gpt-4o"}}, "openai--cred-1"),
+			),
+			catalog:          aliasCatalog,
+			unpricedStrategy: "skip",
+			wantKeys:         []string{"openai--cred-1"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var s *CostOptimized
+			if tt.unpricedStrategy != "" {
+				s = NewCostOptimized(tt.targets, tt.lookup, tt.catalog, tt.unpricedStrategy)
+			} else {
+				s = NewCostOptimized(tt.targets, tt.lookup, tt.catalog)
+			}
+
+			keys, err := s.SelectTargets(req("hello world"))
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("SelectTargets error = %v, want containing %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("SelectTargets: %v", err)
+			}
+			if tt.wantKeys != nil {
+				if len(keys) != len(tt.wantKeys) || keys[0] != tt.wantKeys[0] {
+					t.Fatalf("SelectTargets keys = %v, want %v", keys, tt.wantKeys)
+				}
+				return
+			}
+			if len(keys) == 0 || keys[0] != tt.wantLead {
+				t.Fatalf("SelectTargets leads with %v, want %q first", keys, tt.wantLead)
+			}
+		})
+	}
+}

--- a/internal/streamwrap/wrap.go
+++ b/internal/streamwrap/wrap.go
@@ -47,6 +47,16 @@ type MeterMeta struct {
 	// client supplied it, so it is used for cost lookup and event payloads but
 	// never as a Prometheus label — see MetricModel.
 	Model string
+	// PriceProvider is the provider's canonical vendor identity — the name the
+	// model catalog and price book are keyed on. Provider names the ROUTING
+	// TARGET a stream used and stays on every metric label, event and the
+	// Response it produces; PriceProvider exists solely so a target registered
+	// under a routing alias (Gateway.RegisterProviderAs) is priced as its
+	// underlying provider rather than against a name the catalog has never
+	// heard of. Empty falls back to Provider, which is what every caller that
+	// predates this field — registered under its own canonical name, where the
+	// two already agree — continues to get.
+	PriceProvider string
 	// MetricModel is the bounded form of Model used for Prometheus labels: a
 	// model the gateway cannot route collapses to metrics.UnknownModelLabel so a
 	// client cannot mint unbounded time series. Required whenever Model can carry
@@ -112,6 +122,17 @@ func (m MeterMeta) metricLabelModel() string {
 		return metrics.UnknownModelLabel
 	}
 	return m.MetricModel
+}
+
+// priceProviderName returns the catalog key this stream is priced against:
+// PriceProvider when the caller resolved one, Provider otherwise. Every
+// caller that predates PriceProvider leaves it unset and gets exactly the
+// pricing behaviour it always had.
+func (m MeterMeta) priceProviderName() string {
+	if m.PriceProvider != "" {
+		return m.PriceProvider
+	}
+	return m.Provider
 }
 
 // Measurements are the per-request numbers a completed stream produced. They
@@ -292,7 +313,7 @@ func Meter(ctx context.Context, src <-chan providers.StreamChunk, start time.Tim
 		// plugins it runs persist the cost and cannot compute it themselves.
 		// The same result is handed to finishStreamOnSuccess so the recorded
 		// figure and the reported one cannot diverge.
-		cost := models.Calculate(meta.Catalog, meta.Provider+"/"+meta.Model, models.Usage{
+		cost := models.Calculate(meta.Catalog, meta.priceProviderName()+"/"+meta.Model, models.Usage{
 			PromptTokens:     usage.PromptTokens,
 			CompletionTokens: usage.CompletionTokens,
 			ReasoningTokens:  usage.ReasoningTokens,

--- a/internal/streamwrap/wrap_priceprovider_test.go
+++ b/internal/streamwrap/wrap_priceprovider_test.go
@@ -1,0 +1,117 @@
+package streamwrap
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ferro-labs/ai-gateway/internal/events"
+	"github.com/ferro-labs/ai-gateway/models"
+	"github.com/ferro-labs/ai-gateway/providers"
+)
+
+// ptrF returns a *float64 from a literal, mirroring the helper the strategies
+// package tests keep for the same purpose.
+func ptrF(v float64) *float64 { return &v }
+
+// TestMeter_PriceProviderPricing is issue #396's streaming regression suite.
+// A streaming request through a target registered under a routing alias
+// (Gateway.RegisterProviderAs) must be priced against the alias's canonical
+// vendor identity, never against the alias itself -- the catalog has never
+// heard of it, so pricing the alias directly always resolves to unpriced. It
+// must also keep reporting the alias everywhere attribution reads Provider:
+// Prometheus labels and the published lifecycle event.
+func TestMeter_PriceProviderPricing(t *testing.T) {
+	catalog := models.Catalog{
+		"openai/gpt-4o": {
+			Provider: "openai",
+			ModelID:  "gpt-4o",
+			Mode:     models.ModeChat,
+			Pricing: models.Pricing{
+				InputPerMTokens:  ptrF(5.0),
+				OutputPerMTokens: ptrF(15.0),
+			},
+		},
+	}
+
+	tests := []struct {
+		name          string
+		provider      string
+		priceProvider string // empty leaves MeterMeta.PriceProvider unset
+		wantHasCost   bool
+		wantCostUSD   float64
+	}{
+		{
+			// A caller that predates PriceProvider (every one before this
+			// fix) leaves it unset and must keep pricing on Provider exactly
+			// as it always did -- here that name is not in the catalog, so
+			// the request is correctly unpriced.
+			name:        "PriceProvider unset falls back to Provider",
+			provider:    "openai--cred-1",
+			wantHasCost: false,
+			wantCostUSD: 0,
+		},
+		{
+			// The routing alias "openai--cred-1" is not a catalog entry;
+			// only PriceProvider naming the canonical "openai" identity
+			// prices this request. (100 prompt + 50 completion) tokens at
+			// $5 / $15 per 1M tokens = 0.0005 + 0.00075.
+			name:          "PriceProvider set prices against the canonical identity",
+			provider:      "openai--cred-1",
+			priceProvider: "openai",
+			wantHasCost:   true,
+			wantCostUSD:   0.00125,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var mu sync.Mutex
+			var published []map[string]any
+			publishFn := func(_ context.Context, event events.HookEvent) {
+				mu.Lock()
+				published = append(published, event.Map())
+				mu.Unlock()
+			}
+
+			src := feed(providers.StreamChunk{
+				ID:    "1",
+				Usage: &providers.Usage{PromptTokens: 100, CompletionTokens: 50, TotalTokens: 150},
+			})
+
+			out := Meter(context.Background(), src, time.Now(), MeterMeta{
+				Provider:      tt.provider,
+				PriceProvider: tt.priceProvider,
+				Model:         "gpt-4o",
+				MetricModel:   "gpt-4o",
+				Catalog:       catalog,
+				PublishFn:     publishFn,
+			})
+			for range out { //nolint:revive // empty-block: intentionally draining the stream to completion
+			}
+
+			mu.Lock()
+			defer mu.Unlock()
+			if len(published) != 1 {
+				t.Fatalf("expected 1 publish call, got %d", len(published))
+			}
+			data := published[0]
+
+			// Attribution invariant: the published event always names the
+			// ROUTING alias, never the canonical identity PriceProvider
+			// resolved the cost against.
+			if data["provider"] != tt.provider {
+				t.Errorf("published provider = %v, want routing key %q (attribution must not shift to the canonical name)", data["provider"], tt.provider)
+			}
+
+			hasCost, _ := data["cost_usd"].(float64)
+			if tt.wantHasCost && hasCost != tt.wantCostUSD {
+				t.Errorf("cost_usd = %v, want %v", hasCost, tt.wantCostUSD)
+			}
+			if !tt.wantHasCost && hasCost != 0 {
+				t.Errorf("cost_usd = %v, want 0 (unpriced)", hasCost)
+			}
+		})
+	}
+}

--- a/providers/core/contracts.go
+++ b/providers/core/contracts.go
@@ -66,6 +66,26 @@ func WithName(p Provider, name string) Provider {
 	return &namedProvider{Provider: p, name: name}
 }
 
+// CanonicalName returns the identity beneath any WithName decorator: the
+// vendor name the model catalog and price book are keyed on. A provider
+// registered under its own name returns its own Name(); one registered under a
+// routing alias unwraps to the vendor identity beneath the alias. The bounded
+// walk mirrors As and cannot hang on a self-referential wrapper.
+func CanonicalName(p Provider) string {
+	for i := 0; i < 32; i++ {
+		unwrapper, ok := p.(ProviderUnwrapper)
+		if !ok {
+			break
+		}
+		next := unwrapper.UnwrapProvider()
+		if next == nil {
+			break
+		}
+		p = next
+	}
+	return p.Name()
+}
+
 // As resolves T from p or from an identity decorator beneath it. Every provider
 // in the chain is inspected, including the one reached by the final unwrap. The
 // bounded walk (at most 32 unwraps) prevents a broken third-party decorator that

--- a/providers/core/contracts.go
+++ b/providers/core/contracts.go
@@ -45,6 +45,31 @@ type ProviderUnwrapper interface {
 	UnwrapProvider() Provider
 }
 
+// IdentityUnwrapper exposes the provider whose vendor identity a decorator
+// carries. It is for decorators that change BEHAVIOUR but not identity — the
+// routing layer's circuit breaker, concurrency limiter and model-index view.
+//
+// It is deliberately a separate interface from ProviderUnwrapper rather than a
+// second implementation of it, because the two answer different questions and
+// only one of them is safe to make transparent:
+//
+//   - As walks ProviderUnwrapper to resolve capability interfaces. A
+//     behaviour-adding decorator must NOT be transparent there, or a caller
+//     resolves StreamProvider/EmbeddingProvider straight past the circuit
+//     breaker and concurrency limiter that were wrapped around it, silently
+//     losing the protection.
+//   - CanonicalName walks both, because identity is safe to see through: none
+//     of those decorators claims a vendor of its own, and pricing has to reach
+//     the vendor the catalog is keyed on.
+//
+// Implement this on any decorator that wraps a provider without becoming a
+// different vendor. Without it, CanonicalName stops at the decorator and
+// returns whatever Name() promotes to — which for an aliased registration is
+// the routing alias, so the catalog lookup silently finds nothing.
+type IdentityUnwrapper interface {
+	UnwrapIdentity() Provider
+}
+
 type namedProvider struct {
 	Provider
 	name string
@@ -71,15 +96,23 @@ func WithName(p Provider, name string) Provider {
 // registered under its own name returns its own Name(); one registered under a
 // routing alias unwraps to the vendor identity beneath the alias. The bounded
 // walk mirrors As and cannot hang on a self-referential wrapper.
+// It walks IdentityUnwrapper as well as ProviderUnwrapper. The routing layer
+// hands strategies a provider wrapped in the model-index view, the concurrency
+// limiter and the circuit breaker; none of those is a vendor, and stopping at
+// them returned the routing alias, which the catalog cannot price.
 func CanonicalName(p Provider) string {
-	for i := 0; i < 32; i++ {
-		unwrapper, ok := p.(ProviderUnwrapper)
-		if !ok {
-			break
+	for range 32 {
+		var next Provider
+		switch d := p.(type) {
+		case ProviderUnwrapper:
+			next = d.UnwrapProvider()
+		case IdentityUnwrapper:
+			next = d.UnwrapIdentity()
+		default:
+			return p.Name()
 		}
-		next := unwrapper.UnwrapProvider()
 		if next == nil {
-			break
+			return p.Name()
 		}
 		p = next
 	}

--- a/providers/facade_aliases.go
+++ b/providers/facade_aliases.go
@@ -192,6 +192,9 @@ var RetryAfterFrom = core.RetryAfterFrom
 // WithName re-exports core.WithName.
 var WithName = core.WithName
 
+// CanonicalName re-exports core.CanonicalName.
+var CanonicalName = core.CanonicalName
+
 // As resolves an optional capability through identity-only provider wrappers.
 func As[T any](p Provider) (T, bool) {
 	return core.As[T](p)

--- a/providers/facade_aliases.go
+++ b/providers/facade_aliases.go
@@ -15,6 +15,9 @@ type Provider = core.Provider
 // ProviderUnwrapper is an alias for core.ProviderUnwrapper.
 type ProviderUnwrapper = core.ProviderUnwrapper
 
+// IdentityUnwrapper is an alias for core.IdentityUnwrapper.
+type IdentityUnwrapper = core.IdentityUnwrapper
+
 // StreamProvider is an alias for core.StreamProvider.
 type StreamProvider = core.StreamProvider
 

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -6775,9 +6775,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Summary

A security patch. Every dependency advisory reachable from gateway code is cleared, and registration aliases are priced correctly on the two paths where the alias reached the catalog instead of the vendor identity behind it. No breaking changes, and deployments that register providers under their canonical name are unaffected.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] New provider
- [ ] New plugin
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Performance improvement
- [ ] Refactor / code quality
- [x] Documentation / comments only
- [x] CI / tooling

## Related issues

Fixes #396

## Changes

### Security — Go toolchain to 1.25.13

Seven Go standard-library advisories are reachable from gateway code at the pinned 1.25.12 toolchain, and every one is fixed in 1.25.13: quadratic complexity in `net/url`'s `resolvePath`, JavaScript regexp context tracking in `html/template`, unbounded post-handshake messages in `crypto/tls`, `ReadHeaderTimeout` not applied on the unencrypted HTTP/2 check in `net/http`, recursion depth during decode in `encoding/xml`, maximum recursion depth in `encoding/asn1`, and ASCII-only Punycode labels not rejected in `golang.org/x/net/idna`.

They are reached through provider HTTP clients, the serving path, the request-log store, the streaming reader, the signing proxy, Bedrock's XML response stream, and Vertex AI's OAuth token exchange. No gateway code changes — the fix is the toolchain version.

### Security — dashboard toolchain

`nanoid` moves to 3.3.18, closing a high-severity advisory where a custom generator can loop indefinitely when `size` is zero. It is a build-time tooling dependency, reached through the component-scaffolding CLI's own PostCSS, and is not present in the dashboard bundle the binary embeds. `npm audit` reports zero vulnerabilities.

### Fixed — registration aliases are priced correctly

`RegisterProviderAs`, added in 1.4.2, registers a provider under a routing alias that differs from its canonical vendor identity. 1.4.2 corrected catalog inventory and surface ranking to resolve the canonical identity; pricing still keyed on the alias in two places, so an aliased target was treated as unpriced:

- **Cost-optimized routing** — the strategy built its price key from the routing alias, so an aliased target ranked as unpriced: dropped from routing entirely under `unpriced_strategy: skip`, and ordered wrongly otherwise. Affected every provider.
- **Streaming cost** — a streaming response carries no provider identity of its own, so its cost was computed against the routing alias, a key the catalog cannot price. The span cost, request-log cost and budget spend for a streamed request through an aliased target recorded as zero. Affected every provider.

Both now resolve the canonical identity for the catalog lookup. A third path, non-streaming cost recording, is corrected for completeness: it reads the provider name off the response, and every built-in provider sets that field to its own canonical name, so built-in providers were already priced correctly there. A provider implementation that leaves the field unset was not.

Attribution is unchanged — the routing alias, not the canonical name, still identifies the target in metrics labels, in the span, and in the `Target` field plugins read.

### Documentation

- The README features section becomes a single table, one row per capability, each linking to its page on the docs site, rather than seven prose subsections restating what the docs cover in more depth. The minimal-config YAML is dropped (it duplicated what `ferrogw init` writes), and Performance moves below the reference material — those figures are from one v1.0.0 run and were sitting above the features they support.
- `.gitignore` covers the local `.agents/` and `.codex/` tooling directories.

## Testing

- [x] `make test` passes (unit tests, race detector)
- [x] `make lint` passes
- [x] New tests added for the change (if applicable)
- [ ] `make test-integration` passes (if applicable)
- [ ] Manually tested against a live provider (if provider change)

New regression coverage:

- `gateway_alias_pricing_test.go` — the alias-pricing suite for #396, covering both corrected paths end to end.
- `internal/strategies/costoptimized_test.go` — `TestCostOptimized_AliasPricing`, asserting an aliased target ranks exactly as the same provider registered under its canonical name, including under `unpriced_strategy: skip`.
- `internal/streamwrap/wrap_priceprovider_test.go` — streaming cost resolves the canonical identity.

`make test-integration` was not run locally (it needs Docker for the Postgres testcontainer); CI runs it as part of the merge gate.

## Breaking change notes

None. The alias remains the identity used for attribution everywhere it was before; only the catalog price lookup changes. Deployments registering providers under canonical names see no behaviour change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected pricing for providers registered through routing aliases, including cost-optimized selection and streaming/non-streaming cost tracking.
  * Preserved alias names in responses and usage attribution while applying canonical provider pricing.

* **Documentation**
  * Added release notes for version 1.4.3.
  * Streamlined the README with a consolidated features overview and reorganized performance information.

* **Chores**
  * Updated the required Go version to 1.25.13 across builds, releases, scanning, and testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Review round 1 — resolved

`4956e4c` addresses the findings from automated review.

**Blocker.** The alias-pricing fix did not work in the gateway's own wiring. `CanonicalName` walks `ProviderUnwrapper`, which only the `WithName` decorator implements; strategies are handed a provider wrapped in the model-index view, the concurrency limiter and the circuit breaker, so the walk stopped at the outermost wrapper and returned the routing alias. Cost-optimized routing priced against a key the catalog has never heard of and, under `unpriced_strategy: skip`, dropped the target entirely — the defect this release claims to fix. The strategy-level tests missed it because they build a lookup returning `WithName` directly and never exercise `getStrategy`.

Fixed with `core.IdentityUnwrapper`, deliberately a separate seam from `ProviderUnwrapper`: `As` walks the latter to resolve capability interfaces, so a behaviour-adding decorator must not implement it or a caller resolves `CompleteStream`/`Embed` past the circuit breaker it was wrapped in. `CanonicalName` walks both; `As` walks only the capability seam.

New regression coverage runs through gateway wiring rather than a hand-built lookup, and was verified to fail without the fix.

**Changelog accuracy.** The seventh advisory is in `golang.org/x/net`, not the standard library, and is cleared by the `x/net` version this build already pins rather than by the toolchain bump. Six standard-library advisories are fixed by Go 1.25.13. Internal build detail dropped from the `nanoid` entry.

**README.** Feature-table columns named, plugin sentence completed, no-plugin latency baseline stated explicitly.

## Deferred

The canonical pricing identity is re-derived from the mutable provider map at cost time rather than carried from selection, so a reload repointing an alias at a different vendor mid-request can price against a provider that did not serve it. Tracked as #411 with a fix sketch and acceptance criteria.

Not fixed here: `routeTargets` is generic over `Req, Resp` and shared by all four routed surfaces, so carrying the identity out means changing its return signature across the unified pipeline this release is stabilising — to correct a metering inaccuracy that needs a vendor-changing reload to be observable at all.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR updates the release toolchains and corrects catalog pricing for providers registered under routing aliases.
- Bumps Go build, CI, scanning, and release environments to 1.25.13 and updates the dashboard lockfile.
- Resolves canonical provider identity through routing decorators without bypassing their behavioral protections.
- Uses canonical identity for cost-optimized selection and streamed/non-streamed accounting while preserving routing aliases for attribution.
- Adds gateway-level regression coverage and updates release documentation and README organization.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| providers/core/contracts.go | Introduces a dedicated identity-unwrapping seam so canonical pricing can traverse behavior decorators without exposing capabilities past them. |
| gateway_modelindex.go | Makes the model-index routing view transparent to canonical identity resolution while preserving its capability boundary. |
| gateway_concurrency.go | Makes the concurrency decorator identity-transparent without allowing capability resolution to bypass the limiter. |
| gateway_circuitbreaker.go | Makes the circuit-breaker decorator identity-transparent while retaining enforcement for optional provider capabilities. |
| internal/strategies/costoptimized.go | Prices compatible targets using their canonical provider identity rather than their routing alias. |
| internal/streamwrap/wrap.go | Separates canonical pricing identity from the routing target retained in metrics, events, spans, and plugin attribution. |
| gateway_route_outcome.go | Resolves the canonical catalog key for non-streaming and streaming cost accounting while preserving alias attribution. |
| gateway_alias_pricing_test.go | Exercises alias pricing through the gateway’s real model-index, limiter, and circuit-breaker wiring. |
| go.mod | Raises the declared Go toolchain version to 1.25.13 without changing the module dependency graph. |
| CHANGELOG.md | Documents the security release and accurately distinguishes toolchain-fixed advisories from the external x/net advisory. |
| README.md | Consolidates feature documentation into a linked table and clarifies the performance baseline. |

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    A[Routing alias] --> B[Model-index view]
    B --> C[Concurrency limiter]
    C --> D[Circuit breaker]
    D -->|IdentityUnwrapper chain| E[WithName decorator]
    E --> F[Canonical provider]
    F --> G[Catalog price lookup]
    A --> H[Metrics and request attribution]
```
</details>

<sub>Reviews (3): Last reviewed commit: ["test: cover the circuit breaker in the i..."](https://github.com/ferro-labs/ai-gateway/commit/b9da29e41bd7b3169628c0443fba78868f81d27e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53951566)</sub>

<!-- /greptile_comment -->