### PR TITLE
fix: v1.4.4 — price in-flight requests against the provider that served them

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -55,7 +55,7 @@ GEMINI_API_KEY=
 # TOGETHER_BASE_URL=
 # FIREWORKS_API_KEY=
 # FIREWORKS_BASE_URL=
-# OPENROUTER_API_KEY=          # one key → hundreds of models
+# OPENROUTER_API_KEY=          # API key for OpenRouter
 # OPENROUTER_BASE_URL=
 # DEEPINFRA_API_KEY=
 # DEEPINFRA_BASE_URL=
@@ -126,7 +126,8 @@ GEMINI_API_KEY=
 # ── Ollama (local) ─────────────────────────────────
 # OLLAMA_HOST=http://localhost:11434
 # FERRO_OLLAMA_MODELS=llama3,codellama   # narrows what /v1/models advertises
-# OLLAMA_MODELS=                         # deprecated; Ollama uses this for its models directory
+# OLLAMA_MODELS=                         # deprecated for gateway model selection;
+#                                        # Ollama uses it for its models directory
 
 # ── Ollama Cloud (hosted) ──────────────────────────
 # OLLAMA_API_KEY=

--- a/.env.example
+++ b/.env.example
@@ -8,14 +8,17 @@
 # Kubernetes: use K8s Secrets with envFrom
 #
 # A provider is REGISTERED only when its credential is present, so set at least
-# one. Every HTTP provider also accepts a `<PROVIDER>_BASE_URL` override (write
-# the API root exactly as the vendor documents it, version segment included) to
-# point at a proxy, a self-hosted server, or a regional endpoint — a few are
-# shown commented below; the rest follow the same `<PROVIDER>_BASE_URL` pattern.
+# one. Provider URL overrides point at a proxy, self-hosted server, or regional
+# endpoint. Write API-root values exactly as the vendor documents them, version
+# segment included. Every supported provider variable is listed below.
 
 # ── Master Key (required for dashboard/admin) ─────
 # Generate with: ferrogw init
 MASTER_KEY=
+
+# ── Admin CLI ─────────────────────────────────────
+# FERROGW_URL=http://localhost:8080   # gateway base URL
+# FERROGW_API_KEY=                    # falls back to MASTER_KEY when unset
 
 # ═══════════════════════════════════════════════════════════════════════════
 # PROVIDERS — self-serve API keys (instant signup)
@@ -31,28 +34,45 @@ GEMINI_API_KEY=
 # XAI_API_KEY=
 # XAI_BASE_URL=https://api.x.ai/v1
 # DEEPSEEK_API_KEY=
+# DEEPSEEK_BASE_URL=
 # MISTRAL_API_KEY=
+# MISTRAL_BASE_URL=
 # COHERE_API_KEY=
+# COHERE_BASE_URL=https://api.cohere.com
 # PERPLEXITY_API_KEY=
+# PERPLEXITY_BASE_URL=
 # MOONSHOT_API_KEY=
+# MOONSHOT_BASE_URL=
 # AI21_API_KEY=
+# AI21_BASE_URL=
 
 # ── Fast inference / OSS serving / aggregators ─────
 # GROQ_API_KEY=
+# GROQ_BASE_URL=
 # CEREBRAS_API_KEY=
+# CEREBRAS_BASE_URL=
 # TOGETHER_API_KEY=
+# TOGETHER_BASE_URL=
 # FIREWORKS_API_KEY=
+# FIREWORKS_BASE_URL=
 # OPENROUTER_API_KEY=          # one key → hundreds of models
+# OPENROUTER_BASE_URL=
 # DEEPINFRA_API_KEY=
+# DEEPINFRA_BASE_URL=
 # NOVITA_API_KEY=
+# NOVITA_BASE_URL=
 # SAMBANOVA_API_KEY=
+# SAMBANOVA_BASE_URL=
 # NVIDIA_NIM_API_KEY=
+# NVIDIA_NIM_BASE_URL=
 # QWEN_API_KEY=                # Alibaba DashScope
+# QWEN_BASE_URL=
 
 # ── Hosting platforms ──────────────────────────────
 # HUGGING_FACE_API_KEY=
 # HUGGING_FACE_ENDPOINT=       # optional: a dedicated Inference Endpoint URL
 # REPLICATE_API_TOKEN=         # note: _API_TOKEN, not _API_KEY
+# REPLICATE_BASE_URL=
 # REPLICATE_TEXT_MODELS=meta/meta-llama-3-8b-instruct   # comma-separated; Replicate's model set is config-driven
 # REPLICATE_IMAGE_MODELS=black-forest-labs/flux-schnell
 
@@ -85,8 +105,10 @@ GEMINI_API_KEY=
 # VERTEX_AI_REGION=us-central1
 # Auth is EITHER an API key …
 # VERTEX_AI_API_KEY=
-# … OR a service account (JSON string or a path):
+# … OR a service account JSON string:
 # VERTEX_AI_SERVICE_ACCOUNT_JSON=
+# With neither set, Application Default Credentials are used; for a local file:
+# GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json
 
 # ── Databricks ─────────────────────────────────────
 # DATABRICKS_TOKEN=            # note: _TOKEN, not _API_KEY
@@ -95,6 +117,7 @@ GEMINI_API_KEY=
 # ── Cloudflare Workers AI ──────────────────────────
 # CLOUDFLARE_API_KEY=
 # CLOUDFLARE_ACCOUNT_ID=
+# CLOUDFLARE_BASE_URL=
 
 # ═══════════════════════════════════════════════════════════════════════════
 # PROVIDERS — self-hosted / local
@@ -103,11 +126,11 @@ GEMINI_API_KEY=
 # ── Ollama (local) ─────────────────────────────────
 # OLLAMA_HOST=http://localhost:11434
 # FERRO_OLLAMA_MODELS=llama3,codellama   # narrows what /v1/models advertises
-#                                        # (OLLAMA_MODELS is deprecated — it is Ollama's
-#                                        #  own var for the models DIRECTORY)
+# OLLAMA_MODELS=                         # deprecated; Ollama uses this for its models directory
 
 # ── Ollama Cloud (hosted) ──────────────────────────
 # OLLAMA_API_KEY=
+# OLLAMA_CLOUD_BASE_URL=
 # OLLAMA_CLOUD_MODELS=gpt-oss:120b
 
 # ── Batch + Responses backends ─────────────────────
@@ -120,12 +143,22 @@ GEMINI_API_KEY=
 # GATEWAY_CONFIG=config.yaml
 # GATEWAY_ENV=production        # turns on production-mode startup safety checks
 # LOG_LEVEL=info
+# ALLOW_UNAUTHENTICATED_PROXY=false   # dev only; blocked in production mode
+# ENABLE_PPROF=false            # mounts authenticated /debug/pprof/* routes
 # CORS_ORIGINS is matched literally — there is no wildcard. List each origin.
 # CORS_ORIGINS=http://localhost:3000
 # TRUSTED_PROXIES=10.0.0.0/8    # CIDRs whose X-Forwarded-For is honored
 
+# ── Model catalog and discovery ────────────────────
+# FERRO_MODEL_CATALOG_URL=      # override the remote model catalog URL
+# FERRO_MODEL_CATALOG_TIMEOUT=10s   # set to 0 to skip the remote catalog fetch
+# FERRO_MODEL_DISCOVERY_INTERVAL=   # e.g. 6h; unset disables live discovery
+
 # ── Observability (OpenTelemetry tracing) ──────────
 # OTEL_EXPORTER_OTLP_ENDPOINT=  # setting it turns tracing on; base OTLP endpoint
+# OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=   # signal-specific endpoint; takes precedence
+# OTEL_EXPORTER_OTLP_HEADERS=           # comma-separated key=value exporter headers
+# OTEL_EXPORTER_OTLP_TRACES_HEADERS=    # signal-specific headers; takes precedence
 
 # ── Storage (default: in-memory) ───────────────────
 # Recommended: sqlite for local dev, postgres for production

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,16 @@ All notable changes to Ferro Labs AI Gateway are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.4.4] — 2026-08-18
 
-_Nothing yet._
+### Fixed — in-flight requests keep the provider price selected for them
+
+An alias repointed to a different provider while a request was in flight could
+price that request against the replacement provider, even though the original
+provider served it. Routing now carries the canonical pricing identity captured
+at provider selection through unary and streaming cost accounting. Attribution
+is unchanged: responses, metrics, spans and plugin context still name the
+routing alias.
 
 ## [1.4.3] — 2026-08-17
 

--- a/gateway.go
+++ b/gateway.go
@@ -840,6 +840,16 @@ func (g *Gateway) GetProvider(name string) (providers.Provider, bool) {
 	return p, ok
 }
 
+// pricingProviderFor returns the canonical provider registered under key. An
+// unknown key falls back to itself and remains unpriced by the model catalog.
+func (g *Gateway) pricingProviderFor(key string) string {
+	p, ok := g.GetProvider(key)
+	if !ok || p == nil {
+		return key
+	}
+	return providers.CanonicalName(p)
+}
+
 // Get satisfies providers.ProviderSource (alias for GetProvider).
 func (g *Gateway) Get(name string) (providers.Provider, bool) {
 	return g.GetProvider(name)

--- a/gateway_alias_pricing_test.go
+++ b/gateway_alias_pricing_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ferro-labs/ai-gateway/config"
 	"github.com/ferro-labs/ai-gateway/models"
+	"github.com/ferro-labs/ai-gateway/observability"
 	"github.com/ferro-labs/ai-gateway/pkg/circuitbreaker"
 	"github.com/ferro-labs/ai-gateway/providers"
 )
@@ -179,23 +180,15 @@ func TestRouteResponses_AliasPricingSurvivesProviderReplacement(t *testing.T) {
 	fp := &fakeProvider{}
 	gw.SetObservability(fp)
 	gw.RegisterProviderAs(alias, &mockProvider{name: "mock", models: []string{testModel}})
+	selected, ok := gw.GetProvider(alias)
+	if !ok {
+		t.Fatal("expected original provider to be registered")
+	}
+	gw.RegisterProviderAs(alias, &mockProvider{name: "replacement", models: []string{testModel}})
 
 	usage := providers.Usage{PromptTokens: 100, CompletionTokens: 50, TotalTokens: 150}
-	started := make(chan struct{})
-	release := make(chan struct{})
-	done := make(chan error, 1)
-	go func() {
-		done <- gw.RouteResponses(context.Background(), alias, testModel, "hello", true, 0, &usage,
-			func(context.Context) error {
-				close(started)
-				<-release
-				return nil
-			})
-	}()
-	<-started
-	gw.RegisterProviderAs(alias, &mockProvider{name: "replacement", models: []string{testModel}})
-	close(release)
-	if err := <-done; err != nil {
+	if err := gw.RouteResponsesWithPricingProvider(context.Background(), alias, providers.CanonicalName(selected), testModel, "hello", true, 0, &usage,
+		func(context.Context) error { return nil }); err != nil {
 		t.Fatalf("RouteResponses: %v", err)
 	}
 
@@ -327,6 +320,9 @@ func TestGateway_AliasStreamingPricingSurvivesProviderReplacement(t *testing.T) 
 	sp := fp.rootSpan()
 	if sp == nil {
 		t.Fatal("expected a root span")
+	}
+	if got := sp.attrs[observability.AttrGenAISystem]; got != alias {
+		t.Errorf("stream span provider = %q, want routing key %q", got, alias)
 	}
 	if sp.cost.TotalUSD != aliasPricingWantCostUSD {
 		t.Errorf("stream span cost = %+v, want original provider TotalUSD %.5f", sp.cost, aliasPricingWantCostUSD)

--- a/gateway_alias_pricing_test.go
+++ b/gateway_alias_pricing_test.go
@@ -162,6 +162,39 @@ func TestGateway_AliasPricing_Streaming(t *testing.T) {
 	}
 }
 
+// TestRouteResponses_AliasPricing covers the pass-through pricing path, which
+// does not select a provider through routeTargets and must resolve the target's
+// canonical provider name from the registry instead.
+func TestRouteResponses_AliasPricing(t *testing.T) {
+	const alias = "mock--credential-1"
+	gw, err := newTestGateway(t, config.Config{
+		Strategy: config.StrategyConfig{Mode: config.ModeSingle},
+		Targets:  []config.Target{{VirtualKey: alias}},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	gw.catalog = aliasPricingCatalog()
+
+	fp := &fakeProvider{}
+	gw.SetObservability(fp)
+	gw.RegisterProviderAs(alias, &mockProvider{name: "mock", models: []string{testModel}})
+
+	usage := providers.Usage{PromptTokens: 100, CompletionTokens: 50, TotalTokens: 150}
+	if err := gw.RouteResponses(context.Background(), alias, testModel, "hello", true, 0, &usage,
+		func(context.Context) error { return nil }); err != nil {
+		t.Fatalf("RouteResponses: %v", err)
+	}
+
+	sp := fp.rootSpan()
+	if sp == nil {
+		t.Fatal("expected a root span")
+	}
+	if sp.cost.TotalUSD != aliasPricingWantCostUSD || !sp.cost.ModelFound {
+		t.Errorf("responses span cost = %+v, want TotalUSD %.5f and ModelFound true", sp.cost, aliasPricingWantCostUSD)
+	}
+}
+
 func TestGateway_AliasPricingSurvivesProviderReplacement(t *testing.T) {
 	const alias = "mock--credential-1"
 	gw, err := newTestGateway(t, config.Config{

--- a/gateway_alias_pricing_test.go
+++ b/gateway_alias_pricing_test.go
@@ -37,11 +37,10 @@ func aliasPricingCatalog() models.Catalog {
 // distinct from its provider's canonical name ("mock") must be priced
 // identically to the same provider registered under its canonical name.
 //
-// gateway_route.go computes cost once (`cost := g.calculateCost(resp)`) and
-// feeds the same value to the request logger and the budget plugin, so
-// asserting calculateCost's result covers both request-log cost and budget
-// spend; asserting the span cost covers the third. resp.Provider must keep
-// naming the routing key everywhere attribution reads it.
+// gateway_route.go computes cost once and feeds the same value to the request
+// logger, budget plugin and span, so asserting the span cost covers the shared
+// result. resp.Provider must keep naming the routing key everywhere attribution
+// reads it.
 //
 // The mock leaves Response.Provider unset, matching a provider that does not
 // stamp its own identity: the shape RegisterProviderAs is documented for,
@@ -88,11 +87,6 @@ func TestGateway_AliasPricing(t *testing.T) {
 
 			if resp.Provider != tt.virtualKey {
 				t.Errorf("resp.Provider = %q, want routing key %q", resp.Provider, tt.virtualKey)
-			}
-
-			cost := gw.calculateCost(resp)
-			if !cost.Priced || cost.TotalUSD != aliasPricingWantCostUSD {
-				t.Errorf("calculateCost = %+v, want Priced TotalUSD %.5f", cost, aliasPricingWantCostUSD)
 			}
 
 			sp := fp.rootSpan()
@@ -165,6 +159,131 @@ func TestGateway_AliasPricing_Streaming(t *testing.T) {
 				t.Errorf("stream span cost = %+v, want TotalUSD %.5f", sp.cost, aliasPricingWantCostUSD)
 			}
 		})
+	}
+}
+
+func TestGateway_AliasPricingSurvivesProviderReplacement(t *testing.T) {
+	const alias = "mock--credential-1"
+	gw, err := newTestGateway(t, config.Config{
+		Strategy: config.StrategyConfig{Mode: config.ModeSingle},
+		Targets:  []config.Target{{VirtualKey: alias}},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	gw.catalog = aliasPricingCatalog()
+
+	fp := &fakeProvider{}
+	gw.SetObservability(fp)
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	gw.RegisterProviderAs(alias, &mockProvider{
+		name:   "mock",
+		models: []string{testModel},
+		completeFn: func(context.Context, providers.Request) (*providers.Response, error) {
+			close(started)
+			<-release
+			return &providers.Response{
+				Model: testModel,
+				Usage: providers.Usage{PromptTokens: 100, CompletionTokens: 50},
+			}, nil
+		},
+	})
+
+	type result struct {
+		resp *providers.Response
+		err  error
+	}
+	done := make(chan result, 1)
+	go func() {
+		resp, routeErr := gw.Route(context.Background(), providers.Request{
+			Model:    testModel,
+			Messages: []providers.Message{{Role: "user", Content: "hi"}},
+		})
+		done <- result{resp: resp, err: routeErr}
+	}()
+	<-started
+	gw.RegisterProviderAs(alias, &mockProvider{name: "replacement", models: []string{testModel}})
+	close(release)
+
+	got := <-done
+	if got.err != nil {
+		t.Fatalf("Route: %v", got.err)
+	}
+	if got.resp.Provider != alias {
+		t.Errorf("resp.Provider = %q, want routing key %q", got.resp.Provider, alias)
+	}
+	sp := fp.rootSpan()
+	if sp == nil {
+		t.Fatal("expected a root span")
+	}
+	if sp.cost.TotalUSD != aliasPricingWantCostUSD {
+		t.Errorf("span cost = %+v, want original provider TotalUSD %.5f", sp.cost, aliasPricingWantCostUSD)
+	}
+}
+
+func TestGateway_AliasStreamingPricingSurvivesProviderReplacement(t *testing.T) {
+	const alias = "mock--credential-1"
+	gw, err := newTestGateway(t, config.Config{
+		Strategy: config.StrategyConfig{Mode: config.ModeSingle},
+		Targets:  []config.Target{{VirtualKey: alias}},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	gw.catalog = aliasPricingCatalog()
+
+	fp := &fakeProvider{}
+	gw.SetObservability(fp)
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	gw.RegisterProviderAs(alias, &mockStreamProvider{
+		mockProvider: mockProvider{name: "mock", models: []string{testModel}},
+		streamFn: func(context.Context, providers.Request) (<-chan providers.StreamChunk, error) {
+			close(started)
+			<-release
+			ch := make(chan providers.StreamChunk, 1)
+			ch <- providers.StreamChunk{
+				Model: testModel,
+				Usage: &providers.Usage{PromptTokens: 100, CompletionTokens: 50, TotalTokens: 150},
+			}
+			close(ch)
+			return ch, nil
+		},
+	})
+
+	type result struct {
+		ch  <-chan providers.StreamChunk
+		err error
+	}
+	done := make(chan result, 1)
+	go func() {
+		ch, routeErr := gw.RouteStream(context.Background(), providers.Request{
+			Model:    testModel,
+			Stream:   true,
+			Messages: []providers.Message{{Role: "user", Content: "hi"}},
+		})
+		done <- result{ch: ch, err: routeErr}
+	}()
+	<-started
+	gw.RegisterProviderAs(alias, &mockStreamProvider{
+		mockProvider: mockProvider{name: "replacement", models: []string{testModel}},
+	})
+	close(release)
+
+	got := <-done
+	if got.err != nil {
+		t.Fatalf("RouteStream: %v", got.err)
+	}
+	drainStream(t, got.ch)
+	sp := fp.rootSpan()
+	if sp == nil {
+		t.Fatal("expected a root span")
+	}
+	if sp.cost.TotalUSD != aliasPricingWantCostUSD {
+		t.Errorf("stream span cost = %+v, want original provider TotalUSD %.5f", sp.cost, aliasPricingWantCostUSD)
 	}
 }
 

--- a/gateway_alias_pricing_test.go
+++ b/gateway_alias_pricing_test.go
@@ -162,10 +162,10 @@ func TestGateway_AliasPricing_Streaming(t *testing.T) {
 	}
 }
 
-// TestRouteResponses_AliasPricing covers the pass-through pricing path, which
-// does not select a provider through routeTargets and must resolve the target's
-// canonical provider name from the registry instead.
-func TestRouteResponses_AliasPricing(t *testing.T) {
+// TestRouteResponses_AliasPricingSurvivesProviderReplacement covers the
+// pass-through pricing path, which must capture the target's canonical provider
+// name before forwarding because it does not select through routeTargets.
+func TestRouteResponses_AliasPricingSurvivesProviderReplacement(t *testing.T) {
 	const alias = "mock--credential-1"
 	gw, err := newTestGateway(t, config.Config{
 		Strategy: config.StrategyConfig{Mode: config.ModeSingle},
@@ -181,8 +181,21 @@ func TestRouteResponses_AliasPricing(t *testing.T) {
 	gw.RegisterProviderAs(alias, &mockProvider{name: "mock", models: []string{testModel}})
 
 	usage := providers.Usage{PromptTokens: 100, CompletionTokens: 50, TotalTokens: 150}
-	if err := gw.RouteResponses(context.Background(), alias, testModel, "hello", true, 0, &usage,
-		func(context.Context) error { return nil }); err != nil {
+	started := make(chan struct{})
+	release := make(chan struct{})
+	done := make(chan error, 1)
+	go func() {
+		done <- gw.RouteResponses(context.Background(), alias, testModel, "hello", true, 0, &usage,
+			func(context.Context) error {
+				close(started)
+				<-release
+				return nil
+			})
+	}()
+	<-started
+	gw.RegisterProviderAs(alias, &mockProvider{name: "replacement", models: []string{testModel}})
+	close(release)
+	if err := <-done; err != nil {
 		t.Fatalf("RouteResponses: %v", err)
 	}
 

--- a/gateway_pipeline.go
+++ b/gateway_pipeline.go
@@ -109,13 +109,20 @@ type targetCall[Req, Resp any] func(context.Context, providers.Provider, Req) (R
 // enough, which is chat's case.
 type capabilityGate func(providers.Provider) bool
 
+// routedTarget carries both identities fixed at provider selection. key is the
+// configured routing target used for attribution; priceProvider is the
+// canonical vendor used only for catalog pricing.
+type routedTarget struct {
+	key           string
+	priceProvider string
+}
+
 // routeTargets walks plan and returns the first target's answer.
 //
-// The second return is the target that produced the response or, on failure,
-// the last one attempted. It is empty only when nothing was attempted at all.
-// Callers label metrics and spans with it: a provider error attributed to ""
-// cannot drive per-provider alerting, which is the one thing those series exist
-// for.
+// The second return identifies the target that produced the response or, on
+// failure, the last one attempted. Its key is empty only when nothing was
+// attempted at all. Callers label metrics and spans with key; pricing uses the
+// canonical provider captured from the same selected provider instance.
 //
 // A failure that is not the fault of any target — nothing registered, nothing
 // that serves the model — is reported as core.ErrNoCapableProvider so it
@@ -129,15 +136,15 @@ func routeTargets[Req, Resp any](
 	req Req,
 	gate capabilityGate,
 	call targetCall[Req, Resp],
-) (Resp, string, error) {
+) (Resp, routedTarget, error) {
 	var zero Resp
 
 	keys := g.eligibleKeys(plan, gate)
 
 	var (
-		lastErr  error
-		lastKey  string
-		attempts int
+		lastErr    error
+		lastTarget routedTarget
+		attempts   int
 		// A failure the walk moves past is invisible to the terminal recorder,
 		// which only ever names the last target tried. Under mode: fallback a
 		// provider can fail every request and read zero on
@@ -157,6 +164,7 @@ func routeTargets[Req, Resp any](
 		if !ok {
 			continue
 		}
+		target := routedTarget{key: key, priceProvider: providers.CanonicalName(p)}
 		if plan.responseOutlivesCall {
 			// Composition and order are decorateProvider's, which is the same
 			// pair callUnderResilience applies at the call site — breaker
@@ -171,7 +179,7 @@ func routeTargets[Req, Resp any](
 		if maskedErr != nil {
 			recordProviderErrorCtx(ctx, maskedKey, maskedErr)
 		}
-		lastKey = key
+		lastTarget = target
 
 		started := time.Now()
 		resp, err := attemptTarget(ctx, g, key, p, cb, lim, req, call)
@@ -182,7 +190,7 @@ func routeTargets[Req, Resp any](
 			// included plugin and alias time would rank targets on work no target
 			// did.
 			g.latencyTracker.Record(key, time.Since(started))
-			return resp, key, nil
+			return resp, target, nil
 		}
 		lastErr = fmt.Errorf("target %s: %w", key, err)
 		maskedKey, maskedErr = key, err
@@ -199,14 +207,14 @@ func routeTargets[Req, Resp any](
 	// it is decided on the attempt count alone — never on whether some skipped
 	// target happened to leave an error behind.
 	if attempts == 0 {
-		return zero, "", errNoCapableTarget(plan.model)
+		return zero, routedTarget{}, errNoCapableTarget(plan.model)
 	}
 	if plan.advance {
 		// Only a strategy that falls back can honestly claim this: it really did
 		// ask every candidate. A single-target mode asked one, and says so.
-		return zero, lastKey, fmt.Errorf("all providers failed: %w", lastErr)
+		return zero, lastTarget, fmt.Errorf("all providers failed: %w", lastErr)
 	}
-	return zero, lastKey, lastErr
+	return zero, lastTarget, lastErr
 }
 
 // eligibleKeys narrows a strategy's candidate order to the targets the walk may
@@ -653,19 +661,19 @@ func completeChat(ctx context.Context, p providers.Provider, req providers.Reque
 
 // routeChat runs a non-streaming chat request through the pipeline and returns
 // the response together with the target that served it.
-func (g *Gateway) routeChat(ctx context.Context, s strategies.Strategy, req providers.Request) (*providers.Response, string, error) {
+func (g *Gateway) routeChat(ctx context.Context, s strategies.Strategy, req providers.Request) (*providers.Response, routedTarget, error) {
 	keys, err := s.SelectTargets(req)
 	if err != nil {
-		return nil, "", err
+		return nil, routedTarget{}, err
 	}
-	resp, key, err := routeTargets(ctx, g, g.planFor(req.Model, keys), req, nil, completeChat)
+	resp, target, err := routeTargets(ctx, g, g.planFor(req.Model, keys), req, nil, completeChat)
 	if err != nil {
-		return nil, key, err
+		return nil, target, err
 	}
 	if resp != nil && resp.Provider == "" {
-		resp.Provider = key
+		resp.Provider = target.key
 	}
-	return resp, key, nil
+	return resp, target, nil
 }
 
 // How the remaining surfaces attach.

--- a/gateway_route.go
+++ b/gateway_route.go
@@ -170,6 +170,8 @@ func withUnsupportedParamMode(ctx context.Context, compatMode string) context.Co
 }
 
 // Route routes a request to the appropriate provider based on the configuration.
+//
+//nolint:maintidx // The request lifecycle stays together so plugin, routing, MCP, and accounting stages cannot drift.
 func (g *Gateway) Route(ctx context.Context, req providers.Request) (*providers.Response, error) {
 	ctx, task := trace.NewTask(ctx, "gateway.route")
 	defer task.End()
@@ -307,7 +309,7 @@ func (g *Gateway) Route(ctx context.Context, req providers.Request) (*providers.
 	// Run the request through the pipeline: the strategy's target order, then
 	// per-target retry, breaker and concurrency limit around each provider call.
 	var resp *providers.Response
-	var target string
+	var target routedTarget
 	var providerDuration time.Duration
 	providerStart := time.Now()
 	trace.WithRegion(ctx, "gateway.route.provider.execute", func() {
@@ -320,7 +322,7 @@ func (g *Gateway) Route(ctx context.Context, req providers.Request) (*providers.
 		// target names the last target actually attempted. Reporting "" here
 		// left every non-streaming provider failure in one unlabelled bucket,
 		// which is the one thing per-provider alerting needs.
-		g.routeError(ctx, span, obs, pctx, plugins, target, req.Model, err, latency, originalStream, hooksEnabled, obsEventsActive)
+		g.routeError(ctx, span, obs, pctx, plugins, target.key, req.Model, err, latency, originalStream, hooksEnabled, obsEventsActive)
 		return nil, err
 	}
 
@@ -342,25 +344,25 @@ func (g *Gateway) Route(ctx context.Context, req providers.Request) (*providers.
 	// the LLM until no more tool_calls are present or the depth limit is hit.
 	if mcpExecutorSnapshot != nil && mcpActive {
 		var loopDuration time.Duration
-		var loopProvider string
+		var loopTarget routedTarget
 		var loopUsage core.Usage
-		resp, loopUsage, loopDuration, loopProvider, err = g.runMCPLoop(ctx, mcpExecutorSnapshot, plugins, pctx, s, &provReq, resp)
+		resp, loopUsage, loopDuration, loopTarget, err = g.runMCPLoop(ctx, mcpExecutorSnapshot, plugins, pctx, s, &provReq, resp, target)
 		providerDuration += loopDuration
 		if err != nil {
 			// The turns that completed before the failure spent real tokens, so
 			// they are billed. Reporting only the error charged nothing for
 			// them, which made a prompt that reliably fails late free.
 			if pctx != nil {
-				pctx.Response = &providers.Response{Model: req.Model, Provider: loopProvider, Usage: loopUsage}
+				pctx.Response = &providers.Response{Model: req.Model, Provider: loopTarget.key, Usage: loopUsage}
 			}
-			g.routeError(ctx, span, obs, pctx, plugins, loopProvider, req.Model, err, time.Since(start), originalStream, hooksEnabled, obsEventsActive)
+			g.routeError(ctx, span, obs, pctx, plugins, loopTarget.key, req.Model, err, time.Since(start), originalStream, hooksEnabled, obsEventsActive)
 			return nil, err
 		}
 		// The loop re-contacts the provider, so the target that answered LAST is
 		// the one this request finished on — the same rule the failure path
-		// already applies to loopProvider.
-		if loopProvider != "" {
-			target = loopProvider
+		// already applies to loopTarget.
+		if loopTarget.key != "" {
+			target = loopTarget
 		}
 	}
 	// originalStream is included in the completed event so hook consumers
@@ -371,12 +373,12 @@ func (g *Gateway) Route(ctx context.Context, req providers.Request) (*providers.
 	// the after-request plugins need it: the request logger persists it, and it
 	// cannot be recovered later. recordSuccess is handed the same result rather
 	// than repeating the calculation.
-	cost := g.calculateCost(resp)
+	cost := g.calculateCost(resp, target.priceProvider)
 
 	// Measured before the stage runs, so the duration a logging plugin records
 	// does not include that plugin. Streaming requests take the other path, in
 	// RouteStream, where a time to first token also exists.
-	resp, err = g.runAfterPlugins(ctx, plugins, pctx, resp, target, plugin.Measurements{
+	resp, err = g.runAfterPlugins(ctx, plugins, pctx, resp, target.key, plugin.Measurements{
 		DurationMs: float64(time.Since(start).Microseconds()) / 1000.0,
 		CostUSD:    cost.TotalUSD,
 		HasCost:    cost.Priced,
@@ -474,11 +476,11 @@ func (g *Gateway) metricModel(model string) string {
 // tool messages. Returns the final response, the accumulated provider-call
 // duration (for OverheadMs accounting), the provider name of the last
 // attempted call (for error reporting), and any error.
-func (g *Gateway) runMCPLoop(ctx context.Context, mcpExecutorSnapshot *mcp.Executor, plugins *plugin.Manager, pctx *plugin.Context, s strategies.Strategy, req *providers.Request, resp *providers.Response) (*providers.Response, core.Usage, time.Duration, string, error) {
+func (g *Gateway) runMCPLoop(ctx context.Context, mcpExecutorSnapshot *mcp.Executor, plugins *plugin.Manager, pctx *plugin.Context, s strategies.Strategy, req *providers.Request, resp *providers.Response, initialTarget routedTarget) (*providers.Response, core.Usage, time.Duration, routedTarget, error) {
 	var providerDuration time.Duration
 	var err error
 	depth := 0
-	loopProvider := resp.Provider
+	loopTarget := initialTarget
 	// What this request has spent so far, fed to the per-turn budget check.
 	var (
 		spentUSD    float64
@@ -553,11 +555,11 @@ func (g *Gateway) runMCPLoop(ctx context.Context, mcpExecutorSnapshot *mcp.Execu
 			}
 
 			callStart := time.Now()
-			var target string
+			var target routedTarget
 			resp, target, err = g.routeChat(ctx, s, *req)
 			providerDuration += time.Since(callStart)
-			if target != "" {
-				loopProvider = target
+			if target.key != "" {
+				loopTarget = target
 			}
 			if err != nil {
 				return
@@ -575,7 +577,7 @@ func (g *Gateway) runMCPLoop(ctx context.Context, mcpExecutorSnapshot *mcp.Execu
 			// differently-priced providers, and pricing each against the provider
 			// that served it is strictly better than pricing the total at the
 			// last one's rate.
-			if turnCost := g.calculateCost(resp); turnCost.Priced {
+			if turnCost := g.calculateCost(resp, target.priceProvider); turnCost.Priced {
 				spentUSD += turnCost.TotalUSD
 				spentPriced = true
 			}
@@ -590,5 +592,5 @@ func (g *Gateway) runMCPLoop(ctx context.Context, mcpExecutorSnapshot *mcp.Execu
 	// failed on turn three still spent turns one and two, and returning only an
 	// error billed the caller nothing for them — free, and steerable by any
 	// prompt that reliably fails late.
-	return resp, total, providerDuration, loopProvider, err
+	return resp, total, providerDuration, loopTarget, err
 }

--- a/gateway_route_outcome.go
+++ b/gateway_route_outcome.go
@@ -178,34 +178,17 @@ func cacheServedMeasurements(start time.Time) plugin.Measurements {
 	}
 }
 
-// canonicalPriceKeyLocked resolves routingKey — a resp.Provider or
-// streamwrap.MeterMeta.Provider value, which names the routing target that
-// served the request rather than a vendor — to the canonical vendor identity
-// the model catalog and price book are keyed on. A target registered through
-// RegisterProviderAs is priced as its underlying provider, not the alias the
-// catalog has never heard of. Attribution is untouched: callers keep using
-// routingKey itself for everything except the catalog lookup. Returns
-// routingKey unchanged when no provider is currently registered under it.
-// Caller must hold g.mu (a read lock is sufficient).
-func (g *Gateway) canonicalPriceKeyLocked(routingKey string) string {
-	if p, ok := g.providers[routingKey]; ok {
-		return providers.CanonicalName(p)
-	}
-	return routingKey
-}
-
 // calculateCost prices a response against the current model catalog.
 //
 // Split out because the after-request plugins need the result before
 // recordSuccess runs — the request logger persists it — and pricing a response
 // twice risks the persisted figure and the reported one disagreeing after a
 // catalog refresh lands between them.
-func (g *Gateway) calculateCost(resp *providers.Response) models.CostResult {
+func (g *Gateway) calculateCost(resp *providers.Response, priceProvider string) models.CostResult {
 	g.mu.RLock()
 	catalog := g.catalog
-	priceKey := g.canonicalPriceKeyLocked(resp.Provider)
 	g.mu.RUnlock()
-	return models.Calculate(catalog, priceKey+"/"+resp.Model, models.Usage{
+	return models.Calculate(catalog, priceProvider+"/"+resp.Model, models.Usage{
 		PromptTokens:     resp.Usage.PromptTokens,
 		CompletionTokens: resp.Usage.CompletionTokens,
 		ReasoningTokens:  resp.Usage.ReasoningTokens,

--- a/gateway_stream.go
+++ b/gateway_stream.go
@@ -152,7 +152,8 @@ func (g *Gateway) RouteStream(ctx context.Context, req providers.Request) (<-cha
 	// timer, deferred here purely so a panic can't leak it.
 	startCtx, cancelStart := withRequestDeadline(ctx, requestTimeout)
 	defer cancelStart()
-	providerName, rawCh, targetBreaker, err := g.startStreamWithStrategy(startCtx, ctx, req)
+	target, rawCh, targetBreaker, err := g.startStreamWithStrategy(startCtx, ctx, req)
+	providerName := target.key
 	span.SetAttribute(observability.AttrGenAISystem, providerName)
 	// Stamp the resolved target key (virtual key = provider name in this routing layer).
 	if providerName != "" {
@@ -171,17 +172,11 @@ func (g *Gateway) RouteStream(ctx context.Context, req providers.Request) (<-cha
 	// metrics and event hooks once the stream completes.
 	g.mu.RLock()
 	catalog := g.catalog
-	// Resolved once, alongside the catalog snapshot, from the same live
-	// provider set routing just selected providerName from — see
-	// canonicalPriceKeyLocked. providerName itself keeps naming the routing
-	// target on meta.Provider (attribution: metric labels, the completed/failed
-	// event, resp.Provider); priceProvider exists solely for the cost lookup.
-	priceProvider := g.canonicalPriceKeyLocked(providerName)
 	g.mu.RUnlock()
 
 	meta := streamwrap.MeterMeta{
 		Provider:      providerName,
-		PriceProvider: priceProvider,
+		PriceProvider: target.priceProvider,
 		Model:         req.Model,
 		// Model stays raw for cost lookup and event payloads; only the metric
 		// label is bounded, mirroring the non-streaming path's use of the

--- a/gateway_stream_start.go
+++ b/gateway_stream_start.go
@@ -41,7 +41,7 @@ import (
 // mid-start would otherwise hand the stream's eventual outcome to a fresh
 // breaker whose state machine never admitted it. Nil when the target has no
 // breaker configured.
-func (g *Gateway) startStreamWithStrategy(startCtx, streamCtx context.Context, req providers.Request) (string, <-chan providers.StreamChunk, *circuitbreaker.CircuitBreaker, error) {
+func (g *Gateway) startStreamWithStrategy(startCtx, streamCtx context.Context, req providers.Request) (routedTarget, <-chan providers.StreamChunk, *circuitbreaker.CircuitBreaker, error) {
 	g.mu.Lock()
 	g.ensureCircuitBreakersLocked()
 	g.ensureProviderLimitersLocked()
@@ -49,18 +49,18 @@ func (g *Gateway) startStreamWithStrategy(startCtx, streamCtx context.Context, r
 
 	keys, err := g.streamingTargetOrder(req)
 	if err != nil {
-		return "", nil, nil, err
+		return routedTarget{}, nil, nil, err
 	}
 
 	plan := g.planFor(req.Model, keys)
 	plan.responseOutlivesCall = true
 
 	var admitted *circuitbreaker.CircuitBreaker
-	raw, key, err := routeTargets(startCtx, g, plan, req, streamCapable, startStreamOn(streamCtx, &admitted))
+	raw, target, err := routeTargets(startCtx, g, plan, req, streamCapable, startStreamOn(streamCtx, &admitted))
 	if err != nil {
-		return key, nil, nil, err
+		return target, nil, nil, err
 	}
-	return key, raw, admitted, nil
+	return target, raw, admitted, nil
 }
 
 // streamCapable is streaming's candidacy gate: a target whose provider cannot

--- a/gateway_surface.go
+++ b/gateway_surface.go
@@ -79,12 +79,12 @@ func (r surfaceRecord) pluginView() *providers.Response {
 // the metrics and the span report are the same number — pricing twice is how
 // they come to disagree when a catalog refresh lands between the two calls.
 // Chat splits calculateCost out of recordSuccess for the same reason.
-func (g *Gateway) priceSurface(provider, model string, tokens providers.Usage, imageCount int) surfaceRecord {
-	record := surfaceRecord{provider: provider, model: model, tokens: tokens, imageCount: imageCount}
+func (g *Gateway) priceSurface(target routedTarget, model string, tokens providers.Usage, imageCount int) surfaceRecord {
+	record := surfaceRecord{provider: target.key, model: model, tokens: tokens, imageCount: imageCount}
 	g.mu.RLock()
 	catalog := g.catalog
 	g.mu.RUnlock()
-	record.cost = models.Calculate(catalog, provider+"/"+model, record.billable())
+	record.cost = models.Calculate(catalog, target.priceProvider+"/"+model, record.billable())
 	return record
 }
 
@@ -330,14 +330,14 @@ func (g *Gateway) Embed(ctx context.Context, req providers.EmbeddingRequest) (*p
 	var resp *providers.EmbeddingResponse
 	record, err := g.runSurfaceGovernance(ctx, surfaceEmbeddings, span, start, req.Model, req.Input, func(ctx context.Context, model string) (surfaceRecord, error) {
 		req.Model = model
-		embedded, key, routeErr := g.routeEmbedding(ctx, req)
+		embedded, target, routeErr := g.routeEmbedding(ctx, req)
 		if routeErr != nil {
-			// key still names the last target attempted, which is what a
+			// target still names the last target attempted, which is what a
 			// per-provider error series needs to be worth anything.
-			return surfaceRecord{provider: key, model: req.Model}, routeErr
+			return surfaceRecord{provider: target.key, model: req.Model}, routeErr
 		}
 		resp = embedded
-		return g.priceSurface(key, embedded.Model, providers.Usage{
+		return g.priceSurface(target, embedded.Model, providers.Usage{
 			PromptTokens: embedded.Usage.PromptTokens,
 			TotalTokens:  embedded.Usage.TotalTokens,
 		}, 0), nil
@@ -395,9 +395,9 @@ func (g *Gateway) GenerateImage(ctx context.Context, req providers.ImageRequest)
 	var resp *providers.ImageResponse
 	record, err := g.runSurfaceGovernance(ctx, surfaceImages, span, start, req.Model, req.Prompt, func(ctx context.Context, model string) (surfaceRecord, error) {
 		req.Model = model
-		generated, key, routeErr := g.routeImage(ctx, req)
+		generated, target, routeErr := g.routeImage(ctx, req)
 		if routeErr != nil {
-			return surfaceRecord{provider: key, model: req.Model}, routeErr
+			return surfaceRecord{provider: target.key, model: req.Model}, routeErr
 		}
 		resp = generated
 		// The provider's own token counts, not an empty literal: the gpt-image
@@ -405,7 +405,7 @@ func (g *Gateway) GenerateImage(ctx context.Context, req providers.ImageRequest)
 		// discarding them here priced every such generation at nothing. A
 		// provider that reports none leaves this zero and its request stays
 		// unpriced, exactly as before.
-		return g.priceSurface(key, req.Model, generated.Usage, len(generated.Data)), nil
+		return g.priceSurface(target, req.Model, generated.Usage, len(generated.Data)), nil
 	})
 	latency := time.Since(start)
 	if err != nil {
@@ -462,17 +462,17 @@ func (g *Gateway) Rerank(ctx context.Context, req providers.RerankRequest) (*pro
 	var resp *providers.RerankResponse
 	record, err := g.runSurfaceGovernance(ctx, surfaceRerank, span, start, req.Model, content, func(ctx context.Context, model string) (surfaceRecord, error) {
 		req.Model = model
-		reranked, key, routeErr := g.routeRerank(ctx, req)
+		reranked, target, routeErr := g.routeRerank(ctx, req)
 		if routeErr != nil {
-			// key still names the last target attempted, which a per-provider
+			// target still names the last target attempted, which a per-provider
 			// error series needs to be worth anything.
-			return surfaceRecord{provider: key, model: req.Model}, routeErr
+			return surfaceRecord{provider: target.key, model: req.Model}, routeErr
 		}
 		resp = reranked
 		// Rerank bills in search-units, which the catalog does not yet price, so
 		// the request is left unpriced (zero tokens) rather than costed wrongly —
 		// the same graceful-zero path an unpriced image model takes.
-		return g.priceSurface(key, req.Model, providers.Usage{}, 0), nil
+		return g.priceSurface(target, req.Model, providers.Usage{}, 0), nil
 	})
 	latency := time.Since(start)
 	if err != nil {
@@ -524,12 +524,12 @@ func (g *Gateway) Moderate(ctx context.Context, req providers.ModerationRequest)
 	var resp *providers.ModerationResponse
 	record, err := g.runSurfaceGovernance(ctx, surfaceModeration, span, start, req.Model, req.Input, func(ctx context.Context, model string) (surfaceRecord, error) {
 		req.Model = model
-		moderated, key, routeErr := g.routeModeration(ctx, req)
+		moderated, target, routeErr := g.routeModeration(ctx, req)
 		if routeErr != nil {
-			return surfaceRecord{provider: key, model: req.Model}, routeErr
+			return surfaceRecord{provider: target.key, model: req.Model}, routeErr
 		}
 		resp = moderated
-		return g.priceSurface(key, req.Model, providers.Usage{}, 0), nil
+		return g.priceSurface(target, req.Model, providers.Usage{}, 0), nil
 	})
 	latency := time.Since(start)
 	if err != nil {
@@ -581,12 +581,12 @@ func (g *Gateway) Transcribe(ctx context.Context, req providers.TranscriptionReq
 	var resp *providers.TranscriptionResponse
 	record, err := g.runSurfaceGovernance(ctx, surfaceTranscription, span, start, req.Model, req.Prompt, func(ctx context.Context, model string) (surfaceRecord, error) {
 		req.Model = model
-		transcribed, key, routeErr := g.routeTranscription(ctx, req)
+		transcribed, target, routeErr := g.routeTranscription(ctx, req)
 		if routeErr != nil {
-			return surfaceRecord{provider: key, model: req.Model}, routeErr
+			return surfaceRecord{provider: target.key, model: req.Model}, routeErr
 		}
 		resp = transcribed
-		return g.priceSurface(key, req.Model, providers.Usage{}, 0), nil
+		return g.priceSurface(target, req.Model, providers.Usage{}, 0), nil
 	})
 	latency := time.Since(start)
 	if err != nil {
@@ -638,12 +638,12 @@ func (g *Gateway) Speech(ctx context.Context, req providers.SpeechRequest) (*pro
 	var resp *providers.SpeechResponse
 	record, err := g.runSurfaceGovernance(ctx, surfaceSpeech, span, start, req.Model, req.Input, func(ctx context.Context, model string) (surfaceRecord, error) {
 		req.Model = model
-		synthesized, key, routeErr := g.routeSpeech(ctx, req)
+		synthesized, target, routeErr := g.routeSpeech(ctx, req)
 		if routeErr != nil {
-			return surfaceRecord{provider: key, model: req.Model}, routeErr
+			return surfaceRecord{provider: target.key, model: req.Model}, routeErr
 		}
 		resp = synthesized
-		return g.priceSurface(key, req.Model, providers.Usage{}, 0), nil
+		return g.priceSurface(target, req.Model, providers.Usage{}, 0), nil
 	})
 	latency := time.Since(start)
 	if err != nil {
@@ -876,64 +876,64 @@ func speak(ctx context.Context, p providers.Provider, req providers.SpeechReques
 // EmbeddingProvider, not registered) the request is refused: targets is an
 // allowlist, so a provider that is registered but not listed never serves a
 // request, on this surface or any other.
-func (g *Gateway) routeEmbedding(ctx context.Context, req providers.EmbeddingRequest) (*providers.EmbeddingResponse, string, error) {
+func (g *Gateway) routeEmbedding(ctx context.Context, req providers.EmbeddingRequest) (*providers.EmbeddingResponse, routedTarget, error) {
 	keys, err := g.surfaceTargetOrder(req.Model, surfaceEmbeddings, models.Usage{PromptTokens: 1})
 	if err != nil {
-		return nil, "", err
+		return nil, routedTarget{}, err
 	}
 	return routeTargets(ctx, g, g.planFor(req.Model, keys), req, embeddingCapable, embed)
 }
 
 // routeImage is routeEmbedding's counterpart for image generation; see its doc
 // comment for the shared pipeline it attaches to.
-func (g *Gateway) routeImage(ctx context.Context, req providers.ImageRequest) (*providers.ImageResponse, string, error) {
+func (g *Gateway) routeImage(ctx context.Context, req providers.ImageRequest) (*providers.ImageResponse, routedTarget, error) {
 	imageCount := 1
 	if req.N != nil && *req.N > 0 {
 		imageCount = *req.N
 	}
 	keys, err := g.surfaceTargetOrder(req.Model, surfaceImages, models.Usage{ImageCount: imageCount})
 	if err != nil {
-		return nil, "", err
+		return nil, routedTarget{}, err
 	}
 	return routeTargets(ctx, g, g.planFor(req.Model, keys), req, imageCapable, generateImage)
 }
 
 // routeRerank is routeEmbedding's counterpart for reranking; see its doc comment
 // for the shared pipeline it attaches to.
-func (g *Gateway) routeRerank(ctx context.Context, req providers.RerankRequest) (*providers.RerankResponse, string, error) {
+func (g *Gateway) routeRerank(ctx context.Context, req providers.RerankRequest) (*providers.RerankResponse, routedTarget, error) {
 	keys, err := g.surfaceTargetOrder(req.Model, surfaceRerank, models.Usage{})
 	if err != nil {
-		return nil, "", err
+		return nil, routedTarget{}, err
 	}
 	return routeTargets(ctx, g, g.planFor(req.Model, keys), req, rerankCapable, rerank)
 }
 
 // routeModeration is routeEmbedding's counterpart for moderation; see its doc
 // comment for the shared pipeline it attaches to.
-func (g *Gateway) routeModeration(ctx context.Context, req providers.ModerationRequest) (*providers.ModerationResponse, string, error) {
+func (g *Gateway) routeModeration(ctx context.Context, req providers.ModerationRequest) (*providers.ModerationResponse, routedTarget, error) {
 	keys, err := g.surfaceTargetOrder(req.Model, surfaceModeration, models.Usage{})
 	if err != nil {
-		return nil, "", err
+		return nil, routedTarget{}, err
 	}
 	return routeTargets(ctx, g, g.planFor(req.Model, keys), req, moderationCapable, moderate)
 }
 
 // routeTranscription is routeEmbedding's counterpart for audio transcription;
 // see its doc comment for the shared pipeline it attaches to.
-func (g *Gateway) routeTranscription(ctx context.Context, req providers.TranscriptionRequest) (*providers.TranscriptionResponse, string, error) {
+func (g *Gateway) routeTranscription(ctx context.Context, req providers.TranscriptionRequest) (*providers.TranscriptionResponse, routedTarget, error) {
 	keys, err := g.surfaceTargetOrder(req.Model, surfaceTranscription, models.Usage{})
 	if err != nil {
-		return nil, "", err
+		return nil, routedTarget{}, err
 	}
 	return routeTargets(ctx, g, g.planFor(req.Model, keys), req, transcriptionCapable, transcribe)
 }
 
 // routeSpeech is routeEmbedding's counterpart for text-to-speech; see its doc
 // comment for the shared pipeline it attaches to.
-func (g *Gateway) routeSpeech(ctx context.Context, req providers.SpeechRequest) (*providers.SpeechResponse, string, error) {
+func (g *Gateway) routeSpeech(ctx context.Context, req providers.SpeechRequest) (*providers.SpeechResponse, routedTarget, error) {
 	keys, err := g.surfaceTargetOrder(req.Model, surfaceSpeech, models.Usage{})
 	if err != nil {
-		return nil, "", err
+		return nil, routedTarget{}, err
 	}
 	return routeTargets(ctx, g, g.planFor(req.Model, keys), req, speechCapable, speak)
 }

--- a/internal/proxy/responses.go
+++ b/internal/proxy/responses.go
@@ -22,7 +22,7 @@ import (
 type ResponsesSource interface {
 	providers.ProviderSource
 	ResponsesTarget() string
-	RouteResponses(ctx context.Context, target, model, body string, bodyInspectable bool, maxOutputTokens int, usage *providers.Usage, forward func(context.Context) error) error
+	RouteResponsesWithPricingProvider(ctx context.Context, target, priceProvider, model, body string, bodyInspectable bool, maxOutputTokens int, usage *providers.Usage, forward func(context.Context) error) error
 }
 
 // ResponsesCreate returns the handler for POST /v1/responses. It routes by the
@@ -75,6 +75,7 @@ func ResponsesCreate(src ResponsesSource) http.HandlerFunc {
 
 		projText, inspectable := projectBody(r)
 		providerName := p.Name()
+		priceProvider := providers.CanonicalName(p)
 		authHeaders := pp.AuthHeaders()
 
 		// The usage tee wraps the response body once the upstream headers are in:
@@ -102,7 +103,7 @@ func ResponsesCreate(src ResponsesSource) http.HandlerFunc {
 			return nil
 		}
 
-		err = src.RouteResponses(r.Context(), providerName, model, projText, inspectable, maxOutputTokens, &usage, forward)
+		err = src.RouteResponsesWithPricingProvider(r.Context(), providerName, priceProvider, model, projText, inspectable, maxOutputTokens, &usage, forward)
 		if err != nil && !forwarded {
 			apierror.WriteRouteError(w, err)
 		}

--- a/passthrough.go
+++ b/passthrough.go
@@ -241,7 +241,7 @@ func (g *Gateway) runPassthroughGovernance(
 		// and stays unpriced. Priced here, inside call, so both the plugin and the
 		// no-plugin path (which returns call directly) get it.
 		if err == nil && p.usage != nil && (p.usage.PromptTokens > 0 || p.usage.CompletionTokens > 0 || p.usage.TotalTokens > 0) {
-			record = g.priceSurface(target, model, *p.usage, 0)
+			record = g.priceSurface(routedTarget{key: target, priceProvider: target}, model, *p.usage, 0)
 		}
 		return record, err
 	}

--- a/passthrough.go
+++ b/passthrough.go
@@ -241,7 +241,7 @@ func (g *Gateway) runPassthroughGovernance(
 		// and stays unpriced. Priced here, inside call, so both the plugin and the
 		// no-plugin path (which returns call directly) get it.
 		if err == nil && p.usage != nil && (p.usage.PromptTokens > 0 || p.usage.CompletionTokens > 0 || p.usage.TotalTokens > 0) {
-			record = g.priceSurface(routedTarget{key: target, priceProvider: target}, model, *p.usage, 0)
+			record = g.priceSurface(routedTarget{key: target, priceProvider: g.pricingProviderFor(target)}, model, *p.usage, 0)
 		}
 		return record, err
 	}

--- a/passthrough.go
+++ b/passthrough.go
@@ -221,6 +221,7 @@ func (g *Gateway) runPassthroughGovernance(
 	forward func(context.Context) error,
 ) (surfaceRecord, error) {
 	target, model, body, bodyInspectable := p.target, p.model, p.body, p.bodyInspectable
+	priceProvider := g.pricingProviderFor(target)
 	g.mu.RLock()
 	plugins := g.plugins
 	release := acquirePluginManager(plugins)
@@ -241,7 +242,7 @@ func (g *Gateway) runPassthroughGovernance(
 		// and stays unpriced. Priced here, inside call, so both the plugin and the
 		// no-plugin path (which returns call directly) get it.
 		if err == nil && p.usage != nil && (p.usage.PromptTokens > 0 || p.usage.CompletionTokens > 0 || p.usage.TotalTokens > 0) {
-			record = g.priceSurface(routedTarget{key: target, priceProvider: g.pricingProviderFor(target)}, model, *p.usage, 0)
+			record = g.priceSurface(routedTarget{key: target, priceProvider: priceProvider}, model, *p.usage, 0)
 		}
 		return record, err
 	}

--- a/passthrough.go
+++ b/passthrough.go
@@ -158,6 +158,12 @@ func (g *Gateway) RoutePassthrough(ctx context.Context, target, model, body stri
 // the only differences from RoutePassthrough are the two governance inputs it
 // threads through, both of which RoutePassthrough passes as zero.
 func (g *Gateway) RouteResponses(ctx context.Context, target, model, body string, bodyInspectable bool, maxOutputTokens int, usage *providers.Usage, forward func(context.Context) error) error {
+	return g.RouteResponsesWithPricingProvider(ctx, target, g.pricingProviderFor(target), model, body, bodyInspectable, maxOutputTokens, usage, forward)
+}
+
+// RouteResponsesWithPricingProvider governs a Responses forward using the
+// canonical pricing identity captured when the proxy selected its provider.
+func (g *Gateway) RouteResponsesWithPricingProvider(ctx context.Context, target, priceProvider, model, body string, bodyInspectable bool, maxOutputTokens int, usage *providers.Usage, forward func(context.Context) error) error {
 	start := time.Now()
 	hooksEnabled := g.hasHooks()
 
@@ -181,7 +187,7 @@ func (g *Gateway) RouteResponses(ctx context.Context, target, model, body string
 	defer span.End()
 
 	record, err := g.runPassthroughGovernance(ctx, span, start, passthroughParams{
-		target: target, model: model, body: body, bodyInspectable: bodyInspectable,
+		target: target, priceProvider: priceProvider, model: model, body: body, bodyInspectable: bodyInspectable,
 		maxOutputTokens: maxOutputTokens, usage: usage,
 	}, forward)
 	latency := time.Since(start)
@@ -202,10 +208,10 @@ const surfaceResponses = "responses"
 // forward captured a non-zero one, and maxOutputTokens becomes the plugin
 // request's completion ceiling. The generic pass-through leaves both zero.
 type passthroughParams struct {
-	target, model, body string
-	bodyInspectable     bool
-	maxOutputTokens     int
-	usage               *providers.Usage
+	target, priceProvider, model, body string
+	bodyInspectable                    bool
+	maxOutputTokens                    int
+	usage                              *providers.Usage
 }
 
 // runPassthroughGovernance is the pass-through's plugin stage sequence. It is
@@ -221,7 +227,6 @@ func (g *Gateway) runPassthroughGovernance(
 	forward func(context.Context) error,
 ) (surfaceRecord, error) {
 	target, model, body, bodyInspectable := p.target, p.model, p.body, p.bodyInspectable
-	priceProvider := g.pricingProviderFor(target)
 	g.mu.RLock()
 	plugins := g.plugins
 	release := acquirePluginManager(plugins)
@@ -242,7 +247,7 @@ func (g *Gateway) runPassthroughGovernance(
 		// and stays unpriced. Priced here, inside call, so both the plugin and the
 		// no-plugin path (which returns call directly) get it.
 		if err == nil && p.usage != nil && (p.usage.PromptTokens > 0 || p.usage.CompletionTokens > 0 || p.usage.TotalTokens > 0) {
-			record = g.priceSurface(routedTarget{key: target, priceProvider: priceProvider}, model, *p.usage, 0)
+			record = g.priceSurface(routedTarget{key: target, priceProvider: p.priceProvider}, model, *p.usage, 0)
 		}
 		return record, err
 	}


### PR DESCRIPTION
## Summary

Carries the canonical pricing identity from provider selection through cost accounting, so a request is priced against the provider that actually served it. Closes the race left open by #410, tracked as #411.

Also completes the environment variable reference in the README.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] New provider
- [ ] New plugin
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Performance improvement
- [ ] Refactor / code quality
- [x] Documentation / comments only
- [ ] CI / tooling

## Related issues

Fixes #411

## Changes

### Pricing identity is carried, not re-derived

`canonicalPriceKeyLocked` resolved the vendor identity from the live provider map at cost time, after routing had already chosen a provider instance. A reload landing in that window repointed the alias, and the request was priced against the replacement while the original had served it.

The identity is now captured where the provider is selected and travels with the request through unary and streaming cost accounting, so nothing downstream re-reads a mutable map.

Attribution is unchanged. Responses, metric labels, spans and the `Target` field plugins read all still name the routing alias; only the catalog price lookup uses the canonical name.

The pass-through surface is covered too, since it does not select through `routeTargets` and has to resolve the target's provider from the registry.

## Testing

- [x] `make test` passes (unit tests, race detector)
- [x] `make lint` passes
- [x] New tests added for the change (if applicable)
- [ ] `make test-integration` passes (if applicable)
- [ ] Manually tested against a live provider (if provider change)

Regression coverage lands beside the fix: unary, streaming and pass-through alias pricing, plus a test that replaces the registered provider while a request is in flight and asserts the in-flight request keeps the price of the provider that served it.

`make test-integration` was not run locally (it needs Docker for the Postgres testcontainer); CI runs it as part of the merge gate.

## Breaking change notes

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected pricing for routed requests so in-flight requests consistently use the selected provider’s canonical pricing, including aliases, streaming, and non-streaming responses.
  * Improved cost attribution across budgets, logs, spans, and supported request types.

* **Documentation**
  * Expanded environment configuration guidance for provider URLs, Admin CLI access, Vertex AI credentials, Ollama Cloud, model discovery, profiling, and OpenTelemetry tracing.
  * Clarified Ollama deprecation guidance and provider configuration details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR fixes in-flight alias pricing by carrying the canonical provider identity captured during provider selection through unary, streaming, surface, and Responses cost accounting.
- Introduces `routedTarget` to preserve separate attribution and pricing identities.
- Captures Responses pricing identity from the provider instance selected for forwarding.
- Adds regression coverage for alias replacement during unary, streaming, and Responses requests.
- Expands the environment-variable reference and publishes the 1.4.4 changelog entry.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| gateway_pipeline.go | Carries routing and canonical pricing identities together from the selected provider instance. |
| gateway_route.go | Threads the selected pricing identity through unary and MCP-loop accounting while preserving alias attribution. |
| gateway_stream.go | Uses the canonical identity captured at stream selection rather than re-reading the mutable provider registry. |
| gateway_surface.go | Updates auxiliary surfaces to price with the selected canonical provider while reporting the routing key. |
| internal/proxy/responses.go | Captures forwarding details and canonical pricing identity from the same selected Responses provider. |
| passthrough.go | Adds an explicit pricing-identity path for Responses governance and retains the old method as a compatibility wrapper. |
| gateway_alias_pricing_test.go | Adds regression coverage for provider replacement during unary, streaming, and Responses accounting. |

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant R as Request
    participant S as Provider selection
    participant P as Selected provider
    participant A as Accounting
    R->>S: Route using alias
    S->>S: Capture alias and canonical identity
    S->>P: Forward using selected instance
    P-->>R: Response and usage
    R->>A: Usage plus captured canonical identity
    A->>A: Catalog price lookup
    Note over A: Attribution retains routing alias
```
</details>

<sub>Reviews (4): Last reviewed commit: ["fix: snapshot Responses pricing at provi..."](https://github.com/ferro-labs/ai-gateway/commit/a068fd823c50696de40246a7e2c74d98bba1609a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54252912)</sub>

<!-- /greptile_comment -->