### PR TITLE
docs: move the embeddable gateway to Shipped in ROADMAP.md

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -7,7 +7,6 @@ see [CHANGELOG.md](CHANGELOG.md).
 
 What's next, roughly in priority order:
 
-- **Embeddable gateway** — a public, importable Go entrypoint so the gateway can run inside your own program, not only as the standalone `ferrogw` binary.
 - **Plugin SDK & vendor observability bridges** — external guardrail and transform plugins, plus bridges for LangSmith, Langfuse, Datadog, New Relic, Honeycomb, Grafana, and more, shipped from a companion `ai-gateway-plugins` repo so the core binary stays slim.
 - **Webhook notifications** — configurable alerts for budget limits, error spikes, and circuit-breaker events.
 - **Semantic & Redis-backed caching** — beyond the built-in in-memory cache.
@@ -79,3 +78,4 @@ Everything below is available today.
 - memory / SQLite / PostgreSQL backends
 - Multi-arch container images, a Helm chart, GoReleaser packaging, and Railway & Render deploy templates
 - Official Python and TypeScript SDKs
+- Importable from Go (v1.5.0): `run.Main()` composes the whole `ferrogw` program into your own binary with extra plugins compiled in, `run.Run(ctx, …)` runs it under a context you own, and `httpgateway` mounts the gateway's HTTP surfaces behind your own middleware


### PR DESCRIPTION
## Summary

v1.5.0 shipped the public `run` package (`run.Main()` / `run.Run(ctx, …)`) and `cmd/ferrogw` became a thin caller, so the "Embeddable gateway" roadmap bullet moves under **Shipped → Platform**, next to the `httpgateway` library lane from v1.4.2.

Docs only. Follows #420 / tag `v1.5.0`.

## Test plan

- [x] Rendered locally; no links changed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the roadmap to document Go import entrypoints available since v1.5.0.
  * Removed the “Embeddable gateway” item from the roadmap.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->