### PR TITLE
feat: add importable gateway runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to Ferro Labs AI Gateway are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.0] — 2026-08-29
+
+### Added — the gateway is importable
+
+A new public `run` package exposes the `ferrogw` program to Go code. `run.Main()`
+is what `cmd/ferrogw` now calls; `run.Run(ctx, opts...)` runs the same server
+under a caller-owned context and returns startup and listen errors instead of
+exiting the process, with context cancellation triggering the same graceful
+shutdown as SIGTERM. A custom binary is a `main` that blank-imports its plugins
+and calls `run.Main()` — the process lane. `httpgateway` (since 1.4.2) remains
+the library lane for mounting gateway surfaces behind your own middleware.
+Closes [#206](https://github.com/ferro-labs/ai-gateway/issues/206).
+
+The server now binds its listener before it starts observing shutdown, so a
+cancellation that arrives during startup can no longer leave a listener behind.
+Existing `ferrogw` behaviour — commands, flags, exit codes — is unchanged.
+
 ## [1.4.5] — 2026-08-23
 
 A security patch. The stdio MCP transport now applies the same 10 MiB bound as

--- a/cmd/ferrogw/main.go
+++ b/cmd/ferrogw/main.go
@@ -1,82 +1,9 @@
-// Package main is the entry point for the ferrogw gateway server and CLI.
+// Package main is the ferrogw binary: a thin caller of the importable
+// program in package run, which is what a composed binary calls too.
 package main
 
-import (
-	"os"
-
-	"github.com/ferro-labs/ai-gateway/internal/bootstrap"
-	"github.com/ferro-labs/ai-gateway/internal/cli"
-	"github.com/spf13/cobra"
-
-	// Register built-in plugins so they can be loaded from config.
-	_ "github.com/ferro-labs/ai-gateway/plugin/budget"
-	_ "github.com/ferro-labs/ai-gateway/plugin/cache"
-	_ "github.com/ferro-labs/ai-gateway/plugin/logger"
-	_ "github.com/ferro-labs/ai-gateway/plugin/maxtoken"
-	_ "github.com/ferro-labs/ai-gateway/plugin/ratelimit"
-	_ "github.com/ferro-labs/ai-gateway/plugin/wordfilter"
-)
-
-// newRootCmd builds the fully wired command tree. serve is what the bare
-// `ferrogw` and `ferrogw serve` run; it is a parameter so the argument contract
-// below can be tested without binding a port.
-func newRootCmd(serve func()) *cobra.Command {
-	rootCmd := &cobra.Command{
-		Use:   "ferrogw",
-		Short: "Ferro Labs AI Gateway",
-		Long:  "High-performance AI gateway with smart routing, plugins, and an authenticated Admin API.",
-		// Args is deliberately LEFT NIL, and that is load-bearing. The root is
-		// both the server entrypoint and the parent of every subcommand, so an
-		// unmatched first token must not fall through and boot a gateway.
-		// Cobra's Find applies legacyArgs — which rejects an unknown token for a
-		// root that has subcommands, and names the command you probably meant —
-		// but ONLY when Args is nil. Setting NoArgs here still rejects and loses
-		// the suggestion; setting ArbitraryArgs makes `ferrogw valdate cfg.yaml`
-		// start a server on :8080. TestRootRejectsUnknownSubcommand pins it.
-		// When a command returns an error, the error is the answer. Cobra
-		// otherwise prints the whole usage block after it — and prints it to
-		// STDOUT while the error goes to stderr, so a failing `ferrogw validate`
-		// wrote a flag list into whatever was reading its output. Setting this on
-		// the root covers every subcommand: cobra checks the root's flag as well
-		// as the failing command's.
-		SilenceUsage: true,
-		// Default: start the server (backward compatible).
-		Run: func(_ *cobra.Command, _ []string) {
-			serve()
-		},
-	}
-
-	serveCmd := &cobra.Command{
-		Use:   "serve",
-		Short: "Start the gateway server",
-		Args:  cobra.NoArgs,
-		Run: func(_ *cobra.Command, _ []string) {
-			serve()
-		},
-	}
-
-	rootCmd.AddCommand(serveCmd)
-	rootCmd.AddCommand(cli.InitCmd)
-	rootCmd.AddCommand(cli.ValidateCmd)
-	rootCmd.AddCommand(cli.PluginsCmd)
-	rootCmd.AddCommand(cli.DoctorCmd)
-	rootCmd.AddCommand(cli.StatusCmd)
-	rootCmd.AddCommand(cli.VersionCmd)
-	rootCmd.AddCommand(cli.AdminCmd)
-
-	// Persistent flags for CLI commands.
-	rootCmd.PersistentFlags().String("gateway-url", "",
-		"Gateway base URL (env: FERROGW_URL, default: http://localhost:8080)")
-	rootCmd.PersistentFlags().String("api-key", "",
-		"Admin API key (env: FERROGW_API_KEY)")
-	rootCmd.PersistentFlags().String(cli.FlagFormat, cli.FormatTable,
-		"Output format: table, json, or yaml (not supported by the report commands: init, doctor, status)")
-
-	return rootCmd
-}
+import "github.com/ferro-labs/ai-gateway/run"
 
 func main() {
-	if err := newRootCmd(bootstrap.Serve).Execute(); err != nil {
-		os.Exit(1)
-	}
+	run.Main()
 }

--- a/gateway.go
+++ b/gateway.go
@@ -151,8 +151,12 @@ func New(cfg config.Config, opts ...Option) (*Gateway, error) {
 		gw.constructionCtx = context.Background()
 	}
 
-	catalogResult, err := models.LoadWithInfoContext(gw.constructionCtx)
+	constructionCtx := gw.constructionCtx
+	catalogResult, err := models.LoadWithInfoContext(constructionCtx)
 	gw.constructionCtx = nil
+	if err := constructionCtx.Err(); err != nil {
+		return nil, err
+	}
 	recordCatalogLoad(catalogResult.Source, err)
 	catalog := catalogResult.Catalog
 	if err != nil {

--- a/gateway.go
+++ b/gateway.go
@@ -43,6 +43,7 @@ type Gateway struct {
 	// logger.Default() in New. Set once at construction and never mutated, so it
 	// is read without holding mu.
 	log              *logger.Logger
+	constructionCtx  context.Context
 	config           config.Config
 	catalog          models.Catalog
 	providers        map[string]providers.Provider
@@ -123,6 +124,11 @@ func WithLogger(l *logger.Logger) Option {
 	return func(g *Gateway) { g.log = l }
 }
 
+// WithContext sets the context used by work performed during construction.
+func WithContext(ctx context.Context) Option {
+	return func(g *Gateway) { g.constructionCtx = ctx }
+}
+
 // New creates a new Gateway instance with the given configuration.
 // It validates cfg with ValidateConfig before initialising any resources,
 // returning an error immediately if the config is invalid. This matches the
@@ -141,14 +147,12 @@ func New(cfg config.Config, opts ...Option) (*Gateway, error) {
 	if gw.log == nil {
 		gw.log = logger.Default()
 	}
+	if gw.constructionCtx == nil {
+		gw.constructionCtx = context.Background()
+	}
 
-	// No lifecycle context exists yet at this point in construction (shutdownCtx
-	// is created below), so context.Background() is the only choice available
-	// here. The fetch is bounded by fetchRemote's own client timeout, which an
-	// operator can shorten or disable entirely via FERRO_MODEL_CATALOG_TIMEOUT.
-	// That matters because this runs before the listener binds: until it
-	// returns, the process answers no readiness probe.
-	catalogResult, err := models.LoadWithInfoContext(context.Background())
+	catalogResult, err := models.LoadWithInfoContext(gw.constructionCtx)
+	gw.constructionCtx = nil
 	recordCatalogLoad(catalogResult.Source, err)
 	catalog := catalogResult.Catalog
 	if err != nil {

--- a/gateway_catalog_test.go
+++ b/gateway_catalog_test.go
@@ -2,6 +2,7 @@ package aigateway
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"sort"
@@ -199,7 +200,7 @@ func TestRouting_RejectsUnknownModel(t *testing.T) {
 	}
 }
 
-func TestNewWithContextCancelsCatalogFetch(t *testing.T) {
+func TestNewWithContextStopsConstructionWhenCatalogFetchIsCanceled(t *testing.T) {
 	requestStarted := make(chan struct{})
 	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
 		close(requestStarted)
@@ -210,16 +211,17 @@ func TestNewWithContextCancelsCatalogFetch(t *testing.T) {
 	t.Setenv(models.CatalogFetchTimeoutEnv, time.Minute.String())
 
 	ctx, cancel := context.WithCancel(t.Context())
-	done := make(chan error, 1)
+	type result struct {
+		gw  *Gateway
+		err error
+	}
+	done := make(chan result, 1)
 	go func() {
 		gw, err := New(config.Config{
 			Strategy: config.StrategyConfig{Mode: config.ModeSingle},
 			Targets:  []config.Target{{VirtualKey: "openai"}},
 		}, WithContext(ctx))
-		if gw != nil {
-			_ = gw.Close()
-		}
-		done <- err
+		done <- result{gw: gw, err: err}
 	}()
 
 	select {
@@ -229,9 +231,13 @@ func TestNewWithContextCancelsCatalogFetch(t *testing.T) {
 	}
 	cancel()
 	select {
-	case err := <-done:
-		if err != nil {
-			t.Fatalf("New returned an error after catalog cancellation: %v", err)
+	case got := <-done:
+		if got.gw != nil {
+			_ = got.gw.Close()
+			t.Fatal("New returned a gateway after construction was canceled")
+		}
+		if !errors.Is(got.err, context.Canceled) {
+			t.Fatalf("New error = %v, want context.Canceled", got.err)
 		}
 	case <-time.After(time.Second):
 		t.Fatal("New did not return after context cancellation")

--- a/gateway_catalog_test.go
+++ b/gateway_catalog_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"sort"
 	"testing"
+	"time"
 
 	"github.com/ferro-labs/ai-gateway/config"
 	"github.com/ferro-labs/ai-gateway/models"
@@ -195,6 +196,45 @@ func TestRouting_RejectsUnknownModel(t *testing.T) {
 
 	if _, ok := gw.FindByModel("definitely-not-a-real-model-zzz"); ok {
 		t.Fatal("FindByModel accepted an unknown model")
+	}
+}
+
+func TestNewWithContextCancelsCatalogFetch(t *testing.T) {
+	requestStarted := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		close(requestStarted)
+		<-r.Context().Done()
+	}))
+	t.Cleanup(server.Close)
+	t.Setenv(models.CatalogURLEnv, server.URL)
+	t.Setenv(models.CatalogFetchTimeoutEnv, time.Minute.String())
+
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan error, 1)
+	go func() {
+		gw, err := New(config.Config{
+			Strategy: config.StrategyConfig{Mode: config.ModeSingle},
+			Targets:  []config.Target{{VirtualKey: "openai"}},
+		}, WithContext(ctx))
+		if gw != nil {
+			_ = gw.Close()
+		}
+		done <- err
+	}()
+
+	select {
+	case <-requestStarted:
+	case <-time.After(time.Second):
+		t.Fatal("catalog request did not start")
+	}
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("New returned an error after catalog cancellation: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("New did not return after context cancellation")
 	}
 }
 

--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"net"
 	"net/http"
 	"os"
 	"os/signal"
@@ -138,8 +139,8 @@ const defaultListenAddr = ":8080"
 const shutdownGracePeriod = 15 * time.Second
 
 // Serve runs the full gateway server startup sequence and blocks until the
-// server shuts down.  It exits the process on fatal errors.
-func Serve() {
+// server shuts down or ctx is canceled.
+func Serve(ctx context.Context) error {
 	// Configure the process logger from the environment (LOG_LEVEL) and install
 	// it as the default (mirrored into slog.SetDefault). lg is then threaded
 	// explicitly into the components that hold their own logger.
@@ -148,30 +149,75 @@ func Serve() {
 
 	if err := CheckProductionSafety(); err != nil {
 		lg.Error("startup blocked: unsafe configuration", "error", err)
-		os.Exit(1)
+		return err
 	}
 
-	gw, srv, cfgManager, keyStore, sessionStore, auditStore, logReader, otelShutdown := buildServer(lg)
-	listenErr := runUntilShutdown(gw, srv)
-	gracefulShutdown(srv, gw, cfgManager, keyStore, sessionStore, auditStore, logReader, otelShutdown, listenErr)
+	app, err := buildServer(lg)
+	if err != nil {
+		return err
+	}
+	listenErr := runUntilShutdown(ctx, app.gw, app.srv)
+	gracefulShutdown(app)
+	if listenErr != nil && !errors.Is(listenErr, http.ErrServerClosed) {
+		return listenErr
+	}
+	return nil
+}
+
+type serverRuntime struct {
+	gw           *aigateway.Gateway
+	srv          *http.Server
+	cfgManager   handlers.ConfigManager
+	keyStore     repository.Store
+	sessionStore repository.SessionStore
+	auditStore   repository.AuditStore
+	logReader    requestlog.Reader
+	otelShutdown gwotel.ShutdownFunc
+}
+
+func (app *serverRuntime) resources() []httpserver.NamedResource {
+	return []httpserver.NamedResource{
+		{Name: "gateway", Value: app.gw},
+		{Name: "config manager", Value: app.cfgManager},
+		{Name: "api key store", Value: app.keyStore},
+		{Name: "session store", Value: app.sessionStore},
+		{Name: "audit store", Value: app.auditStore},
+		{Name: "request log store", Value: app.logReader},
+	}
+}
+
+func closeRuntimeResources(resources []httpserver.NamedResource, otelShutdown gwotel.ShutdownFunc) error {
+	err := httpserver.CloseResources(resources...)
+	if otelShutdown != nil {
+		err = errors.Join(err, otelShutdown(context.Background()))
+	}
+	return err
 }
 
 // buildServer runs the startup sequence: it loads configuration, registers
 // providers, initializes observability and the persistence stores, constructs
 // the router and HTTP server, prints the startup banner, and logs readiness.
-// It exits the process on any fatal initialization error and returns the
-// long-lived components needed to run and later shut down the server.
-func buildServer(lg *logger.Logger) (
-	*aigateway.Gateway,
-	*http.Server,
-	handlers.ConfigManager,
-	repository.Store,
-	repository.SessionStore,
-	repository.AuditStore,
-	requestlog.Reader,
-	gwotel.ShutdownFunc,
-) {
-	cfg := LoadConfig()
+// It returns startup errors and the long-lived components needed to run and
+// later shut down the server.
+func buildServer(lg *logger.Logger) (app *serverRuntime, err error) {
+	app = &serverRuntime{}
+	started := app
+	defer func() {
+		if err == nil {
+			return
+		}
+		if closeErr := closeRuntimeResources(started.resources(), started.otelShutdown); closeErr != nil {
+			// Logged here because the CLI silences the returned error: startup
+			// already reported its own failure, and this one must not be lost with it.
+			logger.Default().Error("startup cleanup error", "error", closeErr)
+			err = errors.Join(err, closeErr)
+		}
+	}()
+
+	cfg, err := LoadConfig()
+	if err != nil {
+		return nil, err
+	}
 	// Ahead of RegisterProviders, so an operator reads the rename before the
 	// line reporting the provider that was built from the deprecated variable.
 	LogDeprecatedEnvVars()
@@ -193,8 +239,9 @@ func buildServer(lg *logger.Logger) (
 	logReader, logMaintainer, logReaderBackend, err := CreateRequestLogReaderFromEnv(context.Background())
 	if err != nil {
 		logger.Default().Error("failed to initialize request log reader", "error", err)
-		os.Exit(1)
+		return nil, err
 	}
+	app.logReader = logReader
 	logWriter, _ := logReader.(requestlog.Writer)
 
 	// Initialise OpenTelemetry. Init returns a NoOp provider (and a
@@ -214,10 +261,15 @@ func buildServer(lg *logger.Logger) (
 	obsProvider, otelShutdown, err := gwotel.Init(context.Background(), otelConfigFromGateway(obsCfg))
 	if err != nil {
 		logger.Default().Error("failed to initialize observability", "error", err)
-		os.Exit(1)
+		return nil, err
 	}
+	app.otelShutdown = otelShutdown
 
-	gw := BuildGateway(cfg, registry, logWriter, lg)
+	gw, err := BuildGateway(cfg, registry, logWriter, lg)
+	if err != nil {
+		return nil, err
+	}
+	app.gw = gw
 	gw.SetObservability(obsProvider)
 
 	// Resolve gateway_circuit_breaker_state from this gateway's live breakers on
@@ -230,8 +282,9 @@ func buildServer(lg *logger.Logger) (
 	cfgManager, configStoreBackend, err := CreateConfigManagerFromEnv(context.Background(), gw)
 	if err != nil {
 		logger.Default().Error("failed to initialize config store", "error", err)
-		os.Exit(1)
+		return nil, err
 	}
+	app.cfgManager = cfgManager
 
 	// Config resolution is complete only here: the store, when it holds one,
 	// has just superseded whatever the gateway was built from. Everything
@@ -243,8 +296,9 @@ func buildServer(lg *logger.Logger) (
 	keyStore, keyStoreBackend, err := CreateKeyStoreFromEnv(context.Background())
 	if err != nil {
 		logger.Default().Error("failed to initialize API key store", "error", err)
-		os.Exit(1)
+		return nil, err
 	}
+	app.keyStore = keyStore
 
 	// The session store follows the key store's backend so an operator
 	// configures persistence once (see CreateSessionStoreFromEnv). It is a
@@ -253,8 +307,9 @@ func buildServer(lg *logger.Logger) (
 	sessionStore, _, err := CreateSessionStoreFromEnv(context.Background())
 	if err != nil {
 		logger.Default().Error("failed to initialize session store", "error", err)
-		os.Exit(1)
+		return nil, err
 	}
+	app.sessionStore = sessionStore
 
 	// The audit store follows the key store's backend too, for the same reason
 	// (see CreateAuditStoreFromEnv). It is a distinct store and, for SQLite, a
@@ -262,8 +317,9 @@ func buildServer(lg *logger.Logger) (
 	auditStore, auditStoreBackend, err := CreateAuditStoreFromEnv(context.Background())
 	if err != nil {
 		logger.Default().Error("failed to initialize audit store", "error", err)
-		os.Exit(1)
+		return nil, err
 	}
+	app.auditStore = auditStore
 
 	var corsOrigins []string
 	if origins := os.Getenv("CORS_ORIGINS"); origins != "" {
@@ -282,7 +338,7 @@ func buildServer(lg *logger.Logger) (
 	trustedProxies, err := httpserver.ParseTrustedProxyCIDRs(os.Getenv("TRUSTED_PROXIES"))
 	if err != nil {
 		logger.Default().Error("invalid TRUSTED_PROXIES", "error", err)
-		os.Exit(1)
+		return nil, err
 	}
 
 	rlStore := NewRateLimitStore()
@@ -298,6 +354,7 @@ func buildServer(lg *logger.Logger) (
 		addr = ":" + p
 	}
 	srv := httpserver.NewServer(addr, r)
+	app.srv = srv
 
 	PrintStartupBanner(addr, registry, &active, masterKey, keyStoreBackend, configStoreBackend)
 	logger.Default().Info("ferrogw started",
@@ -310,20 +367,26 @@ func buildServer(lg *logger.Logger) (
 		"audit_store", auditStoreBackend,
 	)
 
-	return gw, srv, cfgManager, keyStore, sessionStore, auditStore, logReader, otelShutdown
+	return app, nil
 }
 
 // runUntilShutdown starts the HTTP server and optional live model discovery,
 // then blocks until an OS signal or a fatal listen error. It returns the listen
 // error observed, if any.
-func runUntilShutdown(gw *aigateway.Gateway, srv *http.Server) error {
-	// Run the server in a goroutine so the main goroutine can block on signal
-	// or a fatal listen error.
+func runUntilShutdown(ctx context.Context, gw *aigateway.Gateway, srv *http.Server) error {
+	listener, err := (&net.ListenConfig{}).Listen(ctx, "tcp", srv.Addr)
+	if err != nil {
+		logger.Default().Error("server error", "error", err)
+		return err
+	}
+
+	// Bind before observing cancellation so graceful shutdown cannot race a
+	// not-yet-started ListenAndServe goroutine and leave a listener behind.
 	serveErr := make(chan error, 1)
-	go func() { serveErr <- srv.ListenAndServe() }()
+	go func() { serveErr <- srv.Serve(listener) }()
 
 	// Block until OS signal or a fatal server error.
-	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	ctx, stop := signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
 
 	// Opt-in live model discovery: refreshes provider model lists in the
 	// background and stops when the lifecycle ctx is cancelled on shutdown.
@@ -344,58 +407,31 @@ func runUntilShutdown(gw *aigateway.Gateway, srv *http.Server) error {
 			logger.Default().Error("server error", "error", listenErr)
 		}
 	}
-	stop() // release signal resources; called explicitly so os.Exit below doesn't bypass it
+	stop()
 	return listenErr
 }
 
 // gracefulShutdown drains the HTTP server, closes the persistence stores, and
-// flushes OTel exporters in that order, then exits the process if the server
-// terminated on a fatal listen error.
-func gracefulShutdown(
-	srv *http.Server,
-	gw *aigateway.Gateway,
-	cfgManager handlers.ConfigManager,
-	keyStore repository.Store,
-	sessionStore repository.SessionStore,
-	auditStore repository.AuditStore,
-	logReader requestlog.Reader,
-	otelShutdown gwotel.ShutdownFunc,
-	listenErr error,
-) {
-	// Shutdown drains active connections before returning — CloseResources must
-	// come after so in-flight requests can still reach the stores.
+// flushes OTel exporters in that order — the same list, in the same order, that
+// a failed startup closes (see buildServer).
+func gracefulShutdown(app *serverRuntime) {
+	// Shutdown drains active connections before returning — the stores must
+	// close after so in-flight requests can still reach them.
 	logger.Default().Info("shutting down gracefully")
 	shutdownCtx, cancel := context.WithTimeout(context.Background(), shutdownGracePeriod)
-	if err := srv.Shutdown(shutdownCtx); err != nil {
+	if err := app.srv.Shutdown(shutdownCtx); err != nil {
 		logger.Default().Error("shutdown error", "error", err)
 	}
 	cancel()
 
-	if err := httpserver.CloseResources(
-		httpserver.NamedResource{Name: "gateway", Value: gw},
-		httpserver.NamedResource{Name: "config manager", Value: cfgManager},
-		httpserver.NamedResource{Name: "api key store", Value: keyStore},
-		httpserver.NamedResource{Name: "session store", Value: sessionStore},
-		httpserver.NamedResource{Name: "audit store", Value: auditStore},
-		httpserver.NamedResource{Name: "request log store", Value: logReader},
-	); err != nil {
+	// OTel drains last so spans emitted during the rest of the shutdown
+	// sequence still reach the collector. The ShutdownFunc from gwotel.Init
+	// applies its own deadline (cfg.ShutdownGrace), hence context.Background().
+	if err := closeRuntimeResources(app.resources(), app.otelShutdown); err != nil {
 		logger.Default().Error("shutdown cleanup error", "error", err)
 	}
 
-	// Drain OTel exporters last so spans emitted during the rest of the
-	// shutdown sequence still reach the collector.
-	// The ShutdownFunc returned by gwotel.Init applies its own internal
-	// deadline derived from cfg.ShutdownGrace, so we pass context.Background()
-	// here rather than duplicating the duration parse.
-	if err := otelShutdown(context.Background()); err != nil {
-		logger.Default().Error("otel shutdown error", "error", err)
-	}
-
 	logger.Default().Info("server stopped")
-
-	if listenErr != nil && !errors.Is(listenErr, http.ErrServerClosed) {
-		os.Exit(1)
-	}
 }
 
 // discoveryIntervalFromEnv reads the FERRO_MODEL_DISCOVERY_INTERVAL env var and
@@ -472,20 +508,20 @@ func warnUnreadConfigFile() {
 // What it returns is the *file's* config, which is not necessarily the config
 // the gateway ends up running: a persistent config store, if it holds one,
 // supersedes this later in startup. ResolveActiveConfig names the winner.
-func LoadConfig() *config.Config {
+func LoadConfig() (*config.Config, error) {
 	cfgPath := configFilePath()
 	if cfgPath == "" {
 		warnUnreadConfigFile()
-		return nil
+		return nil, nil
 	}
 	loaded, err := config.LoadConfig(cfgPath)
 	if err != nil {
 		logger.Default().Error("failed to load config", "error", err)
-		os.Exit(1)
+		return nil, err
 	}
 	if err := config.ValidateConfig(*loaded); err != nil {
 		logger.Default().Error("invalid config", "error", err)
-		os.Exit(1)
+		return nil, err
 	}
 	// "config file loaded" rather than "config loaded": this line describes the
 	// file, and a persisted config may still replace all of it below.
@@ -494,7 +530,7 @@ func LoadConfig() *config.Config {
 		"strategy", loaded.Strategy.Mode,
 		"targets", len(loaded.Targets),
 	)
-	return loaded
+	return loaded, nil
 }
 
 // RegisterProviders auto-registers all providers found via environment variables.
@@ -557,7 +593,7 @@ func registerBedrockProvider(registry *providers.Registry) {
 
 // BuildGateway constructs the Gateway, wires providers, and loads plugins.
 // If cfg is nil a default fallback config is created from the registry.
-func BuildGateway(cfg *config.Config, registry *providers.Registry, logWriter requestlog.Writer, lg *logger.Logger) *aigateway.Gateway {
+func BuildGateway(cfg *config.Config, registry *providers.Registry, logWriter requestlog.Writer, lg *logger.Logger) (*aigateway.Gateway, error) {
 	if cfg == nil {
 		defaultTargets := make([]config.Target, 0, len(registry.List()))
 		for _, name := range registry.List() {
@@ -576,7 +612,7 @@ func BuildGateway(cfg *config.Config, registry *providers.Registry, logWriter re
 	gw, err := aigateway.New(*cfg, aigateway.WithLogger(lg))
 	if err != nil {
 		logger.Default().Error("failed to create gateway", "error", err)
-		os.Exit(1)
+		return nil, err
 	}
 	// Install the shared request-log store before LoadPlugins, so a logging
 	// plugin records through it instead of opening its own.
@@ -590,11 +626,12 @@ func BuildGateway(cfg *config.Config, registry *providers.Registry, logWriter re
 	if len(cfg.Plugins) > 0 {
 		if err := gw.LoadPlugins(); err != nil {
 			logger.Default().Error("failed to load plugins", "error", err)
-			os.Exit(1)
+			_ = gw.Close()
+			return nil, err
 		}
 		logger.Default().Info("plugins loaded", "count", len(cfg.Plugins))
 	}
-	return gw
+	return gw, nil
 }
 
 // warnUnroutableTargets reports every configured target that resolves to no

--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -271,7 +271,7 @@ func buildServer(ctx context.Context, lg *logger.Logger) (app *serverRuntime, er
 	}
 	app.otelShutdown = otelShutdown
 
-	gw, err := BuildGateway(cfg, registry, logWriter, lg)
+	gw, err := BuildGateway(ctx, cfg, registry, logWriter, lg)
 	if err != nil {
 		return nil, err
 	}
@@ -604,7 +604,7 @@ func registerBedrockProvider(registry *providers.Registry) {
 
 // BuildGateway constructs the Gateway, wires providers, and loads plugins.
 // If cfg is nil a default fallback config is created from the registry.
-func BuildGateway(cfg *config.Config, registry *providers.Registry, logWriter requestlog.Writer, lg *logger.Logger) (*aigateway.Gateway, error) {
+func BuildGateway(ctx context.Context, cfg *config.Config, registry *providers.Registry, logWriter requestlog.Writer, lg *logger.Logger) (*aigateway.Gateway, error) {
 	if cfg == nil {
 		defaultTargets := make([]config.Target, 0, len(registry.List()))
 		for _, name := range registry.List() {
@@ -620,7 +620,7 @@ func BuildGateway(cfg *config.Config, registry *providers.Registry, logWriter re
 		)
 	}
 
-	gw, err := aigateway.New(*cfg, aigateway.WithLogger(lg))
+	gw, err := aigateway.New(*cfg, aigateway.WithLogger(lg), aigateway.WithContext(ctx))
 	if err != nil {
 		logger.Default().Error("failed to create gateway", "error", err)
 		return nil, err

--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -134,8 +134,8 @@ func warnProductionRisks(keyStoreBackend string, rateLimitDisabled bool) {
 // defaultListenAddr is the address the HTTP server listens on when PORT is unset.
 const defaultListenAddr = ":8080"
 
-// shutdownGracePeriod bounds how long graceful shutdown waits for in-flight
-// HTTP connections to drain before returning.
+// shutdownGracePeriod bounds the initial drain attempt before shutdown reports
+// a timeout and continues waiting with dependencies still available.
 const shutdownGracePeriod = 15 * time.Second
 
 // Serve runs the full gateway server startup sequence and blocks until the
@@ -146,22 +146,28 @@ func Serve(ctx context.Context) error {
 	// explicitly into the components that hold their own logger.
 	lg := logger.New(logger.FromEnv())
 	logger.SetDefault(lg)
+	if ctx.Err() != nil {
+		return nil
+	}
 
 	if err := CheckProductionSafety(); err != nil {
 		lg.Error("startup blocked: unsafe configuration", "error", err)
 		return err
 	}
 
-	app, err := buildServer(lg)
+	app, err := buildServer(ctx, lg)
 	if err != nil {
+		if ctx.Err() != nil && errors.Is(err, ctx.Err()) {
+			return nil
+		}
 		return err
 	}
 	listenErr := runUntilShutdown(ctx, app.gw, app.srv)
-	gracefulShutdown(app)
-	if listenErr != nil && !errors.Is(listenErr, http.ErrServerClosed) {
-		return listenErr
+	shutdownErr := gracefulShutdown(app, shutdownGracePeriod)
+	if errors.Is(listenErr, http.ErrServerClosed) || (ctx.Err() != nil && errors.Is(listenErr, ctx.Err())) {
+		listenErr = nil
 	}
-	return nil
+	return errors.Join(listenErr, shutdownErr)
 }
 
 type serverRuntime struct {
@@ -199,7 +205,7 @@ func closeRuntimeResources(resources []httpserver.NamedResource, otelShutdown gw
 // the router and HTTP server, prints the startup banner, and logs readiness.
 // It returns startup errors and the long-lived components needed to run and
 // later shut down the server.
-func buildServer(lg *logger.Logger) (app *serverRuntime, err error) {
+func buildServer(ctx context.Context, lg *logger.Logger) (app *serverRuntime, err error) {
 	app = &serverRuntime{}
 	started := app
 	defer func() {
@@ -236,7 +242,7 @@ func buildServer(lg *logger.Logger) (app *serverRuntime, err error) {
 	// logging plugins as they load. The reader is also the writer (one
 	// *SQLWriter serves both the admin log views and the plugin), or nil when
 	// no request-log backend is configured.
-	logReader, logMaintainer, logReaderBackend, err := CreateRequestLogReaderFromEnv(context.Background())
+	logReader, logMaintainer, logReaderBackend, err := CreateRequestLogReaderFromEnv(ctx)
 	if err != nil {
 		logger.Default().Error("failed to initialize request log reader", "error", err)
 		return nil, err
@@ -258,7 +264,7 @@ func buildServer(lg *logger.Logger) (app *serverRuntime, err error) {
 	if cfg != nil {
 		obsCfg = cfg.Observability
 	}
-	obsProvider, otelShutdown, err := gwotel.Init(context.Background(), otelConfigFromGateway(obsCfg))
+	obsProvider, otelShutdown, err := gwotel.Init(ctx, otelConfigFromGateway(obsCfg))
 	if err != nil {
 		logger.Default().Error("failed to initialize observability", "error", err)
 		return nil, err
@@ -276,10 +282,7 @@ func buildServer(lg *logger.Logger) (app *serverRuntime, err error) {
 	// every scrape, rather than from whenever a request last finished.
 	gw.PublishCircuitBreakerMetrics()
 
-	// No lifecycle context exists yet at this point in startup (signal.NotifyContext
-	// is only set up later, in runUntilShutdown), matching the gwotel.Init call
-	// above — these are one-time store-initialization calls, not per-request work.
-	cfgManager, configStoreBackend, err := CreateConfigManagerFromEnv(context.Background(), gw)
+	cfgManager, configStoreBackend, err := CreateConfigManagerFromEnv(ctx, gw)
 	if err != nil {
 		logger.Default().Error("failed to initialize config store", "error", err)
 		return nil, err
@@ -293,7 +296,7 @@ func buildServer(lg *logger.Logger) (app *serverRuntime, err error) {
 	// than from the file.
 	active := ResolveActiveConfig(gw, cfgManager, cfg, configStoreBackend)
 
-	keyStore, keyStoreBackend, err := CreateKeyStoreFromEnv(context.Background())
+	keyStore, keyStoreBackend, err := CreateKeyStoreFromEnv(ctx)
 	if err != nil {
 		logger.Default().Error("failed to initialize API key store", "error", err)
 		return nil, err
@@ -304,7 +307,7 @@ func buildServer(lg *logger.Logger) (app *serverRuntime, err error) {
 	// configures persistence once (see CreateSessionStoreFromEnv). It is a
 	// distinct store, and for SQLite a distinct database file, from the key
 	// store built above.
-	sessionStore, _, err := CreateSessionStoreFromEnv(context.Background())
+	sessionStore, _, err := CreateSessionStoreFromEnv(ctx)
 	if err != nil {
 		logger.Default().Error("failed to initialize session store", "error", err)
 		return nil, err
@@ -314,7 +317,7 @@ func buildServer(lg *logger.Logger) (app *serverRuntime, err error) {
 	// The audit store follows the key store's backend too, for the same reason
 	// (see CreateAuditStoreFromEnv). It is a distinct store and, for SQLite, a
 	// distinct file from the key, session, and config stores.
-	auditStore, auditStoreBackend, err := CreateAuditStoreFromEnv(context.Background())
+	auditStore, auditStoreBackend, err := CreateAuditStoreFromEnv(ctx)
 	if err != nil {
 		logger.Default().Error("failed to initialize audit store", "error", err)
 		return nil, err
@@ -414,24 +417,32 @@ func runUntilShutdown(ctx context.Context, gw *aigateway.Gateway, srv *http.Serv
 // gracefulShutdown drains the HTTP server, closes the persistence stores, and
 // flushes OTel exporters in that order — the same list, in the same order, that
 // a failed startup closes (see buildServer).
-func gracefulShutdown(app *serverRuntime) {
+func gracefulShutdown(app *serverRuntime, gracePeriod time.Duration) error {
 	// Shutdown drains active connections before returning — the stores must
 	// close after so in-flight requests can still reach them.
 	logger.Default().Info("shutting down gracefully")
-	shutdownCtx, cancel := context.WithTimeout(context.Background(), shutdownGracePeriod)
-	if err := app.srv.Shutdown(shutdownCtx); err != nil {
-		logger.Default().Error("shutdown error", "error", err)
-	}
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), gracePeriod)
+	shutdownErr := app.srv.Shutdown(shutdownCtx)
 	cancel()
+	if shutdownErr != nil {
+		logger.Default().Error("shutdown error", "error", shutdownErr)
+		// Shutdown's deadline does not terminate active handlers. Keep shared
+		// resources alive and wait for them before cleanup.
+		if err := app.srv.Shutdown(context.Background()); err != nil {
+			shutdownErr = errors.Join(shutdownErr, err)
+		}
+	}
 
 	// OTel drains last so spans emitted during the rest of the shutdown
 	// sequence still reach the collector. The ShutdownFunc from gwotel.Init
 	// applies its own deadline (cfg.ShutdownGrace), hence context.Background().
-	if err := closeRuntimeResources(app.resources(), app.otelShutdown); err != nil {
-		logger.Default().Error("shutdown cleanup error", "error", err)
+	cleanupErr := closeRuntimeResources(app.resources(), app.otelShutdown)
+	if cleanupErr != nil {
+		logger.Default().Error("shutdown cleanup error", "error", cleanupErr)
 	}
 
 	logger.Default().Info("server stopped")
+	return errors.Join(shutdownErr, cleanupErr)
 }
 
 // discoveryIntervalFromEnv reads the FERRO_MODEL_DISCOVERY_INTERVAL env var and

--- a/internal/bootstrap/configsource_test.go
+++ b/internal/bootstrap/configsource_test.go
@@ -275,7 +275,11 @@ func TestWarnUnreadConfigFile(t *testing.T) {
 	t.Setenv("GATEWAY_CONFIG", "")
 	buf := captureDefaultLogger(t)
 
-	if cfg, err := LoadConfig(); err != nil || cfg != nil {
+	cfg, err := LoadConfig()
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if cfg != nil {
 		t.Fatalf("LoadConfig must not adopt an unnamed file, got %+v", cfg)
 	}
 
@@ -305,7 +309,11 @@ func TestWarnUnreadConfigFile_SilentWhenNamed(t *testing.T) {
 	t.Setenv("GATEWAY_CONFIG", path)
 	buf := captureDefaultLogger(t)
 
-	if cfg, err := LoadConfig(); err != nil || cfg == nil {
+	cfg, err := LoadConfig()
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if cfg == nil {
 		t.Fatal("LoadConfig returned nil for a named, valid config file")
 	}
 	if hasEntry(t, buf, "GATEWAY_CONFIG is unset") {

--- a/internal/bootstrap/configsource_test.go
+++ b/internal/bootstrap/configsource_test.go
@@ -275,7 +275,7 @@ func TestWarnUnreadConfigFile(t *testing.T) {
 	t.Setenv("GATEWAY_CONFIG", "")
 	buf := captureDefaultLogger(t)
 
-	if cfg := LoadConfig(); cfg != nil {
+	if cfg, err := LoadConfig(); err != nil || cfg != nil {
 		t.Fatalf("LoadConfig must not adopt an unnamed file, got %+v", cfg)
 	}
 
@@ -305,7 +305,7 @@ func TestWarnUnreadConfigFile_SilentWhenNamed(t *testing.T) {
 	t.Setenv("GATEWAY_CONFIG", path)
 	buf := captureDefaultLogger(t)
 
-	if cfg := LoadConfig(); cfg == nil {
+	if cfg, err := LoadConfig(); err != nil || cfg == nil {
 		t.Fatal("LoadConfig returned nil for a named, valid config file")
 	}
 	if hasEntry(t, buf, "GATEWAY_CONFIG is unset") {

--- a/internal/bootstrap/runtime_test.go
+++ b/internal/bootstrap/runtime_test.go
@@ -2,8 +2,13 @@ package bootstrap
 
 import (
 	"context"
+	"errors"
+	"net"
+	"net/http"
 	"reflect"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/ferro-labs/ai-gateway/internal/httpserver"
 )
@@ -34,5 +39,105 @@ func TestCloseRuntimeResourcesFlushesOTelLast(t *testing.T) {
 	}
 	if want := []string{"first", "second", "otel"}; !reflect.DeepEqual(order, want) {
 		t.Fatalf("close order = %v, want %v", order, want)
+	}
+}
+
+func TestServeAlreadyCanceledIsGraceful(t *testing.T) {
+	t.Setenv("GATEWAY_CONFIG", "")
+	t.Setenv("API_KEY_STORE_BACKEND", "memory")
+	t.Setenv("CONFIG_STORE_BACKEND", "memory")
+	t.Setenv("REQUEST_LOG_STORE_BACKEND", "")
+	t.Setenv("PORT", "0")
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	if err := Serve(ctx); err != nil {
+		t.Fatalf("Serve(already canceled) = %v, want graceful nil", err)
+	}
+}
+
+func TestGracefulShutdownWaitsForActiveHandlersBeforeClosingResources(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+	handlerDone := make(chan struct{})
+	var cleanupStarted atomic.Bool
+
+	srv := httpserver.NewServer("127.0.0.1:0", http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		close(started)
+		<-release
+		close(handlerDone)
+	}))
+	listener, err := (&net.ListenConfig{}).Listen(t.Context(), "tcp", srv.Addr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	go func() { _ = srv.Serve(listener) }()
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "http://"+listener.Addr().String(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	go func() {
+		resp, requestErr := http.DefaultClient.Do(req)
+		if requestErr == nil {
+			_ = resp.Body.Close()
+		}
+	}()
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("handler did not start")
+	}
+
+	app := &serverRuntime{
+		srv: srv,
+		otelShutdown: func(context.Context) error {
+			cleanupStarted.Store(true)
+			return nil
+		},
+	}
+	done := make(chan error, 1)
+	go func() { done <- gracefulShutdown(app, 10*time.Millisecond) }()
+
+	select {
+	case err := <-done:
+		t.Fatalf("shutdown returned before the handler finished: %v", err)
+	case <-time.After(30 * time.Millisecond):
+	}
+	if cleanupStarted.Load() {
+		t.Fatal("cleanup started while the active handler was still running")
+	}
+
+	close(release)
+	select {
+	case <-handlerDone:
+	case <-time.After(time.Second):
+		t.Fatal("handler did not finish")
+	}
+	if err := <-done; !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("gracefulShutdown error = %v, want shutdown deadline error", err)
+	}
+	if !cleanupStarted.Load() {
+		t.Fatal("cleanup did not run after the handler finished")
+	}
+}
+
+func TestGracefulShutdownReturnsCleanupErrorsAndFlushesOTelLast(t *testing.T) {
+	want := errors.New("cleanup failed")
+	var order []string
+	app := &serverRuntime{
+		srv: httpserver.NewServer("", http.NotFoundHandler()),
+		otelShutdown: func(context.Context) error {
+			order = append(order, "otel")
+			return want
+		},
+	}
+
+	err := gracefulShutdown(app, time.Second)
+	if !errors.Is(err, want) {
+		t.Fatalf("gracefulShutdown error = %v, want cleanup error", err)
+	}
+	if wantOrder := []string{"otel"}; !reflect.DeepEqual(order, wantOrder) {
+		t.Fatalf("close order = %v, want %v", order, wantOrder)
 	}
 }

--- a/internal/bootstrap/runtime_test.go
+++ b/internal/bootstrap/runtime_test.go
@@ -5,12 +5,15 @@ import (
 	"errors"
 	"net"
 	"net/http"
+	"os"
+	"path/filepath"
 	"reflect"
 	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/ferro-labs/ai-gateway/internal/httpserver"
+	"github.com/ferro-labs/ai-gateway/pkg/logger"
 )
 
 type orderedCloser struct {
@@ -53,6 +56,70 @@ func TestServeAlreadyCanceledIsGraceful(t *testing.T) {
 	cancel()
 	if err := Serve(ctx); err != nil {
 		t.Fatalf("Serve(already canceled) = %v, want graceful nil", err)
+	}
+}
+
+func TestServeReturnsProductionSafetyErrors(t *testing.T) {
+	t.Setenv("GATEWAY_ENV", "production")
+	t.Setenv("ALLOW_UNAUTHENTICATED_PROXY", "true")
+
+	if err := Serve(t.Context()); err == nil {
+		t.Fatal("Serve must return production safety errors")
+	}
+}
+
+func TestServeReturnsConfigErrors(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(configPath, []byte("strategy:\n  mode: not-a-mode\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GATEWAY_ENV", "")
+	t.Setenv("ALLOW_UNAUTHENTICATED_PROXY", "")
+	t.Setenv("GATEWAY_CONFIG", configPath)
+
+	if err := Serve(t.Context()); err == nil {
+		t.Fatal("Serve must return config errors")
+	}
+}
+
+func TestBuildServerReturnsCompleteRuntime(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(configPath, []byte("strategy:\n  mode: single\ntargets:\n  - virtual_key: openai\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GATEWAY_CONFIG", configPath)
+	t.Setenv("OPENAI_API_KEY", "test-key")
+	t.Setenv("FERRO_MODEL_CATALOG_TIMEOUT", "0")
+	t.Setenv("API_KEY_STORE_BACKEND", "memory")
+	t.Setenv("CONFIG_STORE_BACKEND", "memory")
+	t.Setenv("REQUEST_LOG_STORE_BACKEND", "")
+	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "")
+	t.Setenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "")
+	t.Setenv("PORT", "0")
+
+	lg := logger.New(logger.FromEnv())
+	app, err := buildServer(t.Context(), lg)
+	if err != nil {
+		t.Fatalf("buildServer: %v", err)
+	}
+	if app.gw == nil || app.srv == nil || app.cfgManager == nil || app.keyStore == nil || app.sessionStore == nil || app.auditStore == nil || app.otelShutdown == nil {
+		t.Fatalf("buildServer returned an incomplete runtime: %+v", app)
+	}
+	if app.srv.Addr != ":0" {
+		t.Errorf("server address = %q, want :0", app.srv.Addr)
+	}
+	t.Cleanup(func() {
+		if err := closeRuntimeResources(app.resources(), app.otelShutdown); err != nil {
+			t.Errorf("close runtime resources: %v", err)
+		}
+	})
+}
+
+func TestRunUntilShutdownReturnsListenErrors(t *testing.T) {
+	srv := httpserver.NewServer("invalid::address", http.NotFoundHandler())
+
+	if err := runUntilShutdown(t.Context(), nil, srv); err == nil {
+		t.Fatal("runUntilShutdown must return listener errors")
 	}
 }
 

--- a/internal/bootstrap/runtime_test.go
+++ b/internal/bootstrap/runtime_test.go
@@ -1,0 +1,38 @@
+package bootstrap
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/ferro-labs/ai-gateway/internal/httpserver"
+)
+
+type orderedCloser struct {
+	name  string
+	order *[]string
+}
+
+func (c *orderedCloser) Close() error {
+	*c.order = append(*c.order, c.name)
+	return nil
+}
+
+func TestCloseRuntimeResourcesFlushesOTelLast(t *testing.T) {
+	var order []string
+	resources := []httpserver.NamedResource{
+		{Name: "first", Value: &orderedCloser{name: "first", order: &order}},
+		{Name: "second", Value: &orderedCloser{name: "second", order: &order}},
+	}
+	shutdown := func(context.Context) error {
+		order = append(order, "otel")
+		return nil
+	}
+
+	if err := closeRuntimeResources(resources, shutdown); err != nil {
+		t.Fatalf("closeRuntimeResources returned an error: %v", err)
+	}
+	if want := []string{"first", "second", "otel"}; !reflect.DeepEqual(order, want) {
+		t.Fatalf("close order = %v, want %v", order, want)
+	}
+}

--- a/internal/bootstrap/runtime_test.go
+++ b/internal/bootstrap/runtime_test.go
@@ -114,8 +114,13 @@ func TestGracefulShutdownWaitsForActiveHandlersBeforeClosingResources(t *testing
 	case <-time.After(time.Second):
 		t.Fatal("handler did not finish")
 	}
-	if err := <-done; !errors.Is(err, context.DeadlineExceeded) {
-		t.Fatalf("gracefulShutdown error = %v, want shutdown deadline error", err)
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("gracefulShutdown error = %v, want shutdown deadline error", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("gracefulShutdown did not return after the handler finished")
 	}
 	if !cleanupStarted.Load() {
 		t.Fatal("cleanup did not run after the handler finished")

--- a/internal/httpserver/close_resources_test.go
+++ b/internal/httpserver/close_resources_test.go
@@ -1,0 +1,31 @@
+package httpserver
+
+import "testing"
+
+type nilCloser struct{ closed *bool }
+
+func (c *nilCloser) Close() error {
+	*c.closed = true // dereferences the receiver, like Gateway.Close does
+	return nil
+}
+
+// A concrete pointer that was never assigned still satisfies the Close
+// assertion once boxed into Value; calling it dereferences nil. Callers build
+// these lists from struct fields that are nil on every early-exit path, so the
+// skip has to live here, where every close routes through.
+func TestCloseResourcesSkipsTypedNilPointer(t *testing.T) {
+	closed := false
+	var never *nilCloser
+
+	err := CloseResources(
+		NamedResource{Name: "never built", Value: never},
+		NamedResource{Name: "built", Value: &nilCloser{closed: &closed}},
+	)
+
+	if err != nil {
+		t.Fatalf("CloseResources returned an error: %v", err)
+	}
+	if !closed {
+		t.Fatal("the non-nil resource was not closed")
+	}
+}

--- a/internal/httpserver/server.go
+++ b/internal/httpserver/server.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"reflect"
 	"time"
 
 	"github.com/ferro-labs/ai-gateway/internal/httpclient"
@@ -48,7 +49,9 @@ func CloseResources(resources ...NamedResource) error {
 	var err error
 	for _, resource := range resources {
 		closer, ok := resource.Value.(interface{ Close() error })
-		if !ok {
+		if !ok || isNilPointer(resource.Value) {
+			// A struct field that was never assigned arrives here as a typed nil:
+			// the assertion succeeds, and Close dereferences it.
 			continue
 		}
 		if closeErr := closer.Close(); closeErr != nil {
@@ -57,4 +60,9 @@ func CloseResources(resources ...NamedResource) error {
 	}
 	httpclient.CloseIdleConnections()
 	return err
+}
+
+func isNilPointer(v any) bool {
+	rv := reflect.ValueOf(v)
+	return rv.Kind() == reflect.Pointer && rv.IsNil()
 }

--- a/run/cli_contract_test.go
+++ b/run/cli_contract_test.go
@@ -1,7 +1,8 @@
-package main
+package run
 
 import (
 	"bytes"
+	"errors"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -14,7 +15,7 @@ func runCLI(t *testing.T, args ...string) (out *bytes.Buffer, served *bool, err 
 	t.Helper()
 	out = &bytes.Buffer{}
 	ran := false
-	root := newRootCmd(func() { ran = true })
+	root := newRootCmd(func() error { ran = true; return nil })
 	root.SetOut(out)
 	root.SetErr(out)
 	root.SetArgs(args)
@@ -94,6 +95,21 @@ func TestCommandErrorPrintsNoUsageBlock(t *testing.T) {
 	}
 }
 
+func TestServeErrorIsNotPrintedTwice(t *testing.T) {
+	out := &bytes.Buffer{}
+	root := newRootCmd(func() error { return errors.New("startup failed") })
+	root.SetOut(out)
+	root.SetErr(out)
+	root.SetArgs([]string{"serve"})
+
+	if err := root.Execute(); err == nil {
+		t.Fatal("serve must return its startup error")
+	}
+	if strings.Contains(out.String(), "startup failed") {
+		t.Fatalf("Cobra printed an error the startup path already logged: %s", out.String())
+	}
+}
+
 // A nil Args is cobra's ArbitraryArgs: the command accepts tokens it will never
 // read, which is how a mistyped invocation becomes a silent no-op. This walks
 // the root's own children — the commands this binary mounts — so one added
@@ -101,7 +117,7 @@ func TestCommandErrorPrintsNoUsageBlock(t *testing.T) {
 // than recursing: `admin`'s leaves are declared in their own file and are that
 // file's contract to state.
 func TestMountedCommandsDeclareAnArgumentPolicy(t *testing.T) {
-	root := newRootCmd(func() {})
+	root := newRootCmd(func() error { return nil })
 	// The root is the exception, and the opposite way round: see
 	// TestRootRejectsUnknownSubcommand.
 	if root.Args != nil {

--- a/run/run.go
+++ b/run/run.go
@@ -25,8 +25,7 @@ import (
 
 type options struct{}
 
-// Option configures the process runtime. v1.5.0 reserves the additive option
-// seam; concrete options will be added only when a runtime consumer needs one.
+// Option configures the process runtime.
 type Option func(*options)
 
 // Run starts ferrogw and blocks until shutdown.
@@ -49,9 +48,11 @@ func Main() {
 
 func newRootCmd(serve func() error) *cobra.Command {
 	rootCmd := &cobra.Command{
-		Use:          "ferrogw",
-		Short:        "Ferro Labs AI Gateway",
-		Long:         "High-performance AI gateway with smart routing, plugins, and an authenticated Admin API.",
+		Use:   "ferrogw",
+		Short: "Ferro Labs AI Gateway",
+		Long:  "Routes AI API requests to configured providers with plugin middleware and an authenticated Admin API.",
+		// Args must remain nil so Cobra reports unknown subcommands.
+		// SilenceUsage avoids printing usage after errors.
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runServe(cmd, serve)

--- a/run/run.go
+++ b/run/run.go
@@ -1,0 +1,87 @@
+// Package run is the importable ferrogw program: the process lane, where the
+// gateway owns the process, the command tree, and configuration. A custom
+// binary is a main that blank-imports its plugins and calls Main. For the
+// library lane — mounting gateway surfaces inside your own server behind
+// your own middleware — see package httpgateway instead.
+package run
+
+import (
+	"context"
+	"os"
+
+	"github.com/ferro-labs/ai-gateway/internal/bootstrap"
+	"github.com/ferro-labs/ai-gateway/internal/cli"
+	"github.com/spf13/cobra"
+
+	// Register the built-in plugins so every binary composed on this package
+	// can load them from config without repeating the list.
+	_ "github.com/ferro-labs/ai-gateway/plugin/budget"
+	_ "github.com/ferro-labs/ai-gateway/plugin/cache"
+	_ "github.com/ferro-labs/ai-gateway/plugin/logger"
+	_ "github.com/ferro-labs/ai-gateway/plugin/maxtoken"
+	_ "github.com/ferro-labs/ai-gateway/plugin/ratelimit"
+	_ "github.com/ferro-labs/ai-gateway/plugin/wordfilter"
+)
+
+type options struct{}
+
+// Option configures the process runtime. v1.5.0 reserves the additive option
+// seam; concrete options will be added only when a runtime consumer needs one.
+type Option func(*options)
+
+// Run starts ferrogw and blocks until shutdown.
+func Run(ctx context.Context, opts ...Option) error {
+	settings := &options{}
+	for _, option := range opts {
+		if option != nil {
+			option(settings)
+		}
+	}
+	return bootstrap.Serve(ctx)
+}
+
+// Main runs the ferrogw CLI and owns process exit behavior.
+func Main() {
+	if err := newRootCmd(func() error { return Run(context.Background()) }).Execute(); err != nil {
+		os.Exit(1)
+	}
+}
+
+func newRootCmd(serve func() error) *cobra.Command {
+	rootCmd := &cobra.Command{
+		Use:          "ferrogw",
+		Short:        "Ferro Labs AI Gateway",
+		Long:         "High-performance AI gateway with smart routing, plugins, and an authenticated Admin API.",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runServe(cmd, serve)
+		},
+	}
+
+	serveCmd := &cobra.Command{
+		Use:   "serve",
+		Short: "Start the gateway server",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runServe(cmd, serve)
+		},
+	}
+
+	rootCmd.AddCommand(serveCmd, cli.InitCmd, cli.ValidateCmd, cli.PluginsCmd, cli.DoctorCmd,
+		cli.StatusCmd, cli.VersionCmd, cli.AdminCmd)
+	rootCmd.PersistentFlags().String("gateway-url", "", "Gateway base URL (env: FERROGW_URL, default: http://localhost:8080)")
+	rootCmd.PersistentFlags().String("api-key", "", "Admin API key (env: FERROGW_API_KEY)")
+	rootCmd.PersistentFlags().String(cli.FlagFormat, cli.FormatTable,
+		"Output format: table, json, or yaml (not supported by the report commands: init, doctor, status)")
+	return rootCmd
+}
+
+func runServe(cmd *cobra.Command, serve func() error) error {
+	err := serve()
+	if err != nil {
+		// Startup already reported the failure through the structured logger.
+		// Keep Cobra from printing the same error a second time.
+		cmd.Root().SilenceErrors = true
+	}
+	return err
+}

--- a/run/run_test.go
+++ b/run/run_test.go
@@ -73,3 +73,17 @@ func TestRunHonorsCanceledContext(t *testing.T) {
 		t.Fatal("Run did not trigger graceful shutdown after context cancellation")
 	}
 }
+
+func TestRunAppliesOptionsAndIgnoresNil(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	applied := false
+
+	err := Run(ctx, nil, func(*options) { applied = true })
+	if err != nil {
+		t.Fatalf("Run returned an error for context cancellation: %v", err)
+	}
+	if !applied {
+		t.Fatal("Run did not apply its option")
+	}
+}

--- a/run/run_test.go
+++ b/run/run_test.go
@@ -1,0 +1,75 @@
+package run
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// isolateStores keeps a developer's shell from steering the boot under test at
+// a real backend: with either backend set to sqlite, the empty-DSN default
+// writes ferrogw-*.db into this package directory.
+func isolateStores(t *testing.T) {
+	t.Helper()
+	t.Setenv("GATEWAY_ENV", "")
+	t.Setenv("ALLOW_UNAUTHENTICATED_PROXY", "")
+	t.Setenv("REQUEST_LOG_STORE_BACKEND", "")
+	t.Setenv("API_KEY_STORE_BACKEND", "")
+	t.Setenv("CONFIG_STORE_BACKEND", "")
+}
+
+func TestRunReturnsStartupErrors(t *testing.T) {
+	t.Setenv("GATEWAY_ENV", "production")
+	t.Setenv("ALLOW_UNAUTHENTICATED_PROXY", "true")
+
+	err := Run(t.Context())
+	if err == nil {
+		t.Fatal("Run must return startup errors instead of terminating the process")
+	}
+}
+
+// A failure inside buildServer — here an invalid config file — used to exit 1
+// after logging. The error return must arrive as an error, not as the panic a
+// typed-nil *Gateway produced when the cleanup path tried to Close it.
+func TestRunReturnsConfigErrorsWithoutPanicking(t *testing.T) {
+	isolateStores(t)
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(configPath, []byte("strategy:\n  mode: not-a-mode\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GATEWAY_CONFIG", configPath)
+
+	err := Run(t.Context())
+	if err == nil {
+		t.Fatal("Run must return the config error")
+	}
+}
+
+func TestRunHonorsCanceledContext(t *testing.T) {
+	isolateStores(t)
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(configPath, []byte("strategy:\n  mode: single\ntargets:\n  - virtual_key: openai\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GATEWAY_CONFIG", configPath)
+	t.Setenv("OPENAI_API_KEY", "test-key")
+	t.Setenv("FERRO_MODEL_CATALOG_TIMEOUT", "0")
+	t.Setenv("PORT", "0")
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	done := make(chan error, 1)
+	go func() { done <- Run(ctx) }()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Run returned an error for context cancellation: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Run did not trigger graceful shutdown after context cancellation")
+	}
+}


### PR DESCRIPTION
## Summary

- add the public `github.com/ferro-labs/ai-gateway/run` package with `Main()` and context-aware `Run(ctx, opts...)`
- move gateway command ownership into the importable runtime while keeping `cmd/ferrogw` as a thin entry point
- return startup/runtime errors to embedders and gracefully close partially initialized resources
- preserve built-in provider and plugin self-registration through static blank imports
- document the v1.5.0 release with the 2026-08-29 changelog date

## Why

This provides a supported composition seam for custom statically linked gateway binaries. External plugins can self-register through blank imports without requiring `ferrogw-builder`, while existing builder workflows remain compatible.

The reserved `Option` API intentionally has no concrete options in v1.5.0; it establishes a stable extension point without adding speculative configuration.

## Closes

- Closes #206

## Related PRs

- static composition proof: ferro-labs/ai-gateway-plugins#1
- release plan and coordinated submodule pointers: ferro-labs/ai-gateway-workspace#2

## Validation

- `make test` (including race coverage)
- `go vet ./...`
- API diff against v1.4.5: additive changes only
- runtime, command, cancellation, and partial-cleanup tests
- external static-composition check in the companion plugins repository

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a public Go package for running the server programmatically.
  - Added context-aware execution with returned startup and listening errors.
  - Context cancellation now performs graceful shutdown, matching termination-signal behavior.
  - Custom binaries can invoke the server while retaining plugin support.
  - Catalog loading now responds to caller-provided cancellation.

- **Bug Fixes**
  - Prevented listeners from remaining active when cancellation occurs during startup.
  - Improved cleanup safety for uninitialized resources.
  - Preserved existing commands, flags, and exit-code behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->







<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds an importable gateway runtime while retaining the existing CLI entry point and plugin self-registration.
- Introduces public `run.Main()` and context-aware `run.Run`.
- Threads caller cancellation through gateway and persistence initialization.
- Refactors startup and shutdown to return errors and clean partially initialized resources.
- Adds lifecycle, cancellation, cleanup, CLI-contract, and catalog-loading tests.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| run/run.go | Adds the public runtime API and moves CLI command ownership into the importable package without leaving an accepted defect. |
| internal/bootstrap/bootstrap.go | Refactors startup, listener ownership, cancellation, partial cleanup, and graceful shutdown; the previously reported cancellation paths are addressed. |
| gateway.go | Adds a construction context and checks cancellation after catalog loading before starting gateway-owned background work. |
| internal/httpserver/server.go | Makes generic resource cleanup safe for typed nil pointers encountered during partial initialization. |
| cmd/ferrogw/main.go | Reduces the binary entry point to a thin call into the new public runtime. |


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Embedder
    participant Run
    participant Bootstrap
    participant Gateway
    participant HTTP
    Embedder->>Run: Run(ctx, options...)
    Run->>Bootstrap: Serve(ctx)
    Bootstrap->>Gateway: BuildGateway(ctx)
    Gateway->>Gateway: Load catalog with ctx
    Bootstrap->>HTTP: Bind listener with ctx
    HTTP-->>Bootstrap: Serve until cancellation/error
    Embedder-->>Run: Cancel ctx
    Bootstrap->>HTTP: Graceful shutdown
    Bootstrap->>Gateway: Close resources
    Bootstrap-->>Run: Return runtime/cleanup error
    Run-->>Embedder: error or nil
```
</details>

<sub>Reviews (4): Last reviewed commit: ["fix: stop startup after cancellation"](https://github.com/ferro-labs/ai-gateway/commit/94dade3de81564614ea454ee1761d6eca3391cd1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58192976)</sub>

<!-- /greptile_comment -->